### PR TITLE
Remove redundant FixtureInfo identity fields from MVR export and add legacy import fallback

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -94,6 +94,7 @@ Changes since `v1.3.0`.
 
 ## Internal changes
 
+- Cleaned up new MVR fixture exports by relying on standard Fixture `uuid` and `name` attributes instead of redundant Perastage FixtureInfo identity fields, while preserving legacy import fallback compatibility.
 - Added Linux text-locale startup validation coverage to prevent regressions in wxWidgets narrow-to-wide string conversion behavior.
 - Improved Debian/Linux test build reliability by linking logger- and config-service-based test executables with the shared diagnostics, app path, filesystem path, config service, and symbol-cache support sources used by the main application.
 - Improved Linux GCC build reliability by separating lightweight GDTF geometry data types from loader declarations, reducing header-order coupling in the 3D resource and bounds systems.

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -2576,20 +2576,6 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
     tinyxml2::XMLElement *info = doc.NewElement("FixtureInfo");
     info->SetAttribute("uuid", stableUuid.c_str());
 
-    tinyxml2::XMLElement *stableIdNode = doc.NewElement("StableId");
-    stableIdNode->SetText(stableUuid.c_str());
-    info->InsertEndChild(stableIdNode);
-
-    tinyxml2::XMLElement *scriptNode = doc.NewElement("Script");
-    scriptNode->SetText(fixtureExportName.c_str());
-    info->InsertEndChild(scriptNode);
-
-    if (!f.instanceName.empty()) {
-      tinyxml2::XMLElement *instanceName = doc.NewElement("InstanceName");
-      instanceName->SetText(f.instanceName.c_str());
-      info->InsertEndChild(instanceName);
-    }
-
     if (!f.category.empty()) {
       tinyxml2::XMLElement *category = doc.NewElement("Category");
       category->SetText(f.category.c_str());

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -894,6 +894,43 @@ static void ReadFixtureCategoryFromUserData(tinyxml2::XMLElement *fixtureNode,
   }
 }
 
+struct LegacyFixtureIdentity {
+  std::string instanceName;
+  std::string stableId;
+};
+
+// Reads legacy Perastage fixture identity fields used by older MVR exports.
+static LegacyFixtureIdentity ReadLegacyFixtureIdentityFromUserData(
+    tinyxml2::XMLElement *fixtureNode) {
+  LegacyFixtureIdentity identity;
+  if (!fixtureNode)
+    return identity;
+
+  tinyxml2::XMLElement *ud = fixtureNode->FirstChildElement("UserData");
+  if (!ud)
+    return identity;
+
+  for (tinyxml2::XMLElement *data = ud->FirstChildElement("Data"); data;
+       data = data->NextSiblingElement("Data")) {
+    tinyxml2::XMLElement *info = data->FirstChildElement("FixtureInfo");
+    if (!info)
+      continue;
+
+    auto readText = [&](const char *name) -> std::string {
+      if (tinyxml2::XMLElement *el = info->FirstChildElement(name)) {
+        if (const char *txt = el->GetText())
+          return Trim(txt);
+      }
+      return {};
+    };
+
+    identity.instanceName = readText("InstanceName");
+    identity.stableId = readText("StableId");
+    return identity;
+  }
+  return identity;
+}
+
 static void ReadSupportHoistInfoFromUserData(tinyxml2::XMLElement *supportNode,
                                              Support &support) {
   for (tinyxml2::XMLElement *ud = supportNode->FirstChildElement("UserData"); ud;
@@ -1996,7 +2033,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
 
   auto resolveStableUuid = [&](const char *kind, tinyxml2::XMLElement *node,
                                const std::string &layerName,
-                               const Matrix &nodeTransform) {
+                               const Matrix &nodeTransform,
+                               const std::string &legacyStableId = {}) {
     const char *uuidAttr = node->Attribute("uuid");
     std::string rawUuid = uuidAttr ? Trim(uuidAttr) : std::string{};
     std::string stableUuid = CanonicalizeUuid(rawUuid);
@@ -2004,13 +2042,17 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
         buildStableIdSeed(kind, node, layerName, nodeTransform, rawUuid);
 
     if (stableUuid.empty()) {
-      if (!rawUuid.empty()) {
+      const std::string legacyUuid = CanonicalizeUuid(Trim(legacyStableId));
+      if (!legacyUuid.empty()) {
+        stableUuid = legacyUuid;
+      } else if (!rawUuid.empty()) {
         LogMessage(Logger::Level::Warn,
                    wxString::Format("MVR import: %s UUID '%s' is invalid. Applying deterministic fallback.",
                                     kind, rawUuid.c_str())
                        .ToStdString());
       }
-      stableUuid = DeriveDeterministicUuid(seed);
+      if (stableUuid.empty())
+        stableUuid = DeriveDeterministicUuid(seed);
     }
 
     if (usedStableUuids.contains(stableUuid)) {
@@ -2068,11 +2110,14 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                          const Matrix &nodeTransform, const Matrix &localTransform,
                          const std::string &parentGroupUuid) {
         Fixture fixture;
+        const LegacyFixtureIdentity legacyIdentity =
+            ReadLegacyFixtureIdentityFromUserData(node);
         const char *rawUuidAttr = node->Attribute("uuid");
         const std::string rawFixtureUuid =
             rawUuidAttr ? Trim(rawUuidAttr) : std::string{};
         fixture.uuid =
-            resolveStableUuid("Fixture", node, layerName, nodeTransform);
+            resolveStableUuid("Fixture", node, layerName, nodeTransform,
+                              legacyIdentity.stableId);
         if (!rawFixtureUuid.empty() && rawFixtureUuid != fixture.uuid)
           fixtureUuidRemap[rawFixtureUuid] = fixture.uuid;
         fixture.layer = layerName;
@@ -2086,6 +2131,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
             nameAttr ? Trim(nameAttr) : std::string{};
         if (!rawFixtureNodeName.empty())
           fixture.instanceName = rawFixtureNodeName;
+        else if (!legacyIdentity.instanceName.empty())
+          fixture.instanceName = legacyIdentity.instanceName;
 
         fixtureIdOf(node, fixture.fixtureIdText, fixture.fixtureIdNumeric);
         fixture.fixtureId = fixture.fixtureIdNumeric;

--- a/tests/mvr_exporter_compliance_test.cpp
+++ b/tests/mvr_exporter_compliance_test.cpp
@@ -602,7 +602,8 @@ int main() {
             assert(nameAttr != nullptr);
             std::string fixtureUuid = uuidAttr;
             std::string fixtureNodeName = nameAttr;
-            assert(fixtureNodeName == "Fixture_" + fixtureUuid);
+            assert(!fixtureNodeName.empty());
+            assert(fixtureNodeName != "Fixture_" + fixtureUuid);
 
             auto *colorNode = cur->FirstChildElement("Color");
             if (fixtureUuid == f2.uuid) {
@@ -639,12 +640,9 @@ int main() {
             const char *metaUuid = info->Attribute("uuid");
             assert(metaUuid != nullptr);
             assert(std::string(metaUuid) == fixtureUuid);
-            auto *stableIdNode = info->FirstChildElement("StableId");
-            assert(stableIdNode != nullptr && stableIdNode->GetText() != nullptr);
-            assert(std::string(stableIdNode->GetText()) == fixtureUuid);
-            auto *scriptNode = info->FirstChildElement("Script");
-            assert(scriptNode != nullptr && scriptNode->GetText() != nullptr);
-            assert(std::string(scriptNode->GetText()) == fixtureNodeName);
+            assert(info->FirstChildElement("InstanceName") == nullptr);
+            assert(info->FirstChildElement("StableId") == nullptr);
+            assert(info->FirstChildElement("Script") == nullptr);
 
             auto *addresses = cur->FirstChildElement("Addresses");
             assert(addresses != nullptr);
@@ -1050,9 +1048,14 @@ int main() {
         "<Scene>"
         "<AUXData><Position uuid=\"LX1\" name=\"LX 1\"/></AUXData>"
         "<Layers><Layer name=\"Default\"><ChildList>"
-        "<Fixture uuid=\"fixture-legacy\" name=\"Fixture\">"
+        "<Fixture uuid=\"fixture-legacy\" name=\"\">"
         "<FixtureID>1</FixtureID><FixtureIDNumeric>1</FixtureIDNumeric>"
         "<GDTFSpec>fixture.gdtf</GDTFSpec><Position>LX1</Position>"
+        "<UserData><Data provider=\"Perastage\" ver=\"1.0\"><FixtureInfo>"
+        "<InstanceName>Legacy Fixture Name</InstanceName>"
+        "<StableId>11111111-1111-4111-8111-111111111111</StableId>"
+        "<Script>LegacyScriptName</Script>"
+        "</FixtureInfo></Data></UserData>"
         "</Fixture>"
         "</ChildList></Layer></Layers>"
         "</Scene></GeneralSceneDescription>";
@@ -1068,6 +1071,9 @@ int main() {
   const MvrScene &importedScene = ConfigManager::Get().GetScene();
   assert(!importedScene.fixtures.empty());
   const Fixture &legacyFixture = importedScene.fixtures.begin()->second;
+  assert(importedScene.fixtures.count("11111111-1111-4111-8111-111111111111") == 1);
+  assert(legacyFixture.uuid == "11111111-1111-4111-8111-111111111111");
+  assert(legacyFixture.instanceName == "Legacy Fixture Name");
   assert(!legacyFixture.position.empty());
   assert(legacyFixture.position != "LX1");
   assert(CanonicalizeUuid(legacyFixture.position) == legacyFixture.position);


### PR DESCRIPTION
### Motivation
- Avoid writing redundant Perastage-only identity metadata into new MVR exports and rely on the official `Fixture` `uuid` and `name` attributes for identity and naming. 
- Preserve backwards compatibility by keeping importer fallback behavior for older Perastage MVRs that still store `InstanceName` / `StableId` inside `FixtureInfo` so old projects keep working. 
- Keep the change narrowly scoped to identity fields and do not alter `Category`, `CategorySource`, `CategoryReason`, `Weight`, `PowerConsumption`, or overall `FixtureInfo` layout.

### Description
- Stop emitting `InstanceName`, `StableId`, and `Script` inside `UserData/Data/FixtureInfo` in the exporter while still writing canonical `Fixture` `uuid` and `name` attributes. 
- Add `ReadLegacyFixtureIdentityFromUserData` to parse legacy `InstanceName`/`StableId` from `FixtureInfo` and use them as fallbacks during import: `StableId` is used only when `Fixture/@uuid` is missing/invalid and `InstanceName` is used only when `Fixture/@name` is empty. 
- Update import logic to accept an optional legacy stable-id when resolving stable UUIDs and to populate `fixture.instanceName` from the legacy field only as a fallback. 
- Update `tests/mvr_exporter_compliance_test.cpp` to assert that newly exported `FixtureInfo` blocks no longer contain `InstanceName`, `StableId`, or `Script`, and add a legacy-MVR import case that verifies legacy `StableId`/`InstanceName` are read as fallbacks. 
- Add a release-note entry in `docs/release-notes-draft.md` describing the MVR fixture identity cleanup.

### Testing
- Ran a repository audit with `rg` for `InstanceName|StableId|Script` to confirm exporter no longer emits those nodes and to locate remaining uses; the only remaining runtime uses are importer fallback handling and an internal GUI `instanceName` field. 
- Ran mandatory repository checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both of which passed. 
- Updated unit test assertions in `tests/mvr_exporter_compliance_test.cpp` to check absence of the legacy nodes and to validate legacy-import fallback, but building/running the C++ test executable in this environment failed because the container lacks `wxWidgets` (CMake configuration error), so the modified test was not executed here; the test source was adjusted and committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3284018e448324b14248fc8658230b)