### PR TITLE
Fix cube primitive height/width axis mapping

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -64,6 +64,7 @@ Changes since `v1.3.0`.
 - Improved fallback dimensions for direct truss model files so GLB and 3DS trusses remain visible and selectable even when model metadata or mesh loading is unavailable.
 - Fixed Add scene object so reusing an existing Perastage basic geometry object copies its primitive geometry data immediately instead of showing a default cube until the project is reopened.
 - Fixed basic geometry edit dialogs so position, screen size, and pipe length fields use the selected project distance units consistently.
+- Fixed cube primitive dimensions so Height now scales the application Z axis and Width scales the Y axis during creation and editing.
 - Fixed 3D truss height labels so they show both the value and suffix in the selected project distance units.
 - Fixed 2D and 3D scene object picking so hollow or U-shaped meshes are selected by their visible geometry instead of their broad bounding boxes.
 

--- a/gui/scene_object_primitive_dialogs.cpp
+++ b/gui/scene_object_primitive_dialogs.cpp
@@ -738,16 +738,17 @@ Matrix BuildSphereScaleTransform(double radiusMeters) {
   return transform;
 }
 
+// Builds a cube scale transform with length on X, width on Y, and height on Z.
 Matrix BuildCubeScaleTransform(double lengthMeters, double heightMeters,
                                double widthMeters) {
   const float sx = static_cast<float>(
       std::max(lengthMeters, 0.01) * kMetersToMillimeters /
       kPrimitiveCubeSizeMillimeters);
   const float sy = static_cast<float>(
-      std::max(heightMeters, 0.01) * kMetersToMillimeters /
+      std::max(widthMeters, 0.01) * kMetersToMillimeters /
       kPrimitiveCubeSizeMillimeters);
   const float sz = static_cast<float>(
-      std::max(widthMeters, 0.01) * kMetersToMillimeters /
+      std::max(heightMeters, 0.01) * kMetersToMillimeters /
       kPrimitiveCubeSizeMillimeters);
 
   Matrix transform;

--- a/gui/scene_object_primitive_editing.cpp
+++ b/gui/scene_object_primitive_editing.cpp
@@ -140,6 +140,7 @@ Matrix ResolveEditableTransform(const SceneObject &object,
 
 } // namespace
 
+// Opens the matching primitive edit dialog and applies accepted geometry changes.
 bool EditPrimitiveObjectByUuid(wxWindow *parent, ConfigManager &cfg,
                                const std::string &uuid) {
   auto &scene = cfg.GetScene();
@@ -221,9 +222,9 @@ bool EditPrimitiveObjectByUuid(wxWindow *parent, ConfigManager &cfg,
     request.name = object.name.empty() ? "Cube" : object.name;
     request.lengthMeters =
         std::max(static_cast<double>(AxisLength(currentTransform.u)), 0.01);
-    request.heightMeters =
-        std::max(static_cast<double>(AxisLength(currentTransform.v)), 0.01);
     request.widthMeters =
+        std::max(static_cast<double>(AxisLength(currentTransform.v)), 0.01);
+    request.heightMeters =
         std::max(static_cast<double>(AxisLength(currentTransform.w)), 0.01);
     accepted = ShowCubeEditDialog(parent, request, placement, [&]() {
       cfg.PushUndoState("apply primitive geometry");


### PR DESCRIPTION
### Motivation
- Users reported that the cube `Height` and `Width` fields were swapped when creating or editing cubes, causing `Height` to affect Y and `Width` to affect Z instead of `Z` and `Y` respectively.

### Description
- Corrected `BuildCubeScaleTransform` in `gui/scene_object_primitive_dialogs.cpp` so `Length` maps to X, `Width` maps to Y, and `Height` maps to Z, and added a one-line comment describing the function purpose.
- Fixed cube edit initialization in `gui/scene_object_primitive_editing.cpp` so existing cubes read `widthMeters` from the Y axis and `heightMeters` from the Z axis, and added a one-line comment above the edit entry function.
- Updated `docs/release-notes-draft.md` with a short release-note entry describing the cube dimension axis fix.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.
- Ran `git diff --check` to validate whitespace and patch sanity and it reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3270a7f5d0832492e4f939b55e8322)