### PR TITLE
Make fixture MVR category metadata type-level and export Fixtures MVR-compliant

### DIFF
--- a/docs/opening-mvr-files.md
+++ b/docs/opening-mvr-files.md
@@ -63,6 +63,8 @@ In addition to MVR exchange, Perastage supports project-based work so you can:
 
 Perastage stores its own layer appearance metadata, including layer colors, in a root-level MVR `UserData/Data` block with `provider="Perastage"`, using Perastage-owned `PerastageLayerAppearance` entries under `LayerAppearanceMap`. This keeps new exports standards-compliant and avoids confusing custom metadata with standard MVR `Layer` nodes, while still allowing Perastage to recover layer colors from its own MVR files when the metadata is preserved. Older Perastage MVR files that used direct `Layer/Color` children or legacy Perastage `LayerAppearanceMap/Layer` entries are still accepted on import, but new exports do not write those legacy structures.
 
+Perastage fixture categories are also stored in root-level `UserData/Data` with `provider="Perastage"`, using `FixtureTypeInfoMap` entries keyed by fixture type/profile instead of custom `UserData` inside individual `Fixture` nodes. New exports keep each Fixture node limited to standard MVR fixture fields, while imports still accept older Perastage files that stored `FixtureInfo` category data inside a Fixture.
+
 When your changes are ready for exchange:
 
 1. Open **File → Export MVR...**.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -93,6 +93,7 @@ Changes since `v1.3.0`.
 - Documented local diagnostics export and release symbol ZIP assets for troubleshooting and maintainer workflows.
 
 ## Internal changes
+- Improved MVR fixture export compatibility by moving Perastage fixture category metadata to root-level type metadata, removing per-fixture custom UserData, and preserving legacy fixture category imports.
 
 - Cleaned up new MVR fixture exports by relying on standard Fixture `uuid` and `name` attributes instead of redundant Perastage FixtureInfo identity fields, while preserving legacy import fallback compatibility.
 - Added Linux text-locale startup validation coverage to prevent regressions in wxWidgets narrow-to-wide string conversion behavior.

--- a/gui/fixturetable/fixture_table_edit_service.cpp
+++ b/gui/fixturetable/fixture_table_edit_service.cpp
@@ -43,6 +43,18 @@ bool IsSameGdtfType(const Fixture &fixture, const std::string &gdtfSpec,
   return !typeName.empty() && fixture.typeName == typeName;
 }
 
+// Checks whether two fixtures share the same category-bearing type profile.
+bool IsSameFixtureCategoryType(const Fixture &fixture, const Fixture &reference) {
+  if (!reference.gdtfSpec.empty()) {
+    if (fixture.gdtfSpec != reference.gdtfSpec)
+      return false;
+    return reference.gdtfMode.empty() || fixture.gdtfMode == reference.gdtfMode;
+  }
+  if (!reference.typeName.empty() && fixture.typeName != reference.typeName)
+    return false;
+  return !reference.typeName.empty();
+}
+
 // Writes GDTF physical properties to the project GDTF file when a type value changes.
 bool UpdateProjectGdtfPhysicalProperties(const MvrScene &scene,
                                          const std::string &gdtfSpec,
@@ -480,6 +492,7 @@ void ApplyAppearanceChanges(FixtureTableEditService::ISceneAdapter &adapter,
   AppendChangeLogIfNeeded(tracking, logChanges);
 }
 
+// Applies category edits and synchronizes the type-level category across matching fixtures.
 void ApplyCategoryChanges(
     FixtureTableEditService::ISceneAdapter &adapter, wxDataViewListCtrl *table,
     const std::vector<std::string> &rowUuids,
@@ -537,6 +550,19 @@ void ApplyCategoryChanges(
       manualCategoriesByType[next.typeName] = next.category;
     }
     TrackUpdatedFixture(it->second, tracking, logChanges);
+
+    for (auto &[uuid, fixture] : scene.fixtures) {
+      if (uuid == it->first || !IsSameFixtureCategoryType(fixture, next))
+        continue;
+      if (fixture.category == next.category &&
+          fixture.categorySource == next.categorySource &&
+          fixture.categorySourceReason == next.categorySourceReason)
+        continue;
+      fixture.category = next.category;
+      fixture.categorySource = next.categorySource;
+      fixture.categorySourceReason = next.categorySourceReason;
+      TrackUpdatedFixture(fixture, tracking, logChanges);
+    }
   }
 
   GdtfDictionary::UpdateCategoriesBulk(manualCategoriesByType);

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -50,6 +50,7 @@ class wxZipStreamLink;
 #include <fstream>
 #include <functional>
 #include <iomanip>
+#include <map>
 #include <regex>
 #include <set>
 #include <sstream>
@@ -92,6 +93,16 @@ struct FixtureExportId {
   int numeric = 0;
 };
 
+struct FixtureTypeCategoryExport {
+  std::string key;
+  std::string gdtfSpec;
+  std::string gdtfMode;
+  std::string manufacturer;
+  std::string model;
+  std::string category;
+  std::string categorySource;
+};
+
 static bool TryParseInt(std::string_view text, int &out);
 static bool ParseMvrAddressNodeText(const std::string &text, int &universeOut,
                                     int &channelOut);
@@ -102,6 +113,15 @@ static std::string ToLowerAscii(std::string value);
 static FixtureExportId ResolveFixtureExportId(const Fixture &fixture);
 static std::unordered_map<std::string, int> BuildFixtureUnitNumbersForExport(
     const std::unordered_map<std::string, Fixture> &fixtures);
+static std::string BuildFixtureTypeCategoryKey(const Fixture &fixture,
+                                               const std::string &gdtfArchivePath);
+static bool IsManualFixtureCategorySource(const std::string &source);
+static void MergeFixtureTypeCategoryExport(
+    std::map<std::string, FixtureTypeCategoryExport> &metadataByType,
+    const Fixture &fixture, const std::string &gdtfArchivePath);
+static void AppendFixtureTypeCategoryMetadata(
+    tinyxml2::XMLDocument &doc, tinyxml2::XMLElement *perastageData,
+    const std::map<std::string, FixtureTypeCategoryExport> &metadataByType);
 
 static bool ShouldExportSupportHoistInfo(const Support &support);
 static bool NearlyEqualPhysicalValue(float lhs, float rhs);
@@ -629,6 +649,94 @@ static std::string SanitizeArchiveRelativePath(const std::string &input,
   return out.generic_string();
 }
 
+
+// Builds a stable fixture type/profile key for root-level category metadata.
+static std::string BuildFixtureTypeCategoryKey(const Fixture &fixture,
+                                               const std::string &gdtfArchivePath) {
+  std::ostringstream key;
+  key << TrimAscii(gdtfArchivePath) << '|' << TrimAscii(fixture.gdtfMode);
+  if (TrimAscii(gdtfArchivePath).empty())
+    key << '|' << TrimAscii(fixture.typeName);
+  std::string value = key.str();
+  for (char &ch : value) {
+    const unsigned char uch = static_cast<unsigned char>(ch);
+    if (uch < 32 || ch == '/' || ch == '\\')
+      ch = '_';
+  }
+  return TrimAscii(value);
+}
+
+// Returns true when a category source represents an explicit user choice.
+static bool IsManualFixtureCategorySource(const std::string &source) {
+  return ToLowerAscii(TrimAscii(source)) == "manual";
+}
+
+// Merges one fixture's category into the type-level export map deterministically.
+static void MergeFixtureTypeCategoryExport(
+    std::map<std::string, FixtureTypeCategoryExport> &metadataByType,
+    const Fixture &fixture, const std::string &gdtfArchivePath) {
+  const std::string category = TrimAscii(fixture.category);
+  if (category.empty())
+    return;
+
+  const std::string key = BuildFixtureTypeCategoryKey(fixture, gdtfArchivePath);
+  if (key.empty())
+    return;
+
+  const std::string source = TrimAscii(fixture.categorySource);
+  auto [it, inserted] = metadataByType.try_emplace(key);
+  FixtureTypeCategoryExport &entry = it->second;
+  if (inserted) {
+    entry.key = key;
+    entry.gdtfSpec = TrimAscii(gdtfArchivePath);
+    entry.gdtfMode = TrimAscii(fixture.gdtfMode);
+    entry.model = TrimAscii(fixture.typeName);
+    entry.category = category;
+    entry.categorySource = source;
+    return;
+  }
+
+  const bool incomingManual = IsManualFixtureCategorySource(source);
+  const bool existingManual = IsManualFixtureCategorySource(entry.categorySource);
+  if (incomingManual && !existingManual) {
+    entry.category = category;
+    entry.categorySource = source;
+  }
+}
+
+// Appends deduplicated fixture category metadata to root Perastage UserData.
+static void AppendFixtureTypeCategoryMetadata(
+    tinyxml2::XMLDocument &doc, tinyxml2::XMLElement *perastageData,
+    const std::map<std::string, FixtureTypeCategoryExport> &metadataByType) {
+  if (!perastageData || metadataByType.empty())
+    return;
+
+  tinyxml2::XMLElement *map = doc.NewElement("FixtureTypeInfoMap");
+  for (const auto &[key, entry] : metadataByType) {
+    tinyxml2::XMLElement *info = doc.NewElement("FixtureTypeInfo");
+    info->SetAttribute("key", entry.key.c_str());
+    if (!entry.gdtfSpec.empty())
+      info->SetAttribute("gdtfSpec", entry.gdtfSpec.c_str());
+    if (!entry.gdtfMode.empty())
+      info->SetAttribute("gdtfMode", entry.gdtfMode.c_str());
+    if (!entry.manufacturer.empty())
+      info->SetAttribute("manufacturer", entry.manufacturer.c_str());
+    if (!entry.model.empty())
+      info->SetAttribute("model", entry.model.c_str());
+
+    tinyxml2::XMLElement *category = doc.NewElement("Category");
+    category->SetText(entry.category.c_str());
+    info->InsertEndChild(category);
+    if (!entry.categorySource.empty()) {
+      tinyxml2::XMLElement *source = doc.NewElement("CategorySource");
+      source->SetText(entry.categorySource.c_str());
+      info->InsertEndChild(source);
+    }
+    map->InsertEndChild(info);
+  }
+  perastageData->InsertEndChild(map);
+}
+
 // Builds the preferred root-level GDTF archive filename for a truss.
 static std::string BuildTrussGdtfArchiveName(const Truss &truss) {
   std::string baseName = TrimAscii(truss.model);
@@ -885,6 +993,16 @@ static bool ValidateMvr16Export(
       }
 
       if (std::string(cur->Name()) == "Fixture") {
+        if (cur->FirstChildElement("UserData")) {
+          wxLogError("MVR export validation failed: Fixture uuid '%s' contains direct UserData",
+                     cur->Attribute("uuid") ? cur->Attribute("uuid") : "(missing uuid)");
+          return false;
+        }
+        if (cur->FirstChildElement("Category") || cur->FirstChildElement("CategorySource") ||
+            cur->FirstChildElement("CategoryReason")) {
+          wxLogError("MVR export validation failed: Fixture contains Perastage category metadata");
+          return false;
+        }
         auto *idNode = cur->FirstChildElement("FixtureID");
         auto *numNode = cur->FirstChildElement("FixtureIDNumeric");
         const std::string fixtureUuid = cur->Attribute("uuid") ? cur->Attribute("uuid") : "(missing uuid)";
@@ -2365,6 +2483,7 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
     trussExportUuids[uuid] = exportUuid;
   }
   tinyxml2::XMLElement *trussInfoMap = doc.NewElement("TrussInfoMap");
+  std::map<std::string, FixtureTypeCategoryExport> fixtureTypeCategoryMetadata;
 
   int exportedRealFixtureGdtfCount = 0;
   int exportedDummyFixtureGdtfCount = 0;
@@ -2433,12 +2552,6 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
     }
     if (fixtureExportId.text.empty())
       fixtureExportId.text = std::to_string(fixtureExportId.numeric);
-    addStr("FixtureID", fixtureExportId.text);
-    addInt("FixtureIDNumeric", fixtureExportId.numeric);
-    auto unitIt = assignedUnitNumbers.find(f.uuid);
-    addInt("UnitNumber", unitIt != assignedUnitNumbers.end() ? unitIt->second : f.unitNumber);
-    addInt("CustomId", f.customId);
-    addInt("CustomIdType", f.customIdType);
     std::string fixtureSourceGdtf = f.gdtfSpec;
     if (fixtureSourceGdtf.empty() && !f.originalMvrGdtfSpec.empty()) {
       fixtureSourceGdtf = f.originalMvrGdtfSpec;
@@ -2511,33 +2624,27 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
       fixtureGdtfArchivePath =
           registerGdtfResource(f.uuid, fixtureSourceGdtf, fixtureName);
     }
+    MergeFixtureTypeCategoryExport(fixtureTypeCategoryMetadata, f, fixtureGdtfArchivePath);
+
+    const Matrix fixtureMatrixToWrite =
+        f.parentGroupUuid.empty()
+            ? f.transform
+            : (f.hasLocalTransform ? f.localTransform : f.transform);
+    std::string mstr = MatrixUtils::FormatMatrix(fixtureMatrixToWrite);
+    tinyxml2::XMLElement *mat = doc.NewElement("Matrix");
+    mat->SetText(mstr.c_str());
+    fe->InsertEndChild(mat);
+
     addStr("GDTFSpec", fixtureGdtfArchivePath);
     // Keep fixture GDTF payloads byte-preserved unless the user intentionally
     // edits type-level physical properties that must be exported through GDTF.
     addStr("GDTFMode", f.gdtfMode);
-    addStr("Focus", f.focus);
-    addStr("Function", f.function);
     if (!f.position.empty() || !f.positionName.empty())
       addStr("Position", resolvePositionReference(f.position, f.positionName));
-
-
-    if (!f.gelColor.empty() && f.gelColor.size() == 7 && f.gelColor[0] == '#') {
-      std::string cie = HexToCie(f.gelColor);
-      tinyxml2::XMLElement *col = doc.NewElement("Color");
-      col->SetText(cie.c_str());
-      fe->InsertEndChild(col);
-    }
-
-    if (f.dmxInvertPan) {
-      tinyxml2::XMLElement *e = doc.NewElement("DMXInvertPan");
-      e->SetText("true");
-      fe->InsertEndChild(e);
-    }
-    if (f.dmxInvertTilt) {
-      tinyxml2::XMLElement *e = doc.NewElement("DMXInvertTilt");
-      e->SetText("true");
-      fe->InsertEndChild(e);
-    }
+    addStr("FixtureID", fixtureExportId.text);
+    addInt("FixtureIDNumeric", fixtureExportId.numeric);
+    auto unitIt = assignedUnitNumbers.find(f.uuid);
+    addInt("UnitNumber", unitIt != assignedUnitNumbers.end() ? unitIt->second : f.unitNumber);
 
     if (!f.address.empty()) {
       const std::string trimmedAddress = TrimAscii(f.address);
@@ -2559,42 +2666,6 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
                 .ToStdString());
       }
     }
-
-    const Matrix fixtureMatrixToWrite =
-        f.parentGroupUuid.empty()
-            ? f.transform
-            : (f.hasLocalTransform ? f.localTransform : f.transform);
-    std::string mstr = MatrixUtils::FormatMatrix(fixtureMatrixToWrite);
-    tinyxml2::XMLElement *mat = doc.NewElement("Matrix");
-    mat->SetText(mstr.c_str());
-    fe->InsertEndChild(mat);
-
-    tinyxml2::XMLElement *ud = doc.NewElement("UserData");
-    tinyxml2::XMLElement *data = doc.NewElement("Data");
-    data->SetAttribute("provider", "Perastage");
-    data->SetAttribute("ver", "1.0");
-    tinyxml2::XMLElement *info = doc.NewElement("FixtureInfo");
-    info->SetAttribute("uuid", stableUuid.c_str());
-
-    if (!f.category.empty()) {
-      tinyxml2::XMLElement *category = doc.NewElement("Category");
-      category->SetText(f.category.c_str());
-      info->InsertEndChild(category);
-    }
-    if (!f.categorySource.empty()) {
-      tinyxml2::XMLElement *categorySource = doc.NewElement("CategorySource");
-      categorySource->SetText(f.categorySource.c_str());
-      info->InsertEndChild(categorySource);
-    }
-    if (!f.categorySourceReason.empty()) {
-      tinyxml2::XMLElement *categoryReason = doc.NewElement("CategoryReason");
-      categoryReason->SetText(f.categorySourceReason.c_str());
-      info->InsertEndChild(categoryReason);
-    }
-
-    data->InsertEndChild(info);
-    ud->InsertEndChild(data);
-    fe->InsertEndChild(ud);
 
     parent->InsertEndChild(fe);
   };
@@ -3317,6 +3388,12 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
       defaultLayerElem->SetAttribute("name", defaultLayerName.c_str());
     defaultLayerElem->InsertEndChild(rootChildList);
     layersNode->InsertEndChild(defaultLayerElem);
+  }
+
+  if (!fixtureTypeCategoryMetadata.empty()) {
+    tinyxml2::XMLElement *rootPerastageDataForFixtures = FindOrCreatePerastageDataNode(doc, root);
+    AppendFixtureTypeCategoryMetadata(doc, rootPerastageDataForFixtures,
+                                      fixtureTypeCategoryMetadata);
   }
 
   if (trussInfoMap->FirstChild()) {

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -857,6 +857,7 @@ static void ApplySupportHoistInfoDefaults(Support &support) {
     support.function = support.hoistFunction;
 }
 
+// Reads legacy per-fixture category metadata from older Perastage MVR exports.
 static void ReadFixtureCategoryFromUserData(tinyxml2::XMLElement *fixtureNode,
                                             Fixture &fixture) {
   if (!fixtureNode)
@@ -1551,6 +1552,71 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
   parseLayerAppearanceMap(root->FirstChildElement("UserData"));
 
 
+  struct RootFixtureTypeCategoryInfo {
+    std::string category;
+    std::string categorySource;
+  };
+  std::unordered_map<std::string, RootFixtureTypeCategoryInfo> rootFixtureCategoryByTypeKey;
+
+  // Builds the root UserData fixture type key used by Perastage exports.
+  auto buildFixtureTypeCategoryKey = [](const std::string &gdtfSpec,
+                                        const std::string &gdtfMode,
+                                        const std::string &typeName) {
+    std::ostringstream key;
+    key << Trim(gdtfSpec) << '|' << Trim(gdtfMode);
+    if (Trim(gdtfSpec).empty())
+      key << '|' << Trim(typeName);
+    std::string value = key.str();
+    for (char &ch : value) {
+      const unsigned char uch = static_cast<unsigned char>(ch);
+      if (uch < 32 || ch == '/' || ch == '\\')
+        ch = '_';
+    }
+    return Trim(value);
+  };
+
+  // Collects root-level Perastage fixture type category metadata.
+  auto parseRootFixtureTypeInfoMap = [&](tinyxml2::XMLElement *userDataNode) {
+    if (!userDataNode)
+      return;
+    for (tinyxml2::XMLElement *data = userDataNode->FirstChildElement("Data"); data;
+         data = data->NextSiblingElement("Data")) {
+      const std::string provider = ToLowerCopy(
+          Trim(data->Attribute("provider") ? data->Attribute("provider") : ""));
+      if (provider != "perastage")
+        continue;
+      for (tinyxml2::XMLElement *map = data->FirstChildElement("FixtureTypeInfoMap"); map;
+           map = map->NextSiblingElement("FixtureTypeInfoMap")) {
+        for (tinyxml2::XMLElement *info = map->FirstChildElement("FixtureTypeInfo"); info;
+             info = info->NextSiblingElement("FixtureTypeInfo")) {
+          std::string key = Trim(info->Attribute("key") ? info->Attribute("key") : "");
+          if (key.empty()) {
+            key = buildFixtureTypeCategoryKey(
+                info->Attribute("gdtfSpec") ? info->Attribute("gdtfSpec") : "",
+                info->Attribute("gdtfMode") ? info->Attribute("gdtfMode") : "",
+                info->Attribute("model") ? info->Attribute("model") : "");
+          }
+          if (key.empty())
+            continue;
+          RootFixtureTypeCategoryInfo categoryInfo;
+          if (tinyxml2::XMLElement *category = info->FirstChildElement("Category")) {
+            if (const char *txt = category->GetText())
+              categoryInfo.category = GdtfFixtureCategory::NormalizeCategory(Trim(txt));
+          }
+          if (tinyxml2::XMLElement *source = info->FirstChildElement("CategorySource")) {
+            if (const char *txt = source->GetText())
+              categoryInfo.categorySource = Trim(txt);
+          }
+          if (!categoryInfo.category.empty() && categoryInfo.categorySource.empty())
+            categoryInfo.categorySource = GdtfFixtureCategory::kManualSource;
+          if (!categoryInfo.category.empty())
+            rootFixtureCategoryByTypeKey[key] = categoryInfo;
+        }
+      }
+    }
+  };
+  parseRootFixtureTypeInfoMap(root->FirstChildElement("UserData"));
+
   std::unordered_map<std::string, tinyxml2::XMLElement *> rootTrussInfoByUuid;
   // Collects root-level Perastage truss metadata by canonical exported UUID.
   auto parseRootTrussInfoMap = [&](tinyxml2::XMLElement *userDataNode) {
@@ -2215,6 +2281,14 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
         fixture.physicalPropertiesDirty = false;
 
         ReadFixtureCategoryFromUserData(node, fixture);
+        const std::string categoryTypeKey = buildFixtureTypeCategoryKey(
+            rawGdtfSpec, fixture.gdtfMode, fixture.typeName);
+        auto rootCategoryIt = rootFixtureCategoryByTypeKey.find(categoryTypeKey);
+        if (rootCategoryIt != rootFixtureCategoryByTypeKey.end()) {
+          fixture.category = rootCategoryIt->second.category;
+          fixture.categorySource = rootCategoryIt->second.categorySource;
+          fixture.categorySourceReason.clear();
+        }
         const std::optional<GdtfDictionary::Entry> &dictionaryEntry =
             getDictionaryEntryCached(fixture.typeName);
         auto posIt = scene.positions.find(fixture.position);

--- a/tests/mvr_fixture_category_roundtrip_test.cpp
+++ b/tests/mvr_fixture_category_roundtrip_test.cpp
@@ -4,6 +4,12 @@
 #include <cassert>
 #include <filesystem>
 #include <fstream>
+#include <memory>
+#include <string>
+
+#include <tinyxml2.h>
+#include <wx/wfstream.h>
+#include <wx/zipstrm.h>
 
 #include <wx/init.h>
 
@@ -15,6 +21,52 @@
 #include "mvrimporter.h"
 #include "projectutils.h"
 
+// Reads GeneralSceneDescription.xml from an exported MVR package.
+static std::string ReadSceneXml(const std::filesystem::path &mvrPath) {
+  wxFileInputStream input(mvrPath.string());
+  wxZipInputStream zip(input);
+  std::unique_ptr<wxZipEntry> entry;
+  while ((entry.reset(zip.GetNextEntry()), entry)) {
+    if (entry->GetName() != "GeneralSceneDescription.xml")
+      continue;
+    std::string xml;
+    char buffer[4096];
+    while (zip.CanRead()) {
+      zip.Read(buffer, sizeof(buffer));
+      const size_t read = zip.LastRead();
+      if (read == 0)
+        break;
+      xml.append(buffer, read);
+    }
+    return xml;
+  }
+  return {};
+}
+
+// Returns true when a fixture's direct XML children follow the expected MVR order.
+static bool FixtureChildrenHaveExpectedOrder(tinyxml2::XMLElement *fixture) {
+  int lastIndex = -1;
+  for (tinyxml2::XMLElement *child = fixture->FirstChildElement(); child;
+       child = child->NextSiblingElement()) {
+    const std::string name = child->Name();
+    int index = -1;
+    if (name == "Matrix") index = 0;
+    else if (name == "GDTFSpec") index = 1;
+    else if (name == "GDTFMode") index = 2;
+    else if (name == "Position") index = 3;
+    else if (name == "FixtureID") index = 4;
+    else if (name == "FixtureIDNumeric") index = 5;
+    else if (name == "UnitNumber") index = 6;
+    else if (name == "Addresses") index = 7;
+    else return false;
+    if (index < lastIndex)
+      return false;
+    lastIndex = index;
+  }
+  return true;
+}
+
+// Verifies fixture category metadata export/import compatibility.
 int main() {
   wxInitializer initializer;
   assert(initializer.IsOk());
@@ -38,7 +90,7 @@ int main() {
   scene.basePath = tempDir.string();
 
   Fixture fixture;
-  fixture.uuid = "fx1";
+  fixture.uuid = "11111111-1111-1111-1111-111111111111";
   fixture.instanceName = "Fixture One";
   fixture.layer = layer.name;
   fixture.typeName = "FixtureType";
@@ -49,7 +101,7 @@ int main() {
   scene.fixtures[fixture.uuid] = fixture;
 
   Fixture fixtureTwo = fixture;
-  fixtureTwo.uuid = "fx2";
+  fixtureTwo.uuid = "22222222-2222-2222-2222-222222222222";
   fixtureTwo.instanceName = "Fixture Two";
   fixtureTwo.typeName = "FixtureType2";
   scene.fixtures[fixtureTwo.uuid] = fixtureTwo;
@@ -61,6 +113,38 @@ int main() {
   MvrExporter exporter;
   assert(exporter.ExportToFile(mvrPath.string()));
 
+  const std::string sceneXmlText = ReadSceneXml(mvrPath);
+  assert(!sceneXmlText.empty());
+  assert(sceneXmlText.find("CategoryReason") == std::string::npos);
+  tinyxml2::XMLDocument xml;
+  assert(xml.Parse(sceneXmlText.c_str()) == tinyxml2::XML_SUCCESS);
+  auto *root = xml.FirstChildElement("GeneralSceneDescription");
+  assert(root != nullptr);
+  auto *rootUserData = root->FirstChildElement("UserData");
+  assert(rootUserData != nullptr);
+  auto *fixtureTypeMap = rootUserData->FirstChildElement("Data")->FirstChildElement("FixtureTypeInfoMap");
+  assert(fixtureTypeMap != nullptr);
+  assert(fixtureTypeMap->FirstChildElement("FixtureTypeInfo") != nullptr);
+  assert(fixtureTypeMap->FirstChildElement("FixtureTypeInfo")->NextSiblingElement("FixtureTypeInfo") == nullptr);
+
+  int exportedFixtureCount = 0;
+  for (auto *layerNode = root->FirstChildElement("Scene")->FirstChildElement("Layers")->FirstChildElement("Layer");
+       layerNode; layerNode = layerNode->NextSiblingElement("Layer")) {
+    auto *childList = layerNode->FirstChildElement("ChildList");
+    if (!childList)
+      continue;
+    for (auto *fixtureNode = childList->FirstChildElement("Fixture"); fixtureNode;
+         fixtureNode = fixtureNode->NextSiblingElement("Fixture")) {
+      ++exportedFixtureCount;
+      assert(fixtureNode->Attribute("uuid") != nullptr);
+      assert(fixtureNode->Attribute("name") != nullptr);
+      assert(fixtureNode->FirstChildElement("UserData") == nullptr);
+      assert(fixtureNode->FirstChildElement("UnitNumber") != nullptr);
+      assert(FixtureChildrenHaveExpectedOrder(fixtureNode));
+    }
+  }
+  assert(exportedFixtureCount == 2);
+
   cfg.Reset();
   GdtfDictionary::ResetSaveCallCountForTesting();
   MvrImporter importer;
@@ -69,9 +153,9 @@ int main() {
 
   const auto &loaded = cfg.GetScene().fixtures;
   assert(loaded.size() == 2);
-  const Fixture &loadedFixture = loaded.at("fx1");
+  const Fixture &loadedFixture = loaded.at("11111111-1111-1111-1111-111111111111");
   assert(loadedFixture.category == "Spot");
-  assert(loaded.at("fx2").category == "Spot");
+  assert(loaded.at("22222222-2222-2222-2222-222222222222").category == "Spot");
 
   // Dictionary should be updated with scene (MVR) priority category.
   auto entry = GdtfDictionary::Get("FixtureType");
@@ -99,8 +183,8 @@ int main() {
   cfg.Reset();
   assert(importer.ImportFromFile(noCategoryMvrPath.string(), false, false));
   const auto &loadedNoCategory = cfg.GetScene().fixtures;
-  assert(loadedNoCategory.at("fx1").category == "Spot");
-  assert(loadedNoCategory.at("fx2").category == "Spot");
+  assert(loadedNoCategory.at("11111111-1111-1111-1111-111111111111").category == "Spot");
+  assert(loadedNoCategory.at("22222222-2222-2222-2222-222222222222").category == "Spot");
 
   std::filesystem::remove_all(tempDir);
   std::filesystem::remove(ProjectUtils::GetDefaultLibraryPath("fixtures") +


### PR DESCRIPTION
### Motivation
- Ensure exported MVR 1.6 files are XSD-compatible by removing non-standard `UserData` from `Fixture` nodes and move Perastage-specific fixture category metadata to a single root-level provider block. 
- Store Category/CategorySource once per fixture type/profile (GDTF+mode/type key) to avoid per-instance duplication and preserve deterministic, manual-over-automatic conflict resolution. 
- Preserve import compatibility with older Perastage MVRs that used per-fixture `FixtureInfo` while preventing new exports from reintroducing legacy per-fixture data. 

### Description
- Exporter: removed per-fixture `UserData/Data/FixtureInfo` emission and instead collects deduplicated type-level metadata into a `FixtureTypeInfoMap` under `GeneralSceneDescription/UserData/Data[@provider="Perastage"]`, using a stable type key and preferring manual sources over automatic ones. 
- Exporter: changed `Fixture` serialization to follow the official MVR child order and fields written (`Matrix`, `GDTFSpec`, `GDTFMode`, `Position`, `FixtureID`, `FixtureIDNumeric`, `UnitNumber`, `Addresses`), omitted `CategoryReason`, and added validation to reject `Fixture/UserData` or direct per-fixture category nodes during export. 
- Importer: added parsing of root `FixtureTypeInfoMap` and application of its `Category`/`CategorySource` to matching fixtures by type key while retaining legacy reading of per-fixture `FixtureInfo` (and translating legacy entries into the new internal, type-level behavior). 
- UI: updated fixture table edit flow to propagate manual category edits across all fixtures that share the same type/profile so the category is effectively type-level in the scene model. 
- Tests & docs: added/updated `tests/mvr_fixture_category_roundtrip_test.cpp` to assert no per-fixture `UserData`, no exported `CategoryReason`, correct fixture child order, presence of `UnitNumber`, and a single root `FixtureTypeInfoMap` entry per type; updated `docs/opening-mvr-files.md` and `docs/release-notes-draft.md` to document the new root-level fixture category storage. 

### Testing
- Ran code health checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both passed. 
- Executed `git diff --check` to ensure no whitespace/patch issues, which passed. 
- Attempted configure/build with `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug` but configuration is blocked in this environment due to missing `wxWidgets` development files, so the new unit test binary could not be built or executed here. 
- Added the regression test `mvr_fixture_category_roundtrip_test` (not executed in this container) which verifies the new export format and legacy-import compatibility.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a328c32c5f88324b318039d6bf13ada)