### PR TITLE
Export fixture Weight/PowerConsumption via GDTF PhysicalDescriptions (remove non-standard MVR children)

### DIFF
--- a/core/gdtf_mutation_audit.cpp
+++ b/core/gdtf_mutation_audit.cpp
@@ -28,6 +28,37 @@ std::string BuildIsoTimestampUtcNow() {
   return stamp.str();
 }
 
+
+// Inserts a FixtureType child before the first following standard sibling.
+tinyxml2::XMLElement *InsertFixtureTypeChildInOrder(
+    tinyxml2::XMLElement *fixtureType, tinyxml2::XMLDocument &doc,
+    const char *name) {
+  tinyxml2::XMLElement *node = doc.NewElement(name);
+  static constexpr const char *kOrder[] = {
+      "AttributeDefinitions", "Wheels", "PhysicalDescriptions", "Models",
+      "Geometries", "DMXModes", "Revisions", "FTPresets", "Protocols"};
+
+  int targetIndex = -1;
+  for (int i = 0; i < static_cast<int>(sizeof(kOrder) / sizeof(kOrder[0])); ++i) {
+    if (std::string(name) == kOrder[i]) {
+      targetIndex = i;
+      break;
+    }
+  }
+
+  if (targetIndex >= 0) {
+    for (tinyxml2::XMLElement *child = fixtureType->FirstChildElement(); child;
+         child = child->NextSiblingElement()) {
+      for (int i = targetIndex + 1; i < static_cast<int>(sizeof(kOrder) / sizeof(kOrder[0])); ++i) {
+        if (std::string(child->Name()) == kOrder[i])
+          return fixtureType->InsertBeforeChild(child, node)->ToElement();
+      }
+    }
+  }
+
+  return fixtureType->InsertEndChild(node)->ToElement();
+}
+
 } // namespace
 
 // Decides how legacy Perastage mutation metadata should be interpreted.
@@ -96,8 +127,7 @@ tinyxml2::XMLElement *EnsureRevisionsNode(tinyxml2::XMLElement *fixtureType,
 
   tinyxml2::XMLElement *revisions = fixtureType->FirstChildElement("Revisions");
   if (!revisions) {
-    revisions = doc.NewElement("Revisions");
-    fixtureType->InsertEndChild(revisions);
+    revisions = InsertFixtureTypeChildInOrder(fixtureType, doc, "Revisions");
   }
   return revisions;
 }
@@ -173,8 +203,8 @@ tinyxml2::XMLElement *EnsurePhysicalPropertiesNode(
   tinyxml2::XMLElement *physicalDescriptions =
       fixtureType->FirstChildElement("PhysicalDescriptions");
   if (!physicalDescriptions) {
-    physicalDescriptions = doc.NewElement("PhysicalDescriptions");
-    fixtureType->InsertEndChild(physicalDescriptions);
+    physicalDescriptions =
+        InsertFixtureTypeChildInOrder(fixtureType, doc, "PhysicalDescriptions");
   }
 
   tinyxml2::XMLElement *properties =

--- a/core/gdtf_mutation_audit.cpp
+++ b/core/gdtf_mutation_audit.cpp
@@ -47,16 +47,24 @@ tinyxml2::XMLElement *InsertFixtureTypeChildInOrder(
   }
 
   if (targetIndex >= 0) {
+    tinyxml2::XMLElement *previousElement = nullptr;
     for (tinyxml2::XMLElement *child = fixtureType->FirstChildElement(); child;
          child = child->NextSiblingElement()) {
-      for (int i = targetIndex + 1; i < static_cast<int>(sizeof(kOrder) / sizeof(kOrder[0])); ++i) {
-        if (std::string(child->Name()) == kOrder[i])
-          return fixtureType->InsertBeforeChild(child, node)->ToElement();
+      for (int i = targetIndex + 1;
+           i < static_cast<int>(sizeof(kOrder) / sizeof(kOrder[0])); ++i) {
+        if (std::string(child->Name()) == kOrder[i]) {
+          tinyxml2::XMLNode *inserted =
+              previousElement ? fixtureType->InsertAfterChild(previousElement, node)
+                              : fixtureType->InsertFirstChild(node);
+          return inserted ? inserted->ToElement() : nullptr;
+        }
       }
+      previousElement = child;
     }
   }
 
-  return fixtureType->InsertEndChild(node)->ToElement();
+  tinyxml2::XMLNode *inserted = fixtureType->InsertEndChild(node);
+  return inserted ? inserted->ToElement() : nullptr;
 }
 
 } // namespace

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -56,6 +56,7 @@ Changes since `v1.3.0`.
 - Fixed MVR layer color persistence so Perastage now stores layer appearance metadata in a standards-compliant root UserData block with Perastage-specific appearance entries, while still importing legacy Layer/Color data from older exports.
 - Fixed MVR and GDTF version metadata so exported MVR files identify the current Perastage app version, generated GDTF files keep GDTF 1.2 compatibility versioning, and intentional GDTF changes are recorded through standard revisions without Perastage-specific custom XML nodes.
 - Fixed MVR fixture UnitNumber export so existing unit numbers are preserved and missing values are generated deterministically by fixture type and stage position.
+- Fixed MVR fixture physical metadata export so Weight and Power Consumption are written through standard GDTF physical properties instead of non-standard Fixture child nodes, while legacy Perastage files still import those values.
 - Restored edge-safe fixture visibility and made fixture hover picking use actual fixture geometry so highlights and labels target the visible fixture instead of broad bounds.
 - Fixed fixture ID edits so saved project files and exported MVR files keep the updated numeric fixture IDs instead of reverting to imported IDs.
 - Fixed command-bar position and rotation value parsing so `t` and `thru` separators distribute selected items the same way as two space-separated values.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -57,6 +57,7 @@ Changes since `v1.3.0`.
 - Fixed MVR and GDTF version metadata so exported MVR files identify the current Perastage app version, generated GDTF files keep GDTF 1.2 compatibility versioning, and intentional GDTF changes are recorded through standard revisions without Perastage-specific custom XML nodes.
 - Fixed MVR fixture UnitNumber export so existing unit numbers are preserved and missing values are generated deterministically by fixture type and stage position.
 - Fixed MVR fixture physical metadata export so Weight and Power Consumption are written through standard GDTF physical properties instead of non-standard Fixture child nodes, while legacy Perastage files still import those values.
+- Improved fixture Weight and Power Consumption editing so changes update the shared GDTF type data and all matching fixtures in the project, keeping calculations and tables aligned with GDTF standards.
 - Restored edge-safe fixture visibility and made fixture hover picking use actual fixture geometry so highlights and labels target the visible fixture instead of broad bounds.
 - Fixed fixture ID edits so saved project files and exported MVR files keep the updated numeric fixture IDs instead of reverting to imported IDs.
 - Fixed command-bar position and rotation value parsing so `t` and `thru` separators distribute selected items the same way as two space-separated values.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -58,6 +58,7 @@ Changes since `v1.3.0`.
 - Fixed MVR fixture UnitNumber export so existing unit numbers are preserved and missing values are generated deterministically by fixture type and stage position.
 - Fixed MVR fixture physical metadata export so Weight and Power Consumption are written through standard GDTF physical properties instead of non-standard Fixture child nodes, while legacy Perastage files still import those values.
 - Improved fixture Weight and Power Consumption editing so changes update the shared GDTF type data and all matching fixtures in the project, keeping calculations and tables aligned with GDTF standards.
+- Fixed Edit Fixture weight changes so shared GDTF type updates also trigger the hoist load recalculation prompt after table synchronization.
 - Restored edge-safe fixture visibility and made fixture hover picking use actual fixture geometry so highlights and labels target the visible fixture instead of broad bounds.
 - Fixed fixture ID edits so saved project files and exported MVR files keep the updated numeric fixture IDs instead of reverting to imported IDs.
 - Fixed command-bar position and rotation value parsing so `t` and `thru` separators distribute selected items the same way as two space-separated values.

--- a/gui/fixtureeditdialog.cpp
+++ b/gui/fixtureeditdialog.cpp
@@ -18,6 +18,8 @@
 #include "fixtureeditdialog.h"
 #include "fixturepreviewpanel.h"
 #include "fixturetablepanel.h"
+#include "configmanager.h"
+#include "guiconfigservices.h"
 #include "filesystem_path_utils.h"
 #include "gdtfdictionary.h"
 #include "gdtfloader.h"
@@ -27,6 +29,7 @@
 #include "symbols/PerastageSvgSymbol.h"
 #include "viewer2dpanel.h"
 #include "viewer3dpanel.h"
+#include "units/units.h"
 #include <wx/datetime.h>
 #include <wx/filedlg.h>
 #include <wx/filename.h>
@@ -81,6 +84,54 @@ bool IsUserFixtureLibraryPath(const std::string &path) {
       PathUtils::PathFromUtf8(ProjectUtils::GetWritableLibraryPath("fixtures")));
 }
 
+
+// Checks whether two fixture records use the same GDTF type-level physical values.
+bool MatchesPhysicalPropertyType(const Fixture &fixture,
+                                 const std::string &gdtfSpec,
+                                 const std::string &typeName) {
+  if (!gdtfSpec.empty() && fixture.gdtfSpec == gdtfSpec)
+    return true;
+  return !typeName.empty() && fixture.typeName == typeName;
+}
+
+// Mirrors a GDTF physical-property edit to every row and fixture of the same type.
+void ApplySharedPhysicalPropertyEdit(wxDataViewListCtrl *table,
+                                     const std::vector<std::string> &rowUuids,
+                                     const std::string &sourceUuid,
+                                     float weightKg, float powerW) {
+  if (!table || sourceUuid.empty())
+    return;
+
+  auto &scene = GetDefaultGuiConfigServices().LegacyConfigManager().GetScene();
+  const auto sourceIt = scene.fixtures.find(sourceUuid);
+  if (sourceIt == scene.fixtures.end())
+    return;
+
+  const std::string gdtfSpec = sourceIt->second.gdtfSpec;
+  const std::string typeName = sourceIt->second.typeName;
+  const auto weightUnitSystem = Units::ParseWeightUnitSystem(
+      GetDefaultGuiConfigServices().LegacyConfigManager().GetValue("ui_weight_unit_system"));
+  const wxVariant powerValue(wxString::Format("%.1f", powerW));
+  const wxVariant weightValue(wxString::FromUTF8(Units::FormatWeightFromKilograms(
+      weightKg, weightUnitSystem, Units::ValueFormatContext::Table)));
+
+  const size_t count = std::min(static_cast<size_t>(table->GetItemCount()), rowUuids.size());
+  for (size_t rowIndex = 0; rowIndex < count; ++rowIndex) {
+    const auto fixtureIt = scene.fixtures.find(rowUuids[rowIndex]);
+    if (fixtureIt == scene.fixtures.end() ||
+        !MatchesPhysicalPropertyType(fixtureIt->second, gdtfSpec, typeName))
+      continue;
+
+    fixtureIt->second.weightKg = weightKg;
+    fixtureIt->second.powerConsumptionW = powerW;
+    fixtureIt->second.physicalPropertiesSource = FixturePhysicalPropertiesSource::Gdtf;
+    fixtureIt->second.physicalPropertiesDirty = false;
+    table->SetValue(powerValue, rowIndex, 16);
+    table->SetValue(weightValue, rowIndex, 17);
+  }
+}
+
+// Parses a floating-point value while preserving the previous value on failure.
 bool ParseFloatOrDefault(const wxString &text, float &out) {
   double parsed = 0.0;
   if (!text.ToDouble(&parsed))
@@ -89,6 +140,7 @@ bool ParseFloatOrDefault(const wxString &text, float &out) {
   return true;
 }
 
+// Updates a fixture table row with a rendered color swatch cell.
 void SetFixtureColorCell(wxDataViewListCtrl *table, int row,
                          const std::string &hexColor) {
   if (!table || row == wxNOT_FOUND || hexColor.empty())
@@ -106,6 +158,7 @@ void SetFixtureColorCell(wxDataViewListCtrl *table, int row,
   table->SetValue(colorValue, row, 19);
 }
 
+// Loads the thumbnail bitmap from a GDTF archive when available.
 bool LoadGdtfThumbnail(const std::string &gdtfPath, wxBitmap &outBitmap) {
   if (gdtfPath.empty())
     return false;
@@ -983,6 +1036,10 @@ void FixtureEditDialog::ApplyChanges() {
               "Could not update GDTF physical properties (Weight/PowerConsumption).",
               "GDTF update", wxOK | wxICON_WARNING, this);
         } else {
+          if (row >= 0 && static_cast<size_t>(row) < panel->rowUuids.size())
+            ApplySharedPhysicalPropertyEdit(table, panel->rowUuids,
+                                            panel->rowUuids[static_cast<size_t>(row)],
+                                            newWeightKg, newPowerW);
           originalPowerW = newPowerW;
           originalWeightKg = newWeightKg;
         }

--- a/gui/fixtureeditdialog.cpp
+++ b/gui/fixtureeditdialog.cpp
@@ -20,6 +20,7 @@
 #include "fixturetablepanel.h"
 #include "configmanager.h"
 #include "guiconfigservices.h"
+#include "hoist_load_recalculation_prompt.h"
 #include "filesystem_path_utils.h"
 #include "gdtfdictionary.h"
 #include "gdtfloader.h"
@@ -41,6 +42,7 @@
 #include <wx/zipstrm.h>
 #include <tinyxml2.h>
 #include <unordered_map>
+#include <unordered_set>
 #include <set>
 #include <cmath>
 #include <memory>
@@ -95,17 +97,17 @@ bool MatchesPhysicalPropertyType(const Fixture &fixture,
 }
 
 // Mirrors a GDTF physical-property edit to every row and fixture of the same type.
-void ApplySharedPhysicalPropertyEdit(wxDataViewListCtrl *table,
-                                     const std::vector<std::string> &rowUuids,
-                                     const std::string &sourceUuid,
-                                     float weightKg, float powerW) {
+std::unordered_set<std::string> ApplySharedPhysicalPropertyEdit(
+    wxDataViewListCtrl *table, const std::vector<std::string> &rowUuids,
+    const std::string &sourceUuid, float weightKg, float powerW) {
+  std::unordered_set<std::string> changedWeightPositions;
   if (!table || sourceUuid.empty())
-    return;
+    return changedWeightPositions;
 
   auto &scene = GetDefaultGuiConfigServices().LegacyConfigManager().GetScene();
   const auto sourceIt = scene.fixtures.find(sourceUuid);
   if (sourceIt == scene.fixtures.end())
-    return;
+    return changedWeightPositions;
 
   const std::string gdtfSpec = sourceIt->second.gdtfSpec;
   const std::string typeName = sourceIt->second.typeName;
@@ -122,6 +124,10 @@ void ApplySharedPhysicalPropertyEdit(wxDataViewListCtrl *table,
         !MatchesPhysicalPropertyType(fixtureIt->second, gdtfSpec, typeName))
       continue;
 
+    if (!Units::NearlyEqualWeightKilograms(fixtureIt->second.weightKg, weightKg, 0.001))
+      changedWeightPositions.insert(fixtureIt->second.positionName.empty()
+                                        ? "Unassigned"
+                                        : fixtureIt->second.positionName);
     fixtureIt->second.weightKg = weightKg;
     fixtureIt->second.powerConsumptionW = powerW;
     fixtureIt->second.physicalPropertiesSource = FixturePhysicalPropertiesSource::Gdtf;
@@ -129,6 +135,7 @@ void ApplySharedPhysicalPropertyEdit(wxDataViewListCtrl *table,
     table->SetValue(powerValue, rowIndex, 16);
     table->SetValue(weightValue, rowIndex, 17);
   }
+  return changedWeightPositions;
 }
 
 // Parses a floating-point value while preserving the previous value on failure.
@@ -1001,6 +1008,8 @@ void FixtureEditDialog::ApplyChanges() {
     }
   }
 
+  std::unordered_set<std::string> changedWeightPositions;
+
   if (!gdtfPath.empty()) {
     if (ctrls.size() > 17) {
       float newPowerW = originalPowerW;
@@ -1037,9 +1046,9 @@ void FixtureEditDialog::ApplyChanges() {
               "GDTF update", wxOK | wxICON_WARNING, this);
         } else {
           if (row >= 0 && static_cast<size_t>(row) < panel->rowUuids.size())
-            ApplySharedPhysicalPropertyEdit(table, panel->rowUuids,
-                                            panel->rowUuids[static_cast<size_t>(row)],
-                                            newWeightKg, newPowerW);
+            changedWeightPositions = ApplySharedPhysicalPropertyEdit(
+                table, panel->rowUuids, panel->rowUuids[static_cast<size_t>(row)],
+                newWeightKg, newPowerW);
           originalPowerW = newPowerW;
           originalWeightKg = newWeightKg;
         }
@@ -1063,6 +1072,9 @@ void FixtureEditDialog::ApplyChanges() {
         updateType, FixtureTablePanel::UpdateTypeForColumn(static_cast<int>(i)));
   }
   panel->UpdateSceneData(true, updateType);
+  HoistLoadRecalculationPrompt::PromptAndApply(
+      GetDefaultGuiConfigServices().LegacyConfigManager(), panel,
+      changedWeightPositions);
   applied = true;
   const bool requiresFullSceneUpdate =
       FixtureTablePanel::RequiresFullViewerSceneUpdate(updateType);

--- a/gui/fixturetable/fixture_table_edit_service.cpp
+++ b/gui/fixturetable/fixture_table_edit_service.cpp
@@ -244,6 +244,7 @@ void ApplyFullRowChanges(
     double pw = 0.0;
     v.GetString().ToDouble(&pw);
     next.powerConsumptionW = static_cast<float>(pw);
+    const bool powerChanged = old.powerConsumptionW != next.powerConsumptionW;
 
     table->GetValue(v, i, 17);
     const float previousWeightKg = next.weightKg;
@@ -254,6 +255,10 @@ void ApplyFullRowChanges(
     }
     const bool weightChanged = !Units::NearlyEqualWeightKilograms(
         previousWeightKg, next.weightKg, 0.001);
+    if (powerChanged || weightChanged) {
+      next.physicalPropertiesSource = FixturePhysicalPropertiesSource::Manual;
+      next.physicalPropertiesDirty = true;
+    }
 
     table->GetValue(v, i, 18);
     next.category = GdtfFixtureCategory::NormalizeCategory(std::string(v.GetString().ToUTF8()));

--- a/gui/fixturetable/fixture_table_edit_service.cpp
+++ b/gui/fixturetable/fixture_table_edit_service.cpp
@@ -6,14 +6,18 @@
 #include "matrixutils.h"
 #include "gdtfdictionary.h"
 #include "gdtf_fixture_category.h"
+#include "gdtf_mutation_audit.h"
+#include "gdtfloader.h"
 
 #include <algorithm>
 #include <cmath>
 #include <unordered_map>
+#include <filesystem>
 
 namespace FixtureTableEditService {
 
 namespace {
+// Returns the localized degree symbol used by angle cells.
 const wxString &DegreeSymbol() {
   static const wxString kDegreeSymbol = wxString::FromUTF8("\xC2\xB0");
   return kDegreeSymbol;
@@ -21,6 +25,75 @@ const wxString &DegreeSymbol() {
 
 constexpr const char *kUnassignedPosition = "Unassigned";
 
+// Resolves a fixture resource path against the scene base path when needed.
+std::string ResolveSceneResourcePath(const MvrScene &scene, const std::string &resourcePath) {
+  if (resourcePath.empty())
+    return {};
+  std::filesystem::path path(resourcePath);
+  if (path.is_relative() && !scene.basePath.empty())
+    path = std::filesystem::path(scene.basePath) / path;
+  return path.string();
+}
+
+// Checks whether two fixtures should share GDTF type-level physical properties.
+bool IsSameGdtfType(const Fixture &fixture, const std::string &gdtfSpec,
+                    const std::string &typeName) {
+  if (!gdtfSpec.empty() && fixture.gdtfSpec == gdtfSpec)
+    return true;
+  return !typeName.empty() && fixture.typeName == typeName;
+}
+
+// Writes GDTF physical properties to the project GDTF file when a type value changes.
+bool UpdateProjectGdtfPhysicalProperties(const MvrScene &scene,
+                                         const std::string &gdtfSpec,
+                                         float weightKg, float powerW) {
+  const std::string resolvedPath = ResolveSceneResourcePath(scene, gdtfSpec);
+  if (resolvedPath.empty())
+    return false;
+  return SetGdtfProperties(resolvedPath, weightKg, powerW,
+                           GdtfMutationAudit::BuildPerastageModifiedBy());
+}
+
+// Updates table cells that mirror shared GDTF type-level physical properties.
+void UpdateMatchingPhysicalPropertyCells(wxDataViewListCtrl *table,
+                                         const std::vector<std::string> &rowUuids,
+                                         const MvrScene &scene,
+                                         const std::string &gdtfSpec,
+                                         const std::string &typeName,
+                                         float weightKg, float powerW,
+                                         Units::WeightUnitSystem weightUnitSystem) {
+  if (!table)
+    return;
+  const size_t count =
+      std::min(static_cast<size_t>(table->GetItemCount()), rowUuids.size());
+  for (size_t row = 0; row < count; ++row) {
+    const auto it = scene.fixtures.find(rowUuids[row]);
+    if (it == scene.fixtures.end() || !IsSameGdtfType(it->second, gdtfSpec, typeName))
+      continue;
+    table->SetValue(wxVariant(wxString::Format("%.1f", powerW)), row, 16);
+    table->SetValue(wxVariant(wxString::FromUTF8(Units::FormatWeightFromKilograms(
+                        weightKg, weightUnitSystem,
+                        Units::ValueFormatContext::Table))),
+                    row, 17);
+  }
+}
+
+// Applies a GDTF type-level physical property edit to every matching fixture.
+void ApplySharedPhysicalProperties(MvrScene &scene, const std::string &gdtfSpec,
+                                   const std::string &typeName, float weightKg,
+                                   float powerW) {
+  for (auto &[uuid, fixture] : scene.fixtures) {
+    (void)uuid;
+    if (!IsSameGdtfType(fixture, gdtfSpec, typeName))
+      continue;
+    fixture.weightKg = weightKg;
+    fixture.powerConsumptionW = powerW;
+    fixture.physicalPropertiesSource = FixturePhysicalPropertiesSource::Gdtf;
+    fixture.physicalPropertiesDirty = false;
+  }
+}
+
+// Normalizes empty position names for grouped physical summaries.
 std::string NormalizePositionName(const std::string &positionName) {
   return positionName.empty() ? kUnassignedPosition : positionName;
 }
@@ -256,8 +329,20 @@ void ApplyFullRowChanges(
     const bool weightChanged = !Units::NearlyEqualWeightKilograms(
         previousWeightKg, next.weightKg, 0.001);
     if (powerChanged || weightChanged) {
-      next.physicalPropertiesSource = FixturePhysicalPropertiesSource::Manual;
-      next.physicalPropertiesDirty = true;
+      if (UpdateProjectGdtfPhysicalProperties(scene, next.gdtfSpec, next.weightKg,
+                                              next.powerConsumptionW)) {
+        UpdateMatchingPhysicalPropertyCells(table, rowUuids, scene, next.gdtfSpec,
+                                            next.typeName, next.weightKg,
+                                            next.powerConsumptionW,
+                                            weightUnitSystem);
+        ApplySharedPhysicalProperties(scene, next.gdtfSpec, next.typeName,
+                                      next.weightKg, next.powerConsumptionW);
+        next.physicalPropertiesSource = FixturePhysicalPropertiesSource::Gdtf;
+        next.physicalPropertiesDirty = false;
+      } else {
+        next.physicalPropertiesSource = FixturePhysicalPropertiesSource::Manual;
+        next.physicalPropertiesDirty = true;
+      }
     }
 
     table->GetValue(v, i, 18);

--- a/gui/mainwindow_fixture_add_flow.cpp
+++ b/gui/mainwindow_fixture_add_flow.cpp
@@ -154,6 +154,8 @@ void MainWindow::AddFixtureFromGdtfPath(const std::string &gdtfPath,
     f.layer = layerName;
     f.weightKg = weight;
     f.powerConsumptionW = power;
+    f.physicalPropertiesSource = FixturePhysicalPropertiesSource::Gdtf;
+    f.physicalPropertiesDirty = false;
     f.color = defaultColor;
     sceneRef.fixtures[f.uuid] = f;
   }

--- a/gui/mainwindow_fixture_replace.cpp
+++ b/gui/mainwindow_fixture_replace.cpp
@@ -265,6 +265,8 @@ void MainWindow::OnReplaceSelectedFixtures(wxCommandEvent &WXUNUSED(event)) {
     target.gdtfMode = replacement.gdtfMode;
     target.weightKg = replacement.weightKg;
     target.powerConsumptionW = replacement.powerConsumptionW;
+    target.physicalPropertiesSource = FixturePhysicalPropertiesSource::Gdtf;
+    target.physicalPropertiesDirty = false;
     target.color = replacementColor;
 
     target.fixtureId = keepFixtureId;

--- a/models/fixture.h
+++ b/models/fixture.h
@@ -20,6 +20,14 @@
 #include <string>
 #include "types.h"
 
+// Tracks where editable fixture physical properties came from.
+enum class FixturePhysicalPropertiesSource {
+    Unknown,
+    Gdtf,
+    LegacyMvrFixtureNode,
+    Manual
+};
+
 // Represents a lighting fixture object parsed from MVR
 struct Fixture {
     std::string uuid;             // Unique identifier from the MVR file
@@ -57,6 +65,9 @@ struct Fixture {
 
     float powerConsumptionW = 0.0f; // Power consumption in watts
     float weightKg = 0.0f;          // Fixture weight in kilograms
+    FixturePhysicalPropertiesSource physicalPropertiesSource =
+        FixturePhysicalPropertiesSource::Unknown; // Source for editable physical values
+    bool physicalPropertiesDirty = false; // True when the user edited physical values
 
     std::string category;         // Fixture category (Spot, Wash, etc.)
     std::string categorySource;   // Category source (Manual, AutoFallback, ...)

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -22,6 +22,7 @@
 #include "configmanager.h"
 #include "dummyprofilelibrary.h"
 #include "gdtf_mutation_audit.h"
+#include "gdtfloader.h"
 #include "logger.h"
 #include "matrixutils.h"
 #include "projectutils.h"
@@ -103,6 +104,10 @@ static std::unordered_map<std::string, int> BuildFixtureUnitNumbersForExport(
     const std::unordered_map<std::string, Fixture> &fixtures);
 
 static bool ShouldExportSupportHoistInfo(const Support &support);
+static bool NearlyEqualPhysicalValue(float lhs, float rhs);
+static bool FixtureNeedsPhysicalGdtfPatch(const Fixture &fixture,
+                                          const std::string &gdtfPath,
+                                          GdtfOverrides &overrides);
 static tinyxml2::XMLElement *FindFirstPerastageUserData(tinyxml2::XMLElement *node);
 static tinyxml2::XMLElement *FindOrCreatePerastageDataNode(tinyxml2::XMLDocument &doc,
                                                             tinyxml2::XMLElement *node);
@@ -131,6 +136,43 @@ static constexpr const char *kMvrProvider = "Perastage";
 static constexpr const char *kPerastageUserDataSchemaVersion = "1.0";
 static constexpr const char *kDummyFallbackFixtureGdtfFileName = "Dummy 1ch.gdtf";
 static constexpr const char *kLegacyFallbackFixtureGdtfFileName = "Generic 1ch.gdtf";
+static constexpr const char *kPhysicalPropertiesRevisionText =
+    "Updated physical properties for Perastage MVR export";
+
+
+// Compares physical values using the exporter tolerance.
+static bool NearlyEqualPhysicalValue(float lhs, float rhs) {
+  return std::fabs(lhs - rhs) <= 0.001f;
+}
+
+// Decides whether fixture edits require a patched exported GDTF copy.
+static bool FixtureNeedsPhysicalGdtfPatch(const Fixture &fixture,
+                                          const std::string &gdtfPath,
+                                          GdtfOverrides &overrides) {
+  if (!fixture.physicalPropertiesDirty || gdtfPath.empty())
+    return false;
+
+  float gdtfWeightKg = 0.0f;
+  float gdtfPowerW = 0.0f;
+  const bool hasGdtfProperties =
+      GetGdtfProperties(gdtfPath, gdtfWeightKg, gdtfPowerW);
+
+  bool needsPatch = false;
+  if (fixture.weightKg > 0.0f &&
+      (!hasGdtfProperties || !NearlyEqualPhysicalValue(fixture.weightKg, gdtfWeightKg))) {
+    overrides.hasWeightKg = true;
+    overrides.weightKg = fixture.weightKg;
+    needsPatch = true;
+  }
+  if (fixture.powerConsumptionW > 0.0f &&
+      (!hasGdtfProperties ||
+       !NearlyEqualPhysicalValue(fixture.powerConsumptionW, gdtfPowerW))) {
+    overrides.hasPowerW = true;
+    overrides.powerW = fixture.powerConsumptionW;
+    needsPatch = true;
+  }
+  return needsPatch;
+}
 
 // Resolves the MVR FixtureID values from the current editable fixture ID.
 static FixtureExportId ResolveFixtureExportId(const Fixture &fixture) {
@@ -1698,6 +1740,7 @@ static bool ZipDir(const std::string &srcDir, const std::string &dstZip) {
   return true;
 }
 
+// Creates a temporary patched GDTF copy for intentional MVR export overrides.
 static std::string CreatePatchedGdtf(const std::string &gdtfPath,
                                      const GdtfOverrides &ov) {
   std::string tempDir = CreateTempDir();
@@ -1760,7 +1803,9 @@ static std::string CreatePatchedGdtf(const std::string &gdtfPath,
 
   if (patched) {
     GdtfMutationAudit::AppendRevision(
-        ft, doc, "Patched fixture metadata for MVR export",
+        ft, doc, (ov.hasWeightKg || ov.hasPowerW)
+                     ? kPhysicalPropertiesRevisionText
+                     : "Patched fixture metadata for MVR export",
         GdtfMutationAudit::BuildPerastageModifiedBy());
   }
 
@@ -1911,6 +1956,7 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
 
   std::vector<ResourceEntry> resourceEntries;
   std::unordered_map<std::string, std::string> sourceToArchivePath;
+  std::unordered_map<std::string, std::string> physicalPatchArchiveByKey;
   std::unordered_map<std::string, std::string> gdtfArchiveByObjectUuid;
   std::unordered_map<std::string, GdtfOverrides> gdtfOverrides;
   std::unordered_map<std::string, std::string> trussArchiveByTypeKey;
@@ -1940,7 +1986,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
       return srcIt->second;
 
     std::string archivePath = EnsureUniqueArchivePath(preferredArchivePath, reservedArchivePaths);
-    sourceToArchivePath[normalizedSource] = archivePath;
+    if (allowReuseBySource)
+      sourceToArchivePath[normalizedSource] = archivePath;
     resourceEntries.push_back({fs::path(normalizedSource), archivePath});
     return archivePath;
   };
@@ -2376,15 +2423,6 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
         fe->InsertEndChild(e);
       }
     };
-    auto addNum = [&](const char *n, float v, const char *unit) {
-      if (v != 0.0f) {
-        tinyxml2::XMLElement *e = doc.NewElement(n);
-        e->SetAttribute("unit", unit);
-        e->SetText(v);
-        fe->InsertEndChild(e);
-      }
-    };
-
     auto idIt = assignedIds.find(f.uuid);
     FixtureExportId fixtureExportId = ResolveFixtureExportId(f);
     if (fixtureExportId.numeric <= 0 && idIt != assignedIds.end())
@@ -2441,22 +2479,47 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
     else if (!fixtureSourceGdtf.empty())
       ++exportedRealFixtureGdtfCount;
     std::string fixtureName = SanitizeArchiveFileName(fixtureSourceGdtf, "fixture.gdtf");
-    std::string fixtureGdtfArchivePath =
-        registerGdtfResource(f.uuid, fixtureSourceGdtf, fixtureName);
+    GdtfOverrides fixtureOverrides;
+    const bool needsPhysicalPatch =
+        FixtureNeedsPhysicalGdtfPatch(f, fixtureSourceGdtf, fixtureOverrides);
+    if (needsPhysicalPatch) {
+      const fs::path archiveName(fixtureName);
+      const std::string stem = archiveName.stem().generic_string();
+      const std::string extension = archiveName.extension().generic_string();
+      fixtureName = SanitizeArchiveFileName(stem + "_physical_" + f.uuid + extension,
+                                            "fixture_physical.gdtf");
+    }
+    std::string fixtureGdtfArchivePath;
+    if (needsPhysicalPatch) {
+      std::ostringstream patchKey;
+      patchKey << normalizeSourcePath(fixtureSourceGdtf) << '|'
+               << (fixtureOverrides.hasWeightKg ? fixtureOverrides.weightKg : -1.0f)
+               << '|'
+               << (fixtureOverrides.hasPowerW ? fixtureOverrides.powerW : -1.0f);
+      auto patchIt = physicalPatchArchiveByKey.find(patchKey.str());
+      if (patchIt != physicalPatchArchiveByKey.end()) {
+        fixtureGdtfArchivePath = patchIt->second;
+        if (!f.uuid.empty())
+          gdtfArchiveByObjectUuid[f.uuid] = fixtureGdtfArchivePath;
+      } else {
+        fixtureGdtfArchivePath =
+            registerGdtfResource(f.uuid, fixtureSourceGdtf, fixtureName, false);
+        physicalPatchArchiveByKey[patchKey.str()] = fixtureGdtfArchivePath;
+        gdtfOverrides[fixtureGdtfArchivePath] = fixtureOverrides;
+      }
+    } else {
+      fixtureGdtfArchivePath =
+          registerGdtfResource(f.uuid, fixtureSourceGdtf, fixtureName);
+    }
     addStr("GDTFSpec", fixtureGdtfArchivePath);
-    // Keep fixture GDTF payloads byte-preserved in exported MVR/project
-    // packages. Fixture-specific metadata such as Color/Weight/Power is
-    // already serialized at fixture level in GeneralSceneDescription.xml.
-    // Repacking fixture GDTFs here can break model/texture references in some
-    // vendor libraries after a save/reload cycle.
+    // Keep fixture GDTF payloads byte-preserved unless the user intentionally
+    // edits type-level physical properties that must be exported through GDTF.
     addStr("GDTFMode", f.gdtfMode);
     addStr("Focus", f.focus);
     addStr("Function", f.function);
     if (!f.position.empty() || !f.positionName.empty())
       addStr("Position", resolvePositionReference(f.position, f.positionName));
 
-    addNum("PowerConsumption", f.powerConsumptionW, "W");
-    addNum("Weight", f.weightKg, "kg");
 
     if (!f.gelColor.empty() && f.gelColor.size() == 7 && f.gelColor[0] == '#') {
       std::string cie = HexToCie(f.gelColor);

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -2114,20 +2114,28 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
           if (const char *txt = colorNode->GetText())
             fixture.gelColor = CieToHex(txt);
         }
+        float legacyPowerConsumptionW = 0.0f;
+        bool hasLegacyPowerConsumption = false;
         if (tinyxml2::XMLElement *pcNode =
                 node->FirstChildElement("PowerConsumption")) {
           if (const char *txt = pcNode->GetText()) {
             float parsed = 0.0f;
-            if (TryParseFloat(txt, parsed))
-              fixture.powerConsumptionW = parsed;
+            if (TryParseFloat(txt, parsed)) {
+              legacyPowerConsumptionW = parsed;
+              hasLegacyPowerConsumption = true;
+            }
           }
         }
+        float legacyWeightKg = 0.0f;
+        bool hasLegacyWeight = false;
         if (tinyxml2::XMLElement *wNode =
                 node->FirstChildElement("Weight")) {
           if (const char *txt = wNode->GetText()) {
             float parsed = 0.0f;
-            if (TryParseFloat(txt, parsed))
-              fixture.weightKg = parsed;
+            if (TryParseFloat(txt, parsed)) {
+              legacyWeightKg = parsed;
+              hasLegacyWeight = true;
+            }
           }
         }
         std::string resolvedGdtfPathForFixture;
@@ -2141,12 +2149,23 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
           const GdtfFixtureMetadata &metadata = getFixtureMetadata(resolvedGdtfPath);
           fixture.typeName = metadata.fixtureName;
           if (metadata.hasProperties) {
-            if (fixture.weightKg == 0.0f)
+            if (metadata.weightKg > 0.0f)
               fixture.weightKg = metadata.weightKg;
-            if (fixture.powerConsumptionW == 0.0f)
+            if (metadata.powerW > 0.0f)
               fixture.powerConsumptionW = metadata.powerW;
+            fixture.physicalPropertiesSource = FixturePhysicalPropertiesSource::Gdtf;
+            fixture.physicalPropertiesDirty = false;
           }
         }
+        if (fixture.weightKg <= 0.0f && hasLegacyWeight) {
+          fixture.weightKg = legacyWeightKg;
+          fixture.physicalPropertiesSource = FixturePhysicalPropertiesSource::LegacyMvrFixtureNode;
+        }
+        if (fixture.powerConsumptionW <= 0.0f && hasLegacyPowerConsumption) {
+          fixture.powerConsumptionW = legacyPowerConsumptionW;
+          fixture.physicalPropertiesSource = FixturePhysicalPropertiesSource::LegacyMvrFixtureNode;
+        }
+        fixture.physicalPropertiesDirty = false;
 
         ReadFixtureCategoryFromUserData(node, fixture);
         const std::optional<GdtfDictionary::Entry> &dictionaryEntry =

--- a/tests/mvr_exporter_compliance_test.cpp
+++ b/tests/mvr_exporter_compliance_test.cpp
@@ -258,6 +258,8 @@ int main() {
   f3.gdtfSpec = (tempDir / "A" / "Same.gdtf").generic_string();
   f3.address = "6.121";
   f3.gelColor = "#00FF00";
+  f3.weightKg = 12.5f;
+  f3.powerConsumptionW = 450.0f;
   scene.fixtures[f3.uuid] = f3;
 
   Fixture fLong;
@@ -613,6 +615,9 @@ int main() {
               assert(std::string(colorNode->GetText()) == "0.300000,0.600000,0.715200");
               sawFixtureGelColor = true;
             }
+
+            assert(cur->FirstChildElement("Weight") == nullptr);
+            assert(cur->FirstChildElement("PowerConsumption") == nullptr);
 
             if (fixtureUuid == fEditedId.uuid) {
               assert(fixtureIdText == "909");


### PR DESCRIPTION
### Motivation
- MVR 1.6 does not permit `Weight` or `PowerConsumption` as direct children of `Fixture`, and these type-level physical properties should live in the referenced GDTF `PhysicalDescriptions/Properties` instead of the MVR `Fixture` node.
- Preserve backward compatibility for older Perastage MVR files while avoiding false-positive GDTF mutations when re-exporting unchanged or GDTF-derived values.
- Ensure intentional user edits to fixture weight/power are persisted in a standards-compliant way by patching exported GDTF copies and stamping a Perastage `Revision` with the app version.
- Keep patched GDTF node insertion and `Revisions` placement compliant with the GDTF fixture-type child order so generated GDTFs remain valid.

### Description
- Stop writing non-standard MVR fixture children by removing direct `Fixture/Weight` and `Fixture/PowerConsumption` export from the MVR exporter and instead include the fixture's `GDTFSpec` reference; exporter code changes live in `mvr/mvrexporter.cpp` and the MVR XML no longer emits those nodes.
- Add provenance and dirty tracking for editable physical properties by introducing `FixturePhysicalPropertiesSource` and `physicalPropertiesDirty` on `Fixture` in `models/fixture.h`, and mark manual edits from the UI as dirty in `gui/fixturetable/fixture_table_edit_service.cpp`, `gui/mainwindow_fixture_add_flow.cpp`, and `gui/mainwindow_fixture_replace.cpp`.
- Preserve legacy import behavior in `mvr/mvrimporter.cpp` by continuing to read direct `Fixture/Weight` and `Fixture/PowerConsumption` as compatibility fallbacks while prioritizing `GetGdtfProperties(...)` values from the referenced GDTF and setting the property source accordingly.
- Export intentional edits through patched GDTF copies by adding `FixtureNeedsPhysicalGdtfPatch` (uses `GetGdtfProperties`) and `CreatePatchedGdtf` usage in `mvr/mvrexporter.cpp`, calling `GdtfMutationAudit::ApplyPhysicalProperties(...)` and `GdtfMutationAudit::AppendRevision(...)` to write `PhysicalDescriptions/Properties` and a standard `Revision` with `ModifiedBy = Perastage <app::kVersion>` when necessary.
- Reuse patched GDTF variants for shared source GDTFs by deduplicating patched archive keys (path + values) and only creating patched copies when the fixture is dirty and values differ beyond a small tolerance, avoiding byte-preserving changes otherwise.
- Ensure GDTF section order and revision insertion correctness by adding `InsertFixtureTypeChildInOrder(...)` and using it from `core/gdtf_mutation_audit.cpp` when creating `PhysicalDescriptions` and `Revisions` nodes.
- Add/adjust test expectations and release notes: updated `tests/mvr_exporter_compliance_test.cpp` to assert exported `Fixture` nodes do not contain `Weight` or `PowerConsumption`, and updated `docs/release-notes-draft.md` to describe the change.

### Testing
- Ran repository quality checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both passed.
- Confirmed via searches that no exporter code still emits fixture-level `Weight`/`PowerConsumption` (`! rg 'addNum\("(PowerConsumption|Weight)", f\.' mvr/mvrexporter.cpp`) and `git diff --check` reported no whitespace/format issues.
- Updated exporter compliance test `tests/mvr_exporter_compliance_test.cpp` to assert absence of direct `Fixture/Weight` and `Fixture/PowerConsumption`, but full test binary execution could not be completed because CMake configuration failed in this container due to missing `wxWidgets` development files (so `mvr_exporter_compliance_test` was not built here).
- All code-style and repository checks included in this run succeeded; compilation and full test-suite runs should be performed in a developer environment with `wxWidgets` available to validate runtime behavior end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3278f43edc8324b4ab18d9608c7498)