### PR TITLE
Export Perastage layer appearance as PerastageLayerAppearance and preserve import compatibility

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -37,7 +37,7 @@ Perastage is designed for lighting designers, programmers, and technicians who n
 ### MVR export
 
 - Exports the current scene back to `.mvr` for interoperability.
-- Stores Perastage-specific layer appearance metadata, including layer colors, in a root-level MVR `UserData/Data` block instead of writing non-standard `Color` children inside `Layer` nodes.
+- Stores Perastage-specific layer appearance metadata, including layer colors, in root-level `UserData/Data` with Perastage-owned `PerastageLayerAppearance` entries instead of writing non-standard color data inside standard `Layer` nodes.
 - Parametric objects exported as Fixture/Truss/Support receive stable non-empty `FixtureID` and globally unique `FixtureIDNumeric` values.
 
 ### GDTF integration and dictionary pipeline

--- a/docs/opening-mvr-files.md
+++ b/docs/opening-mvr-files.md
@@ -61,7 +61,7 @@ In addition to MVR exchange, Perastage supports project-based work so you can:
 
 ## Export MVR
 
-Perastage stores its own layer appearance metadata, including layer colors, in a root-level MVR `UserData/Data` block with `provider="Perastage"`. This keeps new exports standards-compliant while still allowing Perastage to recover layer colors from its own MVR files when the metadata is preserved. Older Perastage MVR files that used direct `Layer/Color` children are still accepted on import, but new exports do not write that legacy structure.
+Perastage stores its own layer appearance metadata, including layer colors, in a root-level MVR `UserData/Data` block with `provider="Perastage"`, using Perastage-owned `PerastageLayerAppearance` entries under `LayerAppearanceMap`. This keeps new exports standards-compliant and avoids confusing custom metadata with standard MVR `Layer` nodes, while still allowing Perastage to recover layer colors from its own MVR files when the metadata is preserved. Older Perastage MVR files that used direct `Layer/Color` children or legacy Perastage `LayerAppearanceMap/Layer` entries are still accepted on import, but new exports do not write those legacy structures.
 
 When your changes are ready for exchange:
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -53,7 +53,7 @@ Changes since `v1.3.0`.
 - Kept the 2D and 3D viewer highlights pinned to the dragged scene element during mouse-drag moves so hover feedback no longer jumps to other elements mid-drag.
 - Fixed quick-click fixture selection in the 3D view so hovered fixtures can still be selected when the precise release pick misses.
 - Fixed MVR fixture Color handling so visualization colors are no longer exported as gel/filter colors, while imported MVR Color values are preserved as fixture gel/filter data.
-- Fixed MVR layer color persistence so Perastage now stores layer appearance metadata in a standards-compliant root UserData block, while still importing legacy Layer/Color data from older exports.
+- Fixed MVR layer color persistence so Perastage now stores layer appearance metadata in a standards-compliant root UserData block with Perastage-specific appearance entries, while still importing legacy Layer/Color data from older exports.
 - Fixed MVR and GDTF version metadata so exported MVR files identify the current Perastage app version, generated GDTF files keep GDTF 1.2 compatibility versioning, and intentional GDTF changes are recorded through standard revisions without Perastage-specific custom XML nodes.
 - Fixed MVR fixture UnitNumber export so existing unit numbers are preserved and missing values are generated deterministically by fixture type and stage position.
 - Restored edge-safe fixture visibility and made fixture hover picking use actual fixture geometry so highlights and labels target the visible fixture instead of broad bounds.

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -1448,7 +1448,7 @@ static void AppendLayerAppearanceMetadata(tinyxml2::XMLDocument &doc,
     if (!map)
       map = doc.NewElement("LayerAppearanceMap");
 
-    tinyxml2::XMLElement *entry = doc.NewElement("Layer");
+    tinyxml2::XMLElement *entry = doc.NewElement("PerastageLayerAppearance");
     const std::string exportUuid = ExportLayerUuid(layerUuid, layer.name);
     if (!exportUuid.empty())
       entry->SetAttribute("uuid", exportUuid.c_str());

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -1487,12 +1487,11 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
         continue;
       for (tinyxml2::XMLElement *map = data->FirstChildElement("LayerAppearanceMap"); map;
            map = map->NextSiblingElement("LayerAppearanceMap")) {
-        for (tinyxml2::XMLElement *entry = map->FirstChildElement("Layer"); entry;
-             entry = entry->NextSiblingElement("Layer")) {
+        auto parseAppearanceEntry = [&](tinyxml2::XMLElement *entry) {
           const std::string color =
               Trim(entry->Attribute("color") ? entry->Attribute("color") : "");
           if (!isHexRgb(color))
-            continue;
+            return;
           const std::string uuid =
               CanonicalizeUuid(Trim(entry->Attribute("uuid") ? entry->Attribute("uuid") : ""));
           const std::string name =
@@ -1501,7 +1500,14 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
             layerColorByUuid[uuid] = color;
           if (!name.empty())
             layerColorByName[name] = color;
-        }
+        };
+
+        for (tinyxml2::XMLElement *entry = map->FirstChildElement("PerastageLayerAppearance");
+             entry; entry = entry->NextSiblingElement("PerastageLayerAppearance"))
+          parseAppearanceEntry(entry);
+        for (tinyxml2::XMLElement *entry = map->FirstChildElement("Layer"); entry;
+             entry = entry->NextSiblingElement("Layer"))
+          parseAppearanceEntry(entry);
       }
     }
   };

--- a/tests/mvr_layer_appearance_userdata_test.cpp
+++ b/tests/mvr_layer_appearance_userdata_test.cpp
@@ -69,8 +69,8 @@ static tinyxml2::XMLElement *FindLayerAppearance(tinyxml2::XMLDocument &doc,
   assert(std::string(data->Attribute("provider")) == "Perastage");
   tinyxml2::XMLElement *map = data->FirstChildElement("LayerAppearanceMap");
   assert(map != nullptr);
-  for (tinyxml2::XMLElement *layer = map->FirstChildElement("Layer"); layer;
-       layer = layer->NextSiblingElement("Layer")) {
+  for (tinyxml2::XMLElement *layer = map->FirstChildElement("PerastageLayerAppearance"); layer;
+       layer = layer->NextSiblingElement("PerastageLayerAppearance")) {
     const char *name = layer->Attribute("name");
     if (name && std::string(name) == layerName)
       return layer;
@@ -97,10 +97,12 @@ static void VerifyExportStructure(const std::filesystem::path &archivePath,
   for (tinyxml2::XMLElement *layer = layers->FirstChildElement("Layer"); layer;
        layer = layer->NextSiblingElement("Layer")) {
     assert(layer->FirstChildElement("Color") == nullptr);
+    assert(layer->Attribute("color") == nullptr);
   }
 
   tinyxml2::XMLElement *appearance = FindLayerAppearance(doc, layerName);
   assert(appearance != nullptr);
+  assert(std::string(appearance->Name()) == "PerastageLayerAppearance");
   assert(std::string(appearance->Attribute("color")) == expectedColor);
 }
 
@@ -156,6 +158,36 @@ static void TestLegacyLayerColorCompatibility(const std::filesystem::path &tempD
   VerifyExportStructure(reexportPath, "Legacy Layer", "#445566");
 }
 
+// Imports legacy Perastage LayerAppearanceMap/Layer entries and reexports current entry names.
+static void TestLegacyLayerAppearanceEntryCompatibility(const std::filesystem::path &tempDir) {
+  const std::filesystem::path legacyPath = tempDir / "legacy-layer-appearance-entry.mvr";
+  const std::string legacyXml =
+      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+      "<GeneralSceneDescription verMajor=\"1\" verMinor=\"6\" provider=\"Perastage\" providerVersion=\"test\">"
+      "<UserData><Data provider=\"Perastage\" ver=\"1.0\"><LayerAppearanceMap>"
+      "<Layer uuid=\"33333333-3333-4333-8333-333333333333\" name=\"Legacy Appearance Layer\" color=\"#AA6633\"/>"
+      "</LayerAppearanceMap></Data></UserData>"
+      "<Scene><Layers><Layer uuid=\"33333333-3333-4333-8333-333333333333\" name=\"Legacy Appearance Layer\">"
+      "<ChildList/></Layer></Layers></Scene>"
+      "</GeneralSceneDescription>";
+  WriteMvrWithSceneXml(legacyPath, legacyXml);
+
+  MvrScene imported;
+  MvrImporter importer;
+  assert(importer.ImportSceneFromFile(legacyPath.generic_string(), imported, false, false));
+  const auto importedLayer = imported.layers.find("33333333-3333-4333-8333-333333333333");
+  assert(importedLayer != imported.layers.end());
+  assert(importedLayer->second.color == "#AA6633");
+
+  auto &cfg = ConfigManager::Get();
+  cfg.Reset();
+  cfg.GetScene() = imported;
+  const std::filesystem::path reexportPath = tempDir / "legacy-layer-appearance-entry-reexport.mvr";
+  MvrExporter exporter;
+  assert(exporter.ExportToFile(reexportPath.generic_string()));
+  VerifyExportStructure(reexportPath, "Legacy Appearance Layer", "#AA6633");
+}
+
 int main() {
   wxInitializer initializer;
   assert(initializer.IsOk());
@@ -166,5 +198,6 @@ int main() {
 
   TestLayerAppearanceRoundtrip(tempDir);
   TestLegacyLayerColorCompatibility(tempDir);
+  TestLegacyLayerAppearanceEntryCompatibility(tempDir);
   return 0;
 }


### PR DESCRIPTION
### Motivation
- Avoid confusing Perastage-owned layer color metadata with standard MVR `Layer` nodes by using an explicit Perastage-specific element name. 
- Keep Perastage MVR exports standards-compliant (no `Layer/Color` children or `color` attributes on standard `Layer` nodes) while preserving backwards compatibility with older Perastage files. 
- Make the importer resilient to both legacy Perastage `LayerAppearanceMap/Layer` entries and the new Perastage-specific entries so existing files continue to import correctly.

### Description
- Updated the exporter to write `PerastageLayerAppearance` entries under the existing root `LayerAppearanceMap` instead of using generic `Layer` elements for Perastage metadata. (`mvr/mvrexporter.cpp`)
- Updated the importer to parse both `PerastageLayerAppearance` and legacy `Layer` entries inside `LayerAppearanceMap` so legacy files and new files are accepted. (`mvr/mvrimporter.cpp`)
- Adjusted the MVR layer appearance unit test to expect `PerastageLayerAppearance`, added an assertion to ensure no `color` attributes or `Color` children appear on standard `Layer` nodes, and added a new test that imports legacy `LayerAppearanceMap/Layer` entries and verifies re-export behavior. (`tests/mvr_layer_appearance_userdata_test.cpp`)
- Updated user-facing documentation and release notes to describe the Perastage-specific appearance entry name and to clarify export/import compatibility behavior. (`docs/opening-mvr-files.md`, `docs/features.md`, `docs/release-notes-draft.md`)

### Testing
- Ran `git diff --check` and it reported no whitespace or diff errors. 
- Ran `tests/check_perastage_tree_modules.sh` and it passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed. 
- Attempted to configure and build the `mvr_layer_appearance_userdata_test` target via `cmake`/`cmake --build` and run the test, but configuration failed in this environment due to missing `wxWidgets` (so the C++ test binary could not be built here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3273f171588324ba06c2ca33dc818a)