### PR TITLE
Fix MVR and GDTF export version metadata

### DIFF
--- a/core/gdtf_mutation_audit.cpp
+++ b/core/gdtf_mutation_audit.cpp
@@ -10,6 +10,7 @@
 namespace GdtfMutationAudit {
 namespace {
 
+// Builds the current UTC timestamp in the GDTF revision date format.
 std::string BuildIsoTimestampUtcNow() {
   using Clock = std::chrono::system_clock;
   const auto now = Clock::now();
@@ -29,6 +30,7 @@ std::string BuildIsoTimestampUtcNow() {
 
 } // namespace
 
+// Decides how legacy Perastage mutation metadata should be interpreted.
 CompatibilityDecision
 InspectCompatibility(const tinyxml2::XMLElement *fixtureType) {
   CompatibilityDecision decision;
@@ -63,6 +65,7 @@ InspectCompatibility(const tinyxml2::XMLElement *fixtureType) {
   return decision;
 }
 
+// Returns the fixture type element used by GDTF mutation helpers.
 tinyxml2::XMLElement *EnsureFixtureType(tinyxml2::XMLDocument &doc) {
   tinyxml2::XMLElement *root = doc.FirstChildElement("GDTF");
   if (root) {
@@ -85,6 +88,7 @@ tinyxml2::XMLElement *EnsureFixtureType(tinyxml2::XMLDocument &doc) {
   return fixtureType;
 }
 
+// Returns or creates the standard GDTF revisions container.
 tinyxml2::XMLElement *EnsureRevisionsNode(tinyxml2::XMLElement *fixtureType,
                                           tinyxml2::XMLDocument &doc) {
   if (!fixtureType)
@@ -98,10 +102,33 @@ tinyxml2::XMLElement *EnsureRevisionsNode(tinyxml2::XMLElement *fixtureType,
   return revisions;
 }
 
+// Builds the standard ModifiedBy value for Perastage-authored GDTF revisions.
 std::string BuildPerastageModifiedBy() {
   return std::string("Perastage ") + app::kVersion;
 }
 
+// Checks whether an equivalent Perastage revision already exists.
+bool HasEquivalentRevision(const tinyxml2::XMLElement *fixtureType,
+                           const std::string &text,
+                           const std::string &modifiedBy,
+                           int userId) {
+  const tinyxml2::XMLElement *revisions =
+      fixtureType ? fixtureType->FirstChildElement("Revisions") : nullptr;
+  for (const tinyxml2::XMLElement *revision =
+           revisions ? revisions->FirstChildElement("Revision") : nullptr;
+       revision; revision = revision->NextSiblingElement("Revision")) {
+    const char *existingText = revision->Attribute("Text");
+    const char *existingModifiedBy = revision->Attribute("ModifiedBy");
+    int existingUserId = -1;
+    revision->QueryIntAttribute("UserID", &existingUserId);
+    if (existingText && existingModifiedBy && existingText == text &&
+        existingModifiedBy == modifiedBy && existingUserId == userId)
+      return true;
+  }
+  return false;
+}
+
+// Appends a standard GDTF Revision unless the same Perastage revision exists.
 void AppendRevision(tinyxml2::XMLElement *fixtureType,
                     tinyxml2::XMLDocument &doc,
                     const std::string &text,
@@ -109,6 +136,11 @@ void AppendRevision(tinyxml2::XMLElement *fixtureType,
                     int userId,
                     const std::string &dateUtcIso8601) {
   if (!fixtureType)
+    return;
+
+  const std::string effectiveModifiedBy =
+      modifiedBy.empty() ? BuildPerastageModifiedBy() : modifiedBy;
+  if (HasEquivalentRevision(fixtureType, text, effectiveModifiedBy, userId))
     return;
 
   tinyxml2::XMLElement *revisions = EnsureRevisionsNode(fixtureType, doc);
@@ -119,32 +151,20 @@ void AppendRevision(tinyxml2::XMLElement *fixtureType,
   const std::string timestamp =
       dateUtcIso8601.empty() ? BuildIsoTimestampUtcNow() : dateUtcIso8601;
   revision->SetAttribute("Date", timestamp.c_str());
-  revision->SetAttribute("ModifiedBy",
-                         modifiedBy.empty() ? BuildPerastageModifiedBy().c_str()
-                                            : modifiedBy.c_str());
+  revision->SetAttribute("ModifiedBy", effectiveModifiedBy.c_str());
   revision->SetAttribute("Text", text.c_str());
   revision->SetAttribute("UserID", userId);
   revisions->InsertEndChild(revision);
 }
 
+// Keeps old mutation-audit callers from writing non-standard GDTF XML nodes.
 void StampPerastageMutationMetadata(tinyxml2::XMLElement *fixtureType,
                                     tinyxml2::XMLDocument &doc) {
-  if (!fixtureType)
-    return;
-
-  tinyxml2::XMLElement *auditNode =
-      fixtureType->FirstChildElement("PerastageMutationAudit");
-  if (!auditNode) {
-    auditNode = doc.NewElement("PerastageMutationAudit");
-    fixtureType->InsertEndChild(auditNode);
-  }
-
-  auditNode->SetAttribute("SchemaVersion", kPerastageGdtfMutationSchemaVersion);
-  auditNode->SetAttribute("PerastageVersion", app::kVersion);
-  auditNode->SetAttribute("PerastageVersionDisplay", app::kVersionDisplay);
-  auditNode->SetAttribute("LastMutationDateUtc", BuildIsoTimestampUtcNow().c_str());
+  (void)fixtureType;
+  (void)doc;
 }
 
+// Returns or creates the GDTF physical properties container.
 tinyxml2::XMLElement *EnsurePhysicalPropertiesNode(
     tinyxml2::XMLElement *fixtureType, tinyxml2::XMLDocument &doc) {
   if (!fixtureType)
@@ -166,6 +186,7 @@ tinyxml2::XMLElement *EnsurePhysicalPropertiesNode(
   return properties;
 }
 
+// Applies physical property values to a GDTF fixture type.
 bool ApplyPhysicalProperties(tinyxml2::XMLElement *fixtureType,
                              tinyxml2::XMLDocument &doc,
                              const std::optional<float> &weightKg,
@@ -201,6 +222,7 @@ bool ApplyPhysicalProperties(tinyxml2::XMLElement *fixtureType,
   return mutated;
 }
 
+// Applies physical properties and records a standard GDTF revision.
 bool ApplyPhysicalPropertiesWithAudit(
     tinyxml2::XMLElement *fixtureType, tinyxml2::XMLDocument &doc,
     const std::optional<float> &weightKg,
@@ -211,7 +233,6 @@ bool ApplyPhysicalPropertiesWithAudit(
   if (!mutated)
     return false;
 
-  StampPerastageMutationMetadata(fixtureType, doc);
   AppendRevision(fixtureType, doc, revisionText, modifiedBy);
   return true;
 }

--- a/core/gdtf_mutation_audit.h
+++ b/core/gdtf_mutation_audit.h
@@ -53,8 +53,7 @@ void AppendRevision(tinyxml2::XMLElement *fixtureType,
                     int userId = 0,
                     const std::string &dateUtcIso8601 = "");
 
-// Stamps Perastage-owned mutation metadata under <FixtureType>.
-// Metadata is stored in <PerastageMutationAudit>.
+// Preserves the legacy call site while avoiding non-standard GDTF metadata.
 void StampPerastageMutationMetadata(tinyxml2::XMLElement *fixtureType,
                                     tinyxml2::XMLDocument &doc);
 

--- a/core/truss_gdtf_builder.cpp
+++ b/core/truss_gdtf_builder.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "truss_gdtf_builder.h"
+#include "app_version.h"
 #include "filesystem_path_utils.h"
 
 #include "json.hpp"
@@ -31,6 +32,8 @@
 #include <array>
 #include <cctype>
 #include <cstdint>
+#include <chrono>
+#include <ctime>
 #include <fstream>
 #include <iomanip>
 #include <memory>
@@ -74,6 +77,21 @@ std::string BuildDeterministicUuid(const std::string &seed) {
   bytes[6] = static_cast<uint8_t>((bytes[6] & 0x0Fu) | 0x50u);
   bytes[8] = static_cast<uint8_t>((bytes[8] & 0x3Fu) | 0x80u);
   return BytesToUuid(bytes);
+}
+
+// Builds the current UTC timestamp used by generated GDTF revisions.
+std::string BuildRevisionTimestampUtcNow() {
+  using Clock = std::chrono::system_clock;
+  const std::time_t nowTime = Clock::to_time_t(Clock::now());
+  std::tm utcTm{};
+#if defined(_WIN32)
+  gmtime_s(&utcTm, &nowTime);
+#else
+  gmtime_r(&nowTime, &utcTm);
+#endif
+  std::ostringstream stamp;
+  stamp << std::put_time(&utcTm, "%Y-%m-%dT%H:%M:%SZ");
+  return stamp.str();
 }
 
 struct TrussSourceData {
@@ -268,6 +286,7 @@ static std::string BuildStableFixtureTypeId(const TrussSourceData &data) {
   return fixtureTypeId;
 }
 
+// Builds a valid GDTF 1.2 description.xml for a generated truss fixture type.
 static std::string BuildDescriptionXml(const TrussSourceData &data) {
   tinyxml2::XMLDocument doc;
   auto *decl = doc.NewDeclaration("xml version=\"1.0\" encoding=\"UTF-8\"");
@@ -295,6 +314,14 @@ static std::string BuildDescriptionXml(const TrussSourceData &data) {
   attributes->InsertEndChild(features);
   attributes->InsertEndChild(attributesNode);
   fixtureType->InsertEndChild(attributes);
+
+  auto *physical = doc.NewElement("PhysicalDescriptions");
+  auto *properties = doc.NewElement("Properties");
+  auto *weight = doc.NewElement("Weight");
+  weight->SetAttribute("Value", data.weightKg);
+  properties->InsertEndChild(weight);
+  physical->InsertEndChild(properties);
+  fixtureType->InsertEndChild(physical);
 
   auto *models = doc.NewElement("Models");
   auto *mainModel = doc.NewElement("Model");
@@ -327,13 +354,15 @@ static std::string BuildDescriptionXml(const TrussSourceData &data) {
   dmxModes->InsertEndChild(mode);
   fixtureType->InsertEndChild(dmxModes);
 
-  auto *physical = doc.NewElement("PhysicalDescriptions");
-  auto *properties = doc.NewElement("Properties");
-  auto *weight = doc.NewElement("Weight");
-  weight->SetAttribute("Value", data.weightKg);
-  properties->InsertEndChild(weight);
-  physical->InsertEndChild(properties);
-  fixtureType->InsertEndChild(physical);
+  auto *revisions = doc.NewElement("Revisions");
+  auto *revision = doc.NewElement("Revision");
+  revision->SetAttribute("Date", BuildRevisionTimestampUtcNow().c_str());
+  revision->SetAttribute("UserID", 0);
+  const std::string modifiedBy = std::string("Perastage ") + app::kVersion;
+  revision->SetAttribute("ModifiedBy", modifiedBy.c_str());
+  revision->SetAttribute("Text", "Generated Perastage auxiliary truss fixture type for MVR export");
+  revisions->InsertEndChild(revision);
+  fixtureType->InsertEndChild(revisions);
 
   tinyxml2::XMLPrinter printer;
   doc.Print(&printer);

--- a/docs/gdtf_mutation_audit.md
+++ b/docs/gdtf_mutation_audit.md
@@ -1,6 +1,6 @@
 # GDTF mutation audit (Perastage)
 
-Perastage centralizes GDTF write traceability in `core/gdtf_mutation_audit.{h,cpp}`.
+Perastage centralizes standard GDTF revision traceability in `core/gdtf_mutation_audit.{h,cpp}`.
 
 ## API
 
@@ -9,24 +9,29 @@ Perastage centralizes GDTF write traceability in `core/gdtf_mutation_audit.{h,cp
 - `AppendRevision(...)`
 - `StampPerastageMutationMetadata(...)`
 
-These helpers are the single integration point for metadata that Perastage owns
-when mutating `description.xml` inside `.gdtf` archives.
+These helpers are the single integration point for standard GDTF revisions that
+Perastage writes when intentionally mutating `description.xml` inside `.gdtf`
+archives. `StampPerastageMutationMetadata(...)` is retained as a compatibility
+no-op for older call sites and must not write non-standard GDTF XML nodes.
 
-## Perastage mutation schema version
+## Legacy Perastage mutation schema version
 
 `kPerastageGdtfMutationSchemaVersion` is a Perastage-owned version marker for the
-shape and semantics of Perastage mutation metadata (for example the
+legacy shape and semantics of Perastage mutation metadata (for example the
 `<PerastageMutationAudit>` node and related attributes).
 
 - It is **independent** from GDTF format versioning.
-- It should be bumped only when Perastage changes its own mutation-audit contract.
+- Perastage does not write this node in new exports.
+- It exists so compatibility code can identify legacy files written by older builds.
 
 ## Relationship with Perastage app version
 
-Each mutation stamp persists the running app version (`app::kVersion` and display
-variant) alongside the schema version. In short:
+Each standard GDTF revision uses `ModifiedBy="Perastage " + app::kVersion`.
+In short:
 
-- **Schema version** = contract version for audit metadata structure.
-- **App version** = concrete Perastage build that performed the mutation.
+- **GDTF DataVersion** = GDTF compatibility version, for example `1.2`.
+- **Revision ModifiedBy app version** = concrete Perastage build that performed
+  the intentional mutation.
 
-This allows distinguishing "which metadata format" from "which app wrote it".
+This keeps Perastage application versioning separate from GDTF format
+compatibility versioning.

--- a/docs/gdtf_mutation_policy.md
+++ b/docs/gdtf_mutation_policy.md
@@ -8,22 +8,22 @@ Perastage currently mutates GDTF archives at the following integration points.
 
 | Module | File | Function(s) | Mutation scope |
 |---|---|---|---|
-| Viewer 3D API | `viewer3d/gdtfloader.cpp` | `SetGdtfProperties(...)` | Writes `PhysicalDescriptions/Properties` (`Weight`, `PowerConsumption`), stamps audit metadata, appends `Revision`, rewrites `.gdtf`. |
-| GUI symbol workflow | `gui/windows/symbol_fixture_applier.cpp` | `RewriteGdtf(...)` + `AppendMutationAuditMetadata(...)` (called by `ApplySymbolsToFixtureGdtf(...)`) | Writes/updates SVG symbol assets and model SVG offsets, stamps audit metadata, appends `Revision`, rewrites `.gdtf`. |
+| Viewer 3D API | `viewer3d/gdtfloader.cpp` | `SetGdtfProperties(...)` | Writes `PhysicalDescriptions/Properties` (`Weight`, `PowerConsumption`), appends a standard `Revision`, rewrites `.gdtf`. |
+| GUI symbol workflow | `gui/windows/symbol_fixture_applier.cpp` | `RewriteGdtf(...)` + `AppendMutationAuditMetadata(...)` (called by `ApplySymbolsToFixtureGdtf(...)`) | Writes/updates SVG symbol assets and model SVG offsets, appends a standard `Revision`, rewrites `.gdtf`. |
 | Project symbol cache manifest | `core/symbol_cache_manifest.cpp` | `SymbolCacheManifest::ValidateFixture(...)`, `MarkFixtureSymbolsValid(...)` | Stores project-level metadata in `.pstg` packages so startup can skip deep GDTF inspection only when the referenced GDTF hash and required view metadata still match. |
-| MVR export patching | `mvr/mvrexporter.cpp` | `CreatePatchedGdtf(...)` | Creates temporary patched GDTF copies for export overrides (manufacturer/model/physical properties/color/dimensions), stamps audit metadata and appends `Revision` when patched. |
-| Shared audit helpers | `core/gdtf_mutation_audit.cpp` | `StampPerastageMutationMetadata(...)`, `AppendRevision(...)`, `ApplyPhysicalPropertiesWithAudit(...)` | Centralizes Perastage-owned mutation metadata and revision-appending semantics used by write flows. |
+| MVR export patching | `mvr/mvrexporter.cpp` | `CreatePatchedGdtf(...)` | Creates temporary patched GDTF copies for export overrides (manufacturer/model/physical properties/color/dimensions), and appends a standard `Revision` when patched. |
+| Shared audit helpers | `core/gdtf_mutation_audit.cpp` | `StampPerastageMutationMetadata(...)`, `AppendRevision(...)`, `ApplyPhysicalPropertiesWithAudit(...)` | Centralizes standard GDTF revision-appending semantics used by write flows. |
 
 ### Notes on ownership
 
-- `core/gdtf_mutation_audit.{h,cpp}` is the single owner of Perastage mutation-audit schema semantics.
-- Write call sites in other modules must use this helper API instead of hand-rolling custom audit XML shapes.
+- `core/gdtf_mutation_audit.{h,cpp}` is the single owner of Perastage GDTF revision semantics.
+- Write call sites in other modules must use this helper API instead of hand-rolling custom revision XML shapes.
 - Fixture SVG symbols remain stored inside their corresponding GDTF files; the `.pstg` symbol cache manifest stores metadata only and never stores SVG payloads.
 - Fixture display color is no longer persisted by mutating `description.xml` model `Color` values in place. The persisted source of truth for default color selection is the Perastage dictionary/project data layer, while `GetGdtfModelColor(...)` remains read-only for legacy fallback reads.
 
 ## 2) Exact `Revision` format used by Perastage
 
-Perastage appends `<Revision />` under `<FixtureType>/<Revisions>` and ensures `<Revisions>` exists when needed.
+Perastage appends `<Revision />` under `<FixtureType>/<Revisions>` and ensures `<Revisions>` exists when needed. Repeated exports do not append a duplicate Perastage revision when the same `Text`, `ModifiedBy`, and `UserID` already exist.
 
 Perastage writes these attributes:
 
@@ -45,19 +45,14 @@ Canonical shape:
 </Revisions>
 ```
 
-## 3) Definition of `kPerastageGdtfMutationSchemaVersion`
+## 3) Legacy `PerastageMutationAudit` compatibility
 
 - Symbol: `GdtfMutationAudit::kPerastageGdtfMutationSchemaVersion`.
 - Location: `core/gdtf_mutation_audit.h`.
 - Current value: `1`.
-- Meaning: version of the **Perastage-owned mutation metadata contract**, not the GDTF specification version.
+- Meaning: legacy version of the former **Perastage-owned mutation metadata contract**, not the GDTF specification version.
 
-This schema version controls semantics for the `<PerastageMutationAudit .../>` node, currently stamped with:
-
-- `SchemaVersion`
-- `PerastageVersion`
-- `PerastageVersionDisplay`
-- `LastMutationDateUtc`
+Perastage no longer writes `<PerastageMutationAudit .../>` into GDTF `description.xml`, because it is not a standard GDTF node. The importer and compatibility helpers may still read and ignore legacy nodes from older files.
 
 ## 4) Compatibility matrix (legacy / current / future reads)
 
@@ -83,9 +78,10 @@ A GDTF mutation change is accepted only if all conditions below hold:
 1. **Mutation correctness**
    - Target payload mutation is present (for example color/properties/SVG view assets+offsets).
    - Fixture symbol validation requires the Perastage top, bottom, front, and side SVG views before project manifest cache entries can skip deep inspection.
-2. **Audit correctness**
-   - `<PerastageMutationAudit>` exists and includes the current schema version.
-   - A new `<Revision>` entry is appended with valid `Date`, `ModifiedBy`, `Text`, `UserID`.
+2. **Revision correctness**
+   - No new `<PerastageMutationAudit>` node is written.
+   - A new `<Revision>` entry is appended with valid `Date`, `ModifiedBy`, `Text`, `UserID` when Perastage intentionally changes a GDTF.
+   - No duplicate identical Perastage revision is appended on repeated exports.
 3. **Compatibility safety**
    - Legacy/no-audit and unknown-schema files remain readable through fallback behavior.
 4. **Archive integrity**
@@ -100,8 +96,8 @@ A GDTF mutation change is accepted only if all conditions below hold:
 - [ ] Apply fixture symbol generation to a fixture and verify the `.gdtf` receives updated top, bottom, front, and side SVG entries and offsets.
 - [ ] Edit fixture color via dictionary/project workflow and verify fixture color persists after reopening without mutating model `Color` in the source `.gdtf`.
 - [ ] Edit fixture physical properties and verify weight/power values persist after reopening.
-- [ ] Inspect resulting `description.xml` and verify `PerastageMutationAudit` + `Revision` attributes follow the policy format.
-- [ ] Export an MVR that triggers patched GDTF overrides and verify the exported patched GDTF carries mutation audit and revision metadata.
+- [ ] Inspect resulting `description.xml` and verify no new `PerastageMutationAudit` node is present and `Revision` attributes follow the policy format.
+- [ ] Export an MVR that triggers patched GDTF overrides and verify the exported patched GDTF carries standard revision metadata.
 - [ ] Confirm legacy GDTF (without `PerastageMutationAudit`) remains loadable.
 - [ ] Confirm unknown/future `SchemaVersion` triggers safe fallback behavior (no hard failure due only to version mismatch).
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -54,6 +54,7 @@ Changes since `v1.3.0`.
 - Fixed quick-click fixture selection in the 3D view so hovered fixtures can still be selected when the precise release pick misses.
 - Fixed MVR fixture Color handling so visualization colors are no longer exported as gel/filter colors, while imported MVR Color values are preserved as fixture gel/filter data.
 - Fixed MVR layer color persistence so Perastage now stores layer appearance metadata in a standards-compliant root UserData block, while still importing legacy Layer/Color data from older exports.
+- Fixed MVR and GDTF version metadata so exported MVR files identify the current Perastage app version, generated GDTF files keep GDTF 1.2 compatibility versioning, and intentional GDTF changes are recorded through standard revisions without Perastage-specific custom XML nodes.
 - Fixed MVR fixture UnitNumber export so existing unit numbers are preserved and missing values are generated deterministically by fixture type and stage position.
 - Restored edge-safe fixture visibility and made fixture hover picking use actual fixture geometry so highlights and labels target the visible fixture instead of broad bounds.
 - Fixed fixture ID edits so saved project files and exported MVR files keep the updated numeric fixture IDs instead of reverting to imported IDs.

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -17,6 +17,7 @@
  */
 #include "mvrexporter.h"
 #include "mvr_preferences.h"
+#include "app_version.h"
 #include "filesystem_path_utils.h"
 #include "configmanager.h"
 #include "dummyprofilelibrary.h"
@@ -127,7 +128,6 @@ static void AppendTrussInfoMetadata(tinyxml2::XMLDocument &doc,
 static void LogLegacyPositionUuidWarning(const std::string &message);
 
 static constexpr const char *kMvrProvider = "Perastage";
-static constexpr const char *kMvrProviderVersion = "1.0";
 static constexpr const char *kDummyFallbackFixtureGdtfFileName = "Dummy 1ch.gdtf";
 static constexpr const char *kLegacyFallbackFixtureGdtfFileName = "Generic 1ch.gdtf";
 
@@ -759,6 +759,10 @@ static bool ValidateMvr16Export(
   if (!provider || std::string(provider).empty() || !providerVersion ||
       std::string(providerVersion).empty()) {
     wxLogError("MVR export validation failed: provider/providerVersion are required for MVR 1.6");
+    return false;
+  }
+  if (std::string(providerVersion) == "1.0" && std::string(app::kVersion) != "1.0") {
+    wxLogError("MVR export validation failed: providerVersion fell back to 1.0 instead of the Perastage app version");
     return false;
   }
 
@@ -1754,7 +1758,6 @@ static std::string CreatePatchedGdtf(const std::string &gdtfPath,
   }
 
   if (patched) {
-    GdtfMutationAudit::StampPerastageMutationMetadata(ft, doc);
     GdtfMutationAudit::AppendRevision(
         ft, doc, "Patched fixture metadata for MVR export",
         GdtfMutationAudit::BuildPerastageModifiedBy());
@@ -2186,10 +2189,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
   tinyxml2::XMLElement *root = doc.NewElement("GeneralSceneDescription");
   root->SetAttribute("verMajor", 1);
   root->SetAttribute("verMinor", 6);
-  root->SetAttribute("provider", scene.provider.empty() ? kMvrProvider : scene.provider.c_str());
-  root->SetAttribute("providerVersion",
-                     scene.providerVersion.empty() ? kMvrProviderVersion
-                                                   : scene.providerVersion.c_str());
+  root->SetAttribute("provider", kMvrProvider);
+  root->SetAttribute("providerVersion", app::kVersion);
   doc.InsertEndChild(root);
 
   if (HasLayerAppearanceMetadata(scene)) {

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -128,6 +128,7 @@ static void AppendTrussInfoMetadata(tinyxml2::XMLDocument &doc,
 static void LogLegacyPositionUuidWarning(const std::string &message);
 
 static constexpr const char *kMvrProvider = "Perastage";
+static constexpr const char *kPerastageUserDataSchemaVersion = "1.0";
 static constexpr const char *kDummyFallbackFixtureGdtfFileName = "Dummy 1ch.gdtf";
 static constexpr const char *kLegacyFallbackFixtureGdtfFileName = "Generic 1ch.gdtf";
 
@@ -1396,7 +1397,7 @@ static tinyxml2::XMLElement *FindOrCreatePerastageDataNode(tinyxml2::XMLDocument
 
   tinyxml2::XMLElement *data = doc.NewElement("Data");
   data->SetAttribute("provider", kMvrProvider);
-  data->SetAttribute("ver", kMvrProviderVersion);
+  data->SetAttribute("ver", kPerastageUserDataSchemaVersion);
   ud->InsertEndChild(data);
   return data;
 }

--- a/tests/mvr_exporter_compliance_test.cpp
+++ b/tests/mvr_exporter_compliance_test.cpp
@@ -166,6 +166,28 @@ static std::string ReadFixtureTypeIdFromGdtf(const fs::path &gdtfPath) {
   return id;
 }
 
+// Verifies generated GDTF files use standard version and revision metadata.
+static void AssertGeneratedGdtfVersioning(const fs::path &gdtfPath) {
+  const auto gdtfEntries = ReadArchiveTextEntries(gdtfPath);
+  auto descriptionIt = gdtfEntries.find("description.xml");
+  assert(descriptionIt != gdtfEntries.end());
+
+  tinyxml2::XMLDocument gdtfDoc;
+  assert(gdtfDoc.Parse(descriptionIt->second.c_str()) == tinyxml2::XML_SUCCESS);
+  tinyxml2::XMLElement *root = gdtfDoc.FirstChildElement("GDTF");
+  assert(root != nullptr);
+  assert(std::string(root->Attribute("DataVersion")) == "1.2");
+  tinyxml2::XMLElement *fixtureType = root->FirstChildElement("FixtureType");
+  assert(fixtureType != nullptr);
+  assert(fixtureType->FirstChildElement("PerastageMutationAudit") == nullptr);
+  tinyxml2::XMLElement *revisions = fixtureType->FirstChildElement("Revisions");
+  assert(revisions != nullptr);
+  tinyxml2::XMLElement *revision = revisions->FirstChildElement("Revision");
+  assert(revision != nullptr);
+  const std::string expectedModifiedBy = std::string("Perastage ") + app::kVersion;
+  assert(std::string(revision->Attribute("ModifiedBy")) == expectedModifiedBy);
+}
+
 int main() {
   wxInitializer initializer;
   assert(initializer.IsOk());
@@ -199,8 +221,8 @@ int main() {
   std::ofstream(duplicateLongNamedGdtf) << "LONG2";
 
   scene.basePath = tempDir.generic_string();
-  scene.provider.clear();
-  scene.providerVersion.clear();
+  scene.provider = "ImportedApp";
+  scene.providerVersion = "9.9";
   scene.versionMajor = 1;
   scene.versionMinor = 6;
   scene.positions["LX1"] = "LX1";
@@ -493,6 +515,8 @@ int main() {
   assert(root->IntAttribute("verMinor") == 6);
   assert(std::string(root->Attribute("provider")) == "Perastage");
   assert(std::string(root->Attribute("providerVersion")) == app::kVersion);
+  assert(std::string(root->Attribute("providerVersion")) != "1.0" ||
+         std::string(app::kVersion) == "1.0");
 
   assert(ReadFixtureUnitNumber(root, "unit-order-bottom") == 1);
   assert(ReadFixtureUnitNumber(root, "unit-order-left") == 2);
@@ -939,6 +963,7 @@ int main() {
     assert(gdtfOut.is_open());
     gdtfOut << mvrGeometryEntries.at(gdtfSpec);
     gdtfOut.close();
+    AssertGeneratedGdtfVersioning(trussGdtfPath);
     fixtureTypeIdByTrussUuid[trussUuid] = ReadFixtureTypeIdFromGdtf(trussGdtfPath);
   }
   assert(fixtureTypeIdByTrussUuid.at(tr.uuid) == fixtureTypeIdByTrussUuid.at(trNonNumeric.uuid));

--- a/tests/symbol_fixture_applier_gdtf_test.cpp
+++ b/tests/symbol_fixture_applier_gdtf_test.cpp
@@ -202,9 +202,7 @@ int main() {
   assert(hasRevision);
 
   tinyxml2::XMLElement *audit = fixtureType->FirstChildElement("PerastageMutationAudit");
-  assert(audit != nullptr);
-  assert(audit->IntAttribute("SchemaVersion") ==
-         GdtfMutationAudit::kPerastageGdtfMutationSchemaVersion);
+  assert(audit == nullptr);
 
   tinyxml2::XMLElement *revision =
       fixtureType->FirstChildElement("Revisions")->FirstChildElement("Revision");


### PR DESCRIPTION
### Motivation
- Ensure MVR `GeneralSceneDescription` root fields follow the MVR spec: `providerVersion` must be the Perastage application version and never silently fall back to a hardcoded value. 
- Keep GDTF `DataVersion` as the GDTF compatibility version and avoid writing non-standard Perastage-only XML nodes into `description.xml`. 
- Provide a centralized, minimal, and deterministic policy for how Perastage records intentional GDTF modifications (use standard `Revisions` entries with `ModifiedBy = "Perastage <app version>"`).

### Description
- MVR export: stop using the hardcoded `kMvrProviderVersion` fallback and always write `GeneralSceneDescription` attributes as `verMajor="1" verMinor="6" provider="Perastage" providerVersion="<app::kVersion>"`, and add validation to detect a silent `"1.0"` fallback. (`mvr/mvrexporter.cpp`, include `app_version.h`).
- GDTF mutation helpers: stop writing the non-standard `<PerastageMutationAudit>` node in new exports by making `StampPerastageMutationMetadata(...)` a compatibility no-op and centralize revision stamping via `AppendRevision(...)`; `AppendRevision` now deduplicates identical Perastage revisions and uses `BuildPerastageModifiedBy()` which includes `app::kVersion`. (`core/gdtf_mutation_audit.{h,cpp}`).
- Generated truss GDTFs: ensure `DataVersion="1.2"`, include deterministic stable `FixtureTypeID`, include `PhysicalDescriptions/Properties` (Weight), preserve valid section order and add a single standard `<Revision>` with `ModifiedBy="Perastage <app version>"` and a UTC timestamp. (`core/truss_gdtf_builder.cpp`).
- Tests and docs: update compliance tests to assert MVR root provider/providerVersion correctness and that generated GDTFs contain `DataVersion="1.2"`, a `Revisions/Revision` with `ModifiedBy="Perastage <app version>"`, and no `PerastageMutationAudit`; update policy and audit docs and `docs/release-notes-draft.md`. (`tests/mvr_exporter_compliance_test.cpp`, `tests/symbol_fixture_applier_gdtf_test.cpp`, `docs/*`).

### Testing
- Ran architecture/regression guardrails: `tests/check_perastage_tree_modules.sh` succeeded and `tests/check_no_configmanager_get_in_gui.sh` succeeded. 
- Ran repository hygiene: `git diff --check` succeeded and local commit was created for the changeset. 
- Attempted to configure/build tests with CMake (`cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`); configure failed in this environment due to missing wxWidgets development packages (`wxWidgets_LIBRARIES` / `wxWidgets_INCLUDE_DIRS`), so full compilation/unit test execution was blocked by the environment rather than code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a326b85e8c88324a6113d789bae91c0)