### PR TITLE
Clarify fixture visual vs MVR color (visualColorHex / mvrFixtureColorHex)

### DIFF
--- a/core/dictionary_bundle.cpp
+++ b/core/dictionary_bundle.cpp
@@ -6,8 +6,8 @@
 #include "projectutils.h"
 
 #include <algorithm>
-#include <chrono>
 #include <cctype>
+#include <chrono>
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
@@ -45,7 +45,8 @@ uint64_t HashBytesFnv1a64(const std::vector<unsigned char> &bytes) {
 }
 
 std::string ToLowerCopy(std::string value) {
-  std::transform(value.begin(), value.end(), value.begin(),
+  std::transform(
+      value.begin(), value.end(), value.begin(),
                  [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
   return value;
 }
@@ -97,7 +98,8 @@ bool IsZipByHeader(const fs::path &path) {
          sig[0] == 'P' && sig[1] == 'K';
 }
 
-bool ReadZipEntryBytes(wxZipInputStream &zip, std::vector<unsigned char> &outBytes) {
+bool ReadZipEntryBytes(wxZipInputStream &zip,
+                       std::vector<unsigned char> &outBytes) {
   outBytes.clear();
   unsigned char chunk[4096];
   for (;;) {
@@ -110,7 +112,8 @@ bool ReadZipEntryBytes(wxZipInputStream &zip, std::vector<unsigned char> &outByt
   return true;
 }
 
-bool WriteZipEntryFromBytes(wxZipOutputStream &zip, const std::string &entryName,
+bool WriteZipEntryFromBytes(wxZipOutputStream &zip,
+                            const std::string &entryName,
                             const std::vector<unsigned char> &bytes) {
   auto *entry = new wxZipEntry(entryName);
   entry->SetMethod(wxZIP_METHOD_DEFLATE);
@@ -148,7 +151,8 @@ fs::path MakeTempStagingDir() {
   return dir;
 }
 
-bool SerializeJsonToBytes(const nlohmann::json &json, std::vector<unsigned char> &outBytes) {
+bool SerializeJsonToBytes(const nlohmann::json &json,
+                          std::vector<unsigned char> &outBytes) {
   const std::string text = json.dump(2);
   outBytes.assign(text.begin(), text.end());
   return true;
@@ -170,7 +174,7 @@ nlohmann::json BuildFixturesEntriesJson(
   for (const auto &name : keys) {
     const auto &entry = dict.at(name);
     if (entry.path.empty() && entry.mode.empty() && entry.category.empty() &&
-        entry.color.empty())
+        entry.visualColorHex.empty())
       continue;
 
     nlohmann::json outputEntry = nlohmann::json::object();
@@ -184,7 +188,8 @@ nlohmann::json BuildFixturesEntriesJson(
       const std::string sourceKey = sourcePath.lexically_normal().string();
       auto archiveIt = sourceToArchivePath.find(sourceKey);
       if (archiveIt == sourceToArchivePath.end()) {
-        const std::string archivePath = "assets/" + BaseNameForArchive(sourcePath, assetIndex++);
+        const std::string archivePath =
+            "assets/" + BaseNameForArchive(sourcePath, assetIndex++);
         std::vector<unsigned char> assetBytes;
         if (!ReadFileBytes(sourcePath, assetBytes)) {
           error = "Could not read fixture asset: " + entry.path;
@@ -208,8 +213,8 @@ nlohmann::json BuildFixturesEntriesJson(
       outputEntry["mode"] = entry.mode;
     if (!entry.category.empty())
       outputEntry["category"] = entry.category;
-    if (!entry.color.empty())
-      outputEntry["color"] = entry.color;
+    if (!entry.visualColorHex.empty())
+      outputEntry["visual_color"] = entry.visualColorHex;
 
     if (!outputEntry.empty())
       entries[name] = std::move(outputEntry);
@@ -218,8 +223,8 @@ nlohmann::json BuildFixturesEntriesJson(
   return entries;
 }
 
-nlohmann::json BuildTrussEntriesJson(
-    const std::unordered_map<std::string, std::string> &dict,
+nlohmann::json
+BuildTrussEntriesJson(const std::unordered_map<std::string, std::string> &dict,
     std::vector<AssetPayload> &assets, std::string &error) {
   nlohmann::json entries = nlohmann::json::object();
   std::unordered_map<std::string, std::string> sourceToArchivePath;
@@ -245,7 +250,8 @@ nlohmann::json BuildTrussEntriesJson(
     const std::string sourceKey = sourcePath.lexically_normal().string();
     auto archiveIt = sourceToArchivePath.find(sourceKey);
     if (archiveIt == sourceToArchivePath.end()) {
-      const std::string archivePath = "assets/" + BaseNameForArchive(sourcePath, assetIndex++);
+      const std::string archivePath =
+          "assets/" + BaseNameForArchive(sourcePath, assetIndex++);
       std::vector<unsigned char> assetBytes;
       if (!ReadFileBytes(sourcePath, assetBytes)) {
         error = "Could not read truss asset: " + source;
@@ -268,9 +274,10 @@ nlohmann::json BuildTrussEntriesJson(
   return entries;
 }
 
-bool WriteBundle(const fs::path &outputZipPath, const std::string &dictionaryType,
-                 const nlohmann::json &entries, const std::vector<AssetPayload> &assets,
-                 std::string &error) {
+bool WriteBundle(const fs::path &outputZipPath,
+                 const std::string &dictionaryType,
+                 const nlohmann::json &entries,
+                 const std::vector<AssetPayload> &assets, std::string &error) {
   wxFileOutputStream output(outputZipPath.string());
   if (!output.IsOk()) {
     error = "Could not create ZIP file";
@@ -328,7 +335,8 @@ bool ExtractArchive(const fs::path &zipPath, const fs::path &destination,
     if (entry->IsDir())
       continue;
 
-    const fs::path outPath = destination / PathUtils::PathFromUtf8(entry->GetName().ToStdString());
+    const fs::path outPath =
+        destination / PathUtils::PathFromUtf8(entry->GetName().ToStdString());
     std::error_code ec;
     fs::create_directories(outPath.parent_path(), ec);
 
@@ -351,7 +359,8 @@ bool ExtractArchive(const fs::path &zipPath, const fs::path &destination,
   return true;
 }
 
-bool ReadJsonFile(const fs::path &path, nlohmann::json &outJson, std::string &error) {
+bool ReadJsonFile(const fs::path &path, nlohmann::json &outJson,
+                  std::string &error) {
   std::ifstream in(path);
   if (!in.is_open()) {
     error = "Could not open JSON file: " + path.string();
@@ -386,7 +395,8 @@ bool ResolveEntryFileField(nlohmann::json &entryJson, std::string &pathOut) {
   return false;
 }
 
-void RewriteEntryFileField(nlohmann::json &entryJson, const std::string &rewrittenPath) {
+void RewriteEntryFileField(nlohmann::json &entryJson,
+                           const std::string &rewrittenPath) {
   if (entryJson.is_string()) {
     entryJson = rewrittenPath;
     return;
@@ -410,7 +420,8 @@ bool ExportFixturesBundle(
   if (!error.empty())
     return false;
 
-  return WriteBundle(PathUtils::PathFromUtf8(outputZipPath), "fixtures", entries, assets, error);
+  return WriteBundle(PathUtils::PathFromUtf8(outputZipPath), "fixtures",
+                     entries, assets, error);
 }
 
 bool ExportTrussesBundle(
@@ -421,10 +432,12 @@ bool ExportTrussesBundle(
   if (!error.empty())
     return false;
 
-  return WriteBundle(PathUtils::PathFromUtf8(outputZipPath), "trusses", entries, assets, error);
+  return WriteBundle(PathUtils::PathFromUtf8(outputZipPath), "trusses", entries,
+                     assets, error);
 }
 
-PreparedImport PrepareBundleImport(const std::string &importPath, Type expectedType) {
+PreparedImport PrepareBundleImport(const std::string &importPath,
+                                   Type expectedType) {
   PreparedImport result;
 
   const fs::path path = PathUtils::PathFromUtf8(importPath);
@@ -437,7 +450,8 @@ PreparedImport PrepareBundleImport(const std::string &importPath, Type expectedT
 
   const fs::path stagingDir = MakeTempStagingDir();
   if (stagingDir.empty()) {
-    result.errors.push_back("Could not create temporary staging directory for bundle import");
+    result.errors.push_back(
+        "Could not create temporary staging directory for bundle import");
     return result;
   }
 
@@ -474,12 +488,14 @@ PreparedImport PrepareBundleImport(const std::string &importPath, Type expectedT
   result.is_bundle = true;
   result.staging_directory = stagingDir;
 
-  if (!manifest.contains("dictionary_type") || !manifest["dictionary_type"].is_string()) {
+  if (!manifest.contains("dictionary_type") ||
+      !manifest["dictionary_type"].is_string()) {
     result.errors.push_back("Bundle manifest missing 'dictionary_type'");
     return result;
   }
 
-  const std::string manifestType = manifest["dictionary_type"].get<std::string>();
+  const std::string manifestType =
+      manifest["dictionary_type"].get<std::string>();
   const std::string expectedTypeText = TypeToString(expectedType);
   if (manifestType != expectedTypeText) {
     result.errors.push_back("Bundle dictionary_type mismatch (expected '" +
@@ -498,7 +514,8 @@ PreparedImport PrepareBundleImport(const std::string &importPath, Type expectedT
     return result;
   }
 
-  const fs::path libraryDir = PathUtils::PathFromUtf8(ProjectUtils::GetWritableLibraryPath(expectedTypeText));
+  const fs::path libraryDir = PathUtils::PathFromUtf8(
+      ProjectUtils::GetWritableLibraryPath(expectedTypeText));
   std::error_code ec;
   fs::create_directories(libraryDir, ec);
 
@@ -514,8 +531,10 @@ PreparedImport PrepareBundleImport(const std::string &importPath, Type expectedT
     }
 
     const std::string archivePath = assetJson["path"].get<std::string>();
-    const std::string expectedChecksum = assetJson["checksum"].get<std::string>();
-    const fs::path extractedPath = stagingDir / PathUtils::PathFromUtf8(archivePath);
+    const std::string expectedChecksum =
+        assetJson["checksum"].get<std::string>();
+    const fs::path extractedPath =
+        stagingDir / PathUtils::PathFromUtf8(archivePath);
     if (!fs::exists(extractedPath)) {
       result.errors.push_back("Bundle asset not found: " + archivePath);
       continue;
@@ -523,7 +542,8 @@ PreparedImport PrepareBundleImport(const std::string &importPath, Type expectedT
 
     std::vector<unsigned char> bytes;
     if (!ReadFileBytes(extractedPath, bytes)) {
-      result.errors.push_back("Could not read extracted bundle asset: " + archivePath);
+      result.errors.push_back("Could not read extracted bundle asset: " +
+                              archivePath);
       continue;
     }
 
@@ -535,7 +555,8 @@ PreparedImport PrepareBundleImport(const std::string &importPath, Type expectedT
 
     const fs::path destPath = libraryDir / extractedPath.filename();
     std::error_code copyEc;
-    fs::copy_file(extractedPath, destPath, fs::copy_options::overwrite_existing, copyEc);
+    fs::copy_file(extractedPath, destPath, fs::copy_options::overwrite_existing,
+                  copyEc);
     if (copyEc) {
       result.errors.push_back("Could not copy bundle asset into library: " +
                               destPath.string());
@@ -549,15 +570,17 @@ PreparedImport PrepareBundleImport(const std::string &importPath, Type expectedT
     return result;
 
   nlohmann::json rewrittenEntries = manifest["entries"];
-  auto rewriteSingle = [&](nlohmann::json &entryJson, const std::string &entryName) {
+  auto rewriteSingle = [&](nlohmann::json &entryJson,
+                           const std::string &entryName) {
     std::string fileField;
     if (!ResolveEntryFileField(entryJson, fileField))
       return;
 
     const auto importedIt = importedAssetToLibraryPath.find(fileField);
     if (importedIt == importedAssetToLibraryPath.end()) {
-      result.errors.push_back("Entry '" + entryName + "' references unknown bundle asset: " +
-                              fileField);
+      result.errors.push_back(
+          "Entry '" + entryName +
+          "' references unknown bundle asset: " + fileField);
       return;
     }
     RewriteEntryFileField(entryJson, importedIt->second);

--- a/core/gdtfdictionary.cpp
+++ b/core/gdtfdictionary.cpp
@@ -16,22 +16,22 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "gdtfdictionary.h"
-#include "filesystem_path_utils.h"
 #include "configmanager.h"
 #include "dictionary_json_contract.h"
 #include "file_import_utils.h"
+#include "filesystem_path_utils.h"
 #include "json.hpp"
 #include "projectutils.h"
 #include "startup_file_access_gate.h"
-#include <wx/wfstream.h>
-#include <wx/zipstrm.h>
-#include <tinyxml2.h>
 #include <algorithm>
 #include <cctype>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <tinyxml2.h>
 #include <vector>
+#include <wx/wfstream.h>
+#include <wx/zipstrm.h>
 
 namespace fs = std::filesystem;
 
@@ -42,7 +42,6 @@ namespace {
 LoadStatus g_lastLoadStatus;
 size_t g_saveCallCountForTesting = 0;
 fs::path GetUserDictFile();
-
 
 constexpr const char *kFixturesDictionaryPathConfigKey =
     "fixtures_dictionary_active_path";
@@ -73,19 +72,22 @@ fs::path ResolveConfiguredDictionaryPath(const fs::path &defaultPath,
     configuredPath = defaultPath.parent_path() / configuredPath;
   }
 
-  if (configuredPath.has_filename() && IsSupportedDictionaryFile(configuredPath)) {
+  if (configuredPath.has_filename() &&
+      IsSupportedDictionaryFile(configuredPath)) {
     std::error_code ec;
     fs::create_directories(configuredPath.parent_path(), ec);
     if (!ec)
       return configuredPath;
     if (warningOut)
-      *warningOut = "Could not create dictionary directory for configured path: " +
+      *warningOut =
+          "Could not create dictionary directory for configured path: " +
                     configuredPath.parent_path().string();
     return defaultPath;
   }
 
   if (warningOut)
-    *warningOut = "Configured fixtures dictionary path is invalid. Expected a .json file path.";
+    *warningOut = "Configured fixtures dictionary path is invalid. Expected a "
+                  ".json file path.";
   return defaultPath;
 }
 
@@ -103,7 +105,6 @@ fs::path GetConfiguredUserDictFile(std::string *warningOut = nullptr) {
     return defaultPath;
   return ResolveConfiguredDictionaryPath(defaultPath, *configured, warningOut);
 }
-
 
 bool PathsMatchForDictionaryEntries(const std::string &lhs,
                                     const std::string &rhs) {
@@ -130,21 +131,22 @@ bool PathsShareFileName(const std::string &lhs, const std::string &rhs) {
 }
 
 std::string NormalizeAsciiKey(std::string value) {
-  std::transform(value.begin(), value.end(), value.begin(),
+  std::transform(
+      value.begin(), value.end(), value.begin(),
                  [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
   value.erase(std::remove_if(value.begin(), value.end(),
                              [](unsigned char ch) {
-                               return std::isspace(ch) != 0 || ch == '_' || ch == '-';
+                               return std::isspace(ch) != 0 || ch == '_' ||
+                                      ch == '-';
                              }),
               value.end());
   return value;
 }
 
 std::optional<std::string> NormalizeHexColor(std::string raw) {
-  raw.erase(std::remove_if(raw.begin(), raw.end(),
-                           [](unsigned char ch) {
-                             return std::isspace(ch) != 0;
-                           }),
+  raw.erase(
+      std::remove_if(raw.begin(), raw.end(),
+                     [](unsigned char ch) { return std::isspace(ch) != 0; }),
             raw.end());
   if (raw.empty())
     return std::string();
@@ -160,8 +162,9 @@ std::optional<std::string> NormalizeHexColor(std::string raw) {
   return "#" + raw;
 }
 
-std::optional<std::string> GetObjectStringByNormalizedKey(
-    const nlohmann::json &value, const std::string &key) {
+std::optional<std::string>
+GetObjectStringByNormalizedKey(const nlohmann::json &value,
+                               const std::string &key) {
   if (!value.is_object())
     return std::nullopt;
   const std::string normalizedTarget = NormalizeAsciiKey(key);
@@ -184,7 +187,8 @@ bool ModesMatchForDictionaryEntries(const std::string &lhs,
   return NormalizeModeKey(lhs) == NormalizeModeKey(rhs);
 }
 
-bool EntriesShareFixtureFamily(const Entry &entry, const std::string &referencePath,
+bool EntriesShareFixtureFamily(const Entry &entry,
+                               const std::string &referencePath,
                                const std::string &referenceMode) {
   const bool samePath =
       PathsMatchForDictionaryEntries(entry.path, referencePath);
@@ -194,7 +198,8 @@ bool EntriesShareFixtureFamily(const Entry &entry, const std::string &referenceP
   return ModesMatchForDictionaryEntries(entry.mode, referenceMode);
 }
 
-void HarmonizeColorsByFixtureFamily(std::unordered_map<std::string, Entry> &dict) {
+void HarmonizeColorsByFixtureFamily(
+    std::unordered_map<std::string, Entry> &dict) {
   std::vector<std::string> keys;
   keys.reserve(dict.size());
   for (const auto &[key, _] : dict)
@@ -206,14 +211,15 @@ void HarmonizeColorsByFixtureFamily(std::unordered_map<std::string, Entry> &dict
     if (sourceIt == dict.end())
       continue;
     const Entry &source = sourceIt->second;
-    if (source.path.empty() || source.mode.empty() || source.color.empty())
+    if (source.path.empty() || source.mode.empty() ||
+        source.visualColorHex.empty())
       continue;
     for (auto &[targetKey, target] : dict) {
       if (targetKey == sourceKey)
         continue;
       if (!EntriesShareFixtureFamily(target, source.path, source.mode))
         continue;
-      target.color = source.color;
+      target.visualColorHex = source.visualColorHex;
     }
   }
 }
@@ -225,7 +231,8 @@ bool IsDummy1ChFallbackType(const std::string &type) {
 bool IsDummy1ChFallbackPath(const std::string &gdtfPath) {
   if (gdtfPath.empty())
     return false;
-  const std::string fileName = PathUtils::PathFromUtf8(gdtfPath).filename().string();
+  const std::string fileName =
+      PathUtils::PathFromUtf8(gdtfPath).filename().string();
   return NormalizeAsciiKey(fileName) == "dummy1ch.gdtf";
 }
 
@@ -240,7 +247,8 @@ std::string NormalizeTypeKey(const std::string &type) {
   return normalized;
 }
 
-// Returns true when the filename optional-comment segment marks a Perastage-authored GDTF.
+// Returns true when the filename optional-comment segment marks a
+// Perastage-authored GDTF.
 bool IsPerastageNamedGdtfFile(const std::filesystem::path &path) {
   const std::string stem = path.stem().string();
   const size_t firstAt = stem.find('@');
@@ -254,7 +262,8 @@ bool IsPerastageNamedGdtfFile(const std::filesystem::path &path) {
   return normalized == "perastage";
 }
 
-// Loads manufacturer and fixture type from a GDTF description.xml payload when available.
+// Loads manufacturer and fixture type from a GDTF description.xml payload when
+// available.
 bool TryReadGdtfIdentityFromDescription(const std::filesystem::path &sourcePath,
                                         std::string &manufacturerOut,
                                         std::string &fixtureTypeOut) {
@@ -284,12 +293,14 @@ bool TryReadGdtfIdentityFromDescription(const std::filesystem::path &sourcePath,
     return false;
 
   tinyxml2::XMLDocument doc;
-  if (doc.Parse(descriptionXml.c_str(), descriptionXml.size()) != tinyxml2::XML_SUCCESS)
+  if (doc.Parse(descriptionXml.c_str(), descriptionXml.size()) !=
+      tinyxml2::XML_SUCCESS)
     return false;
 
   tinyxml2::XMLElement *root = doc.FirstChildElement("GDTF");
   tinyxml2::XMLElement *fixtureType =
-      root ? root->FirstChildElement("FixtureType") : doc.FirstChildElement("FixtureType");
+      root ? root->FirstChildElement("FixtureType")
+           : doc.FirstChildElement("FixtureType");
   if (!fixtureType)
     return false;
 
@@ -300,11 +311,14 @@ bool TryReadGdtfIdentityFromDescription(const std::filesystem::path &sourcePath,
   return !manufacturerOut.empty() || !fixtureTypeOut.empty();
 }
 
-// Builds a canonical Perastage export filename using parsed GDTF identity values.
-std::string BuildPerastageCanonicalGdtfFileName(const std::filesystem::path &sourcePath) {
+// Builds a canonical Perastage export filename using parsed GDTF identity
+// values.
+std::string
+BuildPerastageCanonicalGdtfFileName(const std::filesystem::path &sourcePath) {
   std::string manufacturerName;
   std::string fixtureTypeName;
-  TryReadGdtfIdentityFromDescription(sourcePath, manufacturerName, fixtureTypeName);
+  TryReadGdtfIdentityFromDescription(sourcePath, manufacturerName,
+                                     fixtureTypeName);
 
   if (manufacturerName.empty())
     manufacturerName = "Unknow";
@@ -338,9 +352,10 @@ FindEquivalentTypeKey(const std::unordered_map<std::string, Entry> &dict,
   return std::nullopt;
 }
 
-bool ApplyCategoryUpdateForFile(
-    std::unordered_map<std::string, Entry> &dict, const std::string &type,
-    const std::string &gdtfPath, const std::string &category) {
+bool ApplyCategoryUpdateForFile(std::unordered_map<std::string, Entry> &dict,
+                                const std::string &type,
+                                const std::string &gdtfPath,
+                                const std::string &category) {
   const std::string normalizedType = NormalizeTypeKey(type);
   if (normalizedType.empty())
     return false;
@@ -363,7 +378,8 @@ bool ApplyCategoryUpdateForFile(
   for (auto &[entryType, entry] : dict) {
     if (entryType == keyToUse)
       continue;
-    const bool samePath = PathsMatchForDictionaryEntries(entry.path, sharedPath);
+    const bool samePath =
+        PathsMatchForDictionaryEntries(entry.path, sharedPath);
     const bool sameFileName = PathsShareFileName(entry.path, sharedPath);
     if (!samePath && !sameFileName)
       continue;
@@ -373,7 +389,8 @@ bool ApplyCategoryUpdateForFile(
 }
 
 fs::path GetUserDictFile() {
-  fs::path dir = PathUtils::PathFromUtf8(ProjectUtils::GetWritableLibraryPath("fixtures"));
+  fs::path dir =
+      PathUtils::PathFromUtf8(ProjectUtils::GetWritableLibraryPath("fixtures"));
   if (dir.empty())
     return {};
   std::error_code ec;
@@ -410,7 +427,8 @@ bool WriteDictionaryBackup(const fs::path &sourceFile) {
   fs::path backupFile = sourceFile;
   backupFile += ".bak";
   std::error_code ec;
-  fs::copy_file(sourceFile, backupFile, fs::copy_options::overwrite_existing, ec);
+  fs::copy_file(sourceFile, backupFile, fs::copy_options::overwrite_existing,
+                ec);
   return !ec;
 }
 
@@ -525,13 +543,16 @@ LoadFromFile(const fs::path &file, std::string &error) {
     if (const auto categoryText =
             GetObjectStringByNormalizedKey(value, "category"))
       entry.category = *categoryText;
-    if (const auto colorText = GetObjectStringByNormalizedKey(value, "color")) {
+    auto colorText = GetObjectStringByNormalizedKey(value, "visual_color");
+    if (!colorText)
+      colorText = GetObjectStringByNormalizedKey(value, "color");
+    if (colorText) {
       const auto normalizedColor = NormalizeHexColor(*colorText);
       if (!normalizedColor.has_value()) {
-        entryError = "color must be #RRGGBB when provided";
+        entryError = "visual_color must be #RRGGBB when provided";
         return false;
       }
-      entry.color = *normalizedColor;
+      entry.visualColorHex = *normalizedColor;
     }
     if (const auto importedAtText =
             GetObjectStringByNormalizedKey(value, "imported_at"))
@@ -539,9 +560,9 @@ LoadFromFile(const fs::path &file, std::string &error) {
     if (const auto shaText = GetObjectStringByNormalizedKey(value, "sha256"))
       entry.sha256 = *shaText;
     if (entry.path.empty() && entry.mode.empty() && entry.category.empty() &&
-        entry.color.empty()) {
-      entryError =
-          "entry object must include at least one of file/path/mode/category/color";
+        entry.visualColorHex.empty()) {
+      entryError = "entry object must include at least one of "
+                   "file/path/mode/category/visual_color";
       return false;
     }
     return true;
@@ -586,8 +607,8 @@ LoadFromFile(const fs::path &file, std::string &error) {
   return dict;
 }
 
-DictionaryImportSummary MergeDictionaryEntries(
-    std::unordered_map<std::string, Entry> &current,
+DictionaryImportSummary
+MergeDictionaryEntries(std::unordered_map<std::string, Entry> &current,
     const std::unordered_map<std::string, Entry> &imported,
     DictionaryImportPolicy policy, bool applyChanges) {
   DictionaryImportSummary summary;
@@ -640,7 +661,6 @@ DictionaryImportSummary MergeDictionaryEntries(
 
 } // namespace
 
-
 std::string GetActiveDictionaryFilePath() {
   std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
   return GetConfiguredUserDictFile().string();
@@ -654,7 +674,8 @@ std::string GetActiveDictionaryFileName() {
   return path.filename().string();
 }
 
-bool SetActiveDictionaryFilePath(const std::string &path, std::string *errorOut) {
+bool SetActiveDictionaryFilePath(const std::string &path,
+                                 std::string *errorOut) {
   if (errorOut)
     errorOut->clear();
   std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
@@ -669,13 +690,15 @@ bool SetActiveDictionaryFilePath(const std::string &path, std::string *errorOut)
   std::string warning;
   const fs::path resolvedPath =
       ResolveConfiguredDictionaryPath(defaultPath, path, &warning);
-  if (!warning.empty() && TrimAsciiWhitespace(path) != TrimAsciiWhitespace(defaultPath.string())) {
+  if (!warning.empty() &&
+      TrimAsciiWhitespace(path) != TrimAsciiWhitespace(defaultPath.string())) {
     if (errorOut)
       *errorOut = warning;
     return false;
   }
 
-  const auto previousValue = ConfigManager::Get().GetValue(kFixturesDictionaryPathConfigKey);
+  const auto previousValue =
+      ConfigManager::Get().GetValue(kFixturesDictionaryPathConfigKey);
 
   const std::string trimmedInput = TrimAsciiWhitespace(path);
   if (trimmedInput.empty() || resolvedPath == defaultPath) {
@@ -687,7 +710,8 @@ bool SetActiveDictionaryFilePath(const std::string &path, std::string *errorOut)
 
   if (!ConfigManager::Get().SaveUserConfig()) {
     if (previousValue)
-      ConfigManager::Get().SetValue(kFixturesDictionaryPathConfigKey, *previousValue);
+      ConfigManager::Get().SetValue(kFixturesDictionaryPathConfigKey,
+                                    *previousValue);
     else
       ConfigManager::Get().RemoveKey(kFixturesDictionaryPathConfigKey);
     if (errorOut)
@@ -700,7 +724,8 @@ bool SetActiveDictionaryFilePath(const std::string &path, std::string *errorOut)
       std::string createError;
       if (!Save({}, &createError)) {
         if (previousValue)
-          ConfigManager::Get().SetValue(kFixturesDictionaryPathConfigKey, *previousValue);
+          ConfigManager::Get().SetValue(kFixturesDictionaryPathConfigKey,
+                                        *previousValue);
         else
           ConfigManager::Get().RemoveKey(kFixturesDictionaryPathConfigKey);
         ConfigManager::Get().SaveUserConfig();
@@ -715,7 +740,8 @@ bool SetActiveDictionaryFilePath(const std::string &path, std::string *errorOut)
   std::string loadError;
   if (!LoadFromFile(resolvedPath, loadError)) {
     if (previousValue)
-      ConfigManager::Get().SetValue(kFixturesDictionaryPathConfigKey, *previousValue);
+      ConfigManager::Get().SetValue(kFixturesDictionaryPathConfigKey,
+                                    *previousValue);
     else
       ConfigManager::Get().RemoveKey(kFixturesDictionaryPathConfigKey);
     ConfigManager::Get().SaveUserConfig();
@@ -723,7 +749,6 @@ bool SetActiveDictionaryFilePath(const std::string &path, std::string *errorOut)
       *errorOut = "Could not load selected fixtures dictionary: " + loadError;
     return false;
   }
-
 
   return true;
 }
@@ -740,7 +765,8 @@ std::optional<std::unordered_map<std::string, Entry>> Load() {
     bool mergedSeedEntries = false;
     std::string baseError;
     if (auto baseDict = LoadFromFile(baseFile, baseError)) {
-      MergeSeedEntriesIntoUserDictionary(*userDict, *baseDict, &mergedSeedEntries);
+      MergeSeedEntriesIntoUserDictionary(*userDict, *baseDict,
+                                         &mergedSeedEntries);
       if (mergedSeedEntries) {
         WriteDictionaryBackup(userFile);
         Save(*userDict);
@@ -760,9 +786,9 @@ std::optional<std::unordered_map<std::string, Entry>> Load() {
     return baseDict;
   }
 
-  g_lastLoadStatus.error =
-      "Failed to load user fixtures dictionary ('" + userFile.string() +
-      "'): " + userError + ". Failed to load base fixtures dictionary ('" +
+  g_lastLoadStatus.error = "Failed to load user fixtures dictionary ('" +
+                           userFile.string() + "'): " + userError +
+                           ". Failed to load base fixtures dictionary ('" +
       baseFile.string() + "'): " + baseError;
   std::cerr << "Error: " << g_lastLoadStatus.error << std::endl;
   return std::nullopt;
@@ -793,7 +819,7 @@ bool Save(const std::unordered_map<std::string, Entry> &dict,
   for (const auto &type : keys) {
     const auto &entry = dict.at(type);
     if (entry.path.empty() && entry.mode.empty() && entry.category.empty() &&
-        entry.color.empty())
+        entry.visualColorHex.empty())
       continue;
     nlohmann::json obj;
     if (!entry.path.empty()) {
@@ -806,8 +832,8 @@ bool Save(const std::unordered_map<std::string, Entry> &dict,
       obj["mode"] = entry.mode;
     if (!entry.category.empty())
       obj["category"] = entry.category;
-    if (!entry.color.empty())
-      obj["color"] = entry.color;
+    if (!entry.visualColorHex.empty())
+      obj["visual_color"] = entry.visualColorHex;
     if (!entry.importedAt.empty())
       obj["imported_at"] = entry.importedAt;
     if (!entry.sha256.empty())
@@ -817,7 +843,8 @@ bool Save(const std::unordered_map<std::string, Entry> &dict,
     entries[type] = obj;
   }
 
-  const nlohmann::json root = DictionaryJsonContract::MakeRoot("fixtures", std::move(entries));
+  const nlohmann::json root =
+      DictionaryJsonContract::MakeRoot("fixtures", std::move(entries));
   std::ofstream out(file);
   if (!out.is_open()) {
     if (errorOut)
@@ -828,15 +855,15 @@ bool Save(const std::unordered_map<std::string, Entry> &dict,
   out << root.dump(4);
   if (!out.good()) {
     if (errorOut)
-      *errorOut = "Failed while writing user fixtures dictionary: " +
-                  file.string();
+      *errorOut =
+          "Failed while writing user fixtures dictionary: " + file.string();
     return false;
   }
   out.flush();
   if (!out.good()) {
     if (errorOut)
-      *errorOut = "Failed to flush user fixtures dictionary to disk: " +
-                  file.string();
+      *errorOut =
+          "Failed to flush user fixtures dictionary to disk: " + file.string();
     return false;
   }
   ++g_saveCallCountForTesting;
@@ -844,8 +871,8 @@ bool Save(const std::unordered_map<std::string, Entry> &dict,
 }
 
 // Looks up a fixture type in a preloaded dictionary snapshot.
-std::optional<Entry> FindInLoadedDictionary(
-    const std::unordered_map<std::string, Entry> &dict,
+std::optional<Entry>
+FindInLoadedDictionary(const std::unordered_map<std::string, Entry> &dict,
     const std::string &type, bool validateExistingPath) {
   const std::string normalizedType = NormalizeTypeKey(type);
   if (normalizedType.empty())
@@ -856,7 +883,8 @@ std::optional<Entry> FindInLoadedDictionary(
   auto it = dict.find(*keyOpt);
   if (it == dict.end())
     return std::nullopt;
-  if (validateExistingPath && !it->second.path.empty() && !fs::exists(it->second.path))
+  if (validateExistingPath && !it->second.path.empty() &&
+      !fs::exists(it->second.path))
     return std::nullopt;
   return it->second;
 }
@@ -882,8 +910,9 @@ std::optional<Entry> Get(const std::string &type) {
   return it->second;
 }
 
-std::optional<std::string> GetDefaultColorForFixture(
-    const std::string &type, const std::string &gdtfPath,
+std::optional<std::string>
+GetDefaultVisualColorForFixture(const std::string &type,
+                                const std::string &gdtfPath,
     const std::string &mode) {
   std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
   auto dictOpt = Load();
@@ -895,20 +924,20 @@ std::optional<std::string> GetDefaultColorForFixture(
   if (!normalizedType.empty()) {
     if (auto keyOpt = FindEquivalentTypeKey(dict, normalizedType)) {
       auto byType = dict.find(*keyOpt);
-      if (byType != dict.end() && !byType->second.color.empty())
-        return byType->second.color;
+      if (byType != dict.end() && !byType->second.visualColorHex.empty())
+        return byType->second.visualColorHex;
     }
   }
 
   std::optional<std::string> matchedColor;
   std::string matchedKey;
   for (const auto &[entryType, entry] : dict) {
-    if (entry.color.empty())
+    if (entry.visualColorHex.empty())
       continue;
     if (!EntriesShareFixtureFamily(entry, gdtfPath, mode))
       continue;
     if (!matchedColor || entryType < matchedKey) {
-      matchedColor = entry.color;
+      matchedColor = entry.visualColorHex;
       matchedKey = entryType;
     }
   }
@@ -935,13 +964,14 @@ void UpdateDictionaryEntry(const std::string &type, const Entry &entry) {
 
 // Creates or refreshes a stable @Perastage derivative for a library-owned GDTF.
 std::optional<Entry> CreateOrUpdatePerastageLibraryDerivative(
-    const std::string &type, const std::string &gdtfPath, const std::string &mode,
-    const std::string &category) {
+    const std::string &type, const std::string &gdtfPath,
+    const std::string &mode, const std::string &category) {
   std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
   const std::string normalizedType = NormalizeTypeKey(type);
   if (normalizedType.empty() || gdtfPath.empty())
     return std::nullopt;
-  if (IsDummy1ChFallbackType(normalizedType) || IsDummy1ChFallbackPath(gdtfPath))
+  if (IsDummy1ChFallbackType(normalizedType) ||
+      IsDummy1ChFallbackPath(gdtfPath))
     return std::nullopt;
 
   const fs::path src = PathUtils::PathFromUtf8(gdtfPath);
@@ -951,7 +981,8 @@ std::optional<Entry> CreateOrUpdatePerastageLibraryDerivative(
   if (file.empty())
     return std::nullopt;
 
-  const fs::path dest = IsPerastageNamedGdtfFile(src)
+  const fs::path dest =
+      IsPerastageNamedGdtfFile(src)
                             ? file.parent_path() / src.filename()
                             : file.parent_path() / BuildPerastageCanonicalGdtfFileName(src);
   const auto copyResult = FileImportUtils::CopyWithConflictPolicy(
@@ -973,11 +1004,13 @@ std::optional<Entry> CreateOrUpdatePerastageLibraryDerivative(
   return e;
 }
 
-// Registers an explicit user-library fixture import using deterministic @Perastage derivative rules.
-void Update(const std::string &type, const std::string &gdtfPath, const std::string &mode, const std::string &category) {
-  (void)CreateOrUpdatePerastageLibraryDerivative(type, gdtfPath, mode, category);
+// Registers an explicit user-library fixture import using deterministic
+// @Perastage derivative rules.
+void Update(const std::string &type, const std::string &gdtfPath,
+            const std::string &mode, const std::string &category) {
+  (void)CreateOrUpdatePerastageLibraryDerivative(type, gdtfPath, mode,
+                                                 category);
 }
-
 
 void UpdateCategory(const std::string &type, const std::string &category) {
   UpdateCategoryForFile(type, {}, category);
@@ -1015,12 +1048,14 @@ void UpdateCategoriesBulk(
   Save(dict);
 }
 
-void UpdateColor(const std::string &type, const std::string &color) {
-  UpdateColorForFile(type, {}, {}, color);
+void UpdateVisualColor(const std::string &type, const std::string &color) {
+  UpdateVisualColorForFile(type, {}, {}, color);
 }
 
-void UpdateColorForFile(const std::string &type, const std::string &gdtfPath,
-                        const std::string &mode, const std::string &color) {
+void UpdateVisualColorForFile(const std::string &type,
+                              const std::string &gdtfPath,
+                              const std::string &mode,
+                              const std::string &color) {
   std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
   const std::string normalizedType = NormalizeTypeKey(type);
   if (normalizedType.empty())
@@ -1041,7 +1076,7 @@ void UpdateColorForFile(const std::string &type, const std::string &gdtfPath,
       e.path = gdtfPath;
     if (!mode.empty())
       e.mode = mode;
-    e.color = color;
+    e.visualColorHex = color;
     dict[keyToUse] = e;
   } else {
     if (sharedPath.empty())
@@ -1052,7 +1087,7 @@ void UpdateColorForFile(const std::string &type, const std::string &gdtfPath,
       it->second.path = gdtfPath;
     if (!mode.empty())
       it->second.mode = mode;
-    it->second.color = color;
+    it->second.visualColorHex = color;
   }
 
   if (sharedMode.empty()) {
@@ -1071,7 +1106,7 @@ void UpdateColorForFile(const std::string &type, const std::string &gdtfPath,
       continue;
     if (!EntriesShareFixtureFamily(entry, sharedPath, sharedMode))
       continue;
-    entry.color = color;
+    entry.visualColorHex = color;
   }
   Save(dict);
 }

--- a/core/gdtfdictionary.h
+++ b/core/gdtfdictionary.h
@@ -20,8 +20,8 @@
 #include "dictionary_import.h"
 
 #include <cstddef>
-#include <string>
 #include <optional>
+#include <string>
 #include <unordered_map>
 
 namespace GdtfDictionary {
@@ -34,7 +34,7 @@ namespace GdtfDictionary {
         std::string path; // optional absolute path inside fixtures library
         std::string mode;
         std::string category;
-        std::string color;
+        std::string visualColorHex;
         std::string importedAt; // optional UTC ISO-8601 timestamp
         std::string sha256; // optional file hash for diagnostics
     };
@@ -62,7 +62,7 @@ namespace GdtfDictionary {
     // Lookup priority:
     // 1) Explicit fixture type entry.
     // 2) Any entry sharing the same GDTF file + mode fixture family.
-    std::optional<std::string> GetDefaultColorForFixture(
+    std::optional<std::string> GetDefaultVisualColorForFixture(
         const std::string& type, const std::string& gdtfPath,
         const std::string& mode);
     // Copies a user-selected GDTF into the fixtures library and updates the dictionary.
@@ -78,8 +78,8 @@ namespace GdtfDictionary {
                                const std::string& category);
     void UpdateCategoriesBulk(
         const std::unordered_map<std::string, std::string>& categoriesByType);
-    void UpdateColor(const std::string& type, const std::string& color);
-    void UpdateColorForFile(const std::string& type, const std::string& gdtfPath,
+    void UpdateVisualColor(const std::string& type, const std::string& color);
+    void UpdateVisualColorForFile(const std::string& type, const std::string& gdtfPath,
                             const std::string& mode,
                             const std::string& color);
     DictionaryImportSummary PreviewImportFromFile(

--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -1939,7 +1939,7 @@ bool RiderImporter::ImportText(const std::string &text,
       Layer l;
       l.uuid = name == DEFAULT_LAYER_NAME ? "layer_default" : GenerateUuid();
       l.name = name;
-      l.visualColorHex = layerColor;
+      l.color = layerColor;
       auto [insertedIt, inserted] = scene.layers.emplace(l.uuid, std::move(l));
       layerPtr = &insertedIt->second;
       layerLookup.emplace(layerPtr->name, layerPtr);

--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -20,8 +20,8 @@
 
 #include <algorithm>
 #include <array>
-#include <cerrno>
 #include <cctype>
+#include <cerrno>
 #include <charconv>
 #include <chrono>
 #include <cmath>
@@ -47,8 +47,8 @@
 #include "autopatcher.h"
 #include "configmanager.h"
 #include "fixture.h"
-#include "gdtfdictionary.h"
 #include "gdtf_fixture_category.h"
+#include "gdtfdictionary.h"
 #include "gdtfloader.h"
 #include "hoist_weight_distribution.h"
 #include "layer.h"
@@ -66,9 +66,9 @@ namespace {
 constexpr const char *kPrimitiveCylinderToken = "primitive:cylinder";
 constexpr const char *kPrimitiveCubeToken = "primitive:cube";
 
-
 struct RiderImportTimingStats {
-  std::chrono::steady_clock::time_point startedAt = std::chrono::steady_clock::now();
+  std::chrono::steady_clock::time_point startedAt =
+      std::chrono::steady_clock::now();
   std::unordered_map<std::string, double> phaseMs;
   size_t fixtureCount = 0;
   size_t trussCount = 0;
@@ -81,13 +81,15 @@ void AddRiderImportPhaseTime(RiderImportTimingStats &timing,
                              const std::string &phaseName,
                              std::chrono::steady_clock::time_point startedAt) {
   timing.phaseMs[phaseName] += std::chrono::duration<double, std::milli>(
-      std::chrono::steady_clock::now() - startedAt).count();
+                                   std::chrono::steady_clock::now() - startedAt)
+                                   .count();
 }
 
 // Logs one concise timing line for the completed rider import.
 void LogRiderImportTiming(const RiderImportTimingStats &timing) {
   const auto totalMs = std::chrono::duration<double, std::milli>(
-      std::chrono::steady_clock::now() - timing.startedAt).count();
+                           std::chrono::steady_clock::now() - timing.startedAt)
+                           .count();
   auto phase = [&](const std::string &name) {
     const auto it = timing.phaseMs.find(name);
     return it == timing.phaseMs.end() ? 0.0 : it->second;
@@ -137,24 +139,29 @@ Matrix BuildPipeObjectTransform(float pipeLengthMm, float pipeDiameterMm,
 // Precompiled regexes used by RiderImporter. Keeping them static avoids paying
 // the compilation cost on every import call and makes keyword matching cheap
 // even when processing large riders.
-static const std::regex kTrussLineRe(
-    "^\\s*(?:[-*]\\s*)?(\\d+)\\s+(?:truss|pipe|pipes|vara|varas)\\s+([^\\n]*?)\\s+(\\d+(?:\\.\\d+)?)\\s*(?:m|metros?|meters?)\\b(?:\\s+(?:(?:para|for)\\s+)?(.+))?\\s*$",
+static const std::regex
+    kTrussLineRe("^\\s*(?:[-*]\\s*)?(\\d+)\\s+(?:truss|pipe|pipes|vara|varas)"
+                 "\\s+([^\\n]*?)\\s+(\\d+(?:\\.\\d+)?)\\s*(?:m|metros?|meters?)"
+                 "\\b(?:\\s+(?:(?:para|for)\\s+)?(.+))?\\s*$",
     std::regex::icase);
 static const std::regex kTrussLineNoLengthRe(
-    "^\\s*(?:[-*]\\s*)?(\\d+)\\s+(?:truss|pipe|pipes|vara|varas)\\s+([^\\n]*?)(?:\\s+(?:para|for)\\s+(.+))?\\s*$",
+    "^\\s*(?:[-*]\\s*)?(\\d+)\\s+(?:truss|pipe|pipes|vara|varas)\\s+([^\\n]*?)("
+    "?:\\s+(?:para|for)\\s+(.+))?\\s*$",
     std::regex::icase);
-static const std::regex kTrussRe(
-    "(?:truss|pipe|pipes|vara|varas)[^\\n]*?(\\d+(?:\\.\\d+)?)\\s*(?:m|metros?|meters?)\\b",
+static const std::regex kTrussRe("(?:truss|pipe|pipes|vara|varas)[^\\n]*?(\\d+("
+                                 "?:\\.\\d+)?)\\s*(?:m|metros?|meters?)\\b",
     std::regex::icase);
 static const std::regex kPipeKeywordRe("\\b(?:pipe|pipes|vara|varas)\\b",
                                        std::regex::icase);
-static const std::regex kLengthWithUnitRe(
-    "(\\d+(?:\\.\\d+)?)\\s*(?:m|metros?|meters?)\\b", std::regex::icase);
+static const std::regex
+    kLengthWithUnitRe("(\\d+(?:\\.\\d+)?)\\s*(?:m|metros?|meters?)\\b",
+                      std::regex::icase);
 static const std::regex kHoistLineRe(
     "^\\s*(?:[-*]\\s*)?(\\d+)\\s+(?:motor(?:es)?|hoist(?:s)?)\\b(.*)$",
     std::regex::icase);
-static const std::regex kHoistCapacityRe(
-    "(\\d+(?:[\\.,]\\d+)?)\\s*(kg|kgs?|kilogramos?|kilos?|t|to|tn|ton|tons?|toneladas?)\\b",
+static const std::regex
+    kHoistCapacityRe("(\\d+(?:[\\.,]\\d+)?)\\s*(kg|kgs?|kilogramos?|kilos?|t|"
+                     "to|tn|ton|tons?|toneladas?)\\b",
     std::regex::icase);
 static const std::regex kHoistTargetRe("\\b(?:para|for)\\s+(.+)$",
                                        std::regex::icase);
@@ -162,19 +169,32 @@ static const std::regex kFixtureLineRe("^\\s*(?:[-*]\\s*)?(\\d+)\\s+(.+)$",
                                        std::regex::icase);
 static const std::regex kQuantityOnlyRe("^\\s*(?:[-*]\\s*)?(\\d+)\\s*$");
 static const std::regex kHangLineRe(
-    "^\\s*(LX\\d+|lx\\s*sides?|screen|pantalla|proyecci[oó]n|led\\s*screen|backdrops?|tel[oó]n(?:es)?|puente\\s+de\\s+tel[oó]n(?:es)?|floor|efectos?|calle(?:s)?\\s+a\\s+suelo|ground\\s+lanes?|calle(?:s)?|side(?:s)?)(?:\\s*(?:\\([^\\)]*\\)|\\[[^\\]]*\\]))*\\s*:?\\s*$",
+    "^\\s*(LX\\d+|lx\\s*sides?|screen|pantalla|proyecci[oó]n|led\\s*screen|"
+    "backdrops?|tel[oó]n(?:es)?|puente\\s+de\\s+tel[oó]n(?:es)?|floor|efectos?|"
+    "calle(?:s)?\\s+a\\s+suelo|ground\\s+lanes?|calle(?:s)?|side(?:s)?)(?:\\s*("
+    "?:\\([^\\)]*\\)|\\[[^\\]]*\\]))*\\s*:?\\s*$",
     std::regex::icase);
 static const std::regex kHangHeaderWithSuffixRe(
-    "^\\s*(LX\\d+|lx\\s*sides?|screen|pantalla|proyecci[oó]n|led\\s*screen|backdrops?|tel[oó]n(?:es)?|puente\\s+de\\s+tel[oó]n(?:es)?|floor|efectos?|calle(?:s)?\\s+a\\s+suelo|ground\\s+lanes?|calle(?:s)?|side(?:s)?)(?:\\s+[^:]*)?\\s*:\\s*$",
+    "^\\s*(LX\\d+|lx\\s*sides?|screen|pantalla|proyecci[oó]n|led\\s*screen|"
+    "backdrops?|tel[oó]n(?:es)?|puente\\s+de\\s+tel[oó]n(?:es)?|floor|efectos?|"
+    "calle(?:s)?\\s+a\\s+suelo|ground\\s+lanes?|calle(?:s)?|side(?:s)?)(?:\\s+["
+    "^:]*)?\\s*:\\s*$",
     std::regex::icase);
 static const std::regex kHangFindRe(
-    "(LX\\d+|lx\\s*sides?|screen|pantalla|proyecci[oó]n|led\\s*screen|backdrops?|tel[oó]n(?:es)?|puente\\s+de\\s+tel[oó]n(?:es)?|floor|efectos?|calle(?:s)?\\s+a\\s+suelo|ground\\s+lanes?|calle(?:s)?|side(?:s)?)",
+    "(LX\\d+|lx\\s*sides?|screen|pantalla|proyecci[oó]n|led\\s*screen|"
+    "backdrops?|tel[oó]n(?:es)?|puente\\s+de\\s+tel[oó]n(?:es)?|floor|efectos?|"
+    "calle(?:s)?\\s+a\\s+suelo|ground\\s+lanes?|calle(?:s)?|side(?:s)?)",
                                     std::regex::icase);
 static const std::regex kHangOnlyRe(
-    "^\\s*(LX\\d+|lx\\s*sides?|screen|pantalla|proyecci[oó]n|led\\s*screen|backdrops?|tel[oó]n(?:es)?|puente\\s+de\\s+tel[oó]n(?:es)?|floor|efectos?|calle(?:s)?\\s+a\\s+suelo|ground\\s+lanes?|calle(?:s)?|side(?:s)?)\\s*$",
+    "^\\s*(LX\\d+|lx\\s*sides?|screen|pantalla|proyecci[oó]n|led\\s*screen|"
+    "backdrops?|tel[oó]n(?:es)?|puente\\s+de\\s+tel[oó]n(?:es)?|floor|efectos?|"
+    "calle(?:s)?\\s+a\\s+suelo|ground\\s+lanes?|calle(?:s)?|side(?:s)?)\\s*$",
                                     std::regex::icase);
 static const std::regex kTrailingHangWithCoordinateRe(
-    "(LX\\d+|lx\\s*sides?|screen|pantalla|proyecci[oó]n|led\\s*screen|backdrops?|tel[oó]n(?:es)?|puente\\s+de\\s+tel[oó]n(?:es)?|floor|efectos?|calle(?:s)?\\s+a\\s+suelo|ground\\s+lanes?|calle(?:s)?|side(?:s)?)(?:\\s*((?:\\([^\\)]*\\)|\\[[^\\]]*\\])))?\\s*$",
+    "(LX\\d+|lx\\s*sides?|screen|pantalla|proyecci[oó]n|led\\s*screen|"
+    "backdrops?|tel[oó]n(?:es)?|puente\\s+de\\s+tel[oó]n(?:es)?|floor|efectos?|"
+    "calle(?:s)?\\s+a\\s+suelo|ground\\s+lanes?|calle(?:s)?|side(?:s)?)(?:\\s*("
+    "(?:\\([^\\)]*\\)|\\[[^\\]]*\\])))?\\s*$",
     std::regex::icase);
 static const std::regex kParenthesizedCleanupRe("\\([^\\)]*\\)");
 static const std::regex kBracketedCleanupRe("\\[[^\\]]*\\]");
@@ -193,8 +213,8 @@ std::string StripRiderAnnotations(const std::string &line) {
     return {};
 
   std::string stripped = line;
-  stripped = std::regex_replace(stripped, std::regex("\\*\\([^\\)]*\\)\\*"),
-                                " ");
+  stripped =
+      std::regex_replace(stripped, std::regex("\\*\\([^\\)]*\\)\\*"), " ");
   return Trim(stripped);
 }
 
@@ -255,10 +275,12 @@ std::string ResolveHangTargetFallback(const std::string &raw) {
   return NormalizeHangName(candidate);
 }
 
-bool TryExtractTrailingHangWithCoordinate(std::string &text, std::string &hangOut,
+bool TryExtractTrailingHangWithCoordinate(std::string &text,
+                                          std::string &hangOut,
                                           std::string &coordinateSuffixOut) {
   std::smatch trailingHangMatch;
-  if (!std::regex_search(text, trailingHangMatch, kTrailingHangWithCoordinateRe) ||
+  if (!std::regex_search(text, trailingHangMatch,
+                         kTrailingHangWithCoordinateRe) ||
       trailingHangMatch.size() < 2) {
     return false;
   }
@@ -268,7 +290,8 @@ bool TryExtractTrailingHangWithCoordinate(std::string &text, std::string &hangOu
   if (trailingHangMatch.size() > 2 && trailingHangMatch[2].matched)
     coordinateSuffixOut = Trim(trailingHangMatch[2].str());
 
-  text = Trim(text.substr(0, static_cast<size_t>(trailingHangMatch.position(0))));
+  text =
+      Trim(text.substr(0, static_cast<size_t>(trailingHangMatch.position(0))));
   return !hangOut.empty();
 }
 
@@ -301,7 +324,8 @@ void EnsureFixtureCategoryForImport(const MvrScene &scene, Fixture &fixture) {
   }
 
   auto containsWord = [](std::string value, const std::string &needle) {
-    std::transform(value.begin(), value.end(), value.begin(),
+    std::transform(
+        value.begin(), value.end(), value.begin(),
                    [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
     return value.find(needle) != std::string::npos;
   };
@@ -389,7 +413,8 @@ void EnsureFixtureCategoryForImport(const MvrScene &scene, Fixture &fixture) {
       fixture.categorySourceReason = "name hint gdtf filename";
 
     if (fixture.category.empty() && std::filesystem::exists(gdtfPath)) {
-      const auto inferred = GdtfFixtureCategory::InferFromGdtf(resolvedGdtfPath);
+      const auto inferred =
+          GdtfFixtureCategory::InferFromGdtf(resolvedGdtfPath);
       if (inferred.category != GdtfFixtureCategory::kUnknown) {
         fixture.category = inferred.category;
         fixture.categorySourceReason = inferred.reason;
@@ -426,9 +451,8 @@ bool TryParseFloat(const std::string &text, float &out) {
     return false;
 
   const auto first =
-      std::find_if_not(text.begin(), text.end(), [](unsigned char c) {
-        return std::isspace(c);
-      });
+      std::find_if_not(text.begin(), text.end(),
+                       [](unsigned char c) { return std::isspace(c); });
   if (first == text.end())
     return false;
   const auto last =
@@ -453,9 +477,8 @@ bool TryParseInt(std::string_view text, int &out) {
     return false;
 
   const auto first =
-      std::find_if_not(text.begin(), text.end(), [](unsigned char c) {
-        return std::isspace(c);
-      });
+      std::find_if_not(text.begin(), text.end(),
+                       [](unsigned char c) { return std::isspace(c); });
   if (first == text.end())
     return false;
   const auto last =
@@ -484,8 +507,9 @@ struct TrussCoordinateOverride {
   float zMm = 0.0f;
 };
 
-std::optional<TrussCoordinateOverride> ParseTrussCoordinateOverride(
-    std::string &text, Units::DistanceUnitSystem unitSystem) {
+std::optional<TrussCoordinateOverride>
+ParseTrussCoordinateOverride(std::string &text,
+                             Units::DistanceUnitSystem unitSystem) {
   const size_t open = text.find('(');
   if (open == std::string::npos)
     return std::nullopt;
@@ -498,7 +522,8 @@ std::optional<TrussCoordinateOverride> ParseTrussCoordinateOverride(
   static const std::regex kCoordinateNumberRe("[-+]?\\d+(?:[\\.,]\\d+)?");
   std::vector<double> values;
   values.reserve(3);
-  for (std::sregex_iterator it(inside.begin(), inside.end(), kCoordinateNumberRe),
+  for (std::sregex_iterator
+           it(inside.begin(), inside.end(), kCoordinateNumberRe),
        end;
        it != end && values.size() < 3; ++it) {
     std::string token = it->str();
@@ -506,8 +531,8 @@ std::optional<TrussCoordinateOverride> ParseTrussCoordinateOverride(
     float parsed = 0.0f;
     if (!TryParseFloat(token, parsed))
       continue;
-    values.push_back(
-        Units::DistanceDisplayToMillimeters(static_cast<double>(parsed), unitSystem));
+    values.push_back(Units::DistanceDisplayToMillimeters(
+        static_cast<double>(parsed), unitSystem));
   }
   if (values.empty())
     return std::nullopt;
@@ -535,8 +560,9 @@ std::optional<TrussCoordinateOverride> ParseTrussCoordinateOverride(
   return override;
 }
 
-std::optional<float> ParseTrussMarginOverrideMm(
-    std::string &text, Units::DistanceUnitSystem unitSystem) {
+std::optional<float>
+ParseTrussMarginOverrideMm(std::string &text,
+                           Units::DistanceUnitSystem unitSystem) {
   const size_t open = text.find('[');
   if (open == std::string::npos)
     return std::nullopt;
@@ -555,14 +581,15 @@ std::optional<float> ParseTrussMarginOverrideMm(
 
   text.erase(open, close - open + 1);
   text = Trim(text);
-  return static_cast<float>(
-      Units::DistanceDisplayToMillimeters(static_cast<double>(parsed), unitSystem));
+  return static_cast<float>(Units::DistanceDisplayToMillimeters(
+      static_cast<double>(parsed), unitSystem));
 }
 
 bool TryParseScreenDimensionsMm(const std::string &text, float &widthMm,
                                 float &heightMm) {
   static const std::regex kScreenDimensionRe(
-      "(\\d+(?:[\\.,]\\d+)?)\\s*(?:m|metros?)?\\s*[xX]\\s*(\\d+(?:[\\.,]\\d+)?)\\s*(?:m|metros?)?",
+      "(\\d+(?:[\\.,]\\d+)?)\\s*(?:m|metros?)?\\s*[xX]\\s*(\\d+(?:[\\.,]\\d+)?)"
+      "\\s*(?:m|metros?)?",
       std::regex::icase);
   std::smatch matches;
   if (!std::regex_search(text, matches, kScreenDimensionRe))
@@ -600,8 +627,7 @@ bool IsRenderableTrussGeometry(const std::string &path) {
   if (path.empty())
     return false;
   std::string ext = std::filesystem::path(path).extension().string();
-  std::transform(ext.begin(), ext.end(), ext.begin(),
-                 [](unsigned char c) {
+  std::transform(ext.begin(), ext.end(), ext.begin(), [](unsigned char c) {
                    return static_cast<char>(std::tolower(c));
                  });
   return ext == ".3ds" || ext == ".glb";
@@ -664,9 +690,8 @@ void ForEachSplitPlusPart(std::string_view s, Callback callback) {
 // Splits a plus-separated string into owned, trimmed, non-empty segments.
 std::vector<std::string> SplitPlus(const std::string &s) {
   std::vector<std::string> out;
-  ForEachSplitPlusPart(s, [&](std::string_view item) {
-    out.emplace_back(item);
-  });
+  ForEachSplitPlusPart(s,
+                       [&](std::string_view item) { out.emplace_back(item); });
   return out;
 }
 
@@ -844,10 +869,9 @@ void AssignImportedHoistNames(std::vector<Support *> &supports) {
     support->motorName = support->name;
   }
 
-  auto assignLeftRightNames = [&](std::vector<Support *> &items,
-                                  const std::string &leftPrefix,
-                                  const std::string &rightPrefix,
-                                  bool omitIndexForSingle) {
+  auto assignLeftRightNames =
+      [&](std::vector<Support *> &items, const std::string &leftPrefix,
+          const std::string &rightPrefix, bool omitIndexForSingle) {
     std::vector<Support *> left;
     std::vector<Support *> right;
     for (Support *support : items) {
@@ -863,14 +887,14 @@ void AssignImportedHoistNames(std::vector<Support *> &supports) {
 
     for (size_t i = 0; i < left.size(); ++i) {
       Support *support = left[i];
-      support->name =
-          BuildIndexedName(leftPrefix, static_cast<int>(i + 1), omitIndexForSingle);
+          support->name = BuildIndexedName(leftPrefix, static_cast<int>(i + 1),
+                                           omitIndexForSingle);
       support->motorName = support->name;
     }
     for (size_t i = 0; i < right.size(); ++i) {
       Support *support = right[i];
-      support->name =
-          BuildIndexedName(rightPrefix, static_cast<int>(i + 1), omitIndexForSingle);
+          support->name = BuildIndexedName(rightPrefix, static_cast<int>(i + 1),
+                                           omitIndexForSingle);
       support->motorName = support->name;
     }
   };
@@ -935,8 +959,8 @@ bool TryParseHoistLine(const std::string &line, const std::string &currentHang,
 
 std::string ResolveHoistFunctionForTarget(const std::string &target) {
   const std::string normalized = NormalizeHangName(target);
-  if (normalized == "PA" || normalized == "P.A." ||
-      normalized == "SIDEFILL" || normalized == "OUTFILL")
+  if (normalized == "PA" || normalized == "P.A." || normalized == "SIDEFILL" ||
+      normalized == "OUTFILL")
     return "Audio";
   if (normalized == "SCREEN" || normalized == "LEDSCREEN" ||
       normalized == "VIDEO")
@@ -1119,8 +1143,8 @@ BuildTrussDictionaryLookupKeys(const std::string &modelToken,
   if (!modelToken.empty())
     pushNormalized("TRUSS " + modelToken);
   const std::string simplifiedModelToken = simplifyModelToken(modelToken);
-  if (!simplifiedModelToken.empty() && simplifiedModelToken !=
-                                          TrussDictionary::NormalizeModelKey(modelToken)) {
+  if (!simplifiedModelToken.empty() &&
+      simplifiedModelToken != TrussDictionary::NormalizeModelKey(modelToken)) {
     pushNormalized(simplifiedModelToken);
     pushNormalized("TRUSS " + simplifiedModelToken);
   }
@@ -1155,7 +1179,6 @@ bool RiderImporter::Import(const std::string &path,
     return false;
   return ImportText(text, std::move(progressCallback));
 }
-
 
 struct ParsedRiderImport {
   std::vector<std::string> fixtureRequests;
@@ -1249,10 +1272,9 @@ ParsedRiderImport ParseRiderImport(const std::string &text) {
     }
     const std::string lowerLine = [&line]() {
       std::string lowered = line;
-      std::transform(lowered.begin(), lowered.end(), lowered.begin(),
-                     [](unsigned char c) {
-                       return static_cast<char>(std::tolower(c));
-                     });
+      std::transform(
+          lowered.begin(), lowered.end(), lowered.begin(),
+          [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
       return lowered;
     }();
 
@@ -1351,7 +1373,8 @@ ParsedRiderImport ParseRiderImport(const std::string &text) {
         model.clear();
       } else {
         std::string modelForHang = model;
-        if (const auto coordinateSuffix = ExtractParenthesizedToken(modelForHang);
+        if (const auto coordinateSuffix =
+                ExtractParenthesizedToken(modelForHang);
             coordinateSuffix.has_value()) {
           trussCoordinateSuffix = *coordinateSuffix;
         }
@@ -1359,8 +1382,10 @@ ParsedRiderImport ParseRiderImport(const std::string &text) {
             marginSuffix.has_value()) {
           trussMarginSuffix = *marginSuffix;
         }
-        modelForHang = std::regex_replace(modelForHang, kParenthesizedCleanupRe, "");
-        modelForHang = std::regex_replace(modelForHang, kBracketedCleanupRe, "");
+        modelForHang =
+            std::regex_replace(modelForHang, kParenthesizedCleanupRe, "");
+        modelForHang =
+            std::regex_replace(modelForHang, kBracketedCleanupRe, "");
         modelForHang = Trim(modelForHang);
         if (std::regex_match(modelForHang, kHangOnlyRe)) {
           hang = modelForHang;
@@ -1448,10 +1473,11 @@ ParsedRiderImport ParseRiderImport(const std::string &text) {
         if (std::regex_search(model, targetMatch, kHoistTargetRe) &&
             targetMatch.size() > 1) {
           hang = targetMatch[1].str();
-          model = Trim(model.substr(0, static_cast<size_t>(targetMatch.position(0))));
+          model = Trim(
+              model.substr(0, static_cast<size_t>(targetMatch.position(0))));
         } else if (std::string trailingCoordinateSuffix;
-                   TryExtractTrailingHangWithCoordinate(model, hang,
-                                                        trailingCoordinateSuffix)) {
+                   TryExtractTrailingHangWithCoordinate(
+                       model, hang, trailingCoordinateSuffix)) {
           if (trussCoordinateSuffix.empty())
             trussCoordinateSuffix = trailingCoordinateSuffix;
         } else if (std::regex_match(model, kHangOnlyRe)) {
@@ -1460,7 +1486,8 @@ ParsedRiderImport ParseRiderImport(const std::string &text) {
         }
       }
       if (trussCoordinateSuffix.empty()) {
-        const auto it = hangCoordinateSuffixByHang.find(NormalizeHangName(hang));
+        const auto it =
+            hangCoordinateSuffixByHang.find(NormalizeHangName(hang));
         if (it != hangCoordinateSuffixByHang.end())
           trussCoordinateSuffix = it->second;
       }
@@ -1472,7 +1499,8 @@ ParsedRiderImport ParseRiderImport(const std::string &text) {
       hang = ResolveHangTargetFallback(hang);
       if (hang.empty())
         hang = NormalizeHangName(currentHang);
-      const bool keepLine = riggingKind == RiggingLineKind::Pipe || hang == "BACKDROP";
+      const bool keepLine =
+          riggingKind == RiggingLineKind::Pipe || hang == "BACKDROP";
       if (!keepLine)
         continue;
 
@@ -1511,7 +1539,8 @@ ParsedRiderImport ParseRiderImport(const std::string &text) {
         hang = NormalizeHangName(currentHang);
       if (hang == "FLOOR")
         continue;
-      std::string out = "1 " + riggingKeyword + " " + formatLengthM(lengthM) + "m";
+      std::string out =
+          "1 " + riggingKeyword + " " + formatLengthM(lengthM) + "m";
       if (!hang.empty())
         out += " " + hang;
       riggingLines.push_back(out);
@@ -1520,8 +1549,8 @@ ParsedRiderImport ParseRiderImport(const std::string &text) {
       else
         parsed.trussRequests.push_back(out);
       if (hang.rfind("LX", 0) == 0 &&
-          std::find(lxTargetsInRigging.begin(), lxTargetsInRigging.end(), hang) ==
-              lxTargetsInRigging.end()) {
+          std::find(lxTargetsInRigging.begin(), lxTargetsInRigging.end(),
+                    hang) == lxTargetsInRigging.end()) {
         lxTargetsInRigging.push_back(hang);
       }
       continue;
@@ -1598,8 +1627,8 @@ ParsedRiderImport ParseRiderImport(const std::string &text) {
       std::ostringstream capText;
       capText << std::fixed << std::setprecision(0) << std::round(capacityKg);
       hoistLines.push_back("MOTOR " + capText.str());
-      hoistLines.back() =
-          std::to_string(quantity) + " " + hoistLines.back() + "Kg FOR " + target;
+      hoistLines.back() = std::to_string(quantity) + " " + hoistLines.back() +
+                          "Kg FOR " + target;
     };
     for (const HoistPreviewRequest &request : hoistRequests) {
       if (request.target == "LX") {
@@ -1635,7 +1664,8 @@ std::string BuildFilteredPreviewText(const ParsedRiderImport &parsed) {
   return parsed.filteredPreviewText;
 }
 
-// Produces scene-import text from parsed rider requests without re-filtering raw text.
+// Produces scene-import text from parsed rider requests without re-filtering
+// raw text.
 std::string BuildSceneImportText(const ParsedRiderImport &parsed) {
   return parsed.filteredPreviewText;
 }
@@ -1670,9 +1700,8 @@ struct ImportedGdtfMetadataCache {
 
     ImportedGdtfMetadata metadata;
     metadata.parsedFixtureName = Trim(GetGdtfFixtureName(resolvedGdtfPath));
-    metadata.hasProperties =
-        GetGdtfProperties(resolvedGdtfPath, metadata.weightKg,
-                          metadata.powerConsumptionW);
+    metadata.hasProperties = GetGdtfProperties(
+        resolvedGdtfPath, metadata.weightKg, metadata.powerConsumptionW);
 
     Fixture categoryProbe;
     categoryProbe.gdtfSpec = resolvedGdtfPath;
@@ -1745,7 +1774,8 @@ bool RiderImporter::ImportText(const std::string &text,
   if (text.empty())
     return false;
   RiderImportTimingStats timing;
-  auto reportProgress = [&](std::string stage, int completed = 0, int total = 0) {
+  auto reportProgress = [&](std::string stage, int completed = 0,
+                            int total = 0) {
     if (!progressCallback)
       return;
     progressCallback(ProgressState{std::move(stage), completed, total});
@@ -1759,8 +1789,9 @@ bool RiderImporter::ImportText(const std::string &text,
   auto phaseStartedAt = std::chrono::steady_clock::now();
   const ParsedRiderImport parsedImport =
       skipFixtureFilterPreview ? ParsedRiderImport{} : ParseRiderImport(text);
-  const std::string parsedImportText =
-      skipFixtureFilterPreview ? std::string{} : BuildSceneImportText(parsedImport);
+  const std::string parsedImportText = skipFixtureFilterPreview
+                                           ? std::string{}
+                                           : BuildSceneImportText(parsedImport);
   AddRiderImportPhaseTime(timing, "filter/reduce text", phaseStartedAt);
   const std::string &textToImport =
       parsedImportText.empty() ? text : parsedImportText;
@@ -1770,10 +1801,13 @@ bool RiderImporter::ImportText(const std::string &text,
   phaseStartedAt = std::chrono::steady_clock::now();
   auto trussDictionaryOpt = TrussDictionary::Load();
   AddRiderImportPhaseTime(timing, "load truss dictionary", phaseStartedAt);
-  const std::unordered_map<std::string, GdtfDictionary::Entry> emptyFixtureDictionary;
-  const auto &fixtureDictionary = fixtureDictionaryOpt ? *fixtureDictionaryOpt : emptyFixtureDictionary;
+  const std::unordered_map<std::string, GdtfDictionary::Entry>
+      emptyFixtureDictionary;
+  const auto &fixtureDictionary =
+      fixtureDictionaryOpt ? *fixtureDictionaryOpt : emptyFixtureDictionary;
   const std::unordered_map<std::string, std::string> emptyTrussDictionary;
-  const auto &trussDictionary = trussDictionaryOpt ? *trussDictionaryOpt : emptyTrussDictionary;
+  const auto &trussDictionary =
+      trussDictionaryOpt ? *trussDictionaryOpt : emptyTrussDictionary;
   reportProgress("Parsing lines...", 2, 6);
   const int totalInputLines = [&]() {
     if (textToImport.empty())
@@ -1905,9 +1939,8 @@ bool RiderImporter::ImportText(const std::string &text,
       Layer l;
       l.uuid = name == DEFAULT_LAYER_NAME ? "layer_default" : GenerateUuid();
       l.name = name;
-      l.color = layerColor;
-      auto [insertedIt, inserted] =
-          scene.layers.emplace(l.uuid, std::move(l));
+      l.visualColorHex = layerColor;
+      auto [insertedIt, inserted] = scene.layers.emplace(l.uuid, std::move(l));
       layerPtr = &insertedIt->second;
       layerLookup.emplace(layerPtr->name, layerPtr);
     }
@@ -1963,23 +1996,33 @@ bool RiderImporter::ImportText(const std::string &text,
   std::unordered_map<std::string, TrussCoordinateOverride>
       hangCoordinateOverrides;
   ImportedGdtfMetadataCache importedGdtfMetadataCache;
-  std::unordered_map<std::string, std::optional<GdtfDictionary::Entry>> fixtureDictionaryLookupCache;
-  std::unordered_map<std::string, std::optional<std::string>> trussDictionaryLookupCache;
+  std::unordered_map<std::string, std::optional<GdtfDictionary::Entry>>
+      fixtureDictionaryLookupCache;
+  std::unordered_map<std::string, std::optional<std::string>>
+      trussDictionaryLookupCache;
   int parsedInputLineCount = 0;
 
-  auto lookupFixtureDictionary = [&](const std::string &typeName) -> const std::optional<GdtfDictionary::Entry> & {
+  auto lookupFixtureDictionary = [&](const std::string &typeName)
+      -> const std::optional<GdtfDictionary::Entry> & {
     auto found = fixtureDictionaryLookupCache.find(typeName);
     if (found != fixtureDictionaryLookupCache.end())
       return found->second;
     ++timing.uniqueFixtureLookups;
-    return fixtureDictionaryLookupCache.emplace(typeName, GdtfDictionary::FindInLoadedDictionary(fixtureDictionary, typeName)).first->second;
+    return fixtureDictionaryLookupCache
+        .emplace(typeName, GdtfDictionary::FindInLoadedDictionary(
+                               fixtureDictionary, typeName))
+        .first->second;
   };
-  auto lookupTrussDictionary = [&](const std::string &lookupKey) -> const std::optional<std::string> & {
+  auto lookupTrussDictionary =
+      [&](const std::string &lookupKey) -> const std::optional<std::string> & {
     auto found = trussDictionaryLookupCache.find(lookupKey);
     if (found != trussDictionaryLookupCache.end())
       return found->second;
     ++timing.uniqueTrussLookups;
-    return trussDictionaryLookupCache.emplace(lookupKey, TrussDictionary::FindInLoadedDictionary(trussDictionary, lookupKey)).first->second;
+    return trussDictionaryLookupCache
+        .emplace(lookupKey, TrussDictionary::FindInLoadedDictionary(
+                                trussDictionary, lookupKey))
+        .first->second;
   };
 
   auto addFixtures = [&](int baseQuantity, const std::string &desc) {
@@ -1994,10 +2037,9 @@ bool RiderImporter::ImportText(const std::string &text,
         part = Trim(pm[2]);
       }
       std::string placementKey = Trim(part);
-      std::transform(placementKey.begin(), placementKey.end(), placementKey.begin(),
-                     [](unsigned char c) {
-                       return static_cast<char>(std::tolower(c));
-                     });
+      std::transform(
+          placementKey.begin(), placementKey.end(), placementKey.begin(),
+          [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
       auto &seenTypesForHang = seenFixtureTypesByHangInListing[currentHang];
       if (!placementKey.empty() && seenTypesForHang.count(placementKey) > 0)
         linearPlacementHangs.insert(currentHang);
@@ -2021,8 +2063,8 @@ bool RiderImporter::ImportText(const std::string &text,
           if (layerByType)
             request.layer = "obj " + currentHang;
           else
-            request.layer = currentHang.empty() ? defaultLayer
-                                                : "pos " + currentHang;
+            request.layer =
+                currentHang.empty() ? defaultLayer : "pos " + currentHang;
           screenObjectRequests.push_back(std::move(request));
         }
         return;
@@ -2036,19 +2078,21 @@ bool RiderImporter::ImportText(const std::string &text,
         if (const auto &dictEntry = lookupFixtureDictionary(f.typeName)) {
           f.gdtfSpec = dictEntry->path;
           f.gdtfMode = dictEntry->mode;
-          if (!dictEntry->color.empty())
-            f.color = dictEntry->color;
+          if (!dictEntry->visualColorHex.empty())
+            f.visualColorHex = dictEntry->visualColorHex;
           const std::string dictionaryCategory = Trim(dictEntry->category);
           if (!dictionaryCategory.empty()) {
             f.category = dictionaryCategory;
             f.categorySource = GdtfFixtureCategory::kManualSource;
             f.categorySourceReason.clear();
           }
-          const std::string resolvedGdtfPath = ResolveGdtfPath(scene, f.gdtfSpec);
+          const std::string resolvedGdtfPath =
+              ResolveGdtfPath(scene, f.gdtfSpec);
           phaseStartedAt = std::chrono::steady_clock::now();
-          const ImportedGdtfMetadata &metadata =
-              importedGdtfMetadataCache.Get(scene, resolvedGdtfPath, f.gdtfMode);
-          AddRiderImportPhaseTime(timing, "resolve GDTF metadata", phaseStartedAt);
+          const ImportedGdtfMetadata &metadata = importedGdtfMetadataCache.Get(
+              scene, resolvedGdtfPath, f.gdtfMode);
+          AddRiderImportPhaseTime(timing, "resolve GDTF metadata",
+                                  phaseStartedAt);
           ApplyImportedGdtfMetadata(f, metadata);
         }
         EnsureFixtureCategoryForImport(scene, f);
@@ -2085,8 +2129,9 @@ bool RiderImporter::ImportText(const std::string &text,
         (parsedInputLineCount == 1 ||
          parsedInputLineCount % parsingProgressReportEveryLines == 0 ||
          parsedInputLineCount == totalInputLines)) {
-      reportProgress("Parsing lines... (" + std::to_string(parsedInputLineCount) +
-                         "/" + std::to_string(totalInputLines) + ")",
+      reportProgress("Parsing lines... (" +
+                         std::to_string(parsedInputLineCount) + "/" +
+                         std::to_string(totalInputLines) + ")",
                      2, 6);
     }
     // Remove Windows carriage returns to allow regexes anchored with '$' to
@@ -2178,7 +2223,8 @@ bool RiderImporter::ImportText(const std::string &text,
         std::smatch dm;
         if (std::regex_search(
                 model, dm,
-                std::regex("(\\d+(?:\\.\\d+)?)\\s*[xX]\\s*(\\d+(?:\\.\\d+)?)"))) {
+                std::regex(
+                    "(\\d+(?:\\.\\d+)?)\\s*[xX]\\s*(\\d+(?:\\.\\d+)?)"))) {
           float parsed = 0.0f;
           if (TryParseFloat(dm[1], parsed))
             width = parsed * 10.0f;
@@ -2191,7 +2237,8 @@ bool RiderImporter::ImportText(const std::string &text,
         std::optional<float> marginOverrideMm;
         if (m.size() > 4 && m[4].matched) {
           hang = Trim(m[4]);
-          marginOverrideMm = ParseTrussMarginOverrideMm(hang, distanceUnitSystem);
+          marginOverrideMm =
+              ParseTrussMarginOverrideMm(hang, distanceUnitSystem);
           coordinateOverride =
               ParseTrussCoordinateOverride(hang, distanceUnitSystem);
         } else {
@@ -2327,12 +2374,14 @@ bool RiderImporter::ImportText(const std::string &text,
               phaseStartedAt = std::chrono::steady_clock::now();
               const ImportedTrussDefinitionResult &definition =
                   trussDefinitionCache.Get(*dictPath);
-              AddRiderImportPhaseTime(timing, "resolve truss definitions", phaseStartedAt);
+              AddRiderImportPhaseTime(timing, "resolve truss definitions",
+                                      phaseStartedAt);
               if (definition.loaded) {
                 const Truss &parsed = definition.parsed;
                 if (!parsed.symbolFile.empty())
                   t.symbolFile = parsed.symbolFile;
-                t.modelFile = parsed.modelFile.empty() ? *dictPath : parsed.modelFile;
+                t.modelFile =
+                    parsed.modelFile.empty() ? *dictPath : parsed.modelFile;
                 t.gdtfSpec = parsed.gdtfSpec;
                 t.gdtfMode = parsed.gdtfMode;
                 if (!parsed.manufacturer.empty())
@@ -2365,7 +2414,8 @@ bool RiderImporter::ImportText(const std::string &text,
                 const std::string sideTrussUuid = sideTruss.uuid;
                 phaseStartedAt = std::chrono::steady_clock::now();
                 scene.trusses.emplace(sideTrussUuid, std::move(sideTruss));
-                AddRiderImportPhaseTime(timing, "create trusses", phaseStartedAt);
+                AddRiderImportPhaseTime(timing, "create trusses",
+                                        phaseStartedAt);
                 ++timing.trussCount;
                 importedTrussUuids.push_back(sideTrussUuid);
                 addToLayer(trussLayer, sideTrussUuid);
@@ -2422,8 +2472,8 @@ bool RiderImporter::ImportText(const std::string &text,
                BuildPipeObjectTransform(pipeLengthMm, pipeDiameterMm,
                                         primitiveCylinderHeightMm)});
 
-          importedPipeSpans.push_back({posName, startX, startX + pipeLengthMm, hangY,
-                                       hangZ});
+          importedPipeSpans.push_back(
+              {posName, startX, startX + pipeLengthMm, hangY, hangZ});
           pipeHangNames.insert(posName);
           scene.sceneObjects.emplace(pipeObject.uuid, pipeObject);
           addToLayer(pipeObject.layer, pipeObject.uuid);
@@ -2486,7 +2536,8 @@ bool RiderImporter::ImportText(const std::string &text,
         std::optional<float> marginOverrideMm;
         if (m.size() > 3 && m[3].matched) {
           hang = Trim(m[3]);
-          marginOverrideMm = ParseTrussMarginOverrideMm(hang, distanceUnitSystem);
+          marginOverrideMm =
+              ParseTrussMarginOverrideMm(hang, distanceUnitSystem);
           coordinateOverride =
               ParseTrussCoordinateOverride(hang, distanceUnitSystem);
         } else {
@@ -2494,17 +2545,21 @@ bool RiderImporter::ImportText(const std::string &text,
           if (std::regex_search(model, targetMatch, kHoistTargetRe) &&
               targetMatch.size() > 1) {
             hang = Trim(targetMatch[1].str());
-            model = Trim(model.substr(0, static_cast<size_t>(targetMatch.position(0))));
-            marginOverrideMm = ParseTrussMarginOverrideMm(hang, distanceUnitSystem);
+            model = Trim(
+                model.substr(0, static_cast<size_t>(targetMatch.position(0))));
+            marginOverrideMm =
+                ParseTrussMarginOverrideMm(hang, distanceUnitSystem);
             coordinateOverride =
                 ParseTrussCoordinateOverride(hang, distanceUnitSystem);
           } else if (std::string trailingCoordinateSuffix;
-                     TryExtractTrailingHangWithCoordinate(model, hang,
-                                                          trailingCoordinateSuffix)) {
+                     TryExtractTrailingHangWithCoordinate(
+                         model, hang, trailingCoordinateSuffix)) {
             if (!trailingCoordinateSuffix.empty())
               hang += " " + trailingCoordinateSuffix;
-            marginOverrideMm = ParseTrussMarginOverrideMm(hang, distanceUnitSystem);
-            coordinateOverride = ParseTrussCoordinateOverride(hang, distanceUnitSystem);
+            marginOverrideMm =
+                ParseTrussMarginOverrideMm(hang, distanceUnitSystem);
+            coordinateOverride =
+                ParseTrussCoordinateOverride(hang, distanceUnitSystem);
           } else if (std::regex_match(model, kHangOnlyRe)) {
             hang = model;
             model.clear();
@@ -2538,7 +2593,8 @@ bool RiderImporter::ImportText(const std::string &text,
 
             SceneObject pipeObject;
             pipeObject.uuid = GenerateUuid();
-            pipeObject.layer = layerByType ? ("obj " + posName) : ("pos " + posName);
+            pipeObject.layer =
+                layerByType ? ("obj " + posName) : ("pos " + posName);
             pipeObject.name = "PIPE " + posName;
             pipeObject.transform = BuildCylinderPitchY90LocalTransform();
             pipeObject.transform.o[0] = startX + 0.5f * defaultPipeLengthMm;
@@ -2558,7 +2614,8 @@ bool RiderImporter::ImportText(const std::string &text,
           auto resolveOverride = [&](const std::string &posName) {
             TrussCoordinateOverride resolved;
             bool hasResolved = false;
-            if (const auto hangOverrideIt = hangCoordinateOverrides.find(posName);
+            if (const auto hangOverrideIt =
+                    hangCoordinateOverrides.find(posName);
                 hangOverrideIt != hangCoordinateOverrides.end()) {
               resolved = hangOverrideIt->second;
               hasResolved = true;
@@ -2578,7 +2635,8 @@ bool RiderImporter::ImportText(const std::string &text,
               }
               hasResolved = true;
             }
-            return hasResolved ? std::optional<TrussCoordinateOverride>(resolved)
+            return hasResolved
+                       ? std::optional<TrussCoordinateOverride>(resolved)
                                : std::nullopt;
           };
 
@@ -2599,7 +2657,8 @@ bool RiderImporter::ImportText(const std::string &text,
         std::smatch dm;
         if (std::regex_search(
                 model, dm,
-                std::regex("(\\d+(?:\\.\\d+)?)\\s*[xX]\\s*(\\d+(?:\\.\\d+)?)"))) {
+                std::regex(
+                    "(\\d+(?:\\.\\d+)?)\\s*[xX]\\s*(\\d+(?:\\.\\d+)?)"))) {
           float parsed = 0.0f;
           if (TryParseFloat(dm[1], parsed))
             width = parsed * 10.0f;
@@ -2664,12 +2723,14 @@ bool RiderImporter::ImportText(const std::string &text,
               phaseStartedAt = std::chrono::steady_clock::now();
               const ImportedTrussDefinitionResult &definition =
                   trussDefinitionCache.Get(*dictPath);
-              AddRiderImportPhaseTime(timing, "resolve truss definitions", phaseStartedAt);
+              AddRiderImportPhaseTime(timing, "resolve truss definitions",
+                                      phaseStartedAt);
               if (definition.loaded) {
                 const Truss &parsed = definition.parsed;
                 if (!parsed.symbolFile.empty())
                   t.symbolFile = parsed.symbolFile;
-                t.modelFile = parsed.modelFile.empty() ? *dictPath : parsed.modelFile;
+                t.modelFile =
+                    parsed.modelFile.empty() ? *dictPath : parsed.modelFile;
                 t.gdtfSpec = parsed.gdtfSpec;
                 t.gdtfMode = parsed.gdtfMode;
                 if (!parsed.manufacturer.empty())
@@ -2708,12 +2769,10 @@ bool RiderImporter::ImportText(const std::string &text,
           continue;
         length *= 1000.0f;
         std::string lineWithCoordinateOverride = line;
-        const auto lineMarginOverride =
-            ParseTrussMarginOverrideMm(lineWithCoordinateOverride,
-                                       distanceUnitSystem);
-        const auto lineCoordinateOverride =
-            ParseTrussCoordinateOverride(lineWithCoordinateOverride,
-                                         distanceUnitSystem);
+        const auto lineMarginOverride = ParseTrussMarginOverrideMm(
+            lineWithCoordinateOverride, distanceUnitSystem);
+        const auto lineCoordinateOverride = ParseTrussCoordinateOverride(
+            lineWithCoordinateOverride, distanceUnitSystem);
         std::string hang = currentHang;
         ParseTrussMarginOverrideMm(hang, distanceUnitSystem);
         std::optional<TrussCoordinateOverride> coordinateOverride =
@@ -2777,7 +2836,8 @@ bool RiderImporter::ImportText(const std::string &text,
                                         primitiveCylinderHeightMm)});
           scene.sceneObjects.emplace(pipeObject.uuid, pipeObject);
           addToLayer(pipeObject.layer, pipeObject.uuid);
-          importedPipeSpans.push_back({hang, startX, startX + pipeLengthMm, hangY, hangZ});
+          importedPipeSpans.push_back(
+              {hang, startX, startX + pipeLengthMm, hangY, hangZ});
           pipeHangNames.insert(hang);
           continue;
         }
@@ -2843,12 +2903,14 @@ bool RiderImporter::ImportText(const std::string &text,
             phaseStartedAt = std::chrono::steady_clock::now();
             const ImportedTrussDefinitionResult &definition =
                 trussDefinitionCache.Get(*dictPath);
-            AddRiderImportPhaseTime(timing, "resolve truss definitions", phaseStartedAt);
+            AddRiderImportPhaseTime(timing, "resolve truss definitions",
+                                    phaseStartedAt);
             if (definition.loaded) {
               const Truss &parsed = definition.parsed;
               if (!parsed.symbolFile.empty())
                 t.symbolFile = parsed.symbolFile;
-              t.modelFile = parsed.modelFile.empty() ? *dictPath : parsed.modelFile;
+              t.modelFile =
+                  parsed.modelFile.empty() ? *dictPath : parsed.modelFile;
               t.gdtfSpec = parsed.gdtfSpec;
               t.gdtfMode = parsed.gdtfMode;
               t.manufacturer = parsed.manufacturer;
@@ -2935,7 +2997,8 @@ bool RiderImporter::ImportText(const std::string &text,
       phaseStartedAt = std::chrono::steady_clock::now();
       const ImportedTrussDefinitionResult &definition =
           trussDefinitionCache.Get(t.modelFile);
-      AddRiderImportPhaseTime(timing, "resolve truss definitions", phaseStartedAt);
+      AddRiderImportPhaseTime(timing, "resolve truss definitions",
+                              phaseStartedAt);
       resolved = definition.loaded;
       if (resolved)
         parsed = definition.parsed;
@@ -2946,7 +3009,8 @@ bool RiderImporter::ImportText(const std::string &text,
       phaseStartedAt = std::chrono::steady_clock::now();
       const ImportedTrussDefinitionResult &definition =
           trussDefinitionCache.Get(t.gdtfSpec);
-      AddRiderImportPhaseTime(timing, "resolve truss definitions", phaseStartedAt);
+      AddRiderImportPhaseTime(timing, "resolve truss definitions",
+                              phaseStartedAt);
       resolved = definition.loaded;
       if (resolved)
         parsed = definition.parsed;
@@ -2963,7 +3027,8 @@ bool RiderImporter::ImportText(const std::string &text,
         phaseStartedAt = std::chrono::steady_clock::now();
         const ImportedTrussDefinitionResult &definition =
             trussDefinitionCache.Get(*dictPath);
-        AddRiderImportPhaseTime(timing, "resolve truss definitions", phaseStartedAt);
+        AddRiderImportPhaseTime(timing, "resolve truss definitions",
+                                phaseStartedAt);
         resolved = definition.loaded;
         if (resolved)
           parsed = definition.parsed;
@@ -2983,7 +3048,8 @@ bool RiderImporter::ImportText(const std::string &text,
       if (gdtfDefinitionFailed)
         reasons.emplace_back("LoadTrussDefinition(gdtfSpec) returned false");
       if (dictionaryDefinitionFailed)
-        reasons.emplace_back("LoadTrussDefinition(dictionary model) returned false");
+        reasons.emplace_back(
+            "LoadTrussDefinition(dictionary model) returned false");
       if (reasons.empty())
         reasons.emplace_back("missing or non-renderable symbolFile");
 
@@ -3026,7 +3092,8 @@ bool RiderImporter::ImportText(const std::string &text,
         ResolveTrussSymbolPath(t);
     bool symbolLooksRenderable = IsRenderableTrussGeometry(t.symbolFile);
     bool symbolExists =
-        symbolLooksRenderable && std::filesystem::exists(resolvedSymbolPathAfterDefinition);
+        symbolLooksRenderable &&
+        std::filesystem::exists(resolvedSymbolPathAfterDefinition);
     if (!symbolExists) {
       std::ostringstream reason;
       if (t.symbolFile.empty()) {
@@ -3112,8 +3179,10 @@ bool RiderImporter::ImportText(const std::string &text,
       } else {
         sideTrussInfo.leftX = std::min(sideTrussInfo.leftX, sideX);
         sideTrussInfo.rightX = std::max(sideTrussInfo.rightX, sideX);
-        sideTrussInfo.startY = std::min(sideTrussInfo.startY, std::min(startY, endY));
-        sideTrussInfo.endY = std::max(sideTrussInfo.endY, std::max(startY, endY));
+        sideTrussInfo.startY =
+            std::min(sideTrussInfo.startY, std::min(startY, endY));
+        sideTrussInfo.endY =
+            std::max(sideTrussInfo.endY, std::max(startY, endY));
       }
       continue;
     }
@@ -3226,7 +3295,8 @@ bool RiderImporter::ImportText(const std::string &text,
     screenGeometryScale.u = {request.widthMm / 1000.0f, 0.0f, 0.0f};
     screenGeometryScale.v = {0.0f, kScreenThicknessMm / 1000.0f, 0.0f};
     screenGeometryScale.w = {0.0f, 0.0f, request.heightMm / 1000.0f};
-    screenObject.geometries.push_back({kPrimitiveCubeToken, screenGeometryScale});
+    screenObject.geometries.push_back(
+        {kPrimitiveCubeToken, screenGeometryScale});
     scene.sceneObjects[screenObject.uuid] = screenObject;
     addToLayer(screenObject.layer, screenObject.uuid);
   }
@@ -3256,18 +3326,21 @@ bool RiderImporter::ImportText(const std::string &text,
     support.motorModelSource = "Manual";
     support.weightSource = "Manual";
 
-    const std::string normalizedFunction = NormalizeHoistFunction(hoistFunction);
+    const std::string normalizedFunction =
+        NormalizeHoistFunction(hoistFunction);
     std::string layerName = "rig " + normalizedFunction;
     support.layer = layerName;
 
     const std::string supportUuid = support.uuid;
     scene.supports[supportUuid] = support;
     importedSupportUuids.push_back(supportUuid);
-    addToLayer(layerName, supportUuid, ResolveHoistLayerColor(normalizedFunction));
+    addToLayer(layerName, supportUuid,
+               ResolveHoistLayerColor(normalizedFunction));
   };
 
-  auto distributeAcrossTruss = [&](const std::string &positionName, int quantity,
-                                   float capacityKg, float marginMm,
+  auto distributeAcrossTruss = [&](const std::string &positionName,
+                                   int quantity, float capacityKg,
+                                   float marginMm,
                                    const std::string &hoistFunction) {
     if (quantity <= 0)
       return;
@@ -3275,11 +3348,14 @@ bool RiderImporter::ImportText(const std::string &text,
     auto infoIt = trussInfo.find(positionName);
     if (infoIt != trussInfo.end())
       info = infoIt->second;
-    float startX = info.found ? info.startX + marginMm : -500.0f * (quantity - 1);
+    float startX =
+        info.found ? info.startX + marginMm : -500.0f * (quantity - 1);
     float endX = info.found ? info.endX - marginMm : 500.0f * (quantity - 1);
     if (endX < startX)
       std::swap(startX, endX);
-    const float step = quantity > 1 ? (endX - startX) / static_cast<float>(quantity - 1) : 0.0f;
+    const float step = quantity > 1
+                           ? (endX - startX) / static_cast<float>(quantity - 1)
+                           : 0.0f;
     const float y = info.found ? info.y : getHangPos(positionName);
     const float z = info.found ? info.z : getHangHeight(positionName);
     for (int i = 0; i < quantity; ++i)
@@ -3303,7 +3379,8 @@ bool RiderImporter::ImportText(const std::string &text,
       const float sideX = sideInfo.found ? sideInfo.x : fallbackX;
       float startY = sideInfo.found ? sideInfo.startY : sideTrussInfo.startY;
       float endY = sideInfo.found ? sideInfo.endY : sideTrussInfo.endY;
-      const float z = sideInfo.found ? sideInfo.z
+      const float z = sideInfo.found
+                          ? sideInfo.z
                                      : (sideTrussInfo.found ? sideTrussInfo.z
                                                             : getHangHeight("LX SIDES"));
       const float direction = endY >= startY ? 1.0f : -1.0f;
@@ -3311,7 +3388,8 @@ bool RiderImporter::ImportText(const std::string &text,
       endY -= direction * sideMarginMm;
       if ((direction > 0.0f && endY < startY) ||
           (direction < 0.0f && endY > startY)) {
-        const float center = sideInfo.found ? (sideInfo.startY + sideInfo.endY) * 0.5f
+        const float center = sideInfo.found
+                                 ? (sideInfo.startY + sideInfo.endY) * 0.5f
                                             : (startY + endY) * 0.5f;
         startY = center;
         endY = center;
@@ -3328,12 +3406,14 @@ bool RiderImporter::ImportText(const std::string &text,
     placeOnSide(rightSideHoistSpan, rightCount, sideTrussInfo.rightX);
   };
 
-  auto distributePaOrSidefill = [&](const std::string &positionName, int quantity,
-                                     float capacityKg, bool sidefill,
+  auto distributePaOrSidefill = [&](const std::string &positionName,
+                                    int quantity, float capacityKg,
+                                    bool sidefill,
                                      const std::string &hoistFunction) {
     if (quantity <= 0)
       return;
-    const TrussInfo lxInfo = trussInfo.count("LX1") ? trussInfo["LX1"] : TrussInfo{};
+    const TrussInfo lxInfo =
+        trussInfo.count("LX1") ? trussInfo["LX1"] : TrussInfo{};
     const float baseY = lxInfo.found ? lxInfo.y : getHangPos("LX1");
     const float z = lxInfo.found ? lxInfo.z : getHangHeight("LX1");
     const float spanLeft = lxInfo.found ? lxInfo.startX : -3000.0f;
@@ -3346,13 +3426,16 @@ bool RiderImporter::ImportText(const std::string &text,
     auto placeGroup = [&](int count, float anchorX, float xDirection) {
       if (count <= 0)
         return;
-      const int rows = count <= 2 ? count : static_cast<int>(std::ceil(std::sqrt(count)));
-      const int cols = static_cast<int>(std::ceil(static_cast<float>(count) / rows));
+      const int rows =
+          count <= 2 ? count : static_cast<int>(std::ceil(std::sqrt(count)));
+      const int cols =
+          static_cast<int>(std::ceil(static_cast<float>(count) / rows));
       int placed = 0;
       for (int col = 0; col < cols && placed < count; ++col) {
         for (int row = 0; row < rows && placed < count; ++row) {
           float x = anchorX + xDirection * col * 1000.0f;
-          float yPlaced = y + (rows == 1 ? 0.0f : (row - (rows - 1) * 0.5f) * 1000.0f);
+          float yPlaced =
+              y + (rows == 1 ? 0.0f : (row - (rows - 1) * 0.5f) * 1000.0f);
           placeHoist(x, yPlaced, z, capacityKg, positionName, hoistFunction);
           ++placed;
         }
@@ -3364,14 +3447,16 @@ bool RiderImporter::ImportText(const std::string &text,
   };
 
   for (const HoistRequest &request : hoistRequests) {
-    const std::string hoistFunction = ResolveHoistFunctionForTarget(request.target);
+    const std::string hoistFunction =
+        ResolveHoistFunctionForTarget(request.target);
     if (request.target == "LX") {
       std::vector<std::string> lxNames;
       for (const auto &[name, info] : trussInfo) {
         if (info.found && name.rfind("LX", 0) == 0)
           lxNames.push_back(name);
       }
-      std::sort(lxNames.begin(), lxNames.end(), [](const std::string &a, const std::string &b) {
+      std::sort(lxNames.begin(), lxNames.end(),
+                [](const std::string &a, const std::string &b) {
         return ParseTrailingNumber(a) < ParseTrailingNumber(b);
       });
       if (lxNames.empty())
@@ -3384,11 +3469,11 @@ bool RiderImporter::ImportText(const std::string &text,
                               hoistFunction);
       }
     } else if (request.target == "PA") {
-      distributePaOrSidefill("P.A.", request.quantity, request.capacityKg, false,
-                             hoistFunction);
+      distributePaOrSidefill("P.A.", request.quantity, request.capacityKg,
+                             false, hoistFunction);
     } else if (request.target == "SIDEFILL") {
-      distributePaOrSidefill("SIDEFILL", request.quantity, request.capacityKg, true,
-                             hoistFunction);
+      distributePaOrSidefill("SIDEFILL", request.quantity, request.capacityKg,
+                             true, hoistFunction);
     } else if (request.target == "SCREEN") {
       if (request.quantity <= 0)
         continue;
@@ -3398,7 +3483,8 @@ bool RiderImporter::ImportText(const std::string &text,
         info = infoIt->second;
       const float y = info.found ? info.y : getHangPos("SCREEN");
       const float z = info.found ? info.z : getHangHeight("SCREEN");
-      const float span = info.found ? (info.endX - info.startX) : (1000.0f * request.quantity);
+      const float span =
+          info.found ? (info.endX - info.startX) : (1000.0f * request.quantity);
       const float part = span / static_cast<float>(request.quantity + 1);
       const float startX = info.found ? info.startX : (-0.5f * span);
       for (int i = 0; i < request.quantity; ++i) {
@@ -3407,12 +3493,13 @@ bool RiderImporter::ImportText(const std::string &text,
       }
     } else {
       if (IsLxSidesHangName(request.target)) {
-        distributeAcrossSides(request.quantity, request.capacityKg, hoistFunction);
+        distributeAcrossSides(request.quantity, request.capacityKg,
+                              hoistFunction);
         continue;
       }
       const float marginMm = IsLxHangName(request.target) ? 1000.0f : 2000.0f;
-      distributeAcrossTruss(request.target, request.quantity, request.capacityKg,
-                            marginMm, hoistFunction);
+      distributeAcrossTruss(request.target, request.quantity,
+                            request.capacityKg, marginMm, hoistFunction);
     }
   }
 
@@ -3431,7 +3518,8 @@ bool RiderImporter::ImportText(const std::string &text,
   HoistWeightDistribution::ApplyForImportedSupports(
       scene, importedSupportUuids, roundedRiggingTotalsByPosition);
 
-  // Fill any missing fixture categories before placement so downstream distribution can rely on them.
+  // Fill any missing fixture categories before placement so downstream
+  // distribution can rely on them.
   for (const std::string &uuid : importedFixtureUuids) {
     auto fixtureIt = scene.fixtures.find(uuid);
     if (fixtureIt == scene.fixtures.end())
@@ -3521,10 +3609,10 @@ bool RiderImporter::ImportText(const std::string &text,
     return ordered;
   };
 
-  auto placeFixtureGroup = [&](const std::string &pos,
-                               const std::vector<Fixture *> &fixturesVec,
-                               const std::function<void(Fixture &, float, float,
-                                                        float, float)> &applyPlacement) {
+  auto placeFixtureGroup =
+      [&](const std::string &pos, const std::vector<Fixture *> &fixturesVec,
+          const std::function<void(Fixture &, float, float, float, float)>
+              &applyPlacement) {
     if (fixturesVec.empty())
       return;
 
@@ -3552,8 +3640,7 @@ bool RiderImporter::ImportText(const std::string &text,
     if (total == 1) {
       Fixture *fixture = ordered.front();
       if (fixture) {
-        const float centeredX =
-            info.found ? 0.5f * (startX + endX) : 0.0f;
+            const float centeredX = info.found ? 0.5f * (startX + endX) : 0.0f;
         applyPlacement(*fixture, centeredX, baseY, baseZ, width);
       }
       return;
@@ -3569,10 +3656,9 @@ bool RiderImporter::ImportText(const std::string &text,
   };
 
   auto normalizeCategory = [](std::string category) {
-    std::transform(category.begin(), category.end(), category.begin(),
-                   [](unsigned char c) {
-                     return static_cast<char>(std::tolower(c));
-                   });
+    std::transform(
+        category.begin(), category.end(), category.begin(),
+        [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
     return category;
   };
 
@@ -3580,7 +3666,8 @@ bool RiderImporter::ImportText(const std::string &text,
       normalizeCategory(GdtfFixtureCategory::kBlinder);
   const std::string strobeCategory =
       normalizeCategory(GdtfFixtureCategory::kStrobe);
-  const std::string washCategory = normalizeCategory(GdtfFixtureCategory::kWash);
+  const std::string washCategory =
+      normalizeCategory(GdtfFixtureCategory::kWash);
   const std::string smokeCategory =
       normalizeCategory(GdtfFixtureCategory::kSmoke);
 
@@ -3601,17 +3688,19 @@ bool RiderImporter::ImportText(const std::string &text,
                                   float endY, bool hasSideSpan, float z) {
     if (ordered.empty())
       return;
-    const int leftCount =
-        static_cast<int>(ordered.size()) / 2 + static_cast<int>(ordered.size()) % 2;
+    const int leftCount = static_cast<int>(ordered.size()) / 2 +
+                          static_cast<int>(ordered.size()) % 2;
     const int rightCount = static_cast<int>(ordered.size()) / 2;
-    auto placeSideGroup = [&](int count, float sideX,
+    auto placeSideGroup =
+        [&](int count, float sideX,
                               const std::function<Fixture *(int)> &pickFixture) {
       if (count <= 0)
         return;
       const float effectiveEndY =
-          hasSideSpan ? endY : startY + static_cast<float>(count - 1) * 500.0f;
-      const float step =
-          count > 1 ? (effectiveEndY - startY) / static_cast<float>(count - 1)
+              hasSideSpan ? endY
+                          : startY + static_cast<float>(count - 1) * 500.0f;
+          const float step = count > 1 ? (effectiveEndY - startY) /
+                                             static_cast<float>(count - 1)
                                    : 0.0f;
       for (int i = 0; i < count; ++i) {
         Fixture *fixture = pickFixture(i);
@@ -3622,9 +3711,8 @@ bool RiderImporter::ImportText(const std::string &text,
         fixture->transform.o[2] = z;
       }
     };
-    placeSideGroup(leftCount, leftX, [&](int i) {
-      return ordered[static_cast<size_t>(i)];
-    });
+    placeSideGroup(leftCount, leftX,
+                   [&](int i) { return ordered[static_cast<size_t>(i)]; });
     placeSideGroup(rightCount, rightX, [&](int i) {
       return ordered[ordered.size() - 1U - static_cast<size_t>(i)];
     });
@@ -3658,22 +3746,26 @@ bool RiderImporter::ImportText(const std::string &text,
       }
     }
   }
-  const float smokeStartY =
-      sideTrussInfo.found ? sideTrussInfo.startY + getHangMargin("LX1") : 1000.0f;
-  const float smokeEndY =
-      sideTrussInfo.found ? sideTrussInfo.endY - getHangMargin("LX1") : smokeStartY;
+  const float smokeStartY = sideTrussInfo.found
+                                ? sideTrussInfo.startY + getHangMargin("LX1")
+                                : 1000.0f;
+  const float smokeEndY = sideTrussInfo.found
+                              ? sideTrussInfo.endY - getHangMargin("LX1")
+                              : smokeStartY;
 
   for (auto &[pos, fixturesVec] : fixturesByPos) {
     if (fixturesVec.empty())
       continue;
     if (IsLxSidesHangName(pos)) {
       const std::vector<Fixture *> ordered = buildSymmetricOrder(fixturesVec);
-      const float startY =
-          sideTrussInfo.found ? sideTrussInfo.startY + getHangMargin("LX1") : 1000.0f;
-      const float endY = sideTrussInfo.found ? sideTrussInfo.endY - getHangMargin("LX1")
+      const float startY = sideTrussInfo.found
+                               ? sideTrussInfo.startY + getHangMargin("LX1")
+                               : 1000.0f;
+      const float endY = sideTrussInfo.found
+                             ? sideTrussInfo.endY - getHangMargin("LX1")
                                              : startY;
-      placeFixturesAsSides(ordered, sideTrussInfo.leftX, sideTrussInfo.rightX, startY,
-                           endY, sideTrussInfo.found,
+      placeFixturesAsSides(ordered, sideTrussInfo.leftX, sideTrussInfo.rightX,
+                           startY, endY, sideTrussInfo.found,
                            sideTrussInfo.found ? sideTrussInfo.z : 1000.0f);
       continue;
     }
@@ -3707,23 +3799,24 @@ bool RiderImporter::ImportText(const std::string &text,
         bottomFixtures.push_back(f);
     }
 
-    const std::vector<Fixture *> orderedSmoke = buildSymmetricOrder(smokeFixtures);
-    placeFixturesAsSides(orderedSmoke, smokeLeftX, smokeRightX, smokeStartY, smokeEndY,
-                         sideTrussInfo.found, 0.0f);
+    const std::vector<Fixture *> orderedSmoke =
+        buildSymmetricOrder(smokeFixtures);
+    placeFixturesAsSides(orderedSmoke, smokeLeftX, smokeRightX, smokeStartY,
+                         smokeEndY, sideTrussInfo.found, 0.0f);
 
-    placeFixtureGroup(pos, bottomFixtures,
-                      [&](Fixture &fixture, float x, float baseY, float baseZ,
-                          float width) {
+    placeFixtureGroup(
+        pos, bottomFixtures,
+        [&](Fixture &fixture, float x, float baseY, float baseZ, float width) {
                         fixture.transform.o[0] = x;
-                        fixture.transform.o[1] =
-                            isBackBottomCategory(fixture) ? baseY + width * 0.5f
+          fixture.transform.o[1] = isBackBottomCategory(fixture)
+                                       ? baseY + width * 0.5f
                                                            : baseY - width * 0.5f;
                         fixture.transform.o[2] = baseZ;
                       });
 
-    placeFixtureGroup(pos, topFrontFixtures,
-                      [&](Fixture &fixture, float x, float baseY, float baseZ,
-                          float width) {
+    placeFixtureGroup(
+        pos, topFrontFixtures,
+        [&](Fixture &fixture, float x, float baseY, float baseZ, float width) {
                         fixture.transform.o[0] = x;
                         fixture.transform.o[1] = baseY - width * 0.5f;
                         fixture.transform.o[2] = baseZ + width * 0.5f;
@@ -3743,14 +3836,15 @@ bool RiderImporter::ImportText(const std::string &text,
 
   AddRiderImportPhaseTime(timing, "place imported objects", placementStartedAt);
   const auto identityStartedAt = std::chrono::steady_clock::now();
-  std::unordered_set<std::string> importedFixtureIdSet(importedFixtureUuids.begin(),
-                                                       importedFixtureUuids.end());
+  std::unordered_set<std::string> importedFixtureIdSet(
+      importedFixtureUuids.begin(), importedFixtureUuids.end());
   int highestExistingFixtureId = 100;
   std::unordered_map<std::string, int> nextUnitByType;
   for (const auto &[uuid, fixture] : scene.fixtures) {
     if (importedFixtureIdSet.count(uuid) != 0)
       continue;
-    highestExistingFixtureId = std::max(highestExistingFixtureId, fixture.fixtureId);
+    highestExistingFixtureId =
+        std::max(highestExistingFixtureId, fixture.fixtureId);
 
     int nextUnit = fixture.unitNumber;
     if (nextUnit <= 0)
@@ -3786,7 +3880,8 @@ bool RiderImporter::ImportText(const std::string &text,
         return a->transform.o[0] < b->transform.o[0];
       return a->transform.o[1] < b->transform.o[1];
     });
-    std::string prefix = vec.empty() ? type : baseName(vec.front()->instanceName);
+    std::string prefix =
+        vec.empty() ? type : baseName(vec.front()->instanceName);
     int nextUnitNumber = nextUnitByType[type] + 1;
     for (size_t i = 0; i < vec.size(); ++i) {
       vec[i]->fixtureId = baseId + static_cast<int>(i);
@@ -3794,11 +3889,11 @@ bool RiderImporter::ImportText(const std::string &text,
       vec[i]->instanceName =
           prefix + " " + std::to_string(nextUnitNumber + static_cast<int>(i));
     }
-    baseId =
-        ((baseId - 1 + static_cast<int>(vec.size()) + 99) / 100) * 100 + 1;
+    baseId = ((baseId - 1 + static_cast<int>(vec.size()) + 99) / 100) * 100 + 1;
   }
 
-  AddRiderImportPhaseTime(timing, "assign fixture identities", identityStartedAt);
+  AddRiderImportPhaseTime(timing, "assign fixture identities",
+                          identityStartedAt);
 
   bool hasDefaultLayer = false;
   for (const auto &[uid, layer] : scene.layers) {

--- a/docs/features.md
+++ b/docs/features.md
@@ -42,6 +42,10 @@ Perastage is designed for lighting designers, programmers, and technicians who n
   coloring and is shared by fixture type and mode, while Color Filter is the
   optional per-fixture color imported from and exported to the MVR
   `Fixture/Color` node.
+- Stores Type Color by fixture profile and mode in root-level Perastage
+  `UserData`, allowing table swatches, summaries, legends, and type-based
+  viewer colors to survive project save and reopen without using the standard
+  MVR `Fixture/Color` node.
 - Stores Perastage-specific layer appearance metadata, including layer colors, in root-level `UserData/Data` with Perastage-owned `PerastageLayerAppearance` entries instead of writing non-standard color data inside standard `Layer` nodes.
 - Parametric objects exported as Fixture/Truss/Support receive stable non-empty `FixtureID` and globally unique `FixtureIDNumeric` values.
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -37,10 +37,11 @@ Perastage is designed for lighting designers, programmers, and technicians who n
 ### MVR export
 
 - Exports the current scene back to `.mvr` for interoperability.
-- Keeps **Type Color** separate from **MVR Color**: Type Color is a
+- Keeps **Type Color** separate from **Color Filter**: Type Color is a
   Perastage visual used by plans, summaries, legends, and type-based viewer
-  coloring, while MVR Color is the optional standards-based fixture color
-  imported from and exported to the MVR `Fixture/Color` node.
+  coloring and is shared by fixture type and mode, while Color Filter is the
+  optional per-fixture color imported from and exported to the MVR
+  `Fixture/Color` node.
 - Stores Perastage-specific layer appearance metadata, including layer colors, in root-level `UserData/Data` with Perastage-owned `PerastageLayerAppearance` entries instead of writing non-standard color data inside standard `Layer` nodes.
 - Parametric objects exported as Fixture/Truss/Support receive stable non-empty `FixtureID` and globally unique `FixtureIDNumeric` values.
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -37,12 +37,19 @@ Perastage is designed for lighting designers, programmers, and technicians who n
 ### MVR export
 
 - Exports the current scene back to `.mvr` for interoperability.
+- Keeps **Type Color** separate from **MVR Color**: Type Color is a
+  Perastage visual used by plans, summaries, legends, and type-based viewer
+  coloring, while MVR Color is the optional standards-based fixture color
+  imported from and exported to the MVR `Fixture/Color` node.
 - Stores Perastage-specific layer appearance metadata, including layer colors, in root-level `UserData/Data` with Perastage-owned `PerastageLayerAppearance` entries instead of writing non-standard color data inside standard `Layer` nodes.
 - Parametric objects exported as Fixture/Truss/Support receive stable non-empty `FixtureID` and globally unique `FixtureIDNumeric` values.
 
 ### GDTF integration and dictionary pipeline
 
-- Local fixture dictionary maps textual fixture descriptions to GDTF specs under `library/`.
+- Local fixture dictionary maps textual fixture descriptions to GDTF specs and
+  Perastage visual-color defaults under `library/`. Dictionary files now write
+  the explicit `visual_color` key while continuing to read the legacy `color`
+  key.
 - GDTF-Share download flow is available from the Tools menu.
 - Export packages GDTFs under `gdtf/` with archive-relative forward-slash paths.
 - Filename collisions are handled deterministically (`name (1).gdtf`, etc.) and references are updated.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -57,9 +57,9 @@ Perastage v1.4.0 delivers a long-anticipated refresh of the modelling and riggin
 This release addresses dozens of issues across importing, snapping, editing and export workflows, including:
 
 - **Fixture color compatibility** - corrected the fixture visual-color rename so
-  fixture editing builds correctly, while layer colors and fixture-summary
-  swatches continue to use their existing model fields without build errors or
-  lost display colors.
+  fixture editing and fixture replacement build correctly, while layer colors
+  and fixture-summary swatches continue to use their existing model fields
+  without build errors or lost display colors.
 - **Selection workflow** - using `Ctrl` or `Ctrl+Shift` while clicking in 2D/3D adds to the selection instead of clearing it.  Quick clicks on grouped items select the entire group.
 - **Create-from-text** - normalised rider text now uses the English `FOR` keyword for motor/hoist lines, ensuring consistent import behaviour; text filtering has been optimised for speed and now shares lookup caches across operations.
 - **GDTF persistence** - automatic symbol generation and per-fixture edits update project-owned copies or stable library derivatives without filling the user library with temporary files.  Editing a fixture's weight triggers hoist-load recalculation after the table synchronises.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -29,9 +29,10 @@ Perastage v1.4.0 delivers a long-anticipated refresh of the modelling and riggin
 ## Improvements
 
 - **Clear fixture color semantics** - fixture tables and edit dialogs now show
-  separate Type Color and MVR Color fields. Type Color remains the Perastage
-  appearance used in plans, summaries, legends, and type-based coloring,
-  while MVR Color exclusively controls the standards-based MVR
+  separate Type Color and Color Filter fields. Type Color remains the
+  Perastage appearance shared by fixtures with the same type and mode and used
+  in plans, summaries, legends, and type-based coloring. Color Filter is
+  fixture-specific and exclusively controls the standards-based MVR
   `Fixture/Color` value. Existing fixture dictionaries using `color` continue
   to load and are saved with the clearer `visual_color` key.
 - **Selectable fixtures within groups** - moving a fixture no longer drags its entire group, making it easy to reposition individual fixtures along grouped trusses.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -57,8 +57,9 @@ Perastage v1.4.0 delivers a long-anticipated refresh of the modelling and riggin
 This release addresses dozens of issues across importing, snapping, editing and export workflows, including:
 
 - **Fixture color compatibility** - corrected the fixture visual-color rename so
-  layer colors and fixture-summary swatches continue to use their existing
-  model fields without build errors or lost display colors.
+  fixture editing builds correctly, while layer colors and fixture-summary
+  swatches continue to use their existing model fields without build errors or
+  lost display colors.
 - **Selection workflow** - using `Ctrl` or `Ctrl+Shift` while clicking in 2D/3D adds to the selection instead of clearing it.  Quick clicks on grouped items select the entire group.
 - **Create-from-text** - normalised rider text now uses the English `FOR` keyword for motor/hoist lines, ensuring consistent import behaviour; text filtering has been optimised for speed and now shares lookup caches across operations.
 - **GDTF persistence** - automatic symbol generation and per-fixture edits update project-owned copies or stable library derivatives without filling the user library with temporary files.  Editing a fixture's weight triggers hoist-load recalculation after the table synchronises.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -56,6 +56,9 @@ Perastage v1.4.0 delivers a long-anticipated refresh of the modelling and riggin
 
 This release addresses dozens of issues across importing, snapping, editing and export workflows, including:
 
+- **Fixture color compatibility** - corrected the fixture visual-color rename so
+  layer colors and fixture-summary swatches continue to use their existing
+  model fields without build errors or lost display colors.
 - **Selection workflow** - using `Ctrl` or `Ctrl+Shift` while clicking in 2D/3D adds to the selection instead of clearing it.  Quick clicks on grouped items select the entire group.
 - **Create-from-text** - normalised rider text now uses the English `FOR` keyword for motor/hoist lines, ensuring consistent import behaviour; text filtering has been optimised for speed and now shares lookup caches across operations.
 - **GDTF persistence** - automatic symbol generation and per-fixture edits update project-owned copies or stable library derivatives without filling the user library with temporary files.  Editing a fixture's weight triggers hoist-load recalculation after the table synchronises.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -34,7 +34,10 @@ Perastage v1.4.0 delivers a long-anticipated refresh of the modelling and riggin
   in plans, summaries, legends, and type-based coloring. Color Filter is
   fixture-specific and exclusively controls the standards-based MVR
   `Fixture/Color` value. Existing fixture dictionaries using `color` continue
-  to load and are saved with the clearer `visual_color` key.
+  to load and are saved with the clearer `visual_color` key. Type Colors,
+  including automatically assigned colors, are preserved in root-level
+  Perastage MVR metadata so fixture tables and summaries recover them when a
+  project is reopened.
 - **Selectable fixtures within groups** - moving a fixture no longer drags its entire group, making it easy to reposition individual fixtures along grouped trusses.
 - **On-drag gizmos and feedback** - a 2D position gizmo and highlighted X/Y/Z readouts provide clear movement direction feedback, matching the 3D viewer.
 - **Group selection and highlights** - selecting a grouped member now highlights and transforms the entire root group (including nested groups) and group hover feedback uses clearer colours that match table selections.  Quick clicks select full groups in the 3D view.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -28,6 +28,12 @@ Perastage v1.4.0 delivers a long-anticipated refresh of the modelling and riggin
 
 ## Improvements
 
+- **Clear fixture color semantics** - fixture tables and edit dialogs now show
+  separate Type Color and MVR Color fields. Type Color remains the Perastage
+  appearance used in plans, summaries, legends, and type-based coloring,
+  while MVR Color exclusively controls the standards-based MVR
+  `Fixture/Color` value. Existing fixture dictionaries using `color` continue
+  to load and are saved with the clearer `visual_color` key.
 - **Selectable fixtures within groups** - moving a fixture no longer drags its entire group, making it easy to reposition individual fixtures along grouped trusses.
 - **On-drag gizmos and feedback** - a 2D position gizmo and highlighted X/Y/Z readouts provide clear movement direction feedback, matching the 3D viewer.
 - **Group selection and highlights** - selecting a grouped member now highlights and transforms the entire root group (including nested groups) and group hover feedback uses clearer colours that match table selections.  Quick clicks select full groups in the 3D view.

--- a/gui/dictionaryeditdialog.cpp
+++ b/gui/dictionaryeditdialog.cpp
@@ -971,7 +971,7 @@ void DictionaryEditDialog::BuildLayout() {
   auto *colorRenderer =
       new ColorfulIconTextRenderer(wxDATAVIEW_CELL_INERT, wxALIGN_LEFT);
   colorRenderer->EnableEllipsize(wxELLIPSIZE_NONE);
-  fixtureTable->AppendColumn(new wxDataViewColumn("Visual Color", colorRenderer,
+  fixtureTable->AppendColumn(new wxDataViewColumn("Type Color", colorRenderer,
                                                   kFixtureVisualColorColumn,
                                                   110, wxALIGN_LEFT, flags));
   ColumnUtils::EnforceMinColumnWidth(fixtureTable);

--- a/gui/dictionaryeditdialog.cpp
+++ b/gui/dictionaryeditdialog.cpp
@@ -60,8 +60,8 @@ constexpr int kFixtureModeColumn =
     TableColumnIndices::ToIndex(FixtureDictionaryColumn::Mode);
 constexpr int kFixtureCategoryColumn =
     TableColumnIndices::ToIndex(FixtureDictionaryColumn::Category);
-constexpr int kFixtureColorColumn =
-    TableColumnIndices::ToIndex(FixtureDictionaryColumn::Color);
+constexpr int kFixtureVisualColorColumn =
+    TableColumnIndices::ToIndex(FixtureDictionaryColumn::VisualColor);
 constexpr int kTrussNameColumn =
     TableColumnIndices::ToIndex(TrussDictionaryColumn::Name);
 constexpr int kTrussFileColumn =
@@ -88,7 +88,7 @@ std::optional<std::string> NormalizeFixtureHexColor(const std::string &raw) {
   return "#" + value;
 }
 
-std::string ExtractFixtureColorText(const wxVariant &value) {
+std::string ExtractFixtureVisualColorText(const wxVariant &value) {
   if (value.GetType() == "wxDataViewIconText") {
     wxDataViewIconText iconText;
     iconText << value;
@@ -129,7 +129,7 @@ bool FixturePathsMatchForColorFamily(const std::string &lhs,
          std::filesystem::equivalent(leftPath, rightPath, ec) && !ec;
 }
 
-void SetFixtureColorCell(wxDataViewListCtrl *table, int row,
+void SetFixtureVisualColorCell(wxDataViewListCtrl *table, int row,
                          const std::string &hexColor) {
   if (!table || row == wxNOT_FOUND)
     return;
@@ -138,7 +138,7 @@ void SetFixtureColorCell(wxDataViewListCtrl *table, int row,
   const auto normalized = NormalizeFixtureHexColor(hexColor);
   if (!normalized.has_value() || normalized->empty()) {
     colorValue << wxDataViewIconText(wxString(), wxNullBitmap);
-    table->SetValue(colorValue, row, kFixtureColorColumn);
+    table->SetValue(colorValue, row, kFixtureVisualColorColumn);
     return;
   }
 
@@ -152,7 +152,7 @@ void SetFixtureColorCell(wxDataViewListCtrl *table, int row,
   }
   colorValue << wxDataViewIconText(wxString::FromUTF8(*normalized),
                                    colorSwatch);
-  table->SetValue(colorValue, row, kFixtureColorColumn);
+  table->SetValue(colorValue, row, kFixtureVisualColorColumn);
 }
 
 bool IsRedCell(const ColorfulDataViewListStore *store, int row, int col) {
@@ -223,7 +223,7 @@ struct FixtureRow {
   std::string path;
   std::string mode;
   std::string category;
-  std::string color;
+  std::string visualColorHex;
   std::string sha256;
 };
 
@@ -823,7 +823,7 @@ bool SaveFixturesSnapshotToFile(
   for (const auto &name : keys) {
     const auto &entry = dict.at(name);
     if (entry.path.empty() && entry.mode.empty() && entry.category.empty() &&
-        entry.color.empty())
+        entry.visualColorHex.empty())
       continue;
     nlohmann::json obj;
     if (!entry.path.empty()) {
@@ -849,8 +849,8 @@ bool SaveFixturesSnapshotToFile(
       obj["mode"] = entry.mode;
     if (!entry.category.empty())
       obj["category"] = entry.category;
-    if (!entry.color.empty())
-      obj["color"] = entry.color;
+    if (!entry.visualColorHex.empty())
+      obj["visual_color"] = entry.visualColorHex;
     if (!obj.empty())
       entries[name] = obj;
   }
@@ -971,8 +971,9 @@ void DictionaryEditDialog::BuildLayout() {
   auto *colorRenderer =
       new ColorfulIconTextRenderer(wxDATAVIEW_CELL_INERT, wxALIGN_LEFT);
   colorRenderer->EnableEllipsize(wxELLIPSIZE_NONE);
-  fixtureTable->AppendColumn(new wxDataViewColumn(
-      "Color", colorRenderer, kFixtureColorColumn, 110, wxALIGN_LEFT, flags));
+  fixtureTable->AppendColumn(new wxDataViewColumn("Visual Color", colorRenderer,
+                                                  kFixtureVisualColorColumn,
+                                                  110, wxALIGN_LEFT, flags));
   ColumnUtils::EnforceMinColumnWidth(fixtureTable);
   fixturesSelection = BuildDictionarySelectionControls(
       fixturePanel, fixtureSizer, "Active fixtures dictionary",
@@ -1136,7 +1137,8 @@ void DictionaryEditDialog::LoadFixtures() {
   for (const auto &[name, entry] : *dictOpt) {
     if (entry.path.empty())
       continue;
-    FixtureRow row{ name, entry.path, entry.mode, entry.category, entry.color };
+    FixtureRow row{name, entry.path, entry.mode, entry.category,
+                   entry.visualColorHex};
     rows.push_back(row);
   }
   SortFixtureRows(rows);
@@ -1155,7 +1157,7 @@ void DictionaryEditDialog::LoadFixtures() {
     const int rowIndex = fixtureTable->GetItemCount() - 1;
     if (!fileExists && rowIndex >= 0)
       fixtureStore->SetCellTextColour(static_cast<size_t>(rowIndex), 1, *wxRED);
-    SetFixtureColorCell(fixtureTable, rowIndex, row.color);
+    SetFixtureVisualColorCell(fixtureTable, rowIndex, row.visualColorHex);
     fixturePaths.push_back(row.path);
   }
 
@@ -1224,8 +1226,8 @@ DictionaryEditDialog::BuildFixtureSnapshotFromUi() const {
     fixtureTable->GetValue(modeVar, i, kFixtureModeColumn);
     const std::string mode = std::string(modeVar.GetString().ToUTF8());
     wxVariant colorVar;
-    fixtureTable->GetValue(colorVar, i, kFixtureColorColumn);
-    const std::string color = ExtractFixtureColorText(colorVar);
+    fixtureTable->GetValue(colorVar, i, kFixtureVisualColorColumn);
+    const std::string color = ExtractFixtureVisualColorText(colorVar);
     snapshot.push_back(name + '\n' + path + '\n' + mode + '\n' + color);
   }
   std::sort(snapshot.begin(), snapshot.end());
@@ -1407,8 +1409,8 @@ bool DictionaryEditDialog::SaveFixtures() {
     const std::string category = GdtfFixtureCategory::NormalizeCategory(
         std::string(categoryVar.GetString().ToUTF8()));
     wxVariant colorVar;
-    fixtureTable->GetValue(colorVar, i, kFixtureColorColumn);
-    const std::string rawColor = ExtractFixtureColorText(colorVar);
+    fixtureTable->GetValue(colorVar, i, kFixtureVisualColorColumn);
+    const std::string rawColor = ExtractFixtureVisualColorText(colorVar);
     const auto normalizedColor = NormalizeFixtureHexColor(rawColor);
     if (!normalizedColor.has_value()) {
       wxMessageBox(
@@ -1429,7 +1431,7 @@ bool DictionaryEditDialog::SaveFixtures() {
     entry.path = row.path;
     entry.mode = row.mode;
     entry.category = row.category;
-    entry.color = row.color;
+    entry.visualColorHex = row.visualColorHex;
     entry.importedAt = FileImportUtils::NowUtcIso8601();
     if (!row.sha256.empty())
       entry.sha256 = row.sha256;
@@ -1523,7 +1525,8 @@ void DictionaryEditDialog::OnAdd(wxCommandEvent &WXUNUSED(event)) {
     items.push_back(wxString());
     items.push_back(wxString());
     fixtureTable->AppendItem(items);
-    SetFixtureColorCell(fixtureTable, fixtureTable->GetItemCount() - 1, "");
+    SetFixtureVisualColorCell(fixtureTable, fixtureTable->GetItemCount() - 1,
+                              "");
     fixturePaths.push_back(fullPath);
   } else {
     wxString trussDir =
@@ -1591,7 +1594,7 @@ void DictionaryEditDialog::OnDownloadGdtf(wxCommandEvent &WXUNUSED(event)) {
   }
 }
 
-void DictionaryEditDialog::UpdateFixtureColorForFileAndMode(
+void DictionaryEditDialog::UpdateFixtureVisualColorForFileAndMode(
     int row, const std::string &colorHex) {
   if (!fixtureTable || row < 0 ||
       static_cast<size_t>(row) >= fixturePaths.size())
@@ -1618,11 +1621,11 @@ void DictionaryEditDialog::UpdateFixtureColorForFileAndMode(
         NormalizeFixtureModeKey(std::string(modeVar.GetString().ToUTF8()));
     if (modeKey != targetModeKey)
       continue;
-    SetFixtureColorCell(fixtureTable, i, colorHex);
+    SetFixtureVisualColorCell(fixtureTable, i, colorHex);
   }
 }
 
-void DictionaryEditDialog::SyncFixtureColorForFileAndMode(int row) {
+void DictionaryEditDialog::SyncFixtureVisualColorForFileAndMode(int row) {
   if (!fixtureTable || row < 0 ||
       static_cast<size_t>(row) >= fixturePaths.size())
     return;
@@ -1657,13 +1660,13 @@ void DictionaryEditDialog::SyncFixtureColorForFileAndMode(int row) {
       continue;
 
     wxVariant colorVar;
-    fixtureTable->GetValue(colorVar, i, kFixtureColorColumn);
-    const std::string color = ExtractFixtureColorText(colorVar);
+    fixtureTable->GetValue(colorVar, i, kFixtureVisualColorColumn);
+    const std::string color = ExtractFixtureVisualColorText(colorVar);
     const auto normalizedColor = NormalizeFixtureHexColor(color);
     if (!normalizedColor.has_value() || normalizedColor->empty())
       continue;
 
-    SetFixtureColorCell(fixtureTable, row, *normalizedColor);
+    SetFixtureVisualColorCell(fixtureTable, row, *normalizedColor);
     return;
   }
 }
@@ -2179,7 +2182,7 @@ void DictionaryEditDialog::OnItemActivated(wxDataViewEvent &event) {
         std::string mode = std::string(dlg.GetStringSelection().ToUTF8());
         table->SetValue(wxVariant(wxString::FromUTF8(mode)), row,
                         kFixtureModeColumn);
-        SyncFixtureColorForFileAndMode(row);
+        SyncFixtureVisualColorForFileAndMode(row);
       }
       return;
     }
@@ -2206,11 +2209,11 @@ void DictionaryEditDialog::OnItemActivated(wxDataViewEvent &event) {
       UpdateFixtureCategoryForFile(row, selectedCategory);
       return;
     }
-    if (col == kFixtureColorColumn) {
+    if (col == kFixtureVisualColorColumn) {
       wxVariant current;
       table->GetValue(current, row, col);
       wxString colorString =
-          wxString::FromUTF8(ExtractFixtureColorText(current));
+          wxString::FromUTF8(ExtractFixtureVisualColorText(current));
       wxColour initial(colorString);
       if (colorString.IsEmpty() || !initial.IsOk())
         initial = *wxWHITE;
@@ -2224,7 +2227,7 @@ void DictionaryEditDialog::OnItemActivated(wxDataViewEvent &event) {
           wxString::Format("#%02X%02X%02X", selected.Red(), selected.Green(),
                            selected.Blue())
               .ToStdString();
-      UpdateFixtureColorForFileAndMode(row, hex);
+      UpdateFixtureVisualColorForFileAndMode(row, hex);
       return;
     }
     if (col != kFixtureFileColumn)
@@ -2256,7 +2259,7 @@ void DictionaryEditDialog::OnItemActivated(wxDataViewEvent &event) {
     }
     table->SetValue(wxVariant(wxString::FromUTF8(mode)), row,
                     kFixtureModeColumn);
-    SyncFixtureColorForFileAndMode(row);
+    SyncFixtureVisualColorForFileAndMode(row);
   } else {
     if (col != kTrussFileColumn)
       return;

--- a/gui/dictionaryeditdialog.h
+++ b/gui/dictionaryeditdialog.h
@@ -44,9 +44,10 @@ private:
   bool HasTrussChanges() const;
   void ShowDictionaryLoadStatusMessages();
   bool IsFixturesPage() const;
-  void SyncFixtureColorForFileAndMode(int row);
+  void SyncFixtureVisualColorForFileAndMode(int row);
   void UpdateFixtureCategoryForFile(int row, const std::string &category);
-  void UpdateFixtureColorForFileAndMode(int row, const std::string &colorHex);
+  void UpdateFixtureVisualColorForFileAndMode(int row,
+                                              const std::string &colorHex);
   void OnFixtureTableMouseMove(wxMouseEvent &event);
   void OnFixtureTableMouseLeave(wxMouseEvent &event);
   void OnTrussTableMouseMove(wxMouseEvent &event);

--- a/gui/fixtureeditdialog.cpp
+++ b/gui/fixtureeditdialog.cpp
@@ -1091,6 +1091,14 @@ void FixtureEditDialog::ApplyChanges() {
       panel->ApplyModeForGdtf(gdtfPath, wxString::FromUTF8(mode));
     }
   }
+  if (fixtureColorChanged) {
+    wxDataViewItemArray colorSource;
+    colorSource.Add(table->RowToItem(row));
+    panel->PropagateTypeValues(
+        colorSource,
+        FixtureTableColumns::ToIndex(
+            FixtureTableColumns::Column::VisualColor));
+  }
   panel->ResyncRows(oldOrder, selectedUuids);
   auto updateType = FixtureTablePanel::SceneDataUpdateType::kVisualLabelOnly;
   for (size_t i = 0; i < modifiedColumns.size(); ++i) {

--- a/gui/fixtureeditdialog.cpp
+++ b/gui/fixtureeditdialog.cpp
@@ -16,39 +16,39 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "fixtureeditdialog.h"
+#include "configmanager.h"
+#include "filesystem_path_utils.h"
 #include "fixturepreviewpanel.h"
 #include "fixturetablepanel.h"
-#include "configmanager.h"
-#include "guiconfigservices.h"
-#include "hoist_load_recalculation_prompt.h"
-#include "filesystem_path_utils.h"
+#include "gdtf_mutation_audit.h"
 #include "gdtfdictionary.h"
 #include "gdtfloader.h"
-#include "gdtf_mutation_audit.h"
+#include "guiconfigservices.h"
+#include "hoist_load_recalculation_prompt.h"
 #include "projectutils.h"
 #include "symbolcache.h"
 #include "symbols/PerastageSvgSymbol.h"
+#include "units/units.h"
 #include "viewer2dpanel.h"
 #include "viewer3dpanel.h"
-#include "units/units.h"
+#include <algorithm>
+#include <cmath>
+#include <filesystem>
+#include <initializer_list>
+#include <memory>
+#include <set>
+#include <tinyxml2.h>
+#include <unordered_map>
+#include <unordered_set>
+#include <wx/clrpicker.h>
 #include <wx/datetime.h>
+#include <wx/dcbuffer.h>
 #include <wx/filedlg.h>
 #include <wx/filename.h>
-#include <wx/clrpicker.h>
-#include <wx/dcbuffer.h>
 #include <wx/graphics.h>
 #include <wx/mstream.h>
 #include <wx/wfstream.h>
 #include <wx/zipstrm.h>
-#include <tinyxml2.h>
-#include <unordered_map>
-#include <unordered_set>
-#include <set>
-#include <cmath>
-#include <memory>
-#include <algorithm>
-#include <initializer_list>
-#include <filesystem>
 
 namespace {
 
@@ -82,12 +82,12 @@ bool IsPathInsideDirectory(const std::filesystem::path &path,
 bool IsUserFixtureLibraryPath(const std::string &path) {
   const std::filesystem::path candidate = PathUtils::PathFromUtf8(path);
   return IsPathInsideDirectory(
-      candidate,
-      PathUtils::PathFromUtf8(ProjectUtils::GetWritableLibraryPath("fixtures")));
+      candidate, PathUtils::PathFromUtf8(
+                     ProjectUtils::GetWritableLibraryPath("fixtures")));
 }
 
-
-// Checks whether two fixture records use the same GDTF type-level physical values.
+// Checks whether two fixture records use the same GDTF type-level physical
+// values.
 bool MatchesPhysicalPropertyType(const Fixture &fixture,
                                  const std::string &gdtfSpec,
                                  const std::string &typeName) {
@@ -96,7 +96,8 @@ bool MatchesPhysicalPropertyType(const Fixture &fixture,
   return !typeName.empty() && fixture.typeName == typeName;
 }
 
-// Mirrors a GDTF physical-property edit to every row and fixture of the same type.
+// Mirrors a GDTF physical-property edit to every row and fixture of the same
+// type.
 std::unordered_set<std::string> ApplySharedPhysicalPropertyEdit(
     wxDataViewListCtrl *table, const std::vector<std::string> &rowUuids,
     const std::string &sourceUuid, float weightKg, float powerW) {
@@ -112,25 +113,30 @@ std::unordered_set<std::string> ApplySharedPhysicalPropertyEdit(
   const std::string gdtfSpec = sourceIt->second.gdtfSpec;
   const std::string typeName = sourceIt->second.typeName;
   const auto weightUnitSystem = Units::ParseWeightUnitSystem(
-      GetDefaultGuiConfigServices().LegacyConfigManager().GetValue("ui_weight_unit_system"));
+      GetDefaultGuiConfigServices().LegacyConfigManager().GetValue(
+          "ui_weight_unit_system"));
   const wxVariant powerValue(wxString::Format("%.1f", powerW));
-  const wxVariant weightValue(wxString::FromUTF8(Units::FormatWeightFromKilograms(
+  const wxVariant weightValue(
+      wxString::FromUTF8(Units::FormatWeightFromKilograms(
       weightKg, weightUnitSystem, Units::ValueFormatContext::Table)));
 
-  const size_t count = std::min(static_cast<size_t>(table->GetItemCount()), rowUuids.size());
+  const size_t count =
+      std::min(static_cast<size_t>(table->GetItemCount()), rowUuids.size());
   for (size_t rowIndex = 0; rowIndex < count; ++rowIndex) {
     const auto fixtureIt = scene.fixtures.find(rowUuids[rowIndex]);
     if (fixtureIt == scene.fixtures.end() ||
         !MatchesPhysicalPropertyType(fixtureIt->second, gdtfSpec, typeName))
       continue;
 
-    if (!Units::NearlyEqualWeightKilograms(fixtureIt->second.weightKg, weightKg, 0.001))
+    if (!Units::NearlyEqualWeightKilograms(fixtureIt->second.weightKg, weightKg,
+                                           0.001))
       changedWeightPositions.insert(fixtureIt->second.positionName.empty()
                                         ? "Unassigned"
                                         : fixtureIt->second.positionName);
     fixtureIt->second.weightKg = weightKg;
     fixtureIt->second.powerConsumptionW = powerW;
-    fixtureIt->second.physicalPropertiesSource = FixturePhysicalPropertiesSource::Gdtf;
+    fixtureIt->second.physicalPropertiesSource =
+        FixturePhysicalPropertiesSource::Gdtf;
     fixtureIt->second.physicalPropertiesDirty = false;
     table->SetValue(powerValue, rowIndex, 16);
     table->SetValue(weightValue, rowIndex, 17);
@@ -369,8 +375,8 @@ bool LoadGdtfMetadataSummary(const std::string &gdtfPath,
 
   if (root) {
     if (outSummary.version.empty())
-      outSummary.version =
-          FirstNonEmptyAttribute(root, {"DataVersion", "Version", "CreatedWith"});
+      outSummary.version = FirstNonEmptyAttribute(
+          root, {"DataVersion", "Version", "CreatedWith"});
     if (outSummary.creationDate.empty())
       outSummary.creationDate = FirstNonEmptyAttribute(
           root, {"CreateDate", "CreationDate", "DateCreated"});
@@ -378,7 +384,8 @@ bool LoadGdtfMetadataSummary(const std::string &gdtfPath,
 
   tinyxml2::XMLElement *revisions = fixtureType->FirstChildElement("Revisions");
   if (revisions) {
-    tinyxml2::XMLElement *firstRevision = revisions->FirstChildElement("Revision");
+    tinyxml2::XMLElement *firstRevision =
+        revisions->FirstChildElement("Revision");
     tinyxml2::XMLElement *latestRevision = nullptr;
     for (tinyxml2::XMLElement *rev = revisions->FirstChildElement("Revision");
          rev; rev = rev->NextSiblingElement("Revision")) {
@@ -420,8 +427,8 @@ FixtureEditDialog::FixtureEditDialog(FixtureTablePanel *p, int r)
       new wxStaticBoxSizer(wxVERTICAL, this, "Fixture-specific");
   wxStaticBoxSizer *metadataSizer =
       new wxStaticBoxSizer(wxVERTICAL, this, "GDTF metadata");
-  wxStaticBoxSizer *gdtfGeneralSizer =
-      new wxStaticBoxSizer(wxVERTICAL, this, "GDTF (shared for this fixture type)");
+  wxStaticBoxSizer *gdtfGeneralSizer = new wxStaticBoxSizer(
+      wxVERTICAL, this, "GDTF (shared for this fixture type)");
   wxFlexGridSizer *fixtureGrid = new wxFlexGridSizer(2, 5, 5);
   fixtureGrid->AddGrowableCol(1, 1);
   wxFlexGridSizer *gdtfGrid = new wxFlexGridSizer(2, 5, 5);
@@ -439,7 +446,8 @@ FixtureEditDialog::FixtureEditDialog(FixtureTablePanel *p, int r)
   auto addLabeledControl = [&](size_t index, wxWindow *controlWindow,
                                wxSizer *nestedSizer, bool isGdtfField) {
     wxFlexGridSizer *targetGrid = isGdtfField ? gdtfGrid : fixtureGrid;
-    targetGrid->Add(new wxStaticText(this, wxID_ANY, panel->columnLabels[index]), 0,
+    targetGrid->Add(
+        new wxStaticText(this, wxID_ANY, panel->columnLabels[index]), 0,
                     wxALIGN_CENTER_VERTICAL);
     if (nestedSizer)
       targetGrid->Add(nestedSizer, 1, wxEXPAND);
@@ -480,9 +488,8 @@ FixtureEditDialog::FixtureEditDialog(FixtureTablePanel *p, int r)
       modelCtrl = new wxTextCtrl(this, wxID_ANY);
       if ((size_t)row < panel->gdtfPaths.size())
         modelCtrl->SetValue(panel->gdtfPaths[row]);
-      modelCtrl->Bind(wxEVT_TEXT, [this, i](wxCommandEvent &) {
-        MarkColumnModified(i);
-      });
+      modelCtrl->Bind(wxEVT_TEXT,
+                      [this, i](wxCommandEvent &) { MarkColumnModified(i); });
       hs->Add(modelCtrl, 1, wxEXPAND | wxRIGHT, 5);
       wxButton *browse = new wxButton(this, wxID_ANY, "...");
       hs->Add(browse, 0);
@@ -500,12 +507,14 @@ FixtureEditDialog::FixtureEditDialog(FixtureTablePanel *p, int r)
       int selection = category->FindString(v.GetString());
       if (selection != wxNOT_FOUND)
         category->SetSelection(selection);
-      category->Bind(wxEVT_CHOICE, [this, i](wxCommandEvent &) {
-        MarkColumnModified(i);
-      });
+      category->Bind(wxEVT_CHOICE,
+                     [this, i](wxCommandEvent &) { MarkColumnModified(i); });
       ctrls[i] = category;
       controlWindow = category;
-    } else if (i == 19) {
+    } else if (i == static_cast<size_t>(FixtureTableColumns::ToIndex(
+                        FixtureTableColumns::Column::VisualColor)) ||
+               i == static_cast<size_t>(FixtureTableColumns::ToIndex(
+                        FixtureTableColumns::Column::MvrColor))) {
       wxString colorString;
       if (v.GetType() == "wxDataViewIconText") {
         wxDataViewIconText icon;
@@ -524,7 +533,8 @@ FixtureEditDialog::FixtureEditDialog(FixtureTablePanel *p, int r)
       controlWindow = picker;
     } else {
       wxTextCtrl *tc = new wxTextCtrl(this, wxID_ANY, v.GetString());
-      tc->Bind(wxEVT_TEXT, [this, i](wxCommandEvent &) { MarkColumnModified(i); });
+      tc->Bind(wxEVT_TEXT,
+               [this, i](wxCommandEvent &) { MarkColumnModified(i); });
       ctrls[i] = tc;
       controlWindow = tc;
     }
@@ -545,14 +555,14 @@ FixtureEditDialog::FixtureEditDialog(FixtureTablePanel *p, int r)
   wxFlexGridSizer *metadataGrid = new wxFlexGridSizer(2, 4, 8);
   metadataGrid->AddGrowableCol(1, 1);
   const std::array<wxString, 8> metadataLabels = {
-      "Manufacturer", "Description", "Creation date", "UserID", "ModifiedBy",
-      "Revision", "Last modified", "Version"};
+      "Manufacturer", "Description", "Creation date", "UserID",
+      "ModifiedBy",   "Revision",    "Last modified", "Version"};
   for (size_t i = 0; i < metadataLabels.size(); ++i) {
     metadataGrid->Add(new wxStaticText(this, wxID_ANY, metadataLabels[i]), 0,
                       wxALIGN_CENTER_VERTICAL);
     if (i == 1) {
-      metadataDescriptionCtrl = new wxTextCtrl(
-          this, wxID_ANY, "-", wxDefaultPosition, wxSize(-1, 90),
+      metadataDescriptionCtrl =
+          new wxTextCtrl(this, wxID_ANY, "-", wxDefaultPosition, wxSize(-1, 90),
           wxTE_MULTILINE | wxTE_READONLY);
       metadataDescriptionCtrl->SetMinSize(wxSize(300, 90));
       metadataDescriptionCtrl->ShowPosition(0);
@@ -569,15 +579,16 @@ FixtureEditDialog::FixtureEditDialog(FixtureTablePanel *p, int r)
   gdtfGeneralSizer->Add(gdtfGrid, 1, wxEXPAND | wxALL, 6);
   gdtfGeneralSizer->Add(
       new wxStaticText(this, wxID_ANY,
-                       "Changes in this column update the GDTF file and append a GDTF revision entry."),
+                       "Changes in this column update the GDTF file and append "
+                       "a GDTF revision entry."),
       0, wxLEFT | wxRIGHT | wxBOTTOM, 6);
 
   channelList = new wxTextCtrl(this, wxID_ANY, "", wxDefaultPosition,
                                wxSize(-1, 150), wxTE_MULTILINE | wxTE_READONLY);
   gdtfGeneralSizer->Add(new wxStaticText(this, wxID_ANY, "Mode channels"), 0,
                         wxLEFT | wxRIGHT | wxTOP, 6);
-  gdtfGeneralSizer->Add(channelList, 1,
-                        wxLEFT | wxRIGHT | wxBOTTOM | wxEXPAND, 6);
+  gdtfGeneralSizer->Add(channelList, 1, wxLEFT | wxRIGHT | wxBOTTOM | wxEXPAND,
+                        6);
 
   wxBoxSizer *formSizer = new wxBoxSizer(wxHORIZONTAL);
   wxBoxSizer *leftColumnSizer = new wxBoxSizer(wxVERTICAL);
@@ -614,8 +625,7 @@ FixtureEditDialog::FixtureEditDialog(FixtureTablePanel *p, int r)
 
   wxStaticBoxSizer *imageSizer =
       new wxStaticBoxSizer(wxVERTICAL, this, "Fixture image");
-  fixtureImagePreview =
-      new wxStaticBitmap(this, wxID_ANY, wxBitmap(220, 220));
+  fixtureImagePreview = new wxStaticBitmap(this, wxID_ANY, wxBitmap(220, 220));
   imageSizer->Add(fixtureImagePreview, 0, wxALIGN_CENTER | wxALL, 4);
   rightSizer->Add(imageSizer, 0, wxEXPAND | wxBOTTOM, 5);
   rightSizer->SetMinSize(wxSize(280, -1));
@@ -696,7 +706,9 @@ void FixtureEditDialog::OnBrowse(wxCommandEvent &) {
   UpdateMetadataSummary();
 }
 
-void FixtureEditDialog::OnModeChanged(wxCommandEvent &) { UpdateChannels(true); }
+void FixtureEditDialog::OnModeChanged(wxCommandEvent &) {
+  UpdateChannels(true);
+}
 
 void FixtureEditDialog::OnSymbolPreviewPaint(wxPaintEvent &evt) {
   wxPanel *panelWindow = wxDynamicCast(evt.GetEventObject(), wxPanel);
@@ -729,15 +741,18 @@ void FixtureEditDialog::OnSymbolPreviewPaint(wxPaintEvent &evt) {
 
   const PerastageSvgSymbolData &svg = symbolData[panelIndex];
   wxRect rect = panelWindow->GetClientRect();
-  const double scale = std::min(
-      (rect.GetWidth() - 8.0) / std::max(1.0, svg.viewBoxWidth),
+  const double scale =
+      std::min((rect.GetWidth() - 8.0) / std::max(1.0, svg.viewBoxWidth),
       (rect.GetHeight() - 8.0) / std::max(1.0, svg.viewBoxHeight));
-  const double originX = rect.GetX() + (rect.GetWidth() - svg.viewBoxWidth * scale) * 0.5;
-  const double originY = rect.GetY() + (rect.GetHeight() - svg.viewBoxHeight * scale) * 0.5;
+  const double originX =
+      rect.GetX() + (rect.GetWidth() - svg.viewBoxWidth * scale) * 0.5;
+  const double originY =
+      rect.GetY() + (rect.GetHeight() - svg.viewBoxHeight * scale) * 0.5;
 
   gc->SetPen(wxPen(wxColour(210, 210, 210), 1));
   gc->SetBrush(*wxWHITE_BRUSH);
-  gc->DrawRectangle(rect.GetX(), rect.GetY(), rect.GetWidth(), rect.GetHeight());
+  gc->DrawRectangle(rect.GetX(), rect.GetY(), rect.GetWidth(),
+                    rect.GetHeight());
   gc->SetPen(*wxTRANSPARENT_PEN);
   gc->SetBrush(wxBrush(wxColour(224, 224, 224)));
   for (const auto &poly : svg.fills) {
@@ -788,9 +803,8 @@ void FixtureEditDialog::UpdateVisualizers() {
     gdtfPath = panel->gdtfPaths[row];
   }
   const std::string path = std::string(gdtfPath.ToUTF8());
-  const std::array<SymbolViewKind, 3> views = {SymbolViewKind::Bottom,
-                                                SymbolViewKind::Front,
-                                                SymbolViewKind::Left};
+  const std::array<SymbolViewKind, 3> views = {
+      SymbolViewKind::Bottom, SymbolViewKind::Front, SymbolViewKind::Left};
   for (size_t i = 0; i < views.size(); ++i) {
     PerastageSvgSymbolData loaded;
     symbolAvailability[i] =
@@ -839,9 +853,12 @@ void FixtureEditDialog::UpdateMetadataSummary() {
   const std::array<wxString, 8> values = {
       toValueOrFallback(metadata.manufacturer),
       toValueOrFallback(metadata.description),
-      toValueOrFallback(metadata.creationDate), toValueOrFallback(metadata.userId),
-      toValueOrFallback(metadata.modifiedBy), toValueOrFallback(metadata.revision),
-      toValueOrFallback(metadata.lastModified), toValueOrFallback(metadata.version)};
+      toValueOrFallback(metadata.creationDate),
+      toValueOrFallback(metadata.userId),
+      toValueOrFallback(metadata.modifiedBy),
+      toValueOrFallback(metadata.revision),
+      toValueOrFallback(metadata.lastModified),
+      toValueOrFallback(metadata.version)};
   for (size_t i = 0; i < metadataValueLabels.size() && i < values.size(); ++i) {
     if (i == 1 && metadataDescriptionCtrl) {
       metadataDescriptionCtrl->SetValue(values[i]);
@@ -894,9 +911,8 @@ void FixtureEditDialog::UpdateChannels(bool markChannelCountDirty) {
     func.Trim(true).Trim(false);
     if (func.empty())
       func = "-";
-    const wxString channelLabel = ch.isVirtual
-                                   ? wxString("V")
-                                   : wxString::Format("%d", ch.channel);
+    const wxString channelLabel =
+        ch.isVirtual ? wxString("V") : wxString::Format("%d", ch.channel);
     msg += channelLabel + ": " + func + "\n";
   }
   channelList->SetValue(msg);
@@ -930,8 +946,8 @@ void FixtureEditDialog::ApplyChanges() {
   if ((size_t)row < panel->rowUuids.size())
     selectedUuids.push_back(panel->rowUuids[row]);
 
-  const bool hasUserChanges = std::any_of(modifiedColumns.begin(),
-                                          modifiedColumns.end(),
+  const bool hasUserChanges =
+      std::any_of(modifiedColumns.begin(), modifiedColumns.end(),
                                           [](bool modified) { return modified; });
   if (!hasUserChanges)
     return;
@@ -953,7 +969,10 @@ void FixtureEditDialog::ApplyChanges() {
       auto *category = wxDynamicCast(ctrls[i], wxChoice);
       if (category)
         table->SetValue(wxVariant(category->GetStringSelection()), row, i);
-    } else if (i == 19) {
+    } else if (i == static_cast<size_t>(FixtureTableColumns::ToIndex(
+                        FixtureTableColumns::Column::VisualColor)) ||
+               i == static_cast<size_t>(FixtureTableColumns::ToIndex(
+                        FixtureTableColumns::Column::MvrColor))) {
       auto *picker = wxDynamicCast(ctrls[i], wxColourPickerCtrl);
       if (picker) {
         wxColour selectedColor = picker->GetColour();
@@ -996,15 +1015,19 @@ void FixtureEditDialog::ApplyChanges() {
       (modifiedColumns.size() > 2 && modifiedColumns[2]) ||
       (modifiedColumns.size() > 9 && modifiedColumns[9]);
   const bool fixtureColorChanged =
-      (modifiedColumns.size() > 19 && modifiedColumns[19]);
+      (modifiedColumns.size() >
+           static_cast<size_t>(FixtureTableColumns::ToIndex(
+               FixtureTableColumns::Column::VisualColor)) &&
+       modifiedColumns[static_cast<size_t>(FixtureTableColumns::ToIndex(
+           FixtureTableColumns::Column::VisualColor))]);
 
   if (gdtfTypeOrModelChanged && !fixtureColorChanged) {
     wxVariant typeVar;
     table->GetValue(typeVar, row, 2);
     const std::string currentType = std::string(typeVar.GetString().ToUTF8());
     if (auto dictEntry = GdtfDictionary::Get(currentType)) {
-      if (!dictEntry->color.empty())
-        SetFixtureColorCell(table, row, dictEntry->color);
+      if (!dictEntry->visualColorHex.empty())
+        SetFixtureColorCell(table, row, dictEntry->visualColorHex);
     }
   }
 
@@ -1024,7 +1047,8 @@ void FixtureEditDialog::ApplyChanges() {
       if (gdtfPhysicalCandidateChanged && gdtfPhysicalChanged) {
         std::string writableGdtfPath = std::string(gdtfPath.ToUTF8());
         if (IsUserFixtureLibraryPath(writableGdtfPath)) {
-          auto derivative = GdtfDictionary::CreateOrUpdatePerastageLibraryDerivative(
+          auto derivative =
+              GdtfDictionary::CreateOrUpdatePerastageLibraryDerivative(
               std::string(originalType.ToUTF8()), writableGdtfPath);
           if (derivative && !derivative->path.empty()) {
             writableGdtfPath = derivative->path;
@@ -1035,20 +1059,22 @@ void FixtureEditDialog::ApplyChanges() {
               if (static_cast<size_t>(row) >= panel->gdtfPaths.size())
                 panel->gdtfPaths.resize(static_cast<size_t>(row) + 1);
               panel->gdtfPaths[static_cast<size_t>(row)] = gdtfPath;
-              table->SetValue(wxVariant(wxFileName(gdtfPath).GetFullName()), row, 9);
+              table->SetValue(wxVariant(wxFileName(gdtfPath).GetFullName()),
+                              row, 9);
             }
           }
         }
         if (!SetGdtfProperties(writableGdtfPath, newWeightKg, newPowerW,
                                GdtfMutationAudit::BuildPerastageModifiedBy())) {
-          wxMessageBox(
-              "Could not update GDTF physical properties (Weight/PowerConsumption).",
+          wxMessageBox("Could not update GDTF physical properties "
+                       "(Weight/PowerConsumption).",
               "GDTF update", wxOK | wxICON_WARNING, this);
         } else {
           if (row >= 0 && static_cast<size_t>(row) < panel->rowUuids.size())
             changedWeightPositions = ApplySharedPhysicalPropertyEdit(
-                table, panel->rowUuids, panel->rowUuids[static_cast<size_t>(row)],
-                newWeightKg, newPowerW);
+                table, panel->rowUuids,
+                panel->rowUuids[static_cast<size_t>(row)], newWeightKg,
+                newPowerW);
           originalPowerW = newPowerW;
           originalWeightKg = newWeightKg;
         }
@@ -1059,7 +1085,8 @@ void FixtureEditDialog::ApplyChanges() {
       std::string mode =
           modeChoice ? std::string(modeChoice->GetStringSelection().ToUTF8())
                      : std::string();
-      // Project fixture metadata edits stay project-scoped and do not promote files into the user library.
+      // Project fixture metadata edits stay project-scoped and do not promote
+      // files into the user library.
       panel->ApplyModeForGdtf(gdtfPath, wxString::FromUTF8(mode));
     }
   }
@@ -1069,7 +1096,8 @@ void FixtureEditDialog::ApplyChanges() {
     if (!modifiedColumns[i])
       continue;
     updateType = FixtureTablePanel::CombineUpdateTypes(
-        updateType, FixtureTablePanel::UpdateTypeForColumn(static_cast<int>(i)));
+        updateType,
+        FixtureTablePanel::UpdateTypeForColumn(static_cast<int>(i)));
   }
   panel->UpdateSceneData(true, updateType);
   HoistLoadRecalculationPrompt::PromptAndApply(

--- a/gui/fixtureeditdialog.cpp
+++ b/gui/fixtureeditdialog.cpp
@@ -19,6 +19,7 @@
 #include "configmanager.h"
 #include "filesystem_path_utils.h"
 #include "fixturepreviewpanel.h"
+#include "fixturetable/fixture_table_columns.h"
 #include "fixturetablepanel.h"
 #include "gdtf_mutation_audit.h"
 #include "gdtfdictionary.h"

--- a/gui/fixturetable/fixture_table_columns.cpp
+++ b/gui/fixturetable/fixture_table_columns.cpp
@@ -12,7 +12,7 @@ constexpr std::array<const char *, Count()> kLabels = {
     "Universe",   "Channel",   "Mode",        "Ch Count", "Model file",
     "Pos X",      "Pos Y",     "Pos Z",       "Roll (X)", "Pitch (Y)",
     "Yaw (Z)",    "Power (W)", "Weight (kg)", "Category", "Type Color",
-    "MVR Color"};
+    "Color Filter"};
 constexpr std::array<int, Count()> kWidths = {90,  150, 180, 100, 120, 80, 80,
                                               120, 80,  180, 80,  80,  80, 80,
                                               80,  80,  100, 100, 120, 90, 90};

--- a/gui/fixturetable/fixture_table_columns.cpp
+++ b/gui/fixturetable/fixture_table_columns.cpp
@@ -11,10 +11,11 @@ constexpr std::array<const char *, Count()> kLabels = {
     "Fixture ID", "Name",      "Type",        "Layer",    "Hang Pos",
     "Universe",   "Channel",   "Mode",        "Ch Count", "Model file",
     "Pos X",      "Pos Y",     "Pos Z",       "Roll (X)", "Pitch (Y)",
-    "Yaw (Z)",    "Power (W)", "Weight (kg)", "Category", "Color"};
+    "Yaw (Z)",    "Power (W)", "Weight (kg)", "Category", "Type Color",
+    "MVR Color"};
 constexpr std::array<int, Count()> kWidths = {90,  150, 180, 100, 120, 80, 80,
                                               120, 80,  180, 80,  80,  80, 80,
-                                              80,  80,  100, 100, 120, 80};
+                                              80,  80,  100, 100, 120, 90, 90};
 static_assert(kLabels.size() == Count());
 static_assert(kWidths.size() == Count());
 } // namespace
@@ -84,6 +85,9 @@ bool IsTypeLevelPropagated(Column column) {
 // Checks whether a fixture column stores the Perastage visual color.
 bool IsVisualColor(Column column) { return column == Column::VisualColor; }
 
+// Checks whether a fixture column stores the official MVR Fixture/Color.
+bool IsMvrColor(Column column) { return column == Column::MvrColor; }
+
 // Checks whether a fixture column stores the fixture category.
 bool IsCategory(Column column) { return column == Column::Category; }
 
@@ -117,14 +121,16 @@ void ConfigureColumns(wxDataViewListCtrl *table,
         widths[i], wxALIGN_LEFT, flags));
   }
 
+  for (const Column column : {Column::VisualColor, Column::MvrColor}) {
   auto *colorRenderer =
       new ColorfulIconTextRenderer(wxDATAVIEW_CELL_INERT, wxALIGN_LEFT);
   colorRenderer->EnableEllipsize(wxELLIPSIZE_NONE);
-  const int colorColumn = ToIndex(Column::VisualColor);
+    const int colorColumn = ToIndex(column);
   table->AppendColumn(new wxDataViewColumn(
       columnLabels[static_cast<size_t>(colorColumn)], colorRenderer,
       colorColumn, widths[static_cast<size_t>(colorColumn)], wxALIGN_LEFT,
       flags));
+  }
 
   ColumnUtils::EnforceMinColumnWidth(table);
 }

--- a/gui/fixturetable/fixture_table_columns.h
+++ b/gui/fixturetable/fixture_table_columns.h
@@ -31,6 +31,7 @@ enum class Column : int {
   Weight,
   Category,
   VisualColor,
+  MvrColor,
   Count
 };
 
@@ -50,6 +51,7 @@ bool IsTransform(Column column);
 bool IsPhysicalProperty(Column column);
 bool IsTypeLevelPropagated(Column column);
 bool IsVisualColor(Column column);
+bool IsMvrColor(Column column);
 bool IsCategory(Column column);
 bool IsPatch(Column column);
 void ConfigureColumns(wxDataViewListCtrl *table,

--- a/gui/fixturetable/fixture_table_edit_service.cpp
+++ b/gui/fixturetable/fixture_table_edit_service.cpp
@@ -410,11 +410,21 @@ void ApplyFullRowChanges(
       icon << v;
       wxString txt = icon.GetText();
       if (!txt.IsEmpty())
-        next.color = std::string(txt.ToUTF8());
+        next.visualColorHex = std::string(txt.ToUTF8());
       else
-        next.color.clear();
+        next.visualColorHex.clear();
     } else {
-      next.color = std::string(v.GetString().ToUTF8());
+      next.visualColorHex = std::string(v.GetString().ToUTF8());
+    }
+    table->GetValue(
+        v, i,
+        FixtureTableColumns::ToIndex(FixtureTableColumns::Column::MvrColor));
+    if (v.GetType() == "wxDataViewIconText") {
+      wxDataViewIconText icon;
+      icon << v;
+      next.mvrFixtureColorHex = std::string(icon.GetText().ToUTF8());
+    } else {
+      next.mvrFixtureColorHex = std::string(v.GetString().ToUTF8());
     }
 
     const bool fixtureChanged =
@@ -429,7 +439,8 @@ void ApplyFullRowChanges(
         old.category != next.category ||
         old.categorySource != next.categorySource ||
         old.categorySourceReason != next.categorySourceReason ||
-        old.color != next.color;
+        old.visualColorHex != next.visualColorHex ||
+        old.mvrFixtureColorHex != next.mvrFixtureColorHex;
     if (!fixtureChanged)
       continue;
 
@@ -524,11 +535,11 @@ void ApplyAppearanceChanges(FixtureTableEditService::ISceneAdapter &adapter,
         value, row,
         FixtureTableColumns::ToIndex(FixtureTableColumns::Column::VisualColor));
     const std::string nextColor = ExtractColorValue(value);
-    if (it->second.color == nextColor)
+    if (it->second.visualColorHex == nextColor)
       continue;
 
     PushUndoIfNeeded(adapter, tracking);
-    it->second.color = nextColor;
+    it->second.visualColorHex = nextColor;
     TrackUpdatedFixture(it->second, tracking, logChanges);
   }
 

--- a/gui/fixturetable/fixture_table_edit_service.cpp
+++ b/gui/fixturetable/fixture_table_edit_service.cpp
@@ -523,9 +523,11 @@ void ApplyAppearanceChanges(FixtureTableEditService::ISceneAdapter &adapter,
                             bool logChanges) {
   auto &scene = adapter.GetScene();
   SceneUpdateTracking tracking;
-  const auto targetRows = ResolveTargetRows(table, rowUuids);
+  const size_t rowCount =
+      std::min(static_cast<size_t>(table->GetItemCount()), rowUuids.size());
+  std::unordered_set<std::string> updatedDictionaryKeys;
 
-  for (size_t row : targetRows) {
+  for (size_t row = 0; row < rowCount; ++row) {
     auto it = scene.fixtures.find(rowUuids[row]);
     if (it == scene.fixtures.end())
       continue;
@@ -541,6 +543,15 @@ void ApplyAppearanceChanges(FixtureTableEditService::ISceneAdapter &adapter,
     PushUndoIfNeeded(adapter, tracking);
     it->second.visualColorHex = nextColor;
     TrackUpdatedFixture(it->second, tracking, logChanges);
+
+    const std::string dictionaryKey =
+        it->second.typeName + '\x1f' + it->second.gdtfSpec + '\x1f' +
+        it->second.gdtfMode;
+    if (updatedDictionaryKeys.insert(dictionaryKey).second) {
+      GdtfDictionary::UpdateVisualColorForFile(
+          it->second.typeName, it->second.gdtfSpec, it->second.gdtfMode,
+          nextColor);
+    }
   }
 
   AppendChangeLogIfNeeded(tracking, logChanges);
@@ -648,38 +659,55 @@ void PropagateTypeValues(wxDataViewListCtrl *table,
   if (!column || !FixtureTableColumns::IsTypeLevelPropagated(*column))
     return;
 
-  if (FixtureTableColumns::IsVisualColor(*column))
-    return;
-
-  std::unordered_map<std::string, wxString> typeValues;
+  std::unordered_map<std::string, wxVariant> typeValues;
   for (const auto &it : selections) {
     int r = table->ItemToRow(it);
     if (r == wxNOT_FOUND)
       continue;
-    wxVariant vType, vVal;
+    wxVariant vType, vMode, vVal;
     table->GetValue(
         vType, r,
         FixtureTableColumns::ToIndex(FixtureTableColumns::Column::Type));
+    table->GetValue(
+        vMode, r,
+        FixtureTableColumns::ToIndex(FixtureTableColumns::Column::Mode));
     table->GetValue(vVal, r, col);
-    typeValues[std::string(vType.GetString().ToUTF8())] = vVal.GetString();
+    std::string key = std::string(vType.GetString().ToUTF8());
+    if (FixtureTableColumns::IsVisualColor(*column)) {
+      key.push_back('\x1f');
+      key += std::string(vMode.GetString().ToUTF8());
+    }
+    typeValues[key] = vVal;
   }
 
   unsigned int rowCount = table->GetItemCount();
   for (unsigned int i = 0; i < rowCount; ++i) {
-    wxVariant vType;
+    wxVariant vType, vMode;
     table->GetValue(
         vType, i,
         FixtureTableColumns::ToIndex(FixtureTableColumns::Column::Type));
-    auto it = typeValues.find(std::string(vType.GetString().ToUTF8()));
+    table->GetValue(
+        vMode, i,
+        FixtureTableColumns::ToIndex(FixtureTableColumns::Column::Mode));
+    std::string key = std::string(vType.GetString().ToUTF8());
+    if (FixtureTableColumns::IsVisualColor(*column)) {
+      key.push_back('\x1f');
+      key += std::string(vMode.GetString().ToUTF8());
+    }
+    auto it = typeValues.find(key);
     if (it == typeValues.end())
       continue;
 
     wxVariant currentValue;
     table->GetValue(currentValue, i, col);
-    if (currentValue.GetString() == it->second)
+    if (FixtureTableColumns::IsVisualColor(*column)) {
+      if (ExtractColorValue(currentValue) == ExtractColorValue(it->second))
+        continue;
+    } else if (currentValue.GetString() == it->second.GetString()) {
       continue;
+    }
 
-    table->SetValue(wxVariant(it->second), i, col);
+    table->SetValue(it->second, i, col);
   }
 }
 

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -903,8 +903,13 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
     return;
   }
 
-  if (col ==
-      FixtureTableColumns::ToIndex(FixtureTableColumns::Column::VisualColor)) {
+  const bool isVisualColor =
+      col ==
+      FixtureTableColumns::ToIndex(FixtureTableColumns::Column::VisualColor);
+  const bool isColorFilter =
+      col == FixtureTableColumns::ToIndex(
+                 FixtureTableColumns::Column::MvrColor);
+  if (isVisualColor || isColorFilter) {
     wxColourData data;
     data.SetChooseFull(true);
     wxColour initial(current.GetString());
@@ -930,7 +935,8 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
       if (r != wxNOT_FOUND)
         table->SetValue(var, r, col);
     }
-    PropagateTypeValues(selections, col);
+    if (isVisualColor)
+      PropagateTypeValues(selections, col);
     ResyncRows(oldOrder, selectedUuids);
     const auto updateType = UpdateTypeForColumn(col);
     UpdateSceneData(true, updateType);

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -413,7 +413,7 @@ void FixtureTablePanel::ReloadData() {
     row.push_back(power);
     row.push_back(weight);
     row.push_back(category);
-    wxString color = wxString::FromUTF8(fixture->color);
+    wxString color = wxString::FromUTF8(fixture->visualColorHex);
     if (!color.IsEmpty()) {
       wxColour col(color);
       wxBitmap bmp(16, 16);
@@ -427,6 +427,25 @@ void FixtureTablePanel::ReloadData() {
       wxDataViewIconText iconText(color, bmp);
       wxVariant var;
       var << iconText;
+      row.push_back(var);
+    } else {
+      wxVariant var;
+      var << wxDataViewIconText();
+      row.push_back(var);
+    }
+    wxString mvrColor = wxString::FromUTF8(fixture->mvrFixtureColorHex);
+    if (!mvrColor.IsEmpty()) {
+      wxColour col(mvrColor);
+      wxBitmap bmp(16, 16);
+      {
+        wxMemoryDC dc(bmp);
+        dc.SetPen(*wxTRANSPARENT_PEN);
+        dc.SetBrush(wxBrush(col));
+        dc.DrawRectangle(0, 0, 16, 16);
+        dc.SelectObject(wxNullBitmap);
+      }
+      wxVariant var;
+      var << wxDataViewIconText(mvrColor, bmp);
       row.push_back(var);
     } else {
       wxVariant var;
@@ -548,8 +567,8 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
         table->SetValue(
             wxVariant(wstr), r,
             FixtureTableColumns::ToIndex(FixtureTableColumns::Column::Weight));
-        if (dictColor && !dictColor->color.empty())
-          SetFixtureColorCell(table, r, dictColor->color);
+        if (dictColor && !dictColor->visualColorHex.empty())
+          SetFixtureColorCell(table, r, dictColor->visualColorHex);
         changed = true;
       }
 
@@ -597,8 +616,8 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
         table->SetValue(
             wxVariant(wstr), i,
             FixtureTableColumns::ToIndex(FixtureTableColumns::Column::Weight));
-        if (dictColor && !dictColor->color.empty())
-          SetFixtureColorCell(table, i, dictColor->color);
+        if (dictColor && !dictColor->visualColorHex.empty())
+          SetFixtureColorCell(table, i, dictColor->visualColorHex);
         changed = true;
       }
 

--- a/gui/fixturetablepanel_update_types.cpp
+++ b/gui/fixturetablepanel_update_types.cpp
@@ -31,6 +31,8 @@ FixtureTablePanel::SceneDataUpdateType UpdateTypeForColumnImpl(int column) {
     return SceneDataUpdateType::kCategoryOnly;
   case Column::VisualColor:
     return SceneDataUpdateType::kAppearanceOnly;
+  case Column::MvrColor:
+    return SceneDataUpdateType::kMetadataOnly;
   case Column::FixtureId:
     return SceneDataUpdateType::kFixtureIdOnly;
   case Column::Type:

--- a/gui/layout_view_cache_archive.cpp
+++ b/gui/layout_view_cache_archive.cpp
@@ -98,7 +98,6 @@ bool HashFileContent(const fs::path &root, const fs::path &filePath,
   return input.good() || input.eof();
 }
 
-
 // Builds the archive entry name for a persisted 2D view raster.
 std::string RasterEntryNameForView(int viewId) {
   return std::string(kLayoutViewCacheRasterEntryPrefix) + "view_" +
@@ -127,7 +126,8 @@ void AddSourceAssetPath(const fs::path &root, const std::string &reference,
     files.push_back(*path);
 }
 
-// Collects existing files that are referenced by the scene and affect layout rendering.
+// Collects existing files that are referenced by the scene and affect layout
+// rendering.
 std::vector<fs::path> CollectReferencedSourceAssets(const fs::path &root,
                                                     const MvrScene &scene) {
   std::vector<fs::path> files;
@@ -157,8 +157,8 @@ std::vector<fs::path> CollectReferencedSourceAssets(const fs::path &root,
     AddSourceAssetPath(root, symdefFile, files);
   }
 
-  std::sort(files.begin(), files.end(), [](const fs::path &lhs,
-                                           const fs::path &rhs) {
+  std::sort(files.begin(), files.end(),
+            [](const fs::path &lhs, const fs::path &rhs) {
     return PathToUtf8(lhs) < PathToUtf8(rhs);
   });
   files.erase(std::unique(files.begin(), files.end()), files.end());
@@ -170,7 +170,8 @@ std::optional<std::string> ComputeSourceAssetHash(const MvrScene &scene) {
   if (scene.basePath.empty())
     return std::nullopt;
   std::error_code ec;
-  const fs::path root = fs::weakly_canonical(PathUtils::PathFromUtf8(scene.basePath), ec);
+  const fs::path root =
+      fs::weakly_canonical(PathUtils::PathFromUtf8(scene.basePath), ec);
   if (ec || !fs::is_directory(root, ec))
     return std::nullopt;
 
@@ -247,7 +248,8 @@ nlohmann::json SceneToHashJson(const MvrScene &scene) {
            scene.fixtures.begin(), scene.fixtures.end())) {
     fixtures.push_back({uuid, fixture.layer, fixture.instanceName,
                         fixture.typeName, fixture.gdtfSpec, fixture.gdtfMode,
-                        fixture.color, MatrixToJson(fixture.transform)});
+                        fixture.visualColorHex,
+                        MatrixToJson(fixture.transform)});
   }
   auto trusses = nlohmann::json::array();
   for (const auto &[uuid, truss] : std::map<std::string, Truss>(
@@ -838,7 +840,8 @@ bool ReadCacheEntriesFromProject(
     const std::string entryName = entry->GetName().ToStdString();
     if (entryName == kLayoutViewCacheArchiveEntry) {
       const auto bytes = ReadCurrentZipEntryBytes(zip);
-      outJson.assign(reinterpret_cast<const char *>(bytes.data()), bytes.size());
+      outJson.assign(reinterpret_cast<const char *>(bytes.data()),
+                     bytes.size());
       foundJson = true;
       continue;
     }
@@ -946,8 +949,8 @@ LayoutViewerPanel::CollectPersistentViewCacheResources() const {
       return {};
     }
 
-    nlohmann::json viewDocument =
-        {{"viewId", view.id},
+    nlohmann::json viewDocument = {
+        {"viewId", view.id},
          {"viewHash", StableJsonHash(ViewDefinitionToHashJson(view))},
          {"legacyCaptureContentHash", std::to_string(cache.captureContentHash)},
          {"captureVersion", cache.captureVersion},
@@ -958,10 +961,11 @@ LayoutViewerPanel::CollectPersistentViewCacheResources() const {
     if (hasRasterSnapshot(cache) &&
         cache.persistentRgbaContentHash == HashViewContent(view) &&
         cache.persistentRgba.size() <= kMaxPersistentRasterEntryBytes &&
-        rasterBytes + cache.persistentRgba.size() <= kMaxPersistentRasterBytes) {
+        rasterBytes + cache.persistentRgba.size() <=
+            kMaxPersistentRasterBytes) {
       const std::string rasterEntryName = RasterEntryNameForView(view.id);
-      viewDocument["raster"] =
-          {{"entry", rasterEntryName},
+      viewDocument["raster"] = {
+          {"entry", rasterEntryName},
            {"width", cache.persistentRgbaSize.GetWidth()},
            {"height", cache.persistentRgbaSize.GetHeight()},
            {"renderZoom", cache.persistentRgbaRenderZoom},
@@ -1052,9 +1056,9 @@ void LayoutViewerPanel::HydratePendingPersistentViewCache() {
         GetDefaultGuiConfigServices().LegacyConfigManager().GetScene();
     const auto sourceAssetHash = ComputeSourceAssetHash(scene);
     if (!sourceAssetHash) {
-      Logger::Instance().Log(
-          Logger::Level::Info,
-          "Ignoring layout view cache because source assets could not be hashed.");
+      Logger::Instance().Log(Logger::Level::Info,
+                             "Ignoring layout view cache because source assets "
+                             "could not be hashed.");
       pendingPersistentViewCacheJson_.clear();
       pendingPersistentViewCacheRasters_.clear();
       return;
@@ -1062,9 +1066,9 @@ void LayoutViewerPanel::HydratePendingPersistentViewCache() {
     const std::string sceneHash = StableJsonHash(SceneToHashJson(scene));
     if (document.value("sceneHash", std::string{}) != sceneHash ||
         document.value("sourceAssetHash", std::string{}) != *sourceAssetHash) {
-      Logger::Instance().Log(
-          Logger::Level::Info,
-          "Ignoring layout view cache because source assets or scene data changed.");
+      Logger::Instance().Log(Logger::Level::Info,
+                             "Ignoring layout view cache because source assets "
+                             "or scene data changed.");
       pendingPersistentViewCacheJson_.clear();
       pendingPersistentViewCacheRasters_.clear();
       return;
@@ -1099,8 +1103,8 @@ void LayoutViewerPanel::HydratePendingPersistentViewCache() {
         continue;
       cache.viewState =
           ViewStateFromJson(cachedView.value("viewState", nlohmann::json{}));
-      cache.renderState =
-          RenderStateFromJson(cachedView.value("renderState", nlohmann::json{}));
+      cache.renderState = RenderStateFromJson(
+          cachedView.value("renderState", nlohmann::json{}));
       cache.symbols = SymbolSnapshotFromJson(
           cachedView.value("symbols", nlohmann::json::array()));
       cache.hasCapture = true;
@@ -1126,7 +1130,8 @@ void LayoutViewerPanel::HydratePendingPersistentViewCache() {
         auto rasterIt = pendingPersistentViewCacheRasters_.find(rasterEntry);
         const int rasterWidth = raster.value("width", 0);
         const int rasterHeight = raster.value("height", 0);
-        const size_t rasterBytes = static_cast<size_t>(std::max(0, rasterWidth)) *
+        const size_t rasterBytes =
+            static_cast<size_t>(std::max(0, rasterWidth)) *
                                    static_cast<size_t>(std::max(0, rasterHeight)) * 4;
         if (rasterIt != pendingPersistentViewCacheRasters_.end() &&
             rasterWidth > 0 && rasterHeight > 0 &&
@@ -1146,8 +1151,8 @@ void LayoutViewerPanel::HydratePendingPersistentViewCache() {
       Logger::Instance().Log(
           Logger::Level::Info,
           "Hydrated persistent layout view cache for layout '" +
-              currentLayout.name + "' with view_count=" +
-              std::to_string(hydratedCount));
+              currentLayout.name +
+              "' with view_count=" + std::to_string(hydratedCount));
       renderDirty = true;
     } else {
       Logger::Instance().Log(

--- a/gui/layoutlegenditems.cpp
+++ b/gui/layoutlegenditems.cpp
@@ -18,8 +18,8 @@
 #include "layoutlegenditems.h"
 #include "filesystem_path_utils.h"
 
-#include <filesystem>
 #include <cctype>
+#include <filesystem>
 #include <map>
 
 #include <wx/filename.h>
@@ -64,7 +64,8 @@ std::optional<std::string> NormalizeHexColor(const std::string &raw) {
 }
 } // namespace
 
-// Builds grouped layout legend entries with counts, channels, symbols, and colors.
+// Builds grouped layout legend entries with counts, channels, symbols, and
+// colors.
 std::vector<SharedLayoutLegendItem> BuildSharedLayoutLegendItems() {
   std::map<std::string, LegendAggregate> aggregates;
   const auto &fixtures =
@@ -101,8 +102,9 @@ std::vector<SharedLayoutLegendItem> BuildSharedLayoutLegendItems() {
     scene.basePath = basePath;
     gui::fixtures::FixtureGdtfResolution resolution;
     std::string resolutionError;
-    gui::fixtures::ResolveFixtureGdtfDeterministic(
-        fixture, scene, resolution, resolutionError, "build-layout-legend-items");
+    gui::fixtures::ResolveFixtureGdtfDeterministic(fixture, scene, resolution,
+                                                   resolutionError,
+                                                   "build-layout-legend-items");
 
     LegendAggregate &agg = aggregates[typeName];
     agg.count += 1;
@@ -123,7 +125,7 @@ std::vector<SharedLayoutLegendItem> BuildSharedLayoutLegendItems() {
       agg.gdtfPath = resolution.selectedPath;
 
     const std::optional<std::string> fixtureColor =
-        NormalizeHexColor(fixture.color);
+        NormalizeHexColor(fixture.visualColorHex);
     if (!fixtureColor.has_value())
       continue;
     if (!agg.firstColor.has_value()) {

--- a/gui/layoutviewerpanel_render_invalidation.cpp
+++ b/gui/layoutviewerpanel_render_invalidation.cpp
@@ -72,7 +72,7 @@ size_t HashFixtureValue(const Fixture &fixture) {
   HashCombine(hash, std::hash<std::string>{}(fixture.typeName));
   HashCombine(hash, std::hash<std::string>{}(fixture.gdtfSpec));
   HashCombine(hash, std::hash<std::string>{}(fixture.gdtfMode));
-  HashCombine(hash, std::hash<std::string>{}(fixture.color));
+  HashCombine(hash, std::hash<std::string>{}(fixture.visualColorHex));
   HashCombine(hash, HashMatrixValue(fixture.transform));
   return hash;
 }
@@ -111,11 +111,13 @@ size_t HashSceneMapWithValues(const TMap &items, ValueHasher hasher) {
 
 // Computes a scene-wide hash for data that can affect layout previews.
 size_t LayoutViewerPanel::ComputeSceneContentHash() const {
-  const auto &scene = GetDefaultGuiConfigServices().LegacyConfigManager().GetScene();
+  const auto &scene =
+      GetDefaultGuiConfigServices().LegacyConfigManager().GetScene();
   size_t hash = 0;
   HashCombine(hash, HashSceneMapWithValues(scene.fixtures, HashFixtureValue));
   HashCombine(hash, HashSceneMapWithValues(scene.trusses, HashTrussValue));
-  HashCombine(hash, HashSceneMapWithValues(scene.sceneObjects, HashSceneObjectValue));
+  HashCombine(hash,
+              HashSceneMapWithValues(scene.sceneObjects, HashSceneObjectValue));
   HashCombine(hash, HashSceneMapWithValues(scene.supports, HashSupportValue));
   return hash;
 }
@@ -132,7 +134,8 @@ size_t LayoutViewerPanel::HashViewContent(
   HashCombine(seed, std::hash<bool>{}(view.renderOptions.darkMode));
   if (view.renderOptions.forceBottomViewForTopFixtures.has_value()) {
     HashCombine(seed, std::hash<int>{}(1));
-    HashCombine(seed, std::hash<bool>{}(
+    HashCombine(seed,
+                std::hash<bool>{}(
                           view.renderOptions.forceBottomViewForTopFixtures.value()));
   } else {
     HashCombine(seed, std::hash<int>{}(0));
@@ -172,8 +175,10 @@ size_t LayoutViewerPanel::HashViewContent(
   return seed;
 }
 
-// Marks cached layout rasters dirty only when content or LOD changes require it.
-void LayoutViewerPanel::InvalidateRenderIfFrameChanged(bool includeSceneContent) {
+// Marks cached layout rasters dirty only when content or LOD changes require
+// it.
+void LayoutViewerPanel::InvalidateRenderIfFrameChanged(
+    bool includeSceneContent) {
   const double renderZoom = GetRenderZoom();
   const double pageWidth = currentLayout.pageSetup.PageWidthPt();
   const double pageHeight = currentLayout.pageSetup.PageHeightPt();
@@ -347,9 +352,7 @@ void LayoutViewerPanel::RefreshAfterSceneContentUpdate() {
 }
 
 // Refreshes the layout viewer after selection-only updates.
-void LayoutViewerPanel::RefreshAfterSelectionOnlyUpdate() {
-  Refresh();
-}
+void LayoutViewerPanel::RefreshAfterSelectionOnlyUpdate() { Refresh(); }
 
 // Invalidates render data after fixture symbol changes.
 void LayoutViewerPanel::RefreshAfterFixtureSymbolUpdate() {

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -16,13 +16,13 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "mainwindow.h"
-#include "filesystem_path_utils.h"
 #include "diagnostics/DiagnosticLogger.h"
+#include "filesystem_path_utils.h"
 
 #include <algorithm>
 #include <cctype>
-#include <cmath>
 #include <chrono>
+#include <cmath>
 #include <cstdio>
 #include <cstdlib>
 #include <filesystem>
@@ -30,13 +30,12 @@
 #include <functional>
 #include <iomanip>
 #include <iterator>
-#include <wx/event.h>
 #include <map>
 #include <memory>
 #include <optional>
+#include <random>
 #include <set>
 #include <sstream>
-#include <random>
 #include <string>
 #include <thread>
 #include <tinyxml2.h>
@@ -44,6 +43,7 @@
 #include <wx/app.h>
 #include <wx/artprov.h>
 #include <wx/busyinfo.h>
+#include <wx/colour.h>
 #include <wx/event.h>
 #include <wx/filefn.h>
 #include <wx/filename.h>
@@ -55,29 +55,27 @@
 #include <wx/notebook.h>
 #include <wx/numdlg.h>
 #include <wx/progdlg.h>
+#include <wx/settings.h>
 #include <wx/statbmp.h>
 #include <wx/stdpaths.h>
-#include <wx/settings.h>
 #include <wx/textctrl.h>
 #include <wx/tokenzr.h>
 #include <wx/utils.h>
 #include <wx/wfstream.h>
-#include <wx/colour.h>
 class wxZipStreamLink;
 #include <wx/log.h>
-#include <wx/zipstrm.h>
 #include <wx/richtext/richtextbuffer.h>
+#include <wx/zipstrm.h>
 
 #include "json.hpp"
 
 using json = nlohmann::json;
+#include "LayoutManager.h"
+#include "Viewer2DPrintSettings.h"
 #include "addfixturedialog.h"
 #include "app_version.h"
 #include "autopatcher.h"
 #include "configmanager.h"
-#include "guiconfigservices.h"
-#include "magnet_snap.h"
-#include "highlight_status_bar.h"
 #include "consolepanel.h"
 #include "credentialstore.h"
 #include "dictionaryeditdialog.h"
@@ -90,57 +88,57 @@ using json = nlohmann::json;
 #include "gdtfloader.h"
 #include "gdtfnet.h"
 #include "gdtfsearchdialog.h"
+#include "guiconfigservices.h"
+#include "highlight_status_bar.h"
+#include "hoisttablepanel.h"
+#include "layerpanel.h"
 #include "layout2dviewdialog.h"
-#include "LayoutManager.h"
+#include "layout_render_profiler.h"
+#include "layout_render_status_notifier.h"
+#include "layoutpanel.h"
+#include "layouttextutils.h"
+#include "layoutviewerpanel.h"
+#include "layoutviewerpanel_shared.h"
 #include "layoutviewpresets.h"
+#include "legendutils.h"
+#include "logger.h"
+#include "logindialog.h"
+#include "magnet_snap.h"
 #include "mainwindow_io_controller.h"
 #include "mainwindow_layout_controller.h"
 #include "mainwindow_print_controller.h"
 #include "mainwindow_view_controller.h"
-#include "layoutpanel.h"
-#include "layout_render_profiler.h"
-#include "layoutviewerpanel.h"
-#include "layout_render_status_notifier.h"
-#include "layouttextutils.h"
-#include "layoutviewerpanel_shared.h"
-#include "legendutils.h"
-#include "layerpanel.h"
-#include "logindialog.h"
 #include "markdown.h"
-#include "hoisttablepanel.h"
-#include "viewer2dprintdialog.h"
 #include "mvrexporter.h"
 #include "mvrimporter.h"
 #include "preferencesdialog.h"
+#include "print_diagnostics.h"
 #include "projectutils.h"
-#include "logger.h"
-#include "riggingpanel.h"
 #include "riderimporter.h"
 #include "ridertextdialog.h"
+#include "riggingpanel.h"
 #include "sceneobjecttablepanel.h"
 #include "selectfixturetypedialog.h"
 #include "selectnamedialog.h"
 #include "simplecrypt.h"
 #include "splashscreen.h"
 #include "summarypanel.h"
-#include "tableprinter.h"
-#include "Viewer2DPrintSettings.h"
-#include "viewer2dpdfexporter.h"
-#include "print_diagnostics.h"
 #include "support.h"
-#include "update/update_check_preferences.h"
-#include "update/app_update_service.h"
-#include "update/update_notification_dialog.h"
-#include "units/units.h"
+#include "tableprinter.h"
 #include "trussloader.h"
 #include "trusstablepanel.h"
-#include "viewer2dpanel.h"
+#include "units/units.h"
+#include "update/app_update_service.h"
+#include "update/update_check_preferences.h"
+#include "update/update_notification_dialog.h"
 #include "viewer2doffscreenrenderer.h"
+#include "viewer2dpanel.h"
+#include "viewer2dpdfexporter.h"
+#include "viewer2dprintdialog.h"
 #include "viewer2drenderpanel.h"
 #include "viewer2dstate.h"
-#include "viewer3dpanel.h"
 #include "viewer3dcontroller.h"
-#include "LayoutManager.h"
+#include "viewer3dpanel.h"
 #ifdef _WIN32
 #define popen _popen
 #define pclose _pclose
@@ -154,14 +152,16 @@ void MainWindow::SetInstance(MainWindow *inst) { s_instance = inst; }
 
 namespace {
 
-// Returns true when the status bar text corresponds to fixture symbol auto-update progress.
+// Returns true when the status bar text corresponds to fixture symbol
+// auto-update progress.
 bool IsFixtureSymbolStatusMessage(const wxString &statusText) {
   return statusText.StartsWith("Fixture symbol auto-update");
 }
 
-// Formats a world-space position for the status bar using the active distance units.
-wxString FormatWorldPositionStatusText(
-    const std::array<float, 3> &positionMeters,
+// Formats a world-space position for the status bar using the active distance
+// units.
+wxString
+FormatWorldPositionStatusText(const std::array<float, 3> &positionMeters,
     Units::DistanceUnitSystem distanceUnitSystem) {
   const std::string unitSuffix = Units::DistanceUnitSuffix(distanceUnitSystem);
   std::ostringstream stream;
@@ -187,7 +187,8 @@ constexpr const char *kActiveLayoutNameConfigKey = "layout_active_name";
 bool ProjectContainsLayout(const std::string &layoutName) {
   if (layoutName.empty())
     return false;
-  for (const auto &layout : layouts::LayoutManager::Get().GetLayouts().Items()) {
+  for (const auto &layout :
+       layouts::LayoutManager::Get().GetLayouts().Items()) {
     if (layout.name == layoutName)
       return true;
   }
@@ -206,15 +207,16 @@ std::string ResolveProjectStartupLayoutName(const ConfigManager &cfg) {
   return {};
 }
 
-// Persists missing fixture type auto-colors before scene save and synchronization.
+// Persists missing fixture type auto-colors before scene save and
+// synchronization.
 void PersistFixtureTypeAutoColors(ConfigManager &configManager) {
   auto &scene = configManager.GetScene();
   for (auto &[uuid, fixture] : scene.fixtures) {
     (void)uuid;
-    if (!fixture.color.empty())
+    if (!fixture.visualColorHex.empty())
       continue;
 
-    fixture.color =
+    fixture.visualColorHex =
         Viewer3DController::BuildFixtureTypeAutoColorHex(fixture.gdtfSpec);
   }
 }
@@ -231,10 +233,12 @@ void LogMissingIcon(const std::filesystem::path &path) {
   Logger::Instance().Log(Logger::Level::Warn, message.ToStdString());
 }
 
-// Builds the default UI font with shared sans-serif face resolution and UTF-8 encoding.
+// Builds the default UI font with shared sans-serif face resolution and UTF-8
+// encoding.
 wxFont BuildDefaultUiFont() {
   wxFont defaultFont = wxSystemSettings::GetFont(wxSYS_DEFAULT_GUI_FONT);
-  wxString resolvedFaceName = layoutviewerpanel::detail::ResolveSharedFontFaceName();
+  wxString resolvedFaceName =
+      layoutviewerpanel::detail::ResolveSharedFontFaceName();
   if (!resolvedFaceName.empty()) {
     defaultFont.SetFaceName(resolvedFaceName);
   }
@@ -246,12 +250,11 @@ wxFont BuildDefaultUiFont() {
     const int fallbackSize =
         defaultFont.IsOk() ? defaultFont.GetPointSize() : 10;
     if (resolvedFaceName.empty()) {
-      defaultFont = wxFont(fallbackSize, wxFONTFAMILY_SWISS,
-                           wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL);
+      defaultFont = wxFont(fallbackSize, wxFONTFAMILY_SWISS, wxFONTSTYLE_NORMAL,
+                           wxFONTWEIGHT_NORMAL);
     } else {
-      defaultFont = wxFont(fallbackSize, wxFONTFAMILY_SWISS,
-                           wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false,
-                           resolvedFaceName);
+      defaultFont = wxFont(fallbackSize, wxFONTFAMILY_SWISS, wxFONTSTYLE_NORMAL,
+                           wxFONTWEIGHT_NORMAL, false, resolvedFaceName);
     }
     if (wxFontMapper::Get() &&
         wxFontMapper::Get()->IsEncodingAvailable(wxFONTENCODING_UTF8)) {
@@ -263,30 +266,18 @@ wxFont BuildDefaultUiFont() {
 
 const std::vector<std::string> &GetPreferencesDialogConfigKeys() {
   static const std::vector<std::string> kKeys = {
-      "rider_autopatch",
-      "rider_layer_mode",
-      "ui_distance_unit_system",
-      "ui_weight_unit_system",
-      "app_update_startup_mode",
-      "viewer3d_render_style",
-      "viewer3d_invert_orbit",
-      "rider_lx1_height",
-      "rider_lx2_height",
-      "rider_lx3_height",
-      "rider_lx4_height",
-      "rider_lx5_height",
-      "rider_lx6_height",
-      "rider_lx1_pos",
-      "rider_lx2_pos",
-      "rider_lx3_pos",
-      "rider_lx4_pos",
-      "rider_lx5_pos",
-      "rider_lx6_pos",
-      "rider_lx1_margin",
-      "rider_lx2_margin",
-      "rider_lx3_margin",
-      "rider_lx4_margin",
-      "rider_lx5_margin",
+      "rider_autopatch",         "rider_layer_mode",
+      "ui_distance_unit_system", "ui_weight_unit_system",
+      "app_update_startup_mode", "viewer3d_render_style",
+      "viewer3d_invert_orbit",   "rider_lx1_height",
+      "rider_lx2_height",        "rider_lx3_height",
+      "rider_lx4_height",        "rider_lx5_height",
+      "rider_lx6_height",        "rider_lx1_pos",
+      "rider_lx2_pos",           "rider_lx3_pos",
+      "rider_lx4_pos",           "rider_lx5_pos",
+      "rider_lx6_pos",           "rider_lx1_margin",
+      "rider_lx2_margin",        "rider_lx3_margin",
+      "rider_lx4_margin",        "rider_lx5_margin",
       "rider_lx6_margin",
   };
   return kKeys;
@@ -310,7 +301,8 @@ void RestorePreferencesDialogValues(
     preferences.SetValue(key, value);
 }
 
-// Runs a startup update check and prompts for newer versions that were not dismissed.
+// Runs a startup update check and prompts for newer versions that were not
+// dismissed.
 void RunSilentStartupUpdateCheck(MainWindow *window) {
   if (!window)
     return;
@@ -446,8 +438,8 @@ MainWindow::MainWindow(const wxString &title, IGuiConfigServices *services)
   if (!iconPath.empty() && std::filesystem::exists(iconPath, ec)) {
     icon.LoadFile(PathToWxString(iconPath), wxBITMAP_TYPE_ICO);
   } else {
-    LogMissingIcon(
-        iconPath.empty() ? std::filesystem::path("resources/Perastage.ico")
+    LogMissingIcon(iconPath.empty()
+                       ? std::filesystem::path("resources/Perastage.ico")
                          : iconPath);
   }
   if (!icon.IsOk())
@@ -497,7 +489,8 @@ MainWindow::MainWindow(const wxString &title, IGuiConfigServices *services)
 }
 
 MainWindow::~MainWindow() {
-  guiConfigServices->LegacyConfigManager().SetProjectArchiveResourceProvider({});
+  guiConfigServices->LegacyConfigManager().SetProjectArchiveResourceProvider(
+      {});
   CleanupFixtureAutoUpdateStatusTimer();
   cursorStatusCallbackLifetimeToken.reset();
   if (viewport2DPanel)
@@ -550,8 +543,8 @@ void MainWindow::Ensure2DViewport() {
   viewport2DPanel = new Viewer2DPanel(this);
   std::weak_ptr<int> lifetimeToken = cursorStatusCallbackLifetimeToken;
   viewport2DPanel->SetCursorWorldPositionCallback(
-      [this, lifetimeToken](
-          const std::optional<std::array<float, 3>> &positionMeters,
+      [this,
+       lifetimeToken](const std::optional<std::array<float, 3>> &positionMeters,
           bool highlighted) {
         if (lifetimeToken.expired() || !GetStatusBar())
           return;
@@ -604,7 +597,8 @@ void MainWindow::Ensure2DViewport() {
     auto &paneSummary = auiManager->GetPane("SummaryPanel");
 
     // 2D default: keep Layers/Summary in the outer right column and place
-    // Render Options in the inner right column between viewport and side column.
+    // Render Options in the inner right column between viewport and side
+    // column.
     if (paneLayers.IsOk()) {
       paneLayers.Right().Layer(1).Row(0).Position(0);
     }
@@ -639,7 +633,8 @@ void MainWindow::Ensure2DViewport() {
   }
 }
 
-// Updates the status bar with a world-space position formatted in the active distance units.
+// Updates the status bar with a world-space position formatted in the active
+// distance units.
 void MainWindow::UpdateCursorWorldPositionInStatusBar(
     const std::optional<std::array<float, 3>> &positionMeters) {
   if (!GetStatusBar())
@@ -650,19 +645,20 @@ void MainWindow::UpdateCursorWorldPositionInStatusBar(
   }
 
   ConfigManager &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
-  const auto distanceUnitSystem = Units::ParseDistanceUnitSystem(
-      cfg.GetValue("ui_distance_unit_system"));
-  SetStatusText(FormatWorldPositionStatusText(*positionMeters, distanceUnitSystem),
-                1);
+  const auto distanceUnitSystem =
+      Units::ParseDistanceUnitSystem(cfg.GetValue("ui_distance_unit_system"));
+  SetStatusText(
+      FormatWorldPositionStatusText(*positionMeters, distanceUnitSystem), 1);
 }
 
-// Clears the world-position status text and restores the normal status-bar font color.
+// Clears the world-position status text and restores the normal status-bar font
+// color.
 void MainWindow::ClearCursorWorldPositionInStatusBar() {
   if (!GetStatusBar())
     return;
   ConfigManager &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
-  const auto distanceUnitSystem = Units::ParseDistanceUnitSystem(
-      cfg.GetValue("ui_distance_unit_system"));
+  const auto distanceUnitSystem =
+      Units::ParseDistanceUnitSystem(cfg.GetValue("ui_distance_unit_system"));
   const wxString unitSuffix =
       wxString::FromUTF8(Units::DistanceUnitSuffix(distanceUnitSystem));
   const wxString text =
@@ -674,7 +670,8 @@ void MainWindow::ClearCursorWorldPositionInStatusBar() {
   }
 }
 
-// Updates the status bar with a highlighted world-space position during drag interactions.
+// Updates the status bar with a highlighted world-space position during drag
+// interactions.
 void MainWindow::UpdateHighlightedWorldPositionInStatusBar(
     const std::optional<std::array<float, 3>> &positionMeters) {
   if (!GetStatusBar())
@@ -685,8 +682,8 @@ void MainWindow::UpdateHighlightedWorldPositionInStatusBar(
   }
 
   ConfigManager &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
-  const auto distanceUnitSystem = Units::ParseDistanceUnitSystem(
-      cfg.GetValue("ui_distance_unit_system"));
+  const auto distanceUnitSystem =
+      Units::ParseDistanceUnitSystem(cfg.GetValue("ui_distance_unit_system"));
   const wxString text =
       FormatWorldPositionStatusText(*positionMeters, distanceUnitSystem);
   if (auto *statusBar = dynamic_cast<HighlightStatusBar *>(GetStatusBar())) {
@@ -719,7 +716,8 @@ Viewer2DOffscreenRenderer *MainWindow::GetOffscreenRenderer() {
 
 bool MainWindow::IsLayout2DViewEditing() const { return layout2DViewEditing; }
 
-// Prompts to save pending project changes while ignoring transient startup state before any project is loaded.
+// Prompts to save pending project changes while ignoring transient startup
+// state before any project is loaded.
 bool MainWindow::ConfirmSaveIfDirty(const wxString &actionLabel,
                                     const wxString &dialogTitle) {
   if ((startupProjectLoadPending || startupSplashInitializationPending ||
@@ -730,8 +728,7 @@ bool MainWindow::ConfirmSaveIfDirty(const wxString &actionLabel,
   if (!GetDefaultGuiConfigServices().LegacyConfigManager().IsDirty())
     return true;
 
-  wxMessageDialog dlg(
-      this,
+  wxMessageDialog dlg(this,
       "Do you want to save changes before " + actionLabel + "?",
       dialogTitle, wxYES_NO | wxCANCEL | wxICON_QUESTION);
 
@@ -771,7 +768,8 @@ void MainWindow::SetStartupProjectLoadPending(bool pending) {
   }
 }
 
-// Cancels pending startup-project loading and defers an external file-open path.
+// Cancels pending startup-project loading and defers an external file-open
+// path.
 void MainWindow::CancelStartupProjectLoadForExternalOpenPath(
     const std::string &path) {
   ProjectUtils::SaveLastProjectPath("");
@@ -787,13 +785,15 @@ bool MainWindow::GuardStartupProjectLoadAction(const wxString &actionLabel) {
   if (!startupProjectLoadPending)
     return true;
 
-  wxMessageBox("Please wait until the startup project loading finishes before " +
+  wxMessageBox(
+      "Please wait until the startup project loading finishes before " +
                    actionLabel + ".",
                "Perastage is still loading", wxOK | wxICON_INFORMATION, this);
   return false;
 }
 
-// Loads a project archive and refreshes only the active layout preview during startup.
+// Loads a project archive and refreshes only the active layout preview during
+// startup.
 bool MainWindow::LoadProjectFromPath(const std::string &path,
                                      bool showBlockingLoadUi) {
   diagnostics::DiagnosticLogger::Info(
@@ -844,14 +844,12 @@ bool MainWindow::LoadProjectFromPath(const std::string &path,
   reportProjectLoadProgress("Loading project file...");
 
   LockViewportInteraction();
-  auto finishLoad = [this]() {
-    UnlockViewportInteraction();
-  };
+  auto finishLoad = [this]() { UnlockViewportInteraction(); };
 
   if (!GetDefaultGuiConfigServices().LegacyConfigManager().LoadProject(
           path, [&](const std::string &stage, int completed, int total) {
-            reportProjectLoadProgress(wxString::FromUTF8(stage), false, completed,
-                                      total);
+            reportProjectLoadProgress(wxString::FromUTF8(stage), false,
+                                      completed, total);
           })) {
     projectLoadProgressDialog.reset();
     ClearBlockingProjectLoadUi();
@@ -889,7 +887,8 @@ bool MainWindow::LoadProjectFromPath(const std::string &path,
     layoutPanel->SetCurrentLayout(activeLayoutName);
     layoutPanel->ReloadLayouts();
   }
-  // Inactive layouts stay in LayoutManager, but preview caches build lazily when selected.
+  // Inactive layouts stay in LayoutManager, but preview caches build lazily
+  // when selected.
   if (const auto &loadedLayouts =
           layouts::LayoutManager::Get().GetLayouts().Items();
       !loadedLayouts.empty()) {
@@ -958,8 +957,8 @@ bool MainWindow::LoadProjectFromPath(const std::string &path,
 
   if (showBlockingLoadUi) {
     auto previousCompletionCallback = fixtureSymbolAutoUpdateCompletionCallback;
-    fixtureSymbolAutoUpdateCompletionCallback =
-        [this, previousCompletionCallback]() {
+    fixtureSymbolAutoUpdateCompletionCallback = [this,
+                                                 previousCompletionCallback]() {
           if (previousCompletionCallback)
             previousCompletionCallback();
           ClearBlockingProjectLoadUi();
@@ -1016,7 +1015,8 @@ void MainWindow::LoadStartupProjectFromPath(const std::string &path) {
   SetStartupProjectLoadPending(false);
 }
 
-// Resets project state, UI-bound data, and active layout context for a fresh session.
+// Resets project state, UI-bound data, and active layout context for a fresh
+// session.
 void MainWindow::ResetProject(bool applyLayoutDefaultsForNewProject) {
   activeLayoutName.clear();
   if (layoutViewerPanel)
@@ -1101,8 +1101,7 @@ void MainWindow::SaveCameraSettings() {
     viewport2DPanel->SaveViewToConfig();
 
   if (auiManager) {
-    const std::string perspective =
-        auiManager->SavePerspective().ToStdString();
+    const std::string perspective = auiManager->SavePerspective().ToStdString();
     cfg.SetValue("layout_perspective", perspective);
   }
 }
@@ -1129,7 +1128,6 @@ void MainWindow::SaveUserConfigWithViewport2DState() {
     viewer2d::ApplyState(nullptr, nullptr, cfg, *layoutState, true, false);
 }
 
-
 void MainWindow::UpdateToolBarAvailability() {
   if (!auiManager)
     return;
@@ -1140,7 +1138,8 @@ void MainWindow::UpdateToolBarAvailability() {
   };
 
   const bool hasLayoutViewer = paneShown("LayoutViewer");
-  const bool hasCreationTarget = paneShown("2DViewport") || paneShown("3DViewport") ||
+  const bool hasCreationTarget = paneShown("2DViewport") ||
+                                 paneShown("3DViewport") ||
                                  paneShown("DataNotebook");
   const bool enableViewportTools = !hasLayoutViewer;
 
@@ -1159,8 +1158,8 @@ void MainWindow::UpdateToolBarAvailability() {
     for (const auto &tool : layoutTools) {
       layoutToolBar->EnableTool(tool.id, hasLayoutViewer);
       layoutToolBar->SetToolShortHelp(
-          tool.id,
-          hasLayoutViewer ? tool.help
+          tool.id, hasLayoutViewer
+                       ? tool.help
                           : "Layout tools require an open Layout viewer window");
     }
     layoutToolBar->Refresh();
@@ -1188,11 +1187,16 @@ void MainWindow::UpdateToolBarAvailability() {
   }
 
   if (layoutViewsToolBar) {
-    layoutViewsToolBar->EnableTool(ID_View_Viewport_SelectTool, enableViewportTools);
-    layoutViewsToolBar->EnableTool(ID_View_Viewport_MeasureTool, enableViewportTools);
-    layoutViewsToolBar->EnableTool(ID_View_Viewport_AxisConstraint, enableViewportTools);
-    layoutViewsToolBar->EnableTool(ID_View_Viewport_LeftDragMove, enableViewportTools);
-    layoutViewsToolBar->EnableTool(ID_View_Viewport_Magnet, enableViewportTools);
+    layoutViewsToolBar->EnableTool(ID_View_Viewport_SelectTool,
+                                   enableViewportTools);
+    layoutViewsToolBar->EnableTool(ID_View_Viewport_MeasureTool,
+                                   enableViewportTools);
+    layoutViewsToolBar->EnableTool(ID_View_Viewport_AxisConstraint,
+                                   enableViewportTools);
+    layoutViewsToolBar->EnableTool(ID_View_Viewport_LeftDragMove,
+                                   enableViewportTools);
+    layoutViewsToolBar->EnableTool(ID_View_Viewport_Magnet,
+                                   enableViewportTools);
     layoutViewsToolBar->SetToolShortHelp(
         ID_View_Viewport_SelectTool,
         enableViewportTools ? "Switch to standard selection mode"
@@ -1210,8 +1214,8 @@ void MainWindow::UpdateToolBarAvailability() {
         enableViewportTools ? "Toggle left-click selection dragging"
                             : "Disabled while editing Layout views");
     layoutViewsToolBar->SetToolShortHelp(
-        ID_View_Viewport_Magnet,
-        enableViewportTools ? "Toggle Magnet snapping while dragging"
+        ID_View_Viewport_Magnet, enableViewportTools
+                                     ? "Toggle Magnet snapping while dragging"
                             : "Disabled while editing Layout views");
     layoutViewsToolBar->Refresh();
   }
@@ -1260,7 +1264,8 @@ void MainWindow::UpdateViewMenuChecks() {
   UpdateToolBarAvailability();
 }
 
-// Activates a layout selected from the layout panel after startup loading is complete.
+// Activates a layout selected from the layout panel after startup loading is
+// complete.
 void MainWindow::OnLayoutSelected(wxCommandEvent &event) {
   if (startupProjectLoadPending)
     return;
@@ -1284,7 +1289,8 @@ bool MainWindow::HasActiveLayout2DView() const {
   return false;
 }
 
-// Shows layout-loading status text and enables the busy cursor when the layout viewer is visible.
+// Shows layout-loading status text and enables the busy cursor when the layout
+// viewer is visible.
 void MainWindow::ShowLayoutLoadingIndicator(const wxString &message) {
   if (GetStatusBar())
     SetStatusText(message, 0);
@@ -1309,12 +1315,14 @@ void MainWindow::ClearLayoutLoadingIndicator() {
   layoutRenderCursor.reset();
 }
 
-// Clears the loading indicator when the layout render pipeline reports completion.
+// Clears the loading indicator when the layout render pipeline reports
+// completion.
 void MainWindow::OnLayoutRenderReady(wxCommandEvent &) {
   ClearLayoutLoadingIndicator();
 }
 
-// Mirrors layout-render updates unless fixture symbol generation is currently reporting progress.
+// Mirrors layout-render updates unless fixture symbol generation is currently
+// reporting progress.
 void MainWindow::OnLayoutRenderStatus(wxCommandEvent &event) {
   const wxString statusMessage = event.GetString();
   if (statusMessage.CmpNoCase("Layout render completed.") == 0) {
@@ -1329,7 +1337,8 @@ void MainWindow::OnLayoutRenderStatus(wxCommandEvent &event) {
   ShowLayoutLoadingIndicator(statusMessage);
 }
 
-// Applies the named project layout to the layout viewer and persists it as active.
+// Applies the named project layout to the layout viewer and persists it as
+// active.
 void MainWindow::ActivateLayoutView(const std::string &layoutName) {
   if (!auiManager || layoutName.empty()) {
     ClearLayoutLoadingIndicator();
@@ -1376,8 +1385,7 @@ void MainWindow::ActivateLayoutView(const std::string &layoutName) {
         hasViewId = viewId > 0;
       }
     }
-    if (!hasViewId && selectedLayout &&
-        !selectedLayout->view2dViews.empty()) {
+    if (!hasViewId && selectedLayout && !selectedLayout->view2dViews.empty()) {
       viewId = selectedLayout->view2dViews.front().id;
       hasViewId = viewId > 0;
     }
@@ -1389,9 +1397,11 @@ void MainWindow::ActivateLayoutView(const std::string &layoutName) {
     ApplyLayoutModePerspective();
 }
 
-// Synchronizes pending edits from the active table panel into the scene before save/close operations.
+// Synchronizes pending edits from the active table panel into the scene before
+// save/close operations.
 void MainWindow::SyncSceneData() {
-  // Save uses scene data as source of truth; avoid table-wide resyncs that can overwrite cross-table transforms.
+  // Save uses scene data as source of truth; avoid table-wide resyncs that can
+  // overwrite cross-table transforms.
   PersistFixtureTypeAutoColors(
       GetDefaultGuiConfigServices().LegacyConfigManager());
 }
@@ -1435,7 +1445,8 @@ void MainWindow::SyncLayerVisibilityPanels() {
   }
 }
 
-// Handles startup project-load completion and queues deferred external file opens when needed.
+// Handles startup project-load completion and queues deferred external file
+// opens when needed.
 void MainWindow::OnProjectLoaded(wxCommandEvent &event) {
   bool loaded = event.GetInt() != 0;
   bool clearLastProject = event.GetExtraLong() != 0;

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1407,6 +1407,8 @@ void MainWindow::SyncSceneData() {
 }
 
 void MainWindow::RefreshAfterSceneChange(bool refreshViewport) {
+  PersistFixtureTypeAutoColors(
+      GetDefaultGuiConfigServices().LegacyConfigManager());
   if (fixturePanel)
     fixturePanel->ReloadData();
   if (trussPanel)

--- a/gui/mainwindow_fixture_add_flow.cpp
+++ b/gui/mainwindow_fixture_add_flow.cpp
@@ -15,8 +15,8 @@
  * You should have received a copy of the GNU General Public License
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
-#include "mainwindow.h"
 #include "filesystem_path_utils.h"
+#include "mainwindow.h"
 
 #include <chrono>
 #include <filesystem>
@@ -50,7 +50,8 @@ void MainWindow::AddFixtureFromGdtfPath(const std::string &gdtfPath,
   if (gdtfPath.empty()) {
     wxMessageBox("No GDTF file selected.", "Add fixture", wxOK | wxICON_ERROR);
     if (consolePanel)
-      consolePanel->AppendMessage("[ERROR] Add fixture failed: empty GDTF path");
+      consolePanel->AppendMessage(
+          "[ERROR] Add fixture failed: empty GDTF path");
     return;
   }
   const wxString gdtfPathWx = wxString::FromUTF8(gdtfPath);
@@ -59,9 +60,8 @@ void MainWindow::AddFixtureFromGdtfPath(const std::string &gdtfPath,
     wxMessageBox("The selected GDTF file does not exist.", "Add fixture",
                  wxOK | wxICON_ERROR);
     if (consolePanel)
-      consolePanel->AppendMessage(
-          wxString::Format("[ERROR] Add fixture failed: file not found %s",
-                           gdtfPathWx));
+      consolePanel->AppendMessage(wxString::Format(
+          "[ERROR] Add fixture failed: file not found %s", gdtfPathWx));
     return;
   }
 
@@ -80,9 +80,8 @@ void MainWindow::AddFixtureFromGdtfPath(const std::string &gdtfPath,
     wxMessageBox("Could not read fixture modes from the selected GDTF file.",
                  "Add fixture", wxOK | wxICON_ERROR);
     if (consolePanel)
-      consolePanel->AppendMessage(
-          wxString::Format("[ERROR] Add fixture failed: no modes found in %s",
-                           gdtfPathWx));
+      consolePanel->AppendMessage(wxString::Format(
+          "[ERROR] Add fixture failed: no modes found in %s", gdtfPathWx));
     return;
   }
 
@@ -95,8 +94,8 @@ void MainWindow::AddFixtureFromGdtfPath(const std::string &gdtfPath,
   GetGdtfProperties(gdtfPath, weight, power);
   std::string defaultColor = GetGdtfModelColor(gdtfPath);
   if (auto dictEntry = GdtfDictionary::Get(defaultName)) {
-    if (!dictEntry->color.empty())
-      defaultColor = dictEntry->color;
+    if (!dictEntry->visualColorHex.empty())
+      defaultColor = dictEntry->visualColorHex;
   }
 
   ConfigManager &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
@@ -156,7 +155,7 @@ void MainWindow::AddFixtureFromGdtfPath(const std::string &gdtfPath,
     f.powerConsumptionW = power;
     f.physicalPropertiesSource = FixturePhysicalPropertiesSource::Gdtf;
     f.physicalPropertiesDirty = false;
-    f.color = defaultColor;
+    f.visualColorHex = defaultColor;
     sceneRef.fixtures[f.uuid] = f;
   }
 

--- a/gui/mainwindow_fixture_replace.cpp
+++ b/gui/mainwindow_fixture_replace.cpp
@@ -1,8 +1,8 @@
 #include "mainwindow.h"
 
 #include <algorithm>
-#include <chrono>
 #include <cctype>
+#include <chrono>
 #include <filesystem>
 #include <optional>
 #include <random>
@@ -35,14 +35,14 @@ struct ReplacementFixtureTemplate {
   std::string color;
 };
 
-
 // Normalizes a GDTF path into a comparable lowercase filename token.
 std::string BuildGdtfFileKey(const std::string &gdtfSpec) {
   if (gdtfSpec.empty())
     return {};
   std::string key = std::filesystem::path(gdtfSpec).filename().string();
-  std::transform(key.begin(), key.end(), key.begin(),
-                 [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+  std::transform(key.begin(), key.end(), key.begin(), [](unsigned char c) {
+    return static_cast<char>(std::tolower(c));
+  });
   return key;
 }
 
@@ -54,23 +54,24 @@ std::string GenerateAutoColor() {
       .ToStdString();
 }
 
-// Resolves the replacement color by reusing existing fixture-file color or creating a new group color.
-std::string ResolveReplacementColor(const MvrScene &scene,
-                                    const std::vector<std::string> &selectedUuids,
-                                    const std::string &replacementSpec,
-                                    const std::string &fallbackColor) {
+// Resolves the replacement color by reusing existing fixture-file color or
+// creating a new group color.
+std::string ResolveReplacementColor(
+    const MvrScene &scene, const std::vector<std::string> &selectedUuids,
+    const std::string &replacementSpec, const std::string &fallbackColor) {
   const std::string replacementKey = BuildGdtfFileKey(replacementSpec);
   if (replacementKey.empty())
     return fallbackColor.empty() ? GenerateAutoColor() : fallbackColor;
 
-  std::unordered_set<std::string> selectedSet(selectedUuids.begin(), selectedUuids.end());
+  std::unordered_set<std::string> selectedSet(selectedUuids.begin(),
+                                              selectedUuids.end());
   for (const auto &[uuid, fixture] : scene.fixtures) {
     if (selectedSet.find(uuid) != selectedSet.end())
       continue;
     if (BuildGdtfFileKey(fixture.gdtfSpec) != replacementKey)
       continue;
-    if (!fixture.color.empty())
-      return fixture.color;
+    if (!fixture.visualColorHex.empty())
+      return fixture.visualColorHex;
   }
 
   if (!fallbackColor.empty())
@@ -78,7 +79,8 @@ std::string ResolveReplacementColor(const MvrScene &scene,
   return GenerateAutoColor();
 }
 
-// Extracts the list of selected fixture UUIDs that still exist in the current scene.
+// Extracts the list of selected fixture UUIDs that still exist in the current
+// scene.
 std::vector<std::string> GetSelectedExistingFixtureUuids(ConfigManager &cfg) {
   const auto &scene = cfg.GetScene();
   std::vector<std::string> selected;
@@ -107,7 +109,8 @@ std::optional<std::string> ChooseFixtureMode(wxWindow *parent,
       initialSelection = static_cast<int>(i);
   }
 
-  wxSingleChoiceDialog dlg(parent, "Select fixture mode", "Fixture mode", choices);
+  wxSingleChoiceDialog dlg(parent, "Select fixture mode", "Fixture mode",
+                           choices);
   if (initialSelection != wxNOT_FOUND)
     dlg.SetSelection(initialSelection);
   if (dlg.ShowModal() != wxID_OK)
@@ -117,7 +120,8 @@ std::optional<std::string> ChooseFixtureMode(wxWindow *parent,
 
 } // namespace
 
-// Replaces selected fixtures with a fixture chosen from scene, dictionary, or file source.
+// Replaces selected fixtures with a fixture chosen from scene, dictionary, or
+// file source.
 void MainWindow::OnReplaceSelectedFixtures(wxCommandEvent &WXUNUSED(event)) {
   ConfigManager &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
   auto selectedUuids = GetSelectedExistingFixtureUuids(cfg);
@@ -133,8 +137,7 @@ void MainWindow::OnReplaceSelectedFixtures(wxCommandEvent &WXUNUSED(event)) {
   sourceChoices.push_back("GDTF file");
   wxSingleChoiceDialog sourceDlg(
       this,
-      "Choose the source for the replacement fixture:",
-      "Replace Fixtures",
+      "Choose the source for the replacement fixture:", "Replace Fixtures",
       sourceChoices);
   if (sourceDlg.ShowModal() != wxID_OK)
     return;
@@ -148,8 +151,10 @@ void MainWindow::OnReplaceSelectedFixtures(wxCommandEvent &WXUNUSED(event)) {
     for (const auto &[uuid, fixture] : scene.fixtures) {
       if (fixture.gdtfSpec.empty())
         continue;
-      const std::string modeLabel = fixture.gdtfMode.empty() ? "(no mode)" : fixture.gdtfMode;
-      const std::string label = fixture.typeName + " | " + modeLabel + " | id " + std::to_string(fixture.fixtureId);
+      const std::string modeLabel =
+          fixture.gdtfMode.empty() ? "(no mode)" : fixture.gdtfMode;
+      const std::string label = fixture.typeName + " | " + modeLabel +
+                                " | id " + std::to_string(fixture.fixtureId);
       sceneOptions.emplace_back(label, &fixture);
     }
     if (sceneOptions.empty()) {
@@ -163,8 +168,8 @@ void MainWindow::OnReplaceSelectedFixtures(wxCommandEvent &WXUNUSED(event)) {
       choices.push_back(wxString::FromUTF8(label));
       ordered.push_back(fixture);
     }
-    wxSingleChoiceDialog pickDlg(this, "Choose a fixture from the scene:",
-                                 "Replace Fixtures", choices);
+    wxSingleChoiceDialog pickDlg(
+        this, "Choose a fixture from the scene:", "Replace Fixtures", choices);
     if (pickDlg.ShowModal() != wxID_OK)
       return;
     const int idx = pickDlg.GetSelection();
@@ -209,9 +214,10 @@ void MainWindow::OnReplaceSelectedFixtures(wxCommandEvent &WXUNUSED(event)) {
     replacement.gdtfMode = entries[static_cast<size_t>(idx)].second.mode;
     replacement.color = entries[static_cast<size_t>(idx)].second.color;
   } else {
-    wxString fixDir = wxString::FromUTF8(ProjectUtils::GetWritableLibraryPath("fixtures"));
-    wxFileDialog fdlg(this, "Select GDTF file", fixDir, wxEmptyString,
-                      "*.gdtf", wxFD_OPEN | wxFD_FILE_MUST_EXIST);
+    wxString fixDir =
+        wxString::FromUTF8(ProjectUtils::GetWritableLibraryPath("fixtures"));
+    wxFileDialog fdlg(this, "Select GDTF file", fixDir, wxEmptyString, "*.gdtf",
+                      wxFD_OPEN | wxFD_FILE_MUST_EXIST);
     if (fdlg.ShowModal() != wxID_OK)
       return;
     replacement.gdtfSpec = std::string(fdlg.GetPath().ToUTF8());
@@ -228,7 +234,8 @@ void MainWindow::OnReplaceSelectedFixtures(wxCommandEvent &WXUNUSED(event)) {
     return;
   }
 
-  const auto selectedMode = ChooseFixtureMode(this, replacement.gdtfSpec, replacement.gdtfMode);
+  const auto selectedMode =
+      ChooseFixtureMode(this, replacement.gdtfSpec, replacement.gdtfMode);
   if (!selectedMode.has_value()) {
     wxMessageBox("Could not read fixture modes from the selected GDTF.",
                  "Replace Fixtures", wxOK | wxICON_ERROR, this);
@@ -246,8 +253,8 @@ void MainWindow::OnReplaceSelectedFixtures(wxCommandEvent &WXUNUSED(event)) {
 
   cfg.PushUndoState("replace selected fixtures");
   auto &scene = cfg.GetScene();
-  const std::string replacementColor =
-      ResolveReplacementColor(scene, selectedUuids, replacement.gdtfSpec, replacement.color);
+  const std::string replacementColor = ResolveReplacementColor(
+      scene, selectedUuids, replacement.gdtfSpec, replacement.color);
   for (const std::string &uuid : selectedUuids) {
     auto it = scene.fixtures.find(uuid);
     if (it == scene.fixtures.end())
@@ -267,7 +274,7 @@ void MainWindow::OnReplaceSelectedFixtures(wxCommandEvent &WXUNUSED(event)) {
     target.powerConsumptionW = replacement.powerConsumptionW;
     target.physicalPropertiesSource = FixturePhysicalPropertiesSource::Gdtf;
     target.physicalPropertiesDirty = false;
-    target.color = replacementColor;
+    target.visualColorHex = replacementColor;
 
     target.fixtureId = keepFixtureId;
     target.instanceName = keepName;
@@ -277,7 +284,8 @@ void MainWindow::OnReplaceSelectedFixtures(wxCommandEvent &WXUNUSED(event)) {
     target.transform = keepTransform;
   }
 
-  // Restores the fixture selection so replacement keeps internal UUID targeting stable.
+  // Restores the fixture selection so replacement keeps internal UUID targeting
+  // stable.
   cfg.SetSelectedFixtures(selectedUuids);
   if (fixturePanel)
     fixturePanel->SelectByUuid(selectedUuids, false);

--- a/gui/mainwindow_fixture_replace.cpp
+++ b/gui/mainwindow_fixture_replace.cpp
@@ -32,7 +32,7 @@ struct ReplacementFixtureTemplate {
   std::string gdtfMode;
   float weightKg = 0.0f;
   float powerConsumptionW = 0.0f;
-  std::string color;
+  std::string visualColorHex;
 };
 
 // Normalizes a GDTF path into a comparable lowercase filename token.
@@ -181,7 +181,7 @@ void MainWindow::OnReplaceSelectedFixtures(wxCommandEvent &WXUNUSED(event)) {
     replacement.gdtfMode = picked.gdtfMode;
     replacement.weightKg = picked.weightKg;
     replacement.powerConsumptionW = picked.powerConsumptionW;
-    replacement.color = picked.color;
+    replacement.visualColorHex = picked.visualColorHex;
   } else if (sourceSelection == 1) {
     auto dict = GdtfDictionary::Load();
     if (!dict || dict->empty()) {
@@ -212,7 +212,8 @@ void MainWindow::OnReplaceSelectedFixtures(wxCommandEvent &WXUNUSED(event)) {
     replacement.typeName = entries[static_cast<size_t>(idx)].first;
     replacement.gdtfSpec = entries[static_cast<size_t>(idx)].second.path;
     replacement.gdtfMode = entries[static_cast<size_t>(idx)].second.mode;
-    replacement.color = entries[static_cast<size_t>(idx)].second.color;
+    replacement.visualColorHex =
+        entries[static_cast<size_t>(idx)].second.visualColorHex;
   } else {
     wxString fixDir =
         wxString::FromUTF8(ProjectUtils::GetWritableLibraryPath("fixtures"));
@@ -248,13 +249,14 @@ void MainWindow::OnReplaceSelectedFixtures(wxCommandEvent &WXUNUSED(event)) {
   GetGdtfProperties(replacement.gdtfSpec, weight, power);
   replacement.weightKg = weight;
   replacement.powerConsumptionW = power;
-  if (replacement.color.empty())
-    replacement.color = GetGdtfModelColor(replacement.gdtfSpec);
+  if (replacement.visualColorHex.empty())
+    replacement.visualColorHex = GetGdtfModelColor(replacement.gdtfSpec);
 
   cfg.PushUndoState("replace selected fixtures");
   auto &scene = cfg.GetScene();
   const std::string replacementColor = ResolveReplacementColor(
-      scene, selectedUuids, replacement.gdtfSpec, replacement.color);
+      scene, selectedUuids, replacement.gdtfSpec,
+      replacement.visualColorHex);
   for (const std::string &uuid : selectedUuids) {
     auto it = scene.fixtures.find(uuid);
     if (it == scene.fixtures.end())

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -19,14 +19,14 @@
 #include "filesystem_path_utils.h"
 #include "mainwindow.h"
 #include "mainwindow/controllers/mainwindow_io_controller.h"
-#include "mainwindow_view_controller.h"
 #include "mainwindow_menu_builders.h"
-#include "mainwindow_menu_text_utils.h"
 #include "mainwindow_menu_helpers.h"
+#include "mainwindow_menu_text_utils.h"
+#include "mainwindow_view_controller.h"
 
 #include <algorithm>
-#include <chrono>
 #include <cctype>
+#include <chrono>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
@@ -39,11 +39,11 @@
 
 #include <wx/artprov.h>
 #include <wx/busyinfo.h>
-#include <wx/choice.h>
 #include <wx/choicdlg.h>
+#include <wx/choice.h>
 #include <wx/datetime.h>
-#include <wx/filename.h>
 #include <wx/filefn.h>
+#include <wx/filename.h>
 #include <wx/html/htmlwin.h>
 #include <wx/numdlg.h>
 #include <wx/stdpaths.h>
@@ -53,9 +53,7 @@
 #include "addfixturedialog.h"
 #include "addtrussdialog.h"
 #include "autopatcher.h"
-#include "ui_feature_flags.h"
 #include "configmanager.h"
-#include "guiconfigservices.h"
 #include "consolepanel.h"
 #include "credentialstore.h"
 #include "diagnostics/DiagnosticLogger.h"
@@ -64,11 +62,12 @@
 #include "dictionaryeditdialog.h"
 #include "fixture.h"
 #include "fixturetablepanel.h"
+#include "gdtf_catalog_service.h"
 #include "gdtfdictionary.h"
 #include "gdtfloader.h"
 #include "gdtfnet.h"
-#include "gdtf_catalog_service.h"
 #include "gdtfsearchdialog.h"
+#include "guiconfigservices.h"
 #include "hoist_weight_distribution.h"
 #include "hoisttablepanel.h"
 #include "layerpanel.h"
@@ -76,36 +75,36 @@
 #include "layoutviewerpanel.h"
 #include "loader_obj.h"
 #include "logger.h"
-#include "magnet_snap.h"
 #include "logindialog.h"
+#include "magnet_snap.h"
+#include "mainwindow_gdtf_credentials.h"
 #include "markdown.h"
 #include "preferencesdialog.h"
 #include "projectutils.h"
-#include "rigging_extra_weight_settings.h"
 #include "resource_path_utils.h"
+#include "rigging_extra_weight_settings.h"
 #include "riggingpanel.h"
-#include "scene_object_primitive_dialogs.h"
-#include "scene_object_primitive_creation.h"
 #include "scene_grouping.h"
+#include "scene_object_primitive_creation.h"
+#include "scene_object_primitive_dialogs.h"
 #include "sceneobjecttablepanel.h"
 #include "selectfixturetypedialog.h"
+#include "selection_movement_settings.h"
 #include "selectnamedialog.h"
-#include "mainwindow_gdtf_credentials.h"
 #include "support.h"
-#include "trussloader.h"
-#include "tools/fixture_symbol_generation_tool.h"
 #include "tools/fixture_category_assignment_tool.h"
+#include "tools/fixture_symbol_generation_tool.h"
+#include "trussloader.h"
 #include "trusstablepanel.h"
+#include "ui_feature_flags.h"
 #include "update/app_update_service.h"
 #include "update/update_notification_dialog.h"
 #include "viewer2dpanel.h"
 #include "viewer3dpanel.h"
-#include "selection_movement_settings.h"
 
 // Builds and registers the main application toolbars.
 void MainWindow::CreateToolBars() {
-  const long toolbarStyle =
-      (wxAUI_TB_DEFAULT_STYLE | wxAUI_TB_HORIZONTAL);
+  const long toolbarStyle = (wxAUI_TB_DEFAULT_STYLE | wxAUI_TB_HORIZONTAL);
   fileToolBar = new wxAuiToolBar(this, wxID_ANY, wxDefaultPosition,
                                  wxDefaultSize, toolbarStyle);
   fileToolBar->SetToolBitmapSize(wxSize(16, 16));
@@ -139,8 +138,7 @@ void MainWindow::CreateToolBars() {
   const auto addToolWithDisabledIcon =
       [&](wxAuiToolBar *toolbar, int id, const wxString &label,
           const std::string &iconName, const wxArtID &fallbackArtId,
-          const wxString &shortHelp,
-          wxItemKind kind = wxITEM_NORMAL) {
+          const wxString &shortHelp, wxItemKind kind = wxITEM_NORMAL) {
         toolbar->AddTool(id, label, loadToolbarIcon(iconName, fallbackArtId),
                          shortHelp, kind);
 
@@ -151,8 +149,7 @@ void MainWindow::CreateToolBars() {
                   .GetBitmap(wxSize(16, 16)));
         }
       };
-  fileToolBar->AddTool(ID_File_New, "New",
-                       loadToolbarIcon("file", wxART_NEW),
+  fileToolBar->AddTool(ID_File_New, "New", loadToolbarIcon("file", wxART_NEW),
                        "Create a new project");
   fileToolBar->AddTool(ID_File_Load, "Open",
                        loadToolbarIcon("folder-open", wxART_FILE_OPEN),
@@ -175,11 +172,8 @@ void MainWindow::CreateToolBars() {
   fileToolBar->Realize();
 
   auiManager->AddPane(
-      fileToolBar, wxAuiPaneInfo()
-                       .Name("FileToolbar")
-                       .Caption("File")
-                       .ToolbarPane()
-                       .Top());
+      fileToolBar,
+      wxAuiPaneInfo().Name("FileToolbar").Caption("File").ToolbarPane().Top());
 
   editToolBar = new wxAuiToolBar(this, wxID_ANY, wxDefaultPosition,
                                  wxDefaultSize, toolbarStyle);
@@ -192,40 +186,35 @@ void MainWindow::CreateToolBars() {
                        "Redo last undone action");
   editToolBar->Realize();
   auiManager->AddPane(
-      editToolBar, wxAuiPaneInfo()
-                       .Name("EditToolbar")
-                       .Caption("Edit")
-                       .ToolbarPane()
-                       .Top());
+      editToolBar,
+      wxAuiPaneInfo().Name("EditToolbar").Caption("Edit").ToolbarPane().Top());
 
-  layoutViewsToolBar =
-      new wxAuiToolBar(this, wxID_ANY, wxDefaultPosition, wxDefaultSize,
-                       toolbarStyle);
+  layoutViewsToolBar = new wxAuiToolBar(this, wxID_ANY, wxDefaultPosition,
+                                        wxDefaultSize, toolbarStyle);
   layoutViewsToolBar->SetToolBitmapSize(wxSize(16, 16));
   layoutViewsToolBar->AddTool(ID_View_Layout_Default, "Vista layout 3D",
-                              loadToolbarIcon("box",
-                                              wxART_MISSING_IMAGE),
+                              loadToolbarIcon("box", wxART_MISSING_IMAGE),
                               "Switch to 3D Layout View");
-  layoutViewsToolBar->AddTool(ID_View_Layout_2D, "Vista layout 2D",
-                              loadToolbarIcon("panels-right-bottom",
-                                              wxART_MISSING_IMAGE),
+  layoutViewsToolBar->AddTool(
+      ID_View_Layout_2D, "Vista layout 2D",
+      loadToolbarIcon("panels-right-bottom", wxART_MISSING_IMAGE),
                               "Switch to 2D Layout View");
-  layoutViewsToolBar->AddTool(ID_View_Layout_Mode, "Modo layout",
-                              loadToolbarIcon("square-asterisk",
-                                              wxART_MISSING_IMAGE),
+  layoutViewsToolBar->AddTool(
+      ID_View_Layout_Mode, "Modo layout",
+      loadToolbarIcon("square-asterisk", wxART_MISSING_IMAGE),
                               "Switch to Layout Mode View");
   layoutViewsToolBar->AddSeparator();
-  layoutViewsToolBar->AddTool(ID_View_Viewport_Top, "Top View",
-                              loadToolbarIcon("cube-view-top",
-                                              wxART_MISSING_IMAGE),
+  layoutViewsToolBar->AddTool(
+      ID_View_Viewport_Top, "Top View",
+      loadToolbarIcon("cube-view-top", wxART_MISSING_IMAGE),
                               "Apply top view to active viewport");
-  layoutViewsToolBar->AddTool(ID_View_Viewport_Front, "Front View",
-                              loadToolbarIcon("cube-view-front",
-                                              wxART_MISSING_IMAGE),
+  layoutViewsToolBar->AddTool(
+      ID_View_Viewport_Front, "Front View",
+      loadToolbarIcon("cube-view-front", wxART_MISSING_IMAGE),
                               "Apply front view to active viewport");
-  layoutViewsToolBar->AddTool(ID_View_Viewport_Side, "Side View",
-                              loadToolbarIcon("cube-view-side",
-                                              wxART_MISSING_IMAGE),
+  layoutViewsToolBar->AddTool(
+      ID_View_Viewport_Side, "Side View",
+      loadToolbarIcon("cube-view-side", wxART_MISSING_IMAGE),
                               "Apply side view to active viewport");
   layoutViewsToolBar->AddSeparator();
   addToolWithDisabledIcon(layoutViewsToolBar, ID_View_Viewport_SelectTool,
@@ -244,7 +233,8 @@ void MainWindow::CreateToolBars() {
                           "Toggle left-click selection dragging", wxITEM_CHECK);
   addToolWithDisabledIcon(layoutViewsToolBar, ID_View_Viewport_Magnet, "Magnet",
                           "magnet", wxART_MISSING_IMAGE,
-                          "Toggle Magnet snapping while dragging", wxITEM_CHECK);
+                          "Toggle Magnet snapping while dragging",
+                          wxITEM_CHECK);
   layoutViewsToolBar->ToggleTool(ID_View_Viewport_SelectTool, true);
   layoutViewsToolBar->ToggleTool(ID_View_Viewport_MeasureTool, false);
   layoutViewsToolBar->ToggleTool(
@@ -262,8 +252,7 @@ void MainWindow::CreateToolBars() {
       GetDefaultGuiConfigServices().Preferences().GetValue(
           magnet_snap::kMagnetEnabledConfigKey) == "1");
   layoutViewsToolBar->Realize();
-  auiManager->AddPane(
-      layoutViewsToolBar, wxAuiPaneInfo()
+  auiManager->AddPane(layoutViewsToolBar, wxAuiPaneInfo()
                               .Name("LayoutViewsToolbar")
                               .Caption("Layout Views")
                               .ToolbarPane()
@@ -274,8 +263,8 @@ void MainWindow::CreateToolBars() {
   toolsToolBar->SetToolBitmapSize(wxSize(16, 16));
   addToolWithDisabledIcon(toolsToolBar, ID_Edit_AddFixture, "Add Fixture",
                           "spotlight", wxART_MISSING_IMAGE, "Add fixture");
-  addToolWithDisabledIcon(toolsToolBar, ID_Edit_AddTruss, "Add Truss",
-                          "truss", wxART_MISSING_IMAGE, "Add truss");
+  addToolWithDisabledIcon(toolsToolBar, ID_Edit_AddTruss, "Add Truss", "truss",
+                          wxART_MISSING_IMAGE, "Add truss");
   addToolWithDisabledIcon(toolsToolBar, ID_Edit_AddSceneObject, "Add Object",
                           "guitar", wxART_MISSING_IMAGE, "Add object");
   toolsToolBar->AddSeparator();
@@ -286,8 +275,7 @@ void MainWindow::CreateToolBars() {
                         loadToolbarIcon("notepad-text", wxART_TIP),
                         "Create from text");
   toolsToolBar->Realize();
-  auiManager->AddPane(
-      toolsToolBar, wxAuiPaneInfo()
+  auiManager->AddPane(toolsToolBar, wxAuiPaneInfo()
                         .Name("ToolsToolbar")
                         .Caption("Tools")
                         .ToolbarPane()
@@ -300,20 +288,18 @@ void MainWindow::CreateToolBars() {
                           "Añadir vista 2D", "panel-top-bottom-dashed",
                           wxART_MISSING_IMAGE, "Add 2D View to Layout");
   addToolWithDisabledIcon(layoutToolBar, ID_View_Layout_Legend,
-                          "Añadir leyenda", "layout-list",
-                          wxART_MISSING_IMAGE, "Add fixture legend to layout");
+                          "Añadir leyenda", "layout-list", wxART_MISSING_IMAGE,
+                          "Add fixture legend to layout");
   addToolWithDisabledIcon(layoutToolBar, ID_View_Layout_EventTable,
                           "Añadir tabla de evento", "table", wxART_LIST_VIEW,
                           "Add event table to layout");
   addToolWithDisabledIcon(layoutToolBar, ID_View_Layout_Text, "Añadir texto",
-                          "text-select", wxART_TIP,
-                          "Add text box to layout");
-  addToolWithDisabledIcon(layoutToolBar, ID_View_Layout_Image,
-                          "Añadir imagen", "image-plus",
-                          wxART_MISSING_IMAGE, "Add image to layout");
+                          "text-select", wxART_TIP, "Add text box to layout");
+  addToolWithDisabledIcon(layoutToolBar, ID_View_Layout_Image, "Añadir imagen",
+                          "image-plus", wxART_MISSING_IMAGE,
+                          "Add image to layout");
   layoutToolBar->Realize();
-  auiManager->AddPane(
-      layoutToolBar, wxAuiPaneInfo()
+  auiManager->AddPane(layoutToolBar, wxAuiPaneInfo()
                          .Name("LayoutToolbar")
                          .Caption("Layout")
                          .ToolbarPane()
@@ -323,9 +309,7 @@ void MainWindow::CreateToolBars() {
 }
 
 // Builds and assigns the main application menu bar.
-void MainWindow::CreateMenuBar() {
-  SetMenuBar(BuildMainWindowMenuBar());
-}
+void MainWindow::CreateMenuBar() { SetMenuBar(BuildMainWindowMenuBar()); }
 
 // Starts a new project after guarding startup and save state.
 void MainWindow::OnNew(wxCommandEvent &WXUNUSED(event)) {
@@ -338,8 +322,9 @@ void MainWindow::OnNew(wxCommandEvent &WXUNUSED(event)) {
   ResetProject(true);
 }
 
-// Opens the GDTF search flow, refreshing the remote catalog when credentials are available.
-// Opens the GDTF download workflow and optionally adds the selected fixture.
+// Opens the GDTF search flow, refreshing the remote catalog when credentials
+// are available. Opens the GDTF download workflow and optionally adds the
+// selected fixture.
 void MainWindow::OnDownloadGdtf(wxCommandEvent &WXUNUSED(event)) {
   diagnostics::DiagnosticLogger::Info("GDTF download workflow opened.");
   ConfigManager &configManager =
@@ -356,7 +341,8 @@ void MainWindow::OnDownloadGdtf(wxCommandEvent &WXUNUSED(event)) {
 
   const auto catalogResolveStart = std::chrono::steady_clock::now();
   GdtfCatalogService catalogService;
-  const std::string nowUtc = WxToUtf8(wxDateTime::UNow().FormatISOCombined(' '));
+  const std::string nowUtc =
+      WxToUtf8(wxDateTime::UNow().FormatISOCombined(' '));
 
   std::unique_ptr<wxWindowDisabler> refreshDisabler =
       std::make_unique<wxWindowDisabler>();
@@ -373,10 +359,9 @@ void MainWindow::OnDownloadGdtf(wxCommandEvent &WXUNUSED(event)) {
             }
 
             long loginHttpCode = 0;
-            const bool loginOk =
-                GdtfLogin(activeCredentials->username,
-                         activeCredentials->password, cookieFile,
-                         loginHttpCode);
+            const bool loginOk = GdtfLogin(activeCredentials->username,
+                                           activeCredentials->password,
+                                           cookieFile, loginHttpCode);
             if (!loginOk || loginHttpCode != 200)
               return false;
 
@@ -384,13 +369,13 @@ void MainWindow::OnDownloadGdtf(wxCommandEvent &WXUNUSED(event)) {
             return GdtfGetList(cookieFile, onlineListData, &listHttpCode) &&
                    listHttpCode == 200 && !onlineListData.empty();
           },
-          nowUtc,
-          0);
+          nowUtc, 0);
 
   refreshOverlay.reset();
   refreshDisabler.reset();
 
-  const auto catalogResolveElapsedMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+  const auto catalogResolveElapsedMs =
+      std::chrono::duration_cast<std::chrono::milliseconds>(
       std::chrono::steady_clock::now() - catalogResolveStart)
                                             .count();
 
@@ -410,7 +395,8 @@ void MainWindow::OnDownloadGdtf(wxCommandEvent &WXUNUSED(event)) {
 
   if (consolePanel) {
     consolePanel->AppendMessage(wxString::Format(
-        "[METRIC] GDTF catalog cache_hit=%d cache_miss=%d cache_age_s=%lld refresh_attempted=%d refresh_succeeded=%d resolve_ms=%lld",
+        "[METRIC] GDTF catalog cache_hit=%d cache_miss=%d cache_age_s=%lld "
+        "refresh_attempted=%d refresh_succeeded=%d resolve_ms=%lld",
         catalogResult.metrics.cacheHit ? 1 : 0,
         catalogResult.metrics.cacheMiss ? 1 : 0,
         static_cast<long long>(catalogResult.metrics.cacheAgeSeconds),
@@ -426,19 +412,23 @@ void MainWindow::OnDownloadGdtf(wxCommandEvent &WXUNUSED(event)) {
       this, effectiveListData, effectiveUpdatedAt,
       [&]() -> GdtfSearchDialog::RefreshResult {
         GdtfSearchDialog::RefreshResult refreshResult;
-        refreshResult.updatedAt = WxToUtf8(wxDateTime::UNow().FormatISOCombined(' '));
+        refreshResult.updatedAt =
+            WxToUtf8(wxDateTime::UNow().FormatISOCombined(' '));
         if (!activeCredentials || activeCredentials->username.empty() ||
             activeCredentials->password.empty()) {
-          refreshResult.failureDetails = "No stored GDTF credentials configured.";
+          refreshResult.failureDetails =
+              "No stored GDTF credentials configured.";
           return refreshResult;
         }
 
         long loginHttpCode = 0;
-        const bool loginOk = GdtfLogin(activeCredentials->username,
-                                       activeCredentials->password,
+        const bool loginOk =
+            GdtfLogin(activeCredentials->username, activeCredentials->password,
                                        cookieFile, loginHttpCode);
         if (!loginOk || loginHttpCode != 200) {
-          refreshResult.failureDetails = wxString::Format("Login failed (HTTP %ld).", loginHttpCode).ToStdString();
+          refreshResult.failureDetails =
+              wxString::Format("Login failed (HTTP %ld).", loginHttpCode)
+                  .ToStdString();
           return refreshResult;
         }
 
@@ -512,7 +502,8 @@ void MainWindow::OnDownloadGdtf(wxCommandEvent &WXUNUSED(event)) {
       }
 
       if (consolePanel)
-        consolePanel->AppendMessage("[INFO] Logging into GDTF Share using libcurl");
+        consolePanel->AppendMessage(
+            "[INFO] Logging into GDTF Share using libcurl");
       updateGdtfDownloadBusyOverlay("Logging in to GDTF Share...");
       return GdtfLogin(activeCredentials->username, activeCredentials->password,
                        cookieFile, httpCode);
@@ -550,9 +541,11 @@ void MainWindow::OnDownloadGdtf(wxCommandEvent &WXUNUSED(event)) {
         gdtfDownloadDisabler = std::make_unique<wxWindowDisabler>();
         updateGdtfDownloadBusyOverlay("Downloading GDTF from GDTF Share...");
         if (consolePanel)
-          consolePanel->AppendMessage("[INFO] Downloading via libcurl rid=" + rid);
+          consolePanel->AppendMessage("[INFO] Downloading via libcurl rid=" +
+                                      rid);
         long dlCode = 0;
-        bool ok = GdtfDownload(WxToUtf8(rid), WxToUtf8(dest), cookieFile, dlCode);
+        bool ok =
+            GdtfDownload(WxToUtf8(rid), WxToUtf8(dest), cookieFile, dlCode);
         clearGdtfDownloadBlockingUi();
         if (consolePanel)
           consolePanel->AppendMessage(
@@ -561,18 +554,21 @@ void MainWindow::OnDownloadGdtf(wxCommandEvent &WXUNUSED(event)) {
           diagnostics::DiagnosticLogger::Info(
               "GDTF download completed: " +
               diagnostics::DiagnosticLogger::FileNameOnly(WxToUtf8(dest)));
-          int addNow = wxMessageBox(
-              "GDTF downloaded successfully. Do you want to add it to the project now?",
+          int addNow =
+              wxMessageBox("GDTF downloaded successfully. Do you want to add "
+                           "it to the project now?",
               "Success", wxYES_NO | wxICON_QUESTION, this);
           if (addNow == wxYES)
             AddFixtureFromGdtfPath(WxToUtf8(dest));
         } else {
-          diagnostics::DiagnosticLogger::Error(
-              "GDTF download failed: http=" + std::to_string(dlCode));
-          wxMessageBox("Failed to download GDTF.", "Error", wxOK | wxICON_ERROR);
+          diagnostics::DiagnosticLogger::Error("GDTF download failed: http=" +
+                                               std::to_string(dlCode));
+          wxMessageBox("Failed to download GDTF.", "Error",
+                       wxOK | wxICON_ERROR);
         }
       } else {
-        wxMessageBox("Download information missing.", "Error", wxOK | wxICON_ERROR);
+        wxMessageBox("Download information missing.", "Error",
+                     wxOK | wxICON_ERROR);
       }
     }
   }
@@ -588,7 +584,8 @@ void MainWindow::OnEditDictionaries(wxCommandEvent &WXUNUSED(event)) {
 
 // Opens the writable user library folder in the system file browser.
 void MainWindow::OnOpenUserLibraryFolder(wxCommandEvent &WXUNUSED(event)) {
-  const std::string fixturesPath = ProjectUtils::GetWritableLibraryPath("fixtures");
+  const std::string fixturesPath =
+      ProjectUtils::GetWritableLibraryPath("fixtures");
   if (fixturesPath.empty()) {
     wxMessageBox("Could not resolve writable user library path.",
                  "Open user library folder", wxOK | wxICON_ERROR);
@@ -598,7 +595,8 @@ void MainWindow::OnOpenUserLibraryFolder(wxCommandEvent &WXUNUSED(event)) {
   const std::filesystem::path libraryRoot =
       PathUtils::PathFromUtf8(fixturesPath).parent_path();
   const std::u8string folderPathUtf8 = libraryRoot.u8string();
-  const std::string folderPathBytes(folderPathUtf8.begin(), folderPathUtf8.end());
+  const std::string folderPathBytes(folderPathUtf8.begin(),
+                                    folderPathUtf8.end());
   const wxString folderPath = wxString::FromUTF8(folderPathBytes.c_str());
   if (!wxLaunchDefaultApplication(folderPath)) {
     wxMessageBox("Could not open the user library folder.",
@@ -610,7 +608,8 @@ void MainWindow::OnOpenUserLibraryFolder(wxCommandEvent &WXUNUSED(event)) {
 void MainWindow::OnAutoPatch(wxCommandEvent &WXUNUSED(event)) {
   ConfigManager &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
   cfg.PushUndoState("auto patch");
-  const std::vector<std::string> selectedFixtureUuids = cfg.GetSelectedFixtures();
+  const std::vector<std::string> selectedFixtureUuids =
+      cfg.GetSelectedFixtures();
   if (!selectedFixtureUuids.empty())
     AutoPatcher::AutoPatchSelection(cfg.GetScene(), selectedFixtureUuids);
   else
@@ -645,7 +644,8 @@ void MainWindow::OnDistributeHoistWeights(wxCommandEvent &WXUNUSED(event)) {
   for (const std::string &positionName : hoistPositions)
     choices.Add(wxString::FromUTF8(positionName));
 
-  wxSingleChoiceDialog dialog(this, "Select hang position(s) to distribute hoist weights.",
+  wxSingleChoiceDialog dialog(
+      this, "Select hang position(s) to distribute hoist weights.",
                               "Distribute hoist weights", choices);
   dialog.SetSelection(0);
   if (dialog.ShowModal() != wxID_OK)
@@ -677,8 +677,8 @@ void MainWindow::OnDistributeHoistWeights(wxCommandEvent &WXUNUSED(event)) {
       HoistWeightDistribution::BuildRoundedRiggingTotalByHangPosition(
           scene,
           RiggingExtraWeightSettings::BuildKilogramsByPosition(extraWeights));
-  HoistWeightDistribution::ApplyForImportedSupports(
-      scene, selectedSupportUuids, roundedTotalsByPosition);
+  HoistWeightDistribution::ApplyForImportedSupports(scene, selectedSupportUuids,
+                                                    roundedTotalsByPosition);
   RefreshAfterSceneChange();
 }
 
@@ -741,24 +741,25 @@ void MainWindow::OnAutoColor(wxCommandEvent &WXUNUSED(event)) {
 
   std::map<std::string, std::string> fixtureGroupColors;
   for (auto &[uuid, f] : scene.fixtures) {
-    if (hasFixtureSelection && selectedFixtureSet.find(uuid) == selectedFixtureSet.end())
+    if (hasFixtureSelection &&
+        selectedFixtureSet.find(uuid) == selectedFixtureSet.end())
       continue;
 
     if (hasFixtureSelection) {
       if (f.gdtfSpec.empty()) {
-        f.color = randHex();
+        f.visualColorHex = randHex();
         continue;
       }
       const std::string groupKey = buildFixtureGroupKey(f);
       auto existing = fixtureGroupColors.find(groupKey);
       if (existing == fixtureGroupColors.end()) {
-        const auto dictColor = GdtfDictionary::GetDefaultColorForFixture(
+        const auto dictColor = GdtfDictionary::GetDefaultVisualColorForFixture(
             f.typeName, f.gdtfSpec, f.gdtfMode);
         const std::string chosenColor = dictColor ? *dictColor : randHex();
         fixtureGroupColors[groupKey] = chosenColor;
-        f.color = chosenColor;
+        f.visualColorHex = chosenColor;
       } else {
-        f.color = existing->second;
+        f.visualColorHex = existing->second;
       }
       continue;
     }
@@ -767,14 +768,17 @@ void MainWindow::OnAutoColor(wxCommandEvent &WXUNUSED(event)) {
       auto it = fixtureGroupColors.find(buildFixtureGroupKey(f));
       if (it == fixtureGroupColors.end()) {
         const std::string c =
-            (f.color.empty() || isWhiteColor(f.color)) ? randHex() : f.color;
+            (f.visualColorHex.empty() || isWhiteColor(f.visualColorHex))
+                ? randHex()
+                : f.visualColorHex;
         fixtureGroupColors[buildFixtureGroupKey(f)] = c;
-        f.color = c;
+        f.visualColorHex = c;
       } else {
-        f.color = it->second;
+        f.visualColorHex = it->second;
       }
-    } else if (hasFixtureSelection || f.color.empty() || isWhiteColor(f.color)) {
-      f.color = randHex();
+    } else if (hasFixtureSelection || f.visualColorHex.empty() ||
+               isWhiteColor(f.visualColorHex)) {
+      f.visualColorHex = randHex();
     }
   }
 
@@ -807,8 +811,8 @@ void MainWindow::OnConvertToHoist(wxCommandEvent &WXUNUSED(event)) {
     const auto &fixture = it->second;
 
     Support s;
-    s.uuid = wxString::Format("uuid_%lld_%d", static_cast<long long>(baseId),
-                             idx++)
+    s.uuid =
+        wxString::Format("uuid_%lld_%d", static_cast<long long>(baseId), idx++)
                 .ToStdString();
     s.name = fixture.instanceName;
     s.gdtfSpec = fixture.gdtfSpec;
@@ -821,7 +825,8 @@ void MainWindow::OnConvertToHoist(wxCommandEvent &WXUNUSED(event)) {
     s.capacityKg = 0.0f;
     s.weightKg = 0.0f;
     s.loadKg = fixture.weightKg;
-    s.motorName = fixture.instanceName.empty() ? fixture.typeName : fixture.instanceName;
+    s.motorName =
+        fixture.instanceName.empty() ? fixture.typeName : fixture.instanceName;
     s.motorModel = fixture.gdtfMode;
     s.motorFixtureUuid = fixture.uuid;
     s.hoistDataSource = "Manual";
@@ -849,11 +854,10 @@ void MainWindow::OnConvertToHoist(wxCommandEvent &WXUNUSED(event)) {
   RefreshSummary();
   RefreshRigging();
 
-  wxMessageBox(wxString::Format("Converted %zu fixture(s) to hoists.",
-                                newIds.size()),
+  wxMessageBox(
+      wxString::Format("Converted %zu fixture(s) to hoists.", newIds.size()),
                "Convert to Hoist", wxOK | wxICON_INFORMATION);
 }
-
 
 // Runs the fixture symbol generation tool when the feature is enabled.
 void MainWindow::OnGenerateFixtureSymbols(wxCommandEvent &WXUNUSED(event)) {
@@ -866,8 +870,7 @@ void MainWindow::OnGenerateFixtureSymbols(wxCommandEvent &WXUNUSED(event)) {
 // Runs automatic category assignment for selected fixtures when enabled.
 void MainWindow::OnAssignSelectedFixtureCategory(
     wxCommandEvent &WXUNUSED(event)) {
-  if (!ui::IsFeatureEnabled(
-          ui::FeatureFlag::AssignSelectedFixtureCategory)) {
+  if (!ui::IsFeatureEnabled(ui::FeatureFlag::AssignSelectedFixtureCategory)) {
     return;
   }
 
@@ -880,8 +883,9 @@ void MainWindow::OnClose(wxCommandEvent &event) {
   Close(false);
 }
 
-// Persists state, stops live workers, and detaches IO callbacks before destroying the main window.
-// Finalizes shutdown by saving state and stopping runtime services.
+// Persists state, stops live workers, and detaches IO callbacks before
+// destroying the main window. Finalizes shutdown by saving state and stopping
+// runtime services.
 void MainWindow::OnCloseWindow(wxCloseEvent &event) {
   SaveUserConfigWithViewport2DState();
   if (!ConfirmSaveIfDirty("exiting", "Exit")) {
@@ -972,13 +976,12 @@ void MainWindow::OnShowHelp(wxCommandEvent &WXUNUSED(event)) {
         std::max(900, static_cast<int>(parentSize.x * 0.85)),
         std::max(700, static_cast<int>(parentSize.y * 0.85)));
     wxDialog dlg(this, wxID_ANY, wxString::FromUTF8("Perastage Help"),
-                 wxDefaultPosition,
-                 dialogSize,
+                 wxDefaultPosition, dialogSize,
                  wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER | wxMAXIMIZE_BOX);
     wxBoxSizer *sizer = new wxBoxSizer(wxVERTICAL);
     wxBoxSizer *langSizer = new wxBoxSizer(wxHORIZONTAL);
-    wxStaticText *langLabel = new wxStaticText(
-        &dlg, wxID_ANY, wxString::FromUTF8("Language:"));
+    wxStaticText *langLabel =
+        new wxStaticText(&dlg, wxID_ANY, wxString::FromUTF8("Language:"));
     wxChoice *langChoice = new wxChoice(&dlg, wxID_ANY);
     langChoice->Append(wxString::FromUTF8("English"));
     langChoice->Append(wxString::FromUTF8("Español"));
@@ -1008,8 +1011,8 @@ void MainWindow::OnShowHelp(wxCommandEvent &WXUNUSED(event)) {
     dlg.ShowModal();
   } else {
     wxMessageBox(wxString::FromUTF8("help.md file not found"),
-                 wxString::FromUTF8("Perastage Help"),
-                 wxOK | wxICON_ERROR, this);
+                 wxString::FromUTF8("Perastage Help"), wxOK | wxICON_ERROR,
+                 this);
   }
 }
 
@@ -1018,24 +1021,23 @@ void MainWindow::OnOpenOnlineDocumentation(wxCommandEvent &WXUNUSED(event)) {
   wxLaunchDefaultBrowser("https://perastage.luismaperamato.com/");
 }
 
-
-
-
 // Opens the local diagnostics folder in the system file explorer.
 void MainWindow::OnOpenLogsFolder(wxCommandEvent &WXUNUSED(event)) {
   std::string error;
   const std::filesystem::path logsDirectory =
       diagnostics::DiagnosticPaths::LogsDirectory();
   if (!diagnostics::DiagnosticPaths::EnsureDirectory(logsDirectory, &error)) {
-    diagnostics::DiagnosticLogger::Error("Unable to open logs folder: " + error);
-    wxMessageBox(wxString::FromUTF8("Could not create the logs folder.\n\n" + error),
-                 wxString::FromUTF8("Perastage Diagnostics"),
-                 wxOK | wxICON_ERROR, this);
+    diagnostics::DiagnosticLogger::Error("Unable to open logs folder: " +
+                                         error);
+    wxMessageBox(
+        wxString::FromUTF8("Could not create the logs folder.\n\n" + error),
+        wxString::FromUTF8("Perastage Diagnostics"), wxOK | wxICON_ERROR, this);
     return;
   }
 
   diagnostics::DiagnosticLogger::Info("Open logs folder requested.");
-  const wxString quotedPath = "\"" + wxString::FromUTF8(logsDirectory.string()) + "\"";
+  const wxString quotedPath =
+      "\"" + wxString::FromUTF8(logsDirectory.string()) + "\"";
 #if defined(__WXMSW__)
   const wxString command = "explorer " + quotedPath;
 #elif defined(__WXOSX__)
@@ -1058,21 +1060,25 @@ void MainWindow::OnExportDiagnosticReport(wxCommandEvent &WXUNUSED(event)) {
   std::filesystem::path reportPath;
   std::string error;
   if (!diagnostics::DiagnosticReport::ExportToFile(&reportPath, &error)) {
-    diagnostics::DiagnosticLogger::Error("Diagnostic report export failed: " + error);
-    wxMessageBox(wxString::FromUTF8("Could not export the diagnostic report.\n\n" + error),
+    diagnostics::DiagnosticLogger::Error("Diagnostic report export failed: " +
+                                         error);
+    wxMessageBox(wxString::FromUTF8(
+                     "Could not export the diagnostic report.\n\n" + error),
                  wxString::FromUTF8("Perastage Diagnostics"),
                  wxOK | wxICON_ERROR, this);
     return;
   }
 
   diagnostics::DiagnosticLogger::Info("Diagnostic report exported.");
-  wxMessageBox(wxString::FromUTF8("Diagnostic report exported successfully.\n\n" +
+  wxMessageBox(
+      wxString::FromUTF8("Diagnostic report exported successfully.\n\n" +
                                   reportPath.string()),
-               wxString::FromUTF8("Perastage Diagnostics"),
-               wxOK | wxICON_INFORMATION, this);
+      wxString::FromUTF8("Perastage Diagnostics"), wxOK | wxICON_INFORMATION,
+      this);
 }
 
-// Checks the latest release asynchronously and shows a result dialog with update actions.
+// Checks the latest release asynchronously and shows a result dialog with
+// update actions.
 void MainWindow::OnCheckForUpdates(wxCommandEvent &WXUNUSED(event)) {
   auto busyInfo = std::make_shared<wxBusyInfo>("Checking for updates...");
   auto disabler = std::make_shared<wxWindowDisabler>();
@@ -1082,14 +1088,16 @@ void MainWindow::OnCheckForUpdates(wxCommandEvent &WXUNUSED(event)) {
     const gui::update::CheckResult result = service.CheckForUpdates();
 
     CallAfter([this, result, busyInfo, disabler]() mutable {
-      // Releases busy UI guards before any modal dialog so result popups remain visible.
+      // Releases busy UI guards before any modal dialog so result popups remain
+      // visible.
       busyInfo.reset();
       disabler.reset();
 
       wxString title = "Perastage Updates";
       if (result.status == gui::update::CheckStatus::CheckFailed) {
         wxString message = "Could not check for updates.\n\n";
-        message += result.errorMessage.empty()
+        message +=
+            result.errorMessage.empty()
                        ? wxString::FromUTF8(
                              "Please verify your network connection and try again.")
                        : wxString::FromUTF8(result.errorMessage);
@@ -1186,11 +1194,14 @@ void MainWindow::OnUndo(wxCommandEvent &WXUNUSED(event)) {
   }
   if (viewportPanel) {
     std::vector<std::string> mergedSelection;
-    mergedSelection.insert(mergedSelection.end(), cfg.GetSelectedFixtures().begin(),
+    mergedSelection.insert(mergedSelection.end(),
+                           cfg.GetSelectedFixtures().begin(),
                            cfg.GetSelectedFixtures().end());
-    mergedSelection.insert(mergedSelection.end(), cfg.GetSelectedTrusses().begin(),
+    mergedSelection.insert(mergedSelection.end(),
+                           cfg.GetSelectedTrusses().begin(),
                            cfg.GetSelectedTrusses().end());
-    mergedSelection.insert(mergedSelection.end(), cfg.GetSelectedSupports().begin(),
+    mergedSelection.insert(mergedSelection.end(),
+                           cfg.GetSelectedSupports().begin(),
                            cfg.GetSelectedSupports().end());
     mergedSelection.insert(mergedSelection.end(),
                            cfg.GetSelectedSceneObjects().begin(),
@@ -1236,11 +1247,14 @@ void MainWindow::OnRedo(wxCommandEvent &WXUNUSED(event)) {
   }
   if (viewportPanel) {
     std::vector<std::string> mergedSelection;
-    mergedSelection.insert(mergedSelection.end(), cfg.GetSelectedFixtures().begin(),
+    mergedSelection.insert(mergedSelection.end(),
+                           cfg.GetSelectedFixtures().begin(),
                            cfg.GetSelectedFixtures().end());
-    mergedSelection.insert(mergedSelection.end(), cfg.GetSelectedTrusses().begin(),
+    mergedSelection.insert(mergedSelection.end(),
+                           cfg.GetSelectedTrusses().begin(),
                            cfg.GetSelectedTrusses().end());
-    mergedSelection.insert(mergedSelection.end(), cfg.GetSelectedSupports().begin(),
+    mergedSelection.insert(mergedSelection.end(),
+                           cfg.GetSelectedSupports().begin(),
                            cfg.GetSelectedSupports().end());
     mergedSelection.insert(mergedSelection.end(),
                            cfg.GetSelectedSceneObjects().begin(),
@@ -1333,7 +1347,8 @@ void MainWindow::OnAddTruss(wxCommandEvent &WXUNUSED(event)) {
     if (dlgRes == wxID_OPEN) {
       wxString trussDir =
           wxString::FromUTF8(ProjectUtils::GetWritableLibraryPath("trusses"));
-      wxFileDialog fdlg(this, "Select Truss file", trussDir, wxEmptyString,
+      wxFileDialog fdlg(
+          this, "Select Truss file", trussDir, wxEmptyString,
                         wxString::FromUTF8(GetTrussDefinitionFileDialogWildcard()),
                         wxFD_OPEN | wxFD_FILE_MUST_EXIST);
       if (fdlg.ShowModal() != wxID_OK)
@@ -1351,7 +1366,8 @@ void MainWindow::OnAddTruss(wxCommandEvent &WXUNUSED(event)) {
   } else {
     wxString trussDir =
         wxString::FromUTF8(ProjectUtils::GetWritableLibraryPath("trusses"));
-    wxFileDialog fdlg(this, "Select Truss file", trussDir, wxEmptyString,
+    wxFileDialog fdlg(
+        this, "Select Truss file", trussDir, wxEmptyString,
                       wxString::FromUTF8(GetTrussDefinitionFileDialogWildcard()),
                       wxFD_OPEN | wxFD_FILE_MUST_EXIST);
     if (fdlg.ShowModal() != wxID_OK)
@@ -1373,10 +1389,9 @@ void MainWindow::OnAddTruss(wxCommandEvent &WXUNUSED(event)) {
                          "Add truss: selected extension='" + selectedExtension +
                              "' path='" + path + "'.");
   if (!LoadTrussDefinition(path, baseTruss)) {
-    Logger::Instance().Log(
-        Logger::Level::Warn,
-        "Add truss validation failed: extension='" + selectedExtension +
-            "' path='" + path + "'.");
+    Logger::Instance().Log(Logger::Level::Warn,
+                           "Add truss validation failed: extension='" +
+                               selectedExtension + "' path='" + path + "'.");
     wxMessageBox("Unsupported or unreadable truss file. Supported formats are "
                  "GDTF, GTruss, GLB, and 3DS.",
                  "Error", wxOK | wxICON_ERROR);
@@ -1457,8 +1472,7 @@ void MainWindow::OnAddTruss(wxCommandEvent &WXUNUSED(event)) {
           "' parsingSucceeded=true symbolFile='" + baseTruss.symbolFile +
           "' dimensionsMm=" + std::to_string(baseTruss.lengthMm) + "x" +
           std::to_string(baseTruss.widthMm) + "x" +
-          std::to_string(baseTruss.heightMm) +
-          " updateSceneRequested=" +
+          std::to_string(baseTruss.heightMm) + " updateSceneRequested=" +
           (updateSceneRequested ? std::string("true") : std::string("false")) +
           ".");
   if (viewportPanel) {
@@ -1468,9 +1482,10 @@ void MainWindow::OnAddTruss(wxCommandEvent &WXUNUSED(event)) {
   RefreshSummary();
 }
 
-
-// Converts imported OBJ files into GLB assets so MVR exports always reference official GLB resources.
-std::string NormalizeImportedObjectModelPathToGlb(const std::string &selectedPath,
+// Converts imported OBJ files into GLB assets so MVR exports always reference
+// official GLB resources.
+std::string
+NormalizeImportedObjectModelPathToGlb(const std::string &selectedPath,
                                                   const std::string &sceneBasePath,
                                                   std::string &consoleError) {
   namespace fs = std::filesystem;
@@ -1487,25 +1502,28 @@ std::string NormalizeImportedObjectModelPathToGlb(const std::string &selectedPat
   const fs::path importTempDir = tempRoot / "perastage_imported_objects";
   fs::create_directories(importTempDir, ec);
   if (ec) {
-    consoleError = "Failed preparing temporary directory for OBJ import conversion";
+    consoleError =
+        "Failed preparing temporary directory for OBJ import conversion";
     return selectedPath;
   }
 
-  const std::string uniqueSuffix = std::to_string(
-      static_cast<long long>(std::chrono::steady_clock::now().time_since_epoch().count()));
+  const std::string uniqueSuffix = std::to_string(static_cast<long long>(
+      std::chrono::steady_clock::now().time_since_epoch().count()));
   const std::string targetName =
       sourcePath.stem().string() + "_" + uniqueSuffix + ".glb";
   const fs::path targetPath = importTempDir / targetName;
 
   std::string conversionError;
-  if (!ConvertObjFileToGlb(sourcePath.string(), targetPath.string(), &conversionError)) {
+  if (!ConvertObjFileToGlb(sourcePath.string(), targetPath.string(),
+                           &conversionError)) {
     consoleError = "Failed converting OBJ to GLB: " + conversionError;
     return selectedPath;
   }
 
   if (!sceneBasePath.empty()) {
     const fs::path absTarget = fs::weakly_canonical(targetPath, ec);
-    const fs::path absBase = fs::weakly_canonical(PathUtils::PathFromUtf8(sceneBasePath), ec);
+    const fs::path absBase =
+        fs::weakly_canonical(PathUtils::PathFromUtf8(sceneBasePath), ec);
     if (!ec && !absTarget.empty() && !absBase.empty() &&
         absTarget.string().rfind(absBase.string(), 0) == 0) {
       return fs::relative(absTarget, absBase, ec).string();
@@ -1588,7 +1606,8 @@ void MainWindow::OnAddSceneObject(wxCommandEvent &WXUNUSED(event)) {
     std::string conversionError;
     path = NormalizeImportedObjectModelPathToGlb(path, base, conversionError);
     if (!conversionError.empty() && ConsolePanel::Instance())
-      ConsolePanel::Instance()->AppendMessage(wxString::FromUTF8(conversionError));
+      ConsolePanel::Instance()->AppendMessage(
+          wxString::FromUTF8(conversionError));
     if (!base.empty()) {
       fs::path abs = fs::absolute(path);
       fs::path b = fs::absolute(base);
@@ -1724,9 +1743,10 @@ void MainWindow::OnDelete(wxCommandEvent &WXUNUSED(event)) {
       sceneObjPanel->SelectByUuid(cfg.GetSelectedSceneObjects(), false);
   };
 
-  const bool hasAnySelection =
-      !cfg.GetSelectedFixtures().empty() || !cfg.GetSelectedTrusses().empty() ||
-      !cfg.GetSelectedSupports().empty() || !cfg.GetSelectedSceneObjects().empty();
+  const bool hasAnySelection = !cfg.GetSelectedFixtures().empty() ||
+                               !cfg.GetSelectedTrusses().empty() ||
+                               !cfg.GetSelectedSupports().empty() ||
+                               !cfg.GetSelectedSceneObjects().empty();
   if (hasAnySelection)
     cfg.PushUndoState("delete selected elements");
 

--- a/gui/summarypanel.cpp
+++ b/gui/summarypanel.cpp
@@ -140,8 +140,8 @@ void SummaryPanel::ShowFixtureSummary() {
         auto& row = grouped[fix.typeName];
         row.typeName = fix.typeName;
         row.count += 1;
-    if (row.visualColorHexHex.empty() && !fix.visualColorHex.empty())
-      row.visualColorHexHex = fix.visualColorHex;
+        if (row.colorHex.empty() && !fix.visualColorHex.empty())
+            row.colorHex = fix.visualColorHex;
     }
 
     const auto hiddenFixtureTypes =
@@ -208,8 +208,8 @@ void SummaryPanel::ShowFixtureSummaryRows(
         wxBitmap bmp(16, 16);
         wxMemoryDC dc(bmp);
         wxColour color;
-    if (!rowData.visualColorHexHex.empty() &&
-        color.Set(wxString::FromUTF8(rowData.visualColorHexHex)))
+        if (!rowData.colorHex.empty() &&
+            color.Set(wxString::FromUTF8(rowData.colorHex)))
             dc.SetBrush(wxBrush(color));
         else
             dc.SetBrush(wxBrush(wxColour(128, 128, 128)));

--- a/gui/summarypanel.cpp
+++ b/gui/summarypanel.cpp
@@ -23,12 +23,12 @@
 #include "table_column_indices.h"
 #include "viewer2dpanel.h"
 #include "viewer3dpanel.h"
-#include <wx/colordlg.h>
-#include <wx/dcmemory.h>
-#include <wx/aui/framemanager.h>
 #include <algorithm>
 #include <map>
 #include <unordered_set>
+#include <wx/aui/framemanager.h>
+#include <wx/colordlg.h>
+#include <wx/dcmemory.h>
 
 static SummaryPanel* s_instance = nullptr;
 
@@ -140,8 +140,8 @@ void SummaryPanel::ShowFixtureSummary() {
         auto& row = grouped[fix.typeName];
         row.typeName = fix.typeName;
         row.count += 1;
-        if (row.colorHex.empty() && !fix.color.empty())
-            row.colorHex = fix.color;
+    if (row.visualColorHexHex.empty() && !fix.visualColorHex.empty())
+      row.visualColorHexHex = fix.visualColorHex;
     }
 
     const auto hiddenFixtureTypes =
@@ -208,8 +208,8 @@ void SummaryPanel::ShowFixtureSummaryRows(
         wxBitmap bmp(16, 16);
         wxMemoryDC dc(bmp);
         wxColour color;
-    if (!rowData.colorHex.empty() &&
-        color.Set(wxString::FromUTF8(rowData.colorHex)))
+    if (!rowData.visualColorHexHex.empty() &&
+        color.Set(wxString::FromUTF8(rowData.visualColorHexHex)))
             dc.SetBrush(wxBrush(color));
         else
             dc.SetBrush(wxBrush(wxColour(128, 128, 128)));
@@ -404,8 +404,7 @@ void SummaryPanel::RefreshVisibleViewers() const {
 
 void SummaryPanel::OnItemValueChanged(wxDataViewEvent& event) {
     if (!table || mode != SummaryMode::Fixture ||
-        event.GetColumn() !=
-            FixtureColumnIndex(FixtureSummaryColumn::Visible))
+      event.GetColumn() != FixtureColumnIndex(FixtureSummaryColumn::Visible))
         return;
     const int row = table->ItemToRow(event.GetItem());
     if (row == wxNOT_FOUND)
@@ -443,8 +442,7 @@ void SummaryPanel::OnItemActivated(wxDataViewEvent& event) {
         return;
 
     const std::string typeName =
-        table->GetTextValue(
-                 row, FixtureColumnIndex(FixtureSummaryColumn::Type))
+      table->GetTextValue(row, FixtureColumnIndex(FixtureSummaryColumn::Type))
             .ToStdString();
     auto& colorCfg = (*colorConfigManager);
     auto& fixtures = colorCfg.GetScene().fixtures;
@@ -452,8 +450,8 @@ void SummaryPanel::OnItemActivated(wxDataViewEvent& event) {
     wxColourData data;
     for (const auto& [uuid, fixture] : fixtures) {
         (void)uuid;
-        if (fixture.typeName == typeName && !fixture.color.empty()) {
-            data.SetColour(wxColour(wxString::FromUTF8(fixture.color)));
+    if (fixture.typeName == typeName && !fixture.visualColorHex.empty()) {
+      data.SetColour(wxColour(wxString::FromUTF8(fixture.visualColorHex)));
             break;
         }
     }
@@ -470,7 +468,7 @@ void SummaryPanel::OnItemActivated(wxDataViewEvent& event) {
     for (auto& [uuid, fixture] : fixtures) {
         (void)uuid;
         if (fixture.typeName == typeName)
-            fixture.color = hex;
+      fixture.visualColorHex = hex;
     }
 
     if (FixtureTablePanel::Instance())

--- a/gui/summarypanel.cpp
+++ b/gui/summarypanel.cpp
@@ -19,12 +19,14 @@
 #include "colorstore.h"
 #include "configmanager.h"
 #include "fixturetablepanel.h"
+#include "gdtfdictionary.h"
 #include "guiconfigservices.h"
 #include "table_column_indices.h"
 #include "viewer2dpanel.h"
 #include "viewer3dpanel.h"
 #include <algorithm>
 #include <map>
+#include <set>
 #include <unordered_set>
 #include <wx/aui/framemanager.h>
 #include <wx/colordlg.h>
@@ -465,10 +467,18 @@ void SummaryPanel::OnItemActivated(wxDataViewEvent& event) {
                                            color.Green(), color.Blue())
                               .ToStdString();
     colorCfg.PushUndoState("change fixture type color in project from summary");
+    std::set<std::string> updatedDictionaryKeys;
     for (auto& [uuid, fixture] : fixtures) {
         (void)uuid;
-        if (fixture.typeName == typeName)
-      fixture.visualColorHex = hex;
+        if (fixture.typeName != typeName)
+            continue;
+        fixture.visualColorHex = hex;
+        const std::string dictionaryKey =
+            fixture.gdtfSpec + '\x1f' + fixture.gdtfMode;
+        if (updatedDictionaryKeys.insert(dictionaryKey).second) {
+            GdtfDictionary::UpdateVisualColorForFile(
+                fixture.typeName, fixture.gdtfSpec, fixture.gdtfMode, hex);
+        }
     }
 
     if (FixtureTablePanel::Instance())

--- a/gui/table_column_indices.h
+++ b/gui/table_column_indices.h
@@ -119,7 +119,7 @@ enum class Column : int { CountValue = 0, Type, Count };
 } // namespace ObjectSummaryTableColumns
 
 namespace DictionaryFixtureTableColumns {
-enum class Column : int { Name = 0, File, Mode, Category, Color, Count };
+enum class Column : int { Name = 0, File, Mode, Category, VisualColor, Count };
 } // namespace DictionaryFixtureTableColumns
 
 namespace DictionaryTrussTableColumns {

--- a/gui/tools/scene_model_symbol_capture_service.cpp
+++ b/gui/tools/scene_model_symbol_capture_service.cpp
@@ -29,8 +29,10 @@ struct Bounds3D {
   bool valid = false;
 };
 
-// Transforms a point by a Matrix using local-space basis vectors and translation.
-std::array<float, 3> TransformPoint(const Matrix &m, const std::array<float, 3> &p) {
+// Transforms a point by a Matrix using local-space basis vectors and
+// translation.
+std::array<float, 3> TransformPoint(const Matrix &m,
+                                    const std::array<float, 3> &p) {
   return {m.u[0] * p[0] + m.v[0] * p[1] + m.w[0] * p[2] + m.o[0],
           m.u[1] * p[0] + m.v[1] * p[1] + m.w[1] * p[2] + m.o[1],
           m.u[2] * p[0] + m.v[2] * p[1] + m.w[2] * p[2] + m.o[2]};
@@ -47,7 +49,8 @@ void ExtendBounds(Bounds3D &bounds, const std::array<float, 3> &p) {
   bounds.valid = true;
 }
 
-// Temporarily overrides a fixture color during symbol capture and restores it afterward.
+// Temporarily overrides a fixture color during symbol capture and restores it
+// afterward.
 class ScopedFixtureColorOverride {
 public:
   // Applies an optional temporary fixture color override for symbol capture.
@@ -60,8 +63,8 @@ public:
     auto it = fixtures.find(fixtureUuid);
     if (it == fixtures.end())
       return;
-    previous_.emplace_back(it->first, it->second.color);
-    it->second.color = *forcedHex;
+    previous_.emplace_back(it->first, it->second.visualColorHex);
+    it->second.visualColorHex = *forcedHex;
   }
 
   // Restores any fixture colors overridden during symbol capture.
@@ -70,7 +73,7 @@ public:
     for (const auto &[uuid, color] : previous_) {
       auto it = fixtures.find(uuid);
       if (it != fixtures.end())
-        it->second.color = color;
+        it->second.visualColorHex = color;
     }
   }
 
@@ -79,10 +82,12 @@ private:
   std::vector<std::pair<std::string, std::string>> previous_;
 };
 
-// Temporarily isolates the scene to a single model target for deterministic capture.
+// Temporarily isolates the scene to a single model target for deterministic
+// capture.
 class ScopedSingleModelSceneOverride {
 public:
-  // Replaces scene content with only the requested model target for isolated capture.
+  // Replaces scene content with only the requested model target for isolated
+  // capture.
   ScopedSingleModelSceneOverride(ConfigManager &cfg,
                                  const SceneModelSymbolTarget &target,
                                  bool alignToLocalAxes)
@@ -104,7 +109,8 @@ public:
       if (it != originalFixtures_.end()) {
         Fixture fixture = it->second;
         if (alignToLocalAxes)
-          fixture.transform = AlignRotationToIdentityKeepingScale(fixture.transform);
+          fixture.transform =
+              AlignRotationToIdentityKeepingScale(fixture.transform);
         scene.fixtures.emplace(it->first, std::move(fixture));
       }
       break;
@@ -114,7 +120,8 @@ public:
       if (it != originalTrusses_.end()) {
         Truss truss = it->second;
         if (alignToLocalAxes)
-          truss.transform = AlignRotationToIdentityKeepingScale(truss.transform);
+          truss.transform =
+              AlignRotationToIdentityKeepingScale(truss.transform);
         scene.trusses.emplace(it->first, std::move(truss));
       }
       break;
@@ -124,7 +131,8 @@ public:
       if (it != originalSceneObjects_.end()) {
         SceneObject object = it->second;
         if (alignToLocalAxes)
-          object.transform = AlignRotationToIdentityKeepingScale(object.transform);
+          object.transform =
+              AlignRotationToIdentityKeepingScale(object.transform);
         scene.sceneObjects.emplace(it->first, std::move(object));
       }
       break;
@@ -142,10 +150,12 @@ public:
   }
 
 private:
-  // Rebuilds a transform with identity rotation while preserving scale and translation.
+  // Rebuilds a transform with identity rotation while preserving scale and
+  // translation.
   static Matrix AlignRotationToIdentityKeepingScale(const Matrix &source) {
     Matrix identity = MatrixUtils::Identity();
-    return MatrixUtils::ApplyRotationPreservingScale(source, identity, source.o);
+    return MatrixUtils::ApplyRotationPreservingScale(source, identity,
+                                                     source.o);
   }
 
   ConfigManager &cfg_;
@@ -155,10 +165,12 @@ private:
   std::unordered_map<std::string, Support> originalSupports_;
 };
 
-// Saves and restores 2D viewer state so capture does not affect interactive UI state.
+// Saves and restores 2D viewer state so capture does not affect interactive UI
+// state.
 class ScopedViewer2DCaptureState {
 public:
-  // Stores the current 2D viewer state so capture can run without persisting UI changes.
+  // Stores the current 2D viewer state so capture can run without persisting UI
+  // changes.
   explicit ScopedViewer2DCaptureState(Viewer2DPanel &panel) : panel_(panel) {
     const Viewer2DViewState state = panel_.GetViewState();
     offsetXPixels_ = state.offsetPixelsX;
@@ -192,7 +204,8 @@ private:
   bool preferPerastageSvgSymbolsForLayouts_ = false;
 };
 
-// Applies temporary render overrides tailored for high-contrast symbol extraction.
+// Applies temporary render overrides tailored for high-contrast symbol
+// extraction.
 class ScopedViewer2DRenderOverrides {
 public:
   // Applies temporary render overrides optimized for symbol capture.
@@ -230,7 +243,8 @@ void MirrorImageHorizontally(symbols::RenderedSymbolImage &render) {
   }
 }
 
-// Resolves fixture GDTF geometry bounds for aspect-driven symbol viewport sizing.
+// Resolves fixture GDTF geometry bounds for aspect-driven symbol viewport
+// sizing.
 bool TryResolveFixtureBoundsMmForCapture(ConfigManager &cfg,
                                          const SceneModelSymbolTarget &target,
                                          Bounds3D &bounds) {
@@ -243,8 +257,8 @@ bool TryResolveFixtureBoundsMmForCapture(ConfigManager &cfg,
 
   gui::fixtures::FixtureGdtfResolution resolution;
   std::string error;
-  if (!gui::fixtures::ResolveFixtureGdtfDeterministic(fixtureIt->second, cfg.GetScene(),
-                                                       resolution, error))
+  if (!gui::fixtures::ResolveFixtureGdtfDeterministic(
+          fixtureIt->second, cfg.GetScene(), resolution, error))
     return false;
 
   std::vector<GdtfObject> objects;
@@ -255,16 +269,19 @@ bool TryResolveFixtureBoundsMmForCapture(ConfigManager &cfg,
     if (object.isLens)
       continue;
     for (size_t vi = 0; vi + 2 < object.mesh.vertices.size(); vi += 3) {
-      const std::array<float, 3> local = {
-          object.mesh.vertices[vi], object.mesh.vertices[vi + 1], object.mesh.vertices[vi + 2]};
+      const std::array<float, 3> local = {object.mesh.vertices[vi],
+                                          object.mesh.vertices[vi + 1],
+                                          object.mesh.vertices[vi + 2]};
       ExtendBounds(bounds, TransformPoint(object.transform, local));
     }
   }
   return bounds.valid;
 }
 
-// Returns the expected projected width/height ratio for a symbol view from physical bounds.
-float ComputeCaptureAspectForView(const Bounds3D &bounds, symbols::SymbolView view) {
+// Returns the expected projected width/height ratio for a symbol view from
+// physical bounds.
+float ComputeCaptureAspectForView(const Bounds3D &bounds,
+                                  symbols::SymbolView view) {
   const float x = std::max(1e-3f, bounds.max[0] - bounds.min[0]);
   const float y = std::max(1e-3f, bounds.max[1] - bounds.min[1]);
   const float z = std::max(1e-3f, bounds.max[2] - bounds.min[2]);
@@ -282,10 +299,10 @@ float ComputeCaptureAspectForView(const Bounds3D &bounds, symbols::SymbolView vi
 
 } // namespace
 
-// Captures top/front/side/bottom orthographic renders and converts them into vector symbols.
-SceneModelSymbolCaptureResult
-CaptureSceneModelOrthographicSymbols(Viewer2DOffscreenRenderer &renderer,
-                                     ConfigManager &cfg,
+// Captures top/front/side/bottom orthographic renders and converts them into
+// vector symbols.
+SceneModelSymbolCaptureResult CaptureSceneModelOrthographicSymbols(
+    Viewer2DOffscreenRenderer &renderer, ConfigManager &cfg,
                                      const SceneModelSymbolTarget &target,
                                      const SceneModelSymbolCaptureOptions &options) {
   SceneModelSymbolCaptureResult result;
@@ -297,8 +314,8 @@ CaptureSceneModelOrthographicSymbols(Viewer2DOffscreenRenderer &renderer,
   }
 
   ScopedViewer2DCaptureState scopedPanelState(*capturePanel);
-  ScopedSingleModelSceneOverride isolatedSceneOverride(cfg, target,
-                                                       options.alignToLocalAxes);
+  ScopedSingleModelSceneOverride isolatedSceneOverride(
+      cfg, target, options.alignToLocalAxes);
   ScopedFixtureColorOverride selectedFixtureColorOverride(
       cfg, target.kind == SceneModelKind::Fixture ? target.uuid : std::string(),
       options.forcedFixtureColor);
@@ -332,10 +349,13 @@ CaptureSceneModelOrthographicSymbols(Viewer2DOffscreenRenderer &renderer,
   };
 
   const std::array<CaptureRequest, 4> requests = {
-      CaptureRequest{Viewer2DView::Front, false, false, symbols::SymbolView::Front},
+      CaptureRequest{Viewer2DView::Front, false, false,
+                     symbols::SymbolView::Front},
       CaptureRequest{Viewer2DView::Top, false, false, symbols::SymbolView::Top},
-      CaptureRequest{Viewer2DView::Side, false, true, symbols::SymbolView::Left},
-      CaptureRequest{Viewer2DView::Top, true, false, symbols::SymbolView::Bottom},
+      CaptureRequest{Viewer2DView::Side, false, true,
+                     symbols::SymbolView::Left},
+      CaptureRequest{Viewer2DView::Top, true, false,
+                     symbols::SymbolView::Bottom},
   };
 
   std::vector<symbols::RenderedSymbolImage> renders;
@@ -346,11 +366,15 @@ CaptureSceneModelOrthographicSymbols(Viewer2DOffscreenRenderer &renderer,
 
   for (const auto &request : requests) {
     if (hasFixtureBounds) {
-      const float aspect = ComputeCaptureAspectForView(fixtureBounds, request.symbolView);
-      const int base = std::max(256, std::max(options.viewportSize.GetWidth(),
+      const float aspect =
+          ComputeCaptureAspectForView(fixtureBounds, request.symbolView);
+      const int base =
+          std::max(256, std::max(options.viewportSize.GetWidth(),
                                               options.viewportSize.GetHeight()));
-      const int width = std::max(256, static_cast<int>(aspect >= 1.0f ? base : base * aspect));
-      const int height = std::max(256, static_cast<int>(aspect >= 1.0f ? base / aspect : base));
+      const int width = std::max(
+          256, static_cast<int>(aspect >= 1.0f ? base : base * aspect));
+      const int height = std::max(
+          256, static_cast<int>(aspect >= 1.0f ? base / aspect : base));
       renderer.SetViewportSize(wxSize(width, height));
     } else {
       renderer.SetViewportSize(options.viewportSize);
@@ -365,9 +389,11 @@ CaptureSceneModelOrthographicSymbols(Viewer2DOffscreenRenderer &renderer,
 
     symbols::RenderedSymbolImage render;
     render.view = request.symbolView;
-    const bool ok = capturePanel->RenderToRGBA(render.rgba, render.width, render.height);
+    const bool ok =
+        capturePanel->RenderToRGBA(render.rgba, render.width, render.height);
     if (!ok || render.width <= 0 || render.height <= 0) {
-      result.error = "Could not capture all orthographic source images from the 2D viewer.";
+      result.error = "Could not capture all orthographic source images from "
+                     "the 2D viewer.";
       return result;
     }
     if (request.mirrorSideHorizontally)
@@ -375,7 +401,8 @@ CaptureSceneModelOrthographicSymbols(Viewer2DOffscreenRenderer &renderer,
     renders.push_back(std::move(render));
   }
 
-  auto symbols = symbols::Symbol2DImageBuilder::BuildFromRenderedImages(renders);
+  auto symbols =
+      symbols::Symbol2DImageBuilder::BuildFromRenderedImages(renders);
   if (symbols.size() != requests.size()) {
     result.error = "Could not generate all symbols from captured views.";
     return result;

--- a/models/fixture.h
+++ b/models/fixture.h
@@ -17,8 +17,8 @@
  */
 #pragma once
 
-#include <string>
 #include "types.h"
+#include <string>
 
 // Tracks where editable fixture physical properties came from.
 enum class FixturePhysicalPropertiesSource {
@@ -33,9 +33,11 @@ struct Fixture {
     std::string uuid;             // Unique identifier from the MVR file
     std::string instanceName;     // Name of this fixture instance (from MVR)
     std::string typeName;         // GDTF fixture type name
-    std::string requestedFixtureName; // Original MVR fixture name used for matching
+  std::string
+      requestedFixtureName; // Original MVR fixture name used for matching
     std::string gdtfSpec;         // GDTF file name
-    std::string originalMvrGdtfSpec; // Original MVR GDTF archive reference preserved for safe restore/export
+  std::string originalMvrGdtfSpec; // Original MVR GDTF archive reference
+                                   // preserved for safe restore/export
     std::string gdtfMode;         // GDTF mode name (optional)
     std::string focus;            // Focus reference UUID (optional)
     std::string function;         // Function string (optional)
@@ -47,11 +49,14 @@ struct Fixture {
     std::string matrixRaw;        // Raw matrix string from XML (to be parsed later)
     Matrix transform;             // Parsed transformation matrix
     Matrix localTransform;         // Local transform relative to parent GroupObject
-    bool hasLocalTransform = false; // True when localTransform was explicitly assigned
+  bool hasLocalTransform =
+      false; // True when localTransform was explicitly assigned
     std::string parentGroupUuid;    // Parent GroupObject UUID when grouped
 
-    std::string color;            // Hex RGB visualization color (e.g., "#RRGGBB")
-    std::string gelColor;         // Optional physical gel/filter color exported as MVR Color
+    // Perastage-only visual color used in plans, summaries, legends, and viewers.
+    std::string visualColorHex;
+    // Official MVR Fixture/Color represented as UI hex and converted to/from CIE xyY.
+    std::string mvrFixtureColorHex;
 
     std::string fixtureIdText;    // FixtureID (free-form string identifier from XML)
     int fixtureId = 0;            // Numeric FixtureID fallback used internally
@@ -66,8 +71,10 @@ struct Fixture {
     float powerConsumptionW = 0.0f; // Power consumption in watts
     float weightKg = 0.0f;          // Fixture weight in kilograms
     FixturePhysicalPropertiesSource physicalPropertiesSource =
-        FixturePhysicalPropertiesSource::Unknown; // Source for editable physical values
-    bool physicalPropertiesDirty = false; // True when the user edited physical values
+      FixturePhysicalPropertiesSource::Unknown; // Source for editable physical
+                                                // values
+  bool physicalPropertiesDirty =
+      false; // True when the user edited physical values
 
     std::string category;         // Fixture category (Spot, Wash, etc.)
     std::string categorySource;   // Category source (Manual, AutoFallback, ...)

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -16,20 +16,20 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "mvrexporter.h"
-#include "mvr_preferences.h"
 #include "app_version.h"
-#include "filesystem_path_utils.h"
 #include "configmanager.h"
 #include "dummyprofilelibrary.h"
+#include "filesystem_path_utils.h"
 #include "gdtf_mutation_audit.h"
 #include "gdtfloader.h"
 #include "logger.h"
 #include "matrixutils.h"
-#include "projectutils.h"
+#include "mvr_preferences.h"
 #include "primitive_model_resources.h"
+#include "projectutils.h"
 #include "support.h"
-#include "uuidutils.h"
 #include "truss_gdtf_builder.h"
+#include "uuidutils.h"
 
 #include <wx/wfstream.h>
 #include <wx/wx.h>
@@ -51,14 +51,14 @@ class wxZipStreamLink;
 #include <functional>
 #include <iomanip>
 #include <map>
+#include <optional>
 #include <regex>
 #include <set>
 #include <sstream>
-#include <unordered_set>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
-#include <optional>
 
 namespace fs = std::filesystem;
 
@@ -113,7 +113,8 @@ static std::string ToLowerAscii(std::string value);
 static FixtureExportId ResolveFixtureExportId(const Fixture &fixture);
 static std::unordered_map<std::string, int> BuildFixtureUnitNumbersForExport(
     const std::unordered_map<std::string, Fixture> &fixtures);
-static std::string BuildFixtureTypeCategoryKey(const Fixture &fixture,
+static std::string
+BuildFixtureTypeCategoryKey(const Fixture &fixture,
                                                const std::string &gdtfArchivePath);
 static bool IsManualFixtureCategorySource(const std::string &source);
 static void MergeFixtureTypeCategoryExport(
@@ -128,8 +129,10 @@ static bool NearlyEqualPhysicalValue(float lhs, float rhs);
 static bool FixtureNeedsPhysicalGdtfPatch(const Fixture &fixture,
                                           const std::string &gdtfPath,
                                           GdtfOverrides &overrides);
-static tinyxml2::XMLElement *FindFirstPerastageUserData(tinyxml2::XMLElement *node);
-static tinyxml2::XMLElement *FindOrCreatePerastageDataNode(tinyxml2::XMLDocument &doc,
+static tinyxml2::XMLElement *
+FindFirstPerastageUserData(tinyxml2::XMLElement *node);
+static tinyxml2::XMLElement *
+FindOrCreatePerastageDataNode(tinyxml2::XMLDocument &doc,
                                                             tinyxml2::XMLElement *node);
 
 static void AppendSupportHoistInfoUserData(tinyxml2::XMLDocument &doc,
@@ -154,11 +157,12 @@ static void LogLegacyPositionUuidWarning(const std::string &message);
 
 static constexpr const char *kMvrProvider = "Perastage";
 static constexpr const char *kPerastageUserDataSchemaVersion = "1.0";
-static constexpr const char *kDummyFallbackFixtureGdtfFileName = "Dummy 1ch.gdtf";
-static constexpr const char *kLegacyFallbackFixtureGdtfFileName = "Generic 1ch.gdtf";
+static constexpr const char *kDummyFallbackFixtureGdtfFileName =
+    "Dummy 1ch.gdtf";
+static constexpr const char *kLegacyFallbackFixtureGdtfFileName =
+    "Generic 1ch.gdtf";
 static constexpr const char *kPhysicalPropertiesRevisionText =
     "Updated physical properties for Perastage MVR export";
-
 
 // Compares physical values using the exporter tolerance.
 static bool NearlyEqualPhysicalValue(float lhs, float rhs) {
@@ -179,7 +183,8 @@ static bool FixtureNeedsPhysicalGdtfPatch(const Fixture &fixture,
 
   bool needsPatch = false;
   if (fixture.weightKg > 0.0f &&
-      (!hasGdtfProperties || !NearlyEqualPhysicalValue(fixture.weightKg, gdtfWeightKg))) {
+      (!hasGdtfProperties ||
+       !NearlyEqualPhysicalValue(fixture.weightKg, gdtfWeightKg))) {
     overrides.hasWeightKg = true;
     overrides.weightKg = fixture.weightKg;
     needsPatch = true;
@@ -197,19 +202,20 @@ static bool FixtureNeedsPhysicalGdtfPatch(const Fixture &fixture,
 // Resolves the MVR FixtureID values from the current editable fixture ID.
 static FixtureExportId ResolveFixtureExportId(const Fixture &fixture) {
   FixtureExportId id;
-  id.numeric = fixture.fixtureId > 0 ? fixture.fixtureId : fixture.fixtureIdNumeric;
+  id.numeric =
+      fixture.fixtureId > 0 ? fixture.fixtureId : fixture.fixtureIdNumeric;
   if (id.numeric <= 0)
     id.numeric = 0;
 
   const bool importedNumericStillMatches =
-      fixture.fixtureIdNumeric > 0 && fixture.fixtureId == fixture.fixtureIdNumeric;
+      fixture.fixtureIdNumeric > 0 &&
+      fixture.fixtureId == fixture.fixtureIdNumeric;
   if (importedNumericStillMatches)
     id.text = TrimAscii(fixture.fixtureIdText);
   if (id.text.empty() && id.numeric > 0)
     id.text = std::to_string(id.numeric);
   return id;
 }
-
 
 // Builds a normalized fixture type key for UnitNumber export grouping.
 static std::string BuildFixtureUnitNumberTypeKey(const Fixture &fixture) {
@@ -231,8 +237,8 @@ static std::string BuildFixtureUnitNumberTypeKey(const Fixture &fixture) {
     return normalized;
   };
 
-  for (const std::string *candidate : {&fixture.typeName, &fixture.gdtfSpec,
-                                       &fixture.requestedFixtureName,
+  for (const std::string *candidate :
+       {&fixture.typeName, &fixture.gdtfSpec, &fixture.requestedFixtureName,
                                        &fixture.instanceName}) {
     std::string key = normalize(*candidate);
     if (!key.empty())
@@ -241,7 +247,8 @@ static std::string BuildFixtureUnitNumberTypeKey(const Fixture &fixture) {
   return "Unknown";
 }
 
-// Prepares deterministic UnitNumber values for fixtures without mutating the editable scene.
+// Prepares deterministic UnitNumber values for fixtures without mutating the
+// editable scene.
 static std::unordered_map<std::string, int> BuildFixtureUnitNumbersForExport(
     const std::unordered_map<std::string, Fixture> &fixtures) {
   struct FixtureRef {
@@ -324,7 +331,8 @@ static std::string Read3dsCString(std::ifstream &file, std::streampos endPos) {
   return output;
 }
 
-static std::vector<std::string> Collect3dsTextureReferences(const fs::path &modelPath) {
+static std::vector<std::string>
+Collect3dsTextureReferences(const fs::path &modelPath) {
   std::vector<std::string> references;
   std::ifstream file(modelPath, std::ios::binary);
   if (!file.is_open())
@@ -393,7 +401,8 @@ static std::vector<std::string> Collect3dsTextureReferences(const fs::path &mode
   return references;
 }
 
-static std::vector<std::string> CollectGltfTextureReferences(const fs::path &modelPath) {
+static std::vector<std::string>
+CollectGltfTextureReferences(const fs::path &modelPath) {
   std::vector<std::string> references;
   std::ifstream file(modelPath);
   if (!file.is_open())
@@ -449,8 +458,8 @@ static bool ResolveTextureDependencyPath(const fs::path &modelPath,
   }
 
   std::error_code ec;
-  for (const auto &entry :
-       fs::directory_iterator(modelDir, fs::directory_options::skip_permission_denied, ec)) {
+  for (const auto &entry : fs::directory_iterator(
+           modelDir, fs::directory_options::skip_permission_denied, ec)) {
     if (ec)
       break;
     if (!entry.is_regular_file())
@@ -471,22 +480,27 @@ enum class TrussGeometryAuthority {
 };
 
 static TrussGeometryAuthority GetTrussGeometryAuthoritySetting() {
-  const float rawValue = ConfigManager::Get().GetFloat("mvr_truss_geometry_authority");
-  return rawValue >= 0.5f ? TrussGeometryAuthority::Gdtf : TrussGeometryAuthority::MvrGeometry;
+  const float rawValue =
+      ConfigManager::Get().GetFloat("mvr_truss_geometry_authority");
+  return rawValue >= 0.5f ? TrussGeometryAuthority::Gdtf
+                          : TrussGeometryAuthority::MvrGeometry;
 }
 
 static std::string TrimAscii(std::string value) {
   auto isSpace = [](unsigned char c) { return std::isspace(c); };
-  value.erase(value.begin(), std::find_if(value.begin(), value.end(),
+  value.erase(value.begin(),
+              std::find_if(value.begin(), value.end(),
                                           [&](unsigned char c) { return !isSpace(c); }));
   value.erase(std::find_if(value.rbegin(), value.rend(),
-                           [&](unsigned char c) { return !isSpace(c); }).base(),
+                           [&](unsigned char c) { return !isSpace(c); })
+                  .base(),
               value.end());
   return value;
 }
 
 static std::string ToLowerAscii(std::string value) {
-  std::transform(value.begin(), value.end(), value.begin(),
+  std::transform(
+      value.begin(), value.end(), value.begin(),
                  [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
   return value;
 }
@@ -495,7 +509,8 @@ static void LogLegacyPositionUuidWarning(const std::string &message) {
   Logger::Instance().Log(Logger::Level::Warn, message);
 }
 
-static std::string TruncateFileNamePreservingExtension(const std::string &fileName,
+static std::string
+TruncateFileNamePreservingExtension(const std::string &fileName,
                                                        size_t maxLength) {
   if (fileName.size() <= maxLength)
     return fileName;
@@ -549,12 +564,15 @@ static bool ContainsArchiveFileNameCaseInsensitive(
 }
 
 // Creates a unique root-level MVR archive filename from any source-like path.
-static std::string EnsureUniqueArchivePath(const std::string &proposed,
+static std::string
+EnsureUniqueArchivePath(const std::string &proposed,
                                            std::unordered_set<std::string> &usedPaths) {
   constexpr size_t kMaxArchiveEntryNameLength = 120;
   std::string normalized = SanitizeArchiveFileName(proposed, "resource.bin");
-  normalized = TruncateFileNamePreservingExtension(normalized, kMaxArchiveEntryNameLength);
-  if (normalized.empty() || fs::path(normalized).stem().generic_string().empty())
+  normalized = TruncateFileNamePreservingExtension(normalized,
+                                                   kMaxArchiveEntryNameLength);
+  if (normalized.empty() ||
+      fs::path(normalized).stem().generic_string().empty())
     normalized = "resource.bin";
   if (!ContainsArchiveFileNameCaseInsensitive(usedPaths, normalized)) {
     usedPaths.insert(normalized);
@@ -618,13 +636,15 @@ static std::string SanitizeArchiveFileName(const std::string &input,
   const std::string fileName = fs::path(candidate).filename().generic_string();
   if (!fileName.empty())
     return TruncateFileNamePreservingExtension(
-        sanitizeSingleFileName(fileName, fallbackName), kMaxArchiveFileNameLength);
+        sanitizeSingleFileName(fileName, fallbackName),
+        kMaxArchiveFileNameLength);
   return TruncateFileNamePreservingExtension(
       sanitizeSingleFileName("", fallbackName), kMaxArchiveFileNameLength);
 }
 
 // Sanitizes arbitrary input into a relative archive path for legacy helpers.
-static std::string SanitizeArchiveRelativePath(const std::string &input,
+static std::string
+SanitizeArchiveRelativePath(const std::string &input,
                                                const std::string &fallbackName) {
   std::string candidate = TrimAscii(input);
   std::replace(candidate.begin(), candidate.end(), '\\', '/');
@@ -649,9 +669,9 @@ static std::string SanitizeArchiveRelativePath(const std::string &input,
   return out.generic_string();
 }
 
-
 // Builds a stable fixture type/profile key for root-level category metadata.
-static std::string BuildFixtureTypeCategoryKey(const Fixture &fixture,
+static std::string
+BuildFixtureTypeCategoryKey(const Fixture &fixture,
                                                const std::string &gdtfArchivePath) {
   std::ostringstream key;
   key << TrimAscii(gdtfArchivePath) << '|' << TrimAscii(fixture.gdtfMode);
@@ -671,7 +691,8 @@ static bool IsManualFixtureCategorySource(const std::string &source) {
   return ToLowerAscii(TrimAscii(source)) == "manual";
 }
 
-// Merges one fixture's category into the type-level export map deterministically.
+// Merges one fixture's category into the type-level export map
+// deterministically.
 static void MergeFixtureTypeCategoryExport(
     std::map<std::string, FixtureTypeCategoryExport> &metadataByType,
     const Fixture &fixture, const std::string &gdtfArchivePath) {
@@ -697,7 +718,8 @@ static void MergeFixtureTypeCategoryExport(
   }
 
   const bool incomingManual = IsManualFixtureCategorySource(source);
-  const bool existingManual = IsManualFixtureCategorySource(entry.categorySource);
+  const bool existingManual =
+      IsManualFixtureCategorySource(entry.categorySource);
   if (incomingManual && !existingManual) {
     entry.category = category;
     entry.categorySource = source;
@@ -742,7 +764,8 @@ static std::string BuildTrussGdtfArchiveName(const Truss &truss) {
   std::string baseName = TrimAscii(truss.model);
   if (baseName.empty()) {
     if (truss.lengthMm > 0.0f) {
-      const int lengthMeters = static_cast<int>(std::lround(truss.lengthMm / 1000.0f));
+      const int lengthMeters =
+          static_cast<int>(std::lround(truss.lengthMm / 1000.0f));
       if (lengthMeters > 0)
         baseName = "truss " + std::to_string(lengthMeters) + "m";
     }
@@ -760,29 +783,21 @@ static std::string BuildTrussGdtfArchiveName(const Truss &truss) {
 // Builds the internal truss type key used for export-time resource reuse.
 static std::string BuildTrussTypeKey(const Truss &truss) {
   std::ostringstream key;
-  key << TrimAscii(truss.gdtfSpec) << '|'
-      << TrimAscii(truss.modelFile) << '|'
-      << TrimAscii(truss.manufacturer) << '|'
-      << TrimAscii(truss.model) << '|'
-      << TrimAscii(truss.crossSection) << '|'
-      << truss.lengthMm << '|'
-      << truss.widthMm << '|'
-      << truss.heightMm << '|'
-      << truss.weightKg;
+  key << TrimAscii(truss.gdtfSpec) << '|' << TrimAscii(truss.modelFile) << '|'
+      << TrimAscii(truss.manufacturer) << '|' << TrimAscii(truss.model) << '|'
+      << TrimAscii(truss.crossSection) << '|' << truss.lengthMm << '|'
+      << truss.widthMm << '|' << truss.heightMm << '|' << truss.weightKg;
   return key.str();
 }
 
 // Builds path-free Perastage truss type metadata for exported UserData.
-static std::string BuildExportTrussTypeKey(const Truss &truss,
+static std::string
+BuildExportTrussTypeKey(const Truss &truss,
                                            const std::string &auxGdtfArchivePath) {
   std::ostringstream key;
-  key << TrimAscii(truss.manufacturer) << '|'
-      << TrimAscii(truss.model) << '|'
-      << TrimAscii(truss.crossSection) << '|'
-      << truss.lengthMm << '|'
-      << truss.widthMm << '|'
-      << truss.heightMm << '|'
-      << truss.weightKg << '|'
+  key << TrimAscii(truss.manufacturer) << '|' << TrimAscii(truss.model) << '|'
+      << TrimAscii(truss.crossSection) << '|' << truss.lengthMm << '|'
+      << truss.widthMm << '|' << truss.heightMm << '|' << truss.weightKg << '|'
       << SanitizeArchiveFileName(auxGdtfArchivePath, "");
   std::string value = key.str();
   for (char &ch : value) {
@@ -793,7 +808,8 @@ static std::string BuildExportTrussTypeKey(const Truss &truss,
   return TrimAscii(value);
 }
 
-static const char *ToRepresentationText(Truss::GeometryRepresentation representation) {
+static const char *
+ToRepresentationText(Truss::GeometryRepresentation representation) {
   switch (representation) {
   case Truss::GeometryRepresentation::SymbolSymdef:
     return "SymbolSymdef";
@@ -821,18 +837,22 @@ static bool IsValidMvrFileName(const std::string &value) {
   return value.find('/') == std::string::npos &&
          value.find('\\') == std::string::npos &&
          value.find(':') == std::string::npos &&
-         value.find('*') == std::string::npos && value.find('?') == std::string::npos &&
-         value.find('"') == std::string::npos && value.find('<') == std::string::npos &&
-         value.find('>') == std::string::npos && value.find('|') == std::string::npos &&
-         value != "." && value != "..";
+         value.find('*') == std::string::npos &&
+         value.find('?') == std::string::npos &&
+         value.find('"') == std::string::npos &&
+         value.find('<') == std::string::npos &&
+         value.find('>') == std::string::npos &&
+         value.find('|') == std::string::npos && value != "." && value != "..";
 }
 
 // Returns true when exported metadata text looks like a local filesystem path.
 static bool LooksLikeLocalFilesystemPath(const std::string &value) {
   const std::string trimmed = TrimAscii(value);
   const std::string lower = ToLowerAscii(trimmed);
-  return trimmed.find('\\') != std::string::npos || trimmed.rfind("/", 0) == 0 ||
-         (trimmed.size() >= 3 && std::isalpha(static_cast<unsigned char>(trimmed[0])) &&
+  return trimmed.find('\\') != std::string::npos ||
+         trimmed.rfind("/", 0) == 0 ||
+         (trimmed.size() >= 3 &&
+          std::isalpha(static_cast<unsigned char>(trimmed[0])) &&
           trimmed[1] == ':' && (trimmed[2] == '/' || trimmed[2] == '\\')) ||
          lower.find("/users/") != std::string::npos ||
          lower.find("/home/") != std::string::npos ||
@@ -849,20 +869,18 @@ static bool IsCanonicalUuidString(const std::string &value) {
 
 // Returns a stable, unique MVR Symbol UUID for the current export.
 static std::string ResolveExportSymbolUuid(
-    const std::string &candidateUuid,
-    const std::string &containerUuid,
-    const std::string &symdefUuid,
-    const std::string &deterministicSeed,
+    const std::string &candidateUuid, const std::string &containerUuid,
+    const std::string &symdefUuid, const std::string &deterministicSeed,
     std::unordered_set<std::string> &usedSymbolUuids,
-    std::vector<std::string> *exportWarnings,
-    const std::string &context) {
+    std::vector<std::string> *exportWarnings, const std::string &context) {
   const std::string canonicalCandidate = CanonicalizeUuid(candidateUuid);
   const std::string canonicalContainer = CanonicalizeUuid(containerUuid);
   const std::string canonicalSymdef = CanonicalizeUuid(symdefUuid);
   const bool candidateConflicts =
       !canonicalCandidate.empty() &&
       (usedSymbolUuids.contains(canonicalCandidate) ||
-       (!canonicalContainer.empty() && canonicalCandidate == canonicalContainer) ||
+       (!canonicalContainer.empty() &&
+        canonicalCandidate == canonicalContainer) ||
        (!canonicalSymdef.empty() && canonicalCandidate == canonicalSymdef));
 
   if (!canonicalCandidate.empty() && !candidateConflicts) {
@@ -871,7 +889,8 @@ static std::string ResolveExportSymbolUuid(
   }
 
   if (!TrimAscii(candidateUuid).empty() && exportWarnings) {
-    exportWarnings->push_back("MVR export replaced invalid or conflicting Symbol uuid '" +
+    exportWarnings->push_back(
+        "MVR export replaced invalid or conflicting Symbol uuid '" +
                               TrimAscii(candidateUuid) + "' for " + context + ".");
   }
 
@@ -888,7 +907,8 @@ static std::string ResolveExportSymbolUuid(
   }
 }
 
-// Validate MVR 1.6 XML/archive consistency while downgrading missing resource issues to warnings.
+// Validate MVR 1.6 XML/archive consistency while downgrading missing resource
+// issues to warnings.
 static bool ValidateMvr16Export(
     tinyxml2::XMLDocument &doc,
     const std::unordered_map<std::string, std::string> &gdtfPathsByUuid,
@@ -896,11 +916,13 @@ static bool ValidateMvr16Export(
     std::vector<std::string> *exportWarnings) {
   tinyxml2::XMLElement *root = doc.FirstChildElement("GeneralSceneDescription");
   if (!root) {
-    wxLogError("MVR export validation failed: missing GeneralSceneDescription root");
+    wxLogError(
+        "MVR export validation failed: missing GeneralSceneDescription root");
     return false;
   }
 
-  if (root->IntAttribute("verMajor") != 1 || root->IntAttribute("verMinor") != 6) {
+  if (root->IntAttribute("verMajor") != 1 ||
+      root->IntAttribute("verMinor") != 6) {
     wxLogError("MVR export validation failed: root version must be 1.6");
     return false;
   }
@@ -909,11 +931,14 @@ static bool ValidateMvr16Export(
   const char *providerVersion = root->Attribute("providerVersion");
   if (!provider || std::string(provider).empty() || !providerVersion ||
       std::string(providerVersion).empty()) {
-    wxLogError("MVR export validation failed: provider/providerVersion are required for MVR 1.6");
+    wxLogError("MVR export validation failed: provider/providerVersion are "
+               "required for MVR 1.6");
     return false;
   }
-  if (std::string(providerVersion) == "1.0" && std::string(app::kVersion) != "1.0") {
-    wxLogError("MVR export validation failed: providerVersion fell back to 1.0 instead of the Perastage app version");
+  if (std::string(providerVersion) == "1.0" &&
+      std::string(app::kVersion) != "1.0") {
+    wxLogError("MVR export validation failed: providerVersion fell back to 1.0 "
+               "instead of the Perastage app version");
     return false;
   }
 
@@ -925,24 +950,29 @@ static bool ValidateMvr16Export(
 
   if (tinyxml2::XMLElement *scene = root->FirstChildElement("Scene")) {
     if (tinyxml2::XMLElement *layers = scene->FirstChildElement("Layers")) {
-      for (tinyxml2::XMLElement *layer = layers->FirstChildElement("Layer"); layer;
-           layer = layer->NextSiblingElement("Layer")) {
+      for (tinyxml2::XMLElement *layer = layers->FirstChildElement("Layer");
+           layer; layer = layer->NextSiblingElement("Layer")) {
         if (layer->FirstChildElement("Color")) {
-          wxLogError("MVR export validation failed: Layer/Color is not valid in MVR 1.6");
+          wxLogError("MVR export validation failed: Layer/Color is not valid "
+                     "in MVR 1.6");
           return false;
         }
       }
     }
     if (scene->FirstChildElement("UserData")) {
-      wxLogError("MVR export validation failed: Scene/UserData is not valid in MVR 1.6");
+      wxLogError("MVR export validation failed: Scene/UserData is not valid in "
+                 "MVR 1.6");
       return false;
     }
     if (tinyxml2::XMLElement *aux = scene->FirstChildElement("AUXData")) {
       for (tinyxml2::XMLElement *pos = aux->FirstChildElement("Position"); pos;
            pos = pos->NextSiblingElement("Position")) {
-        const std::string uuid = TrimAscii(pos->Attribute("uuid") ? pos->Attribute("uuid") : "");
+        const std::string uuid =
+            TrimAscii(pos->Attribute("uuid") ? pos->Attribute("uuid") : "");
         if (!IsCanonicalUuidString(uuid)) {
-          wxLogError("MVR export validation failed: Position uuid '%s' is not canonical", uuid);
+          wxLogError("MVR export validation failed: Position uuid '%s' is not "
+                     "canonical",
+                     uuid);
           return false;
         }
         positionUuids.insert(uuid);
@@ -963,50 +993,68 @@ static bool ValidateMvr16Export(
       tinyxml2::XMLElement *cur = stack.back();
       stack.pop_back();
       if (std::string(cur->Name()) == "Symbol") {
-        const tinyxml2::XMLElement *parent = cur->Parent() ? cur->Parent()->ToElement() : nullptr;
-        const std::string context = parent && parent->Name() ? std::string(parent->Name()) : "unknown";
-        const std::string symbolUuid = TrimAscii(cur->Attribute("uuid") ? cur->Attribute("uuid") : "");
-        const std::string symdefUuid = TrimAscii(cur->Attribute("symdef") ? cur->Attribute("symdef") : "");
+        const tinyxml2::XMLElement *parent =
+            cur->Parent() ? cur->Parent()->ToElement() : nullptr;
+        const std::string context =
+            parent && parent->Name() ? std::string(parent->Name()) : "unknown";
+        const std::string symbolUuid =
+            TrimAscii(cur->Attribute("uuid") ? cur->Attribute("uuid") : "");
+        const std::string symdefUuid =
+            TrimAscii(cur->Attribute("symdef") ? cur->Attribute("symdef") : "");
         if (!IsCanonicalUuidString(symbolUuid)) {
-          wxLogError("MVR export validation failed: Symbol in %s has missing or non-canonical uuid '%s'",
+          wxLogError("MVR export validation failed: Symbol in %s has missing "
+                     "or non-canonical uuid '%s'",
                      context, symbolUuid);
           return false;
         }
         if (symdefUuid.empty()) {
-          wxLogError("MVR export validation failed: Symbol uuid '%s' in %s has no symdef",
+          wxLogError("MVR export validation failed: Symbol uuid '%s' in %s has "
+                     "no symdef",
                      symbolUuid, context);
           return false;
         }
       }
 
       if (std::string(cur->Name()) == "Truss") {
-        const std::string trussUuid = TrimAscii(cur->Attribute("uuid") ? cur->Attribute("uuid") : "");
+        const std::string trussUuid =
+            TrimAscii(cur->Attribute("uuid") ? cur->Attribute("uuid") : "");
         if (!IsCanonicalUuidString(trussUuid)) {
-          wxLogError("MVR export validation failed: Truss uuid '%s' is missing or non-canonical", trussUuid);
+          wxLogError("MVR export validation failed: Truss uuid '%s' is missing "
+                     "or non-canonical",
+                     trussUuid);
           return false;
         }
         exportedTrussUuids.insert(trussUuid);
         if (cur->FirstChildElement("UserData")) {
-          wxLogError("MVR export validation failed: Truss uuid '%s' contains direct UserData", trussUuid);
+          wxLogError("MVR export validation failed: Truss uuid '%s' contains "
+                     "direct UserData",
+                     trussUuid);
           return false;
         }
       }
 
       if (std::string(cur->Name()) == "Fixture") {
         if (cur->FirstChildElement("UserData")) {
-          wxLogError("MVR export validation failed: Fixture uuid '%s' contains direct UserData",
-                     cur->Attribute("uuid") ? cur->Attribute("uuid") : "(missing uuid)");
+          wxLogError("MVR export validation failed: Fixture uuid '%s' contains "
+                     "direct UserData",
+                     cur->Attribute("uuid") ? cur->Attribute("uuid")
+                                            : "(missing uuid)");
           return false;
         }
-        if (cur->FirstChildElement("Category") || cur->FirstChildElement("CategorySource") ||
+        if (cur->FirstChildElement("Category") ||
+            cur->FirstChildElement("CategorySource") ||
             cur->FirstChildElement("CategoryReason")) {
-          wxLogError("MVR export validation failed: Fixture contains Perastage category metadata");
+          wxLogError("MVR export validation failed: Fixture contains Perastage "
+                     "category metadata");
           return false;
         }
         auto *idNode = cur->FirstChildElement("FixtureID");
         auto *numNode = cur->FirstChildElement("FixtureIDNumeric");
-        const std::string fixtureUuid = cur->Attribute("uuid") ? cur->Attribute("uuid") : "(missing uuid)";
-        const std::string fixtureName = cur->Attribute("name") ? cur->Attribute("name") : "(unnamed fixture)";
+        const std::string fixtureUuid =
+            cur->Attribute("uuid") ? cur->Attribute("uuid") : "(missing uuid)";
+        const std::string fixtureName = cur->Attribute("name")
+                                            ? cur->Attribute("name")
+                                            : "(unnamed fixture)";
 
         const std::string fixtureId =
             idNode && idNode->GetText() ? TrimAscii(idNode->GetText()) : "";
@@ -1014,42 +1062,48 @@ static bool ValidateMvr16Export(
             numNode && numNode->GetText() ? TrimAscii(numNode->GetText()) : "";
         int fixtureNumeric = 0;
 
-        if (fixtureId.empty() || !TryParseInt(fixtureNumericText, fixtureNumeric) ||
+        if (fixtureId.empty() ||
+            !TryParseInt(fixtureNumericText, fixtureNumeric) ||
             fixtureNumeric <= 0) {
           wxLogError(
-              "MVR export validation failed: Fixture '%s' (uuid=%s) must have a non-empty FixtureID and a positive integer FixtureIDNumeric",
+              "MVR export validation failed: Fixture '%s' (uuid=%s) must have "
+              "a non-empty FixtureID and a positive integer FixtureIDNumeric",
               fixtureName, fixtureUuid);
           return false;
         }
 
         auto *unitNode = cur->FirstChildElement("UnitNumber");
         int unitValue = 0;
-        const std::string unitText =
-            unitNode && unitNode->GetText() ? TrimAscii(unitNode->GetText()) : "";
-        if (unitText.empty() || !TryParseInt(unitText, unitValue) || unitValue <= 0) {
-          wxLogError(
-              "MVR export validation failed: Fixture '%s' (uuid=%s) must have a positive integer UnitNumber",
+        const std::string unitText = unitNode && unitNode->GetText()
+                                         ? TrimAscii(unitNode->GetText())
+                                         : "";
+        if (unitText.empty() || !TryParseInt(unitText, unitValue) ||
+            unitValue <= 0) {
+          wxLogError("MVR export validation failed: Fixture '%s' (uuid=%s) "
+                     "must have a positive integer UnitNumber",
               fixtureName, fixtureUuid);
           return false;
         }
 
         if (auto *addresses = cur->FirstChildElement("Addresses"); addresses) {
           std::unordered_set<int> usedBreaks;
-          for (auto *addressNode = addresses->FirstChildElement("Address"); addressNode;
+          for (auto *addressNode = addresses->FirstChildElement("Address");
+               addressNode;
                addressNode = addressNode->NextSiblingElement("Address")) {
             int breakNum = 0;
-            const std::string breakText = addressNode->Attribute("break")
+            const std::string breakText =
+                addressNode->Attribute("break")
                                               ? TrimAscii(addressNode->Attribute("break"))
                                               : "0";
             if (!TryParseInt(breakText, breakNum) || breakNum < 0) {
-              wxLogError(
-                  "MVR export validation failed: Fixture '%s' (uuid=%s) has invalid Address break '%s'",
+              wxLogError("MVR export validation failed: Fixture '%s' (uuid=%s) "
+                         "has invalid Address break '%s'",
                   fixtureName, fixtureUuid, breakText);
               return false;
             }
             if (!usedBreaks.insert(breakNum).second) {
-              wxLogError(
-                  "MVR export validation failed: Fixture '%s' (uuid=%s) has duplicate Address break %d",
+              wxLogError("MVR export validation failed: Fixture '%s' (uuid=%s) "
+                         "has duplicate Address break %d",
                   fixtureName, fixtureUuid, breakNum);
               return false;
             }
@@ -1059,28 +1113,33 @@ static bool ValidateMvr16Export(
             int universe = 0;
             int channel = 0;
             if (!ParseMvrAddressNodeText(addressText, universe, channel)) {
-              wxLogError(
-                  "MVR export validation failed: Fixture '%s' (uuid=%s) has invalid Address value '%s'",
+              wxLogError("MVR export validation failed: Fixture '%s' (uuid=%s) "
+                         "has invalid Address value '%s'",
                   fixtureName, fixtureUuid, addressText);
               return false;
             }
-
           }
         }
       }
 
       if (std::string(cur->Name()) == "Position") {
-        const tinyxml2::XMLElement *parent = cur->Parent() ? cur->Parent()->ToElement() : nullptr;
-        const std::string parentName = parent ? std::string(parent->Name()) : std::string{};
+        const tinyxml2::XMLElement *parent =
+            cur->Parent() ? cur->Parent()->ToElement() : nullptr;
+        const std::string parentName =
+            parent ? std::string(parent->Name()) : std::string{};
         const bool isObjectPositionRef =
-            parentName == "Fixture" || parentName == "Truss" || parentName == "Support" ||
-            parentName == "VideoScreen" || parentName == "Projector";
+            parentName == "Fixture" || parentName == "Truss" ||
+            parentName == "Support" || parentName == "VideoScreen" ||
+            parentName == "Projector";
         if (isObjectPositionRef) {
-          const std::string positionRef = TrimAscii(cur->GetText() ? cur->GetText() : "");
+          const std::string positionRef =
+              TrimAscii(cur->GetText() ? cur->GetText() : "");
           if (positionRef.empty())
             continue;
           if (!IsCanonicalUuidString(positionRef)) {
-            wxLogError("MVR export validation failed: Position reference '%s' is not canonical", positionRef);
+            wxLogError("MVR export validation failed: Position reference '%s' "
+                       "is not canonical",
+                       positionRef);
             return false;
           }
           referencedPositionUuids.insert(positionRef);
@@ -1105,7 +1164,8 @@ static bool ValidateMvr16Export(
     for (const tinyxml2::XMLAttribute *attr = cur->FirstAttribute(); attr;
          attr = attr->Next()) {
       std::string attrName = attr->Name();
-      std::transform(attrName.begin(), attrName.end(), attrName.begin(),
+      std::transform(
+          attrName.begin(), attrName.end(), attrName.begin(),
                      [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
       if (attrName == "filename")
         referencedFiles.emplace_back(attr->Value());
@@ -1127,21 +1187,28 @@ static bool ValidateMvr16Export(
         if (std::string(cur->Name()) == tagName) {
           bool isMultipatchChild = false;
           if (const char *mp = cur->Attribute("multipatch"); mp)
-            isMultipatchChild = std::string(mp) == "true" || std::string(mp) == "1";
+            isMultipatchChild =
+                std::string(mp) == "true" || std::string(mp) == "1";
           if (!isMultipatchChild) {
-            const char *idText = cur->FirstChildElement("FixtureID")
+            const char *idText =
+                cur->FirstChildElement("FixtureID")
                                      ? cur->FirstChildElement("FixtureID")->GetText()
                                      : nullptr;
-            const char *numText = cur->FirstChildElement("FixtureIDNumeric")
+            const char *numText =
+                cur->FirstChildElement("FixtureIDNumeric")
                                       ? cur->FirstChildElement("FixtureIDNumeric")->GetText()
                                       : nullptr;
             if (!idText || TrimAscii(idText).empty() || !numText) {
-              wxLogError("MVR export validation failed: %s is missing FixtureID/FixtureIDNumeric", tagName);
+              wxLogError("MVR export validation failed: %s is missing "
+                         "FixtureID/FixtureIDNumeric",
+                         tagName);
               return false;
             }
             int numeric = 0;
-            if (!TryParseInt(numText, numeric) || numeric <= 0 || !numericIds.insert(numeric).second) {
-              wxLogError("MVR export validation failed: FixtureIDNumeric must be globally unique positive integer");
+            if (!TryParseInt(numText, numeric) || numeric <= 0 ||
+                !numericIds.insert(numeric).second) {
+              wxLogError("MVR export validation failed: FixtureIDNumeric must "
+                         "be globally unique positive integer");
               return false;
             }
           }
@@ -1150,41 +1217,54 @@ static bool ValidateMvr16Export(
             const char *txt = gdtf->GetText();
             std::string value = txt ? txt : "";
             if (!IsValidMvrFileName(value)) {
-              wxLogError("MVR export validation failed: GDTFSpec '%s' is not a valid archive-relative FileName", value);
+              wxLogError("MVR export validation failed: GDTFSpec '%s' is not a "
+                         "valid archive-relative FileName",
+                         value);
               return false;
             }
-            auto uidIt = gdtfPathsByUuid.find(cur->Attribute("uuid") ? cur->Attribute("uuid") : "");
+            auto uidIt = gdtfPathsByUuid.find(
+                cur->Attribute("uuid") ? cur->Attribute("uuid") : "");
             if (uidIt != gdtfPathsByUuid.end() && uidIt->second != value) {
-              wxLogError("MVR export validation failed: GDTFSpec mismatch for object uuid '%s'", cur->Attribute("uuid"));
+              wxLogError("MVR export validation failed: GDTFSpec mismatch for "
+                         "object uuid '%s'",
+                         cur->Attribute("uuid"));
               return false;
             }
             auto gdtfArchiveIt = archiveEntryCount.find(value);
-            if (gdtfArchiveIt == archiveEntryCount.end() || gdtfArchiveIt->second < 1) {
+            if (gdtfArchiveIt == archiveEntryCount.end() ||
+                gdtfArchiveIt->second < 1) {
               if (exportWarnings)
-                exportWarnings->push_back("Referenced file '" + value +
+                exportWarnings->push_back(
+                    "Referenced file '" + value +
                                           "' is missing from the archive and will be omitted.");
             } else if (gdtfArchiveIt->second > 1) {
               if (exportWarnings)
-                exportWarnings->push_back("Referenced file '" + value +
+                exportWarnings->push_back(
+                    "Referenced file '" + value +
                                           "' appears multiple times; duplicates will be ignored.");
             }
           }
 
           if (std::string(tagName) == "Support") {
             if (!cur->FirstChildElement("Geometries")) {
-              wxLogError("MVR export validation failed: Support uuid '%s' has no Geometries",
+              wxLogError("MVR export validation failed: Support uuid '%s' has "
+                         "no Geometries",
                          cur->Attribute("uuid") ? cur->Attribute("uuid") : "");
               return false;
             }
             if (!cur->FirstChildElement("ChainLength")) {
-              wxLogError("MVR export validation failed: Support uuid '%s' has no ChainLength",
+              wxLogError("MVR export validation failed: Support uuid '%s' has "
+                         "no ChainLength",
                          cur->Attribute("uuid") ? cur->Attribute("uuid") : "");
               return false;
             }
-            const bool hasGdtfSpec = cur->FirstChildElement("GDTFSpec") != nullptr;
-            const bool hasGdtfMode = cur->FirstChildElement("GDTFMode") != nullptr;
+            const bool hasGdtfSpec =
+                cur->FirstChildElement("GDTFSpec") != nullptr;
+            const bool hasGdtfMode =
+                cur->FirstChildElement("GDTFMode") != nullptr;
             if (hasGdtfSpec != hasGdtfMode) {
-              wxLogError("MVR export validation failed: Support uuid '%s' has inconsistent GDTFSpec/GDTFMode",
+              wxLogError("MVR export validation failed: Support uuid '%s' has "
+                         "inconsistent GDTFSpec/GDTFMode",
                          cur->Attribute("uuid") ? cur->Attribute("uuid") : "");
               return false;
             }
@@ -1198,27 +1278,37 @@ static bool ValidateMvr16Export(
     }
   }
 
-  if (tinyxml2::XMLElement *rootUserData = root->FirstChildElement("UserData")) {
-    for (tinyxml2::XMLElement *data = rootUserData->FirstChildElement("Data"); data;
-         data = data->NextSiblingElement("Data")) {
-      const std::string provider = ToLowerAscii(TrimAscii(data->Attribute("provider") ? data->Attribute("provider") : ""));
+  if (tinyxml2::XMLElement *rootUserData =
+          root->FirstChildElement("UserData")) {
+    for (tinyxml2::XMLElement *data = rootUserData->FirstChildElement("Data");
+         data; data = data->NextSiblingElement("Data")) {
+      const std::string provider = ToLowerAscii(TrimAscii(
+          data->Attribute("provider") ? data->Attribute("provider") : ""));
       if (provider != "perastage")
         continue;
-      for (tinyxml2::XMLElement *map = data->FirstChildElement("TrussInfoMap"); map;
-           map = map->NextSiblingElement("TrussInfoMap")) {
-        for (tinyxml2::XMLElement *info = map->FirstChildElement("TrussInfo"); info;
-             info = info->NextSiblingElement("TrussInfo")) {
-          const std::string uuid = TrimAscii(info->Attribute("uuid") ? info->Attribute("uuid") : "");
-          if (!IsCanonicalUuidString(uuid) || !exportedTrussUuids.contains(uuid)) {
-            wxLogError("MVR export validation failed: root TrussInfo references invalid exported Truss uuid '%s'", uuid);
+      for (tinyxml2::XMLElement *map = data->FirstChildElement("TrussInfoMap");
+           map; map = map->NextSiblingElement("TrussInfoMap")) {
+        for (tinyxml2::XMLElement *info = map->FirstChildElement("TrussInfo");
+             info; info = info->NextSiblingElement("TrussInfo")) {
+          const std::string uuid =
+              TrimAscii(info->Attribute("uuid") ? info->Attribute("uuid") : "");
+          if (!IsCanonicalUuidString(uuid) ||
+              !exportedTrussUuids.contains(uuid)) {
+            wxLogError("MVR export validation failed: root TrussInfo "
+                       "references invalid exported Truss uuid '%s'",
+                       uuid);
             return false;
           }
           for (const char *nodeName : {"ModelFile", "AuxGdtf", "TypeKey"}) {
-            if (tinyxml2::XMLElement *pathNode = info->FirstChildElement(nodeName)) {
-              const std::string value = TrimAscii(pathNode->GetText() ? pathNode->GetText() : "");
-              if (LooksLikeLocalFilesystemPath(value) || value.find('/') != std::string::npos ||
+            if (tinyxml2::XMLElement *pathNode =
+                    info->FirstChildElement(nodeName)) {
+              const std::string value =
+                  TrimAscii(pathNode->GetText() ? pathNode->GetText() : "");
+              if (LooksLikeLocalFilesystemPath(value) ||
+                  value.find('/') != std::string::npos ||
                   value.find('\\') != std::string::npos) {
-                wxLogError("MVR export validation failed: Perastage UserData %s contains non-portable path text '%s'",
+                wxLogError("MVR export validation failed: Perastage UserData "
+                           "%s contains non-portable path text '%s'",
                            nodeName, value);
                 return false;
               }
@@ -1226,34 +1316,51 @@ static bool ValidateMvr16Export(
           }
         }
       }
-      if (tinyxml2::XMLElement *manifest = data->FirstChildElement("TrussSidecarManifest")) {
-        for (tinyxml2::XMLElement *type = manifest->FirstChildElement("Type"); type;
-             type = type->NextSiblingElement("Type")) {
-          const std::string key = TrimAscii(type->Attribute("key") ? type->Attribute("key") : "");
-          const std::string gdtf = TrimAscii(type->Attribute("gdtf") ? type->Attribute("gdtf") : "");
-          if (LooksLikeLocalFilesystemPath(key) || key.find('/') != std::string::npos ||
+      if (tinyxml2::XMLElement *manifest =
+              data->FirstChildElement("TrussSidecarManifest")) {
+        for (tinyxml2::XMLElement *type = manifest->FirstChildElement("Type");
+             type; type = type->NextSiblingElement("Type")) {
+          const std::string key =
+              TrimAscii(type->Attribute("key") ? type->Attribute("key") : "");
+          const std::string gdtf =
+              TrimAscii(type->Attribute("gdtf") ? type->Attribute("gdtf") : "");
+          if (LooksLikeLocalFilesystemPath(key) ||
+              key.find('/') != std::string::npos ||
               key.find('\\') != std::string::npos) {
-            wxLogError("MVR export validation failed: Perastage UserData TrussSidecarManifest Type key contains non-portable path text '%s'",
+            wxLogError("MVR export validation failed: Perastage UserData "
+                       "TrussSidecarManifest Type key contains non-portable "
+                       "path text '%s'",
                        key);
             return false;
           }
           if (!IsValidMvrFileName(gdtf)) {
-            wxLogError("MVR export validation failed: Perastage UserData TrussSidecarManifest Type gdtf '%s' is not a root-level MVR filename",
+            wxLogError("MVR export validation failed: Perastage UserData "
+                       "TrussSidecarManifest Type gdtf '%s' is not a "
+                       "root-level MVR filename",
                        gdtf);
             return false;
           }
         }
-        for (tinyxml2::XMLElement *inst = manifest->FirstChildElement("Instance"); inst;
-             inst = inst->NextSiblingElement("Instance")) {
-          const std::string uuid = TrimAscii(inst->Attribute("uuid") ? inst->Attribute("uuid") : "");
-          if (!IsCanonicalUuidString(uuid) || !exportedTrussUuids.contains(uuid)) {
-            wxLogError("MVR export validation failed: Truss sidecar manifest references invalid exported Truss uuid '%s'", uuid);
+        for (tinyxml2::XMLElement *inst =
+                 manifest->FirstChildElement("Instance");
+             inst; inst = inst->NextSiblingElement("Instance")) {
+          const std::string uuid =
+              TrimAscii(inst->Attribute("uuid") ? inst->Attribute("uuid") : "");
+          if (!IsCanonicalUuidString(uuid) ||
+              !exportedTrussUuids.contains(uuid)) {
+            wxLogError("MVR export validation failed: Truss sidecar manifest "
+                       "references invalid exported Truss uuid '%s'",
+                       uuid);
             return false;
           }
-          const std::string typeKey = TrimAscii(inst->Attribute("typeKey") ? inst->Attribute("typeKey") : "");
-          if (LooksLikeLocalFilesystemPath(typeKey) || typeKey.find('/') != std::string::npos ||
+          const std::string typeKey = TrimAscii(
+              inst->Attribute("typeKey") ? inst->Attribute("typeKey") : "");
+          if (LooksLikeLocalFilesystemPath(typeKey) ||
+              typeKey.find('/') != std::string::npos ||
               typeKey.find('\\') != std::string::npos) {
-            wxLogError("MVR export validation failed: Perastage UserData TrussSidecarManifest Instance typeKey contains non-portable path text '%s'",
+            wxLogError("MVR export validation failed: Perastage UserData "
+                       "TrussSidecarManifest Instance typeKey contains "
+                       "non-portable path text '%s'",
                        typeKey);
             return false;
           }
@@ -1266,14 +1373,17 @@ static bool ValidateMvr16Export(
   std::unordered_set<std::string> warnedDuplicateFiles;
   for (const auto &fileRef : referencedFiles) {
     if (!IsValidMvrFileName(fileRef)) {
-      wxLogError("MVR export validation failed: invalid FileName reference '%s'", fileRef);
+      wxLogError(
+          "MVR export validation failed: invalid FileName reference '%s'",
+          fileRef);
       return false;
     }
 
     auto fileRefIt = archiveEntryCount.find(fileRef);
     if (fileRefIt == archiveEntryCount.end() || fileRefIt->second < 1) {
       if (exportWarnings && warnedMissingFiles.insert(fileRef).second) {
-        exportWarnings->push_back("Referenced file '" + fileRef +
+        exportWarnings->push_back(
+            "Referenced file '" + fileRef +
                                   "' is missing from the archive and will be omitted.");
       }
       continue;
@@ -1281,7 +1391,8 @@ static bool ValidateMvr16Export(
 
     if (fileRefIt->second > 1) {
       if (exportWarnings && warnedDuplicateFiles.insert(fileRef).second) {
-        exportWarnings->push_back("Referenced file '" + fileRef +
+        exportWarnings->push_back(
+            "Referenced file '" + fileRef +
                                   "' appears multiple times; duplicates will be ignored.");
       }
     }
@@ -1289,7 +1400,9 @@ static bool ValidateMvr16Export(
 
   for (const auto &[archivePath, count] : archiveEntryCount) {
     if (!IsValidMvrFileName(archivePath)) {
-      wxLogError("MVR export validation failed: ZIP entry '%s' is not a root-level MVR filename", archivePath);
+      wxLogError("MVR export validation failed: ZIP entry '%s' is not a "
+                 "root-level MVR filename",
+                 archivePath);
       return false;
     }
     if (archivePath.empty()) {
@@ -1297,14 +1410,17 @@ static bool ValidateMvr16Export(
       return false;
     }
     if (count != 1) {
-      wxLogError("MVR export validation failed: duplicate ZIP entry '%s'", archivePath);
+      wxLogError("MVR export validation failed: duplicate ZIP entry '%s'",
+                 archivePath);
       return false;
     }
   }
 
   for (const auto &positionRef : referencedPositionUuids) {
     if (!positionUuids.contains(positionRef)) {
-      wxLogError("MVR export validation failed: Position reference '%s' has no AUXData/Position definition", positionRef);
+      wxLogError("MVR export validation failed: Position reference '%s' has no "
+                 "AUXData/Position definition",
+                 positionRef);
       return false;
     }
   }
@@ -1312,7 +1428,8 @@ static bool ValidateMvr16Export(
   return true;
 }
 
-// Normalizes archive entry paths for stable comparisons during resource pruning.
+// Normalizes archive entry paths for stable comparisons during resource
+// pruning.
 static std::string NormalizeArchiveEntryPath(std::string path) {
   path = TrimAscii(std::move(path));
   std::replace(path.begin(), path.end(), '\\', '/');
@@ -1323,7 +1440,8 @@ static std::string NormalizeArchiveEntryPath(std::string path) {
   return path;
 }
 
-// Collects every archive-relative file path referenced by file-bearing XML attributes.
+// Collects every archive-relative file path referenced by file-bearing XML
+// attributes.
 static std::unordered_set<std::string>
 CollectReferencedArchivePaths(const tinyxml2::XMLDocument &doc) {
   std::unordered_set<std::string> referencedPaths;
@@ -1363,8 +1481,8 @@ CollectReferencedArchivePaths(const tinyxml2::XMLDocument &doc) {
       }
     }
 
-    for (const tinyxml2::XMLElement *child = current->FirstChildElement(); child;
-         child = child->NextSiblingElement()) {
+    for (const tinyxml2::XMLElement *child = current->FirstChildElement();
+         child; child = child->NextSiblingElement()) {
       stack.push_back(child);
     }
   }
@@ -1372,7 +1490,8 @@ CollectReferencedArchivePaths(const tinyxml2::XMLDocument &doc) {
   return referencedPaths;
 }
 
-// Logs referenced and pruned archive paths to diagnose unexpected retained resources.
+// Logs referenced and pruned archive paths to diagnose unexpected retained
+// resources.
 static void LogResourcePruneDiagnostics(
     const std::unordered_set<std::string> &referencedArchivePaths,
     const std::vector<ResourceEntry> &allResourceEntries,
@@ -1380,16 +1499,14 @@ static void LogResourcePruneDiagnostics(
   std::unordered_set<std::string> keptNormalized;
   keptNormalized.reserve(keptResourceEntries.size());
   for (const auto &entry : keptResourceEntries) {
-    const std::string normalized =
-        NormalizeArchiveEntryPath(entry.archivePath);
+    const std::string normalized = NormalizeArchiveEntryPath(entry.archivePath);
     if (!normalized.empty())
       keptNormalized.insert(normalized);
   }
 
   size_t prunedCount = 0;
   for (const auto &entry : allResourceEntries) {
-    const std::string normalized =
-        NormalizeArchiveEntryPath(entry.archivePath);
+    const std::string normalized = NormalizeArchiveEntryPath(entry.archivePath);
     if (normalized.empty())
       continue;
     if (!keptNormalized.contains(normalized)) {
@@ -1404,12 +1521,15 @@ static void LogResourcePruneDiagnostics(
       Logger::Level::Info,
       "MVR export resource pruning summary: referenced_paths=" +
           std::to_string(referencedArchivePaths.size()) +
-          ", planned_resources_before=" + std::to_string(allResourceEntries.size()) +
-          ", planned_resources_after=" + std::to_string(keptResourceEntries.size()) +
+          ", planned_resources_before=" +
+          std::to_string(allResourceEntries.size()) +
+          ", planned_resources_after=" +
+          std::to_string(keptResourceEntries.size()) +
           ", pruned=" + std::to_string(prunedCount));
 }
 
-// Returns whether a Symdef has enough geometry data to flatten into Geometry3D nodes.
+// Returns whether a Symdef has enough geometry data to flatten into Geometry3D
+// nodes.
 static bool CanFlattenSymdefGeometry(const MvrScene &scene,
                                      const std::string &symdefUuid) {
   auto geoIt = scene.symdefGeometries.find(symdefUuid);
@@ -1421,20 +1541,25 @@ static bool CanFlattenSymdefGeometry(const MvrScene &scene,
   }
 
   auto fileIt = scene.symdefFiles.find(symdefUuid);
-  return fileIt != scene.symdefFiles.end() && !TrimAscii(fileIt->second).empty();
+  return fileIt != scene.symdefFiles.end() &&
+         !TrimAscii(fileIt->second).empty();
 }
 
-// Collects Symdef UUIDs referenced by trusses that preserve Symbol/Symdef geometry representation.
+// Collects Symdef UUIDs referenced by trusses that preserve Symbol/Symdef
+// geometry representation.
 static std::unordered_set<std::string>
-CollectReferencedSymdefUuids(const MvrScene &scene, const MvrExportOptions &options) {
+CollectReferencedSymdefUuids(const MvrScene &scene,
+                             const MvrExportOptions &options) {
   std::unordered_set<std::string> referencedSymdefs;
   for (const auto &[uuid, truss] : scene.trusses) {
-    if (truss.sourceRepresentation != Truss::GeometryRepresentation::SymbolSymdef)
+    if (truss.sourceRepresentation !=
+        Truss::GeometryRepresentation::SymbolSymdef)
       continue;
     const std::string symdefUuid = TrimAscii(truss.sourceSymdefUuid);
     if (symdefUuid.empty())
       continue;
-    if (options.trussGeometryExportMode == MvrTrussGeometryExportMode::DirectGeometry3DForTrussSymbols &&
+    if (options.trussGeometryExportMode ==
+            MvrTrussGeometryExportMode::DirectGeometry3DForTrussSymbols &&
         CanFlattenSymdefGeometry(scene, symdefUuid))
       continue;
     referencedSymdefs.insert(symdefUuid);
@@ -1446,12 +1571,15 @@ static bool TryParseInt(std::string_view text, int &out) {
   if (text.empty())
     return false;
 
-  const auto first = std::find_if_not(text.begin(), text.end(),
+  const auto first =
+      std::find_if_not(text.begin(), text.end(),
                                       [](unsigned char c) { return std::isspace(c); });
   if (first == text.end())
     return false;
-  const auto last = std::find_if_not(text.rbegin(), text.rend(),
-                                     [](unsigned char c) { return std::isspace(c); }).base();
+  const auto last =
+      std::find_if_not(text.rbegin(), text.rend(), [](unsigned char c) {
+        return std::isspace(c);
+      }).base();
   std::string_view trimmed(&(*first), static_cast<size_t>(last - first));
 
   int value = 0;
@@ -1505,14 +1633,15 @@ int ComputeAbsoluteDmx(int universe1Based, int address1Based) {
 
 static bool ShouldExportSupportHoistInfo(const Support &support) {
   return support.capacityKg != 0.0f || support.weightKg != 0.0f ||
-         support.loadKg != 0.0f ||
-         !support.hoistFunction.empty() || !support.motorName.empty() ||
-         !support.motorManufacturer.empty() || !support.motorModel.empty() ||
-         !support.motorFixtureUuid.empty() || !support.useMotorDefaults ||
-         !support.dummyProfileId.empty() || !support.dummyPreset.empty() ||
+         support.loadKg != 0.0f || !support.hoistFunction.empty() ||
+         !support.motorName.empty() || !support.motorManufacturer.empty() ||
+         !support.motorModel.empty() || !support.motorFixtureUuid.empty() ||
+         !support.useMotorDefaults || !support.dummyProfileId.empty() ||
+         !support.dummyPreset.empty() ||
          NormalizeHoistDataSource(support.hoistDataSource) != "Inherited" ||
          NormalizeHoistDataSource(support.motorNameSource) != "Inherited" ||
-         NormalizeHoistDataSource(support.motorManufacturerSource) != "Inherited" ||
+         NormalizeHoistDataSource(support.motorManufacturerSource) !=
+             "Inherited" ||
          NormalizeHoistDataSource(support.motorModelSource) != "Inherited" ||
          NormalizeHoistDataSource(support.capacitySource) != "Inherited" ||
          NormalizeHoistDataSource(support.weightSource) != "Inherited" ||
@@ -1520,7 +1649,8 @@ static bool ShouldExportSupportHoistInfo(const Support &support) {
 }
 
 // Finds the first UserData element that already contains Perastage-owned data.
-static tinyxml2::XMLElement *FindFirstPerastageUserData(tinyxml2::XMLElement *node) {
+static tinyxml2::XMLElement *
+FindFirstPerastageUserData(tinyxml2::XMLElement *node) {
   if (!node)
     return nullptr;
 
@@ -1539,7 +1669,8 @@ static tinyxml2::XMLElement *FindFirstPerastageUserData(tinyxml2::XMLElement *no
 }
 
 // Finds or creates the Perastage Data element under a valid parent node.
-static tinyxml2::XMLElement *FindOrCreatePerastageDataNode(tinyxml2::XMLDocument &doc,
+static tinyxml2::XMLElement *
+FindOrCreatePerastageDataNode(tinyxml2::XMLDocument &doc,
                                                             tinyxml2::XMLElement *node) {
   tinyxml2::XMLElement *ud = FindFirstPerastageUserData(node);
   if (!ud) {
@@ -1549,8 +1680,8 @@ static tinyxml2::XMLElement *FindOrCreatePerastageDataNode(tinyxml2::XMLDocument
 
   for (tinyxml2::XMLElement *data = ud->FirstChildElement("Data"); data;
        data = data->NextSiblingElement("Data")) {
-    const std::string provider =
-        TrimAscii(data->Attribute("provider") ? data->Attribute("provider") : "");
+    const std::string provider = TrimAscii(
+        data->Attribute("provider") ? data->Attribute("provider") : "");
     if (provider.empty() || ToLowerAscii(provider) == "perastage")
       return data;
   }
@@ -1569,26 +1700,28 @@ static std::string ExportLayerUuid(const std::string &layerUuid,
     return {};
   return IsCanonicalUuidString(layerUuid)
              ? layerUuid
-             : DeriveDeterministicUuid("mvr:layer:" + layerName + ":" + layerUuid);
+             : DeriveDeterministicUuid("mvr:layer:" + layerName + ":" +
+                                       layerUuid);
 }
 
 // Returns true when the color can be stored as Perastage #RRGGBB metadata.
 static bool IsLayerColorMetadataValue(const std::string &color) {
   if (color.size() != 7 || color[0] != '#')
     return false;
-  return std::all_of(color.begin() + 1, color.end(), [](unsigned char ch) {
-    return std::isxdigit(ch) != 0;
-  });
+  return std::all_of(color.begin() + 1, color.end(),
+                     [](unsigned char ch) { return std::isxdigit(ch) != 0; });
 }
 
 // Returns true when any layer has Perastage color metadata to export.
 static bool HasLayerAppearanceMetadata(const MvrScene &scene) {
-  return std::any_of(scene.layers.begin(), scene.layers.end(), [](const auto &entry) {
+  return std::any_of(scene.layers.begin(), scene.layers.end(),
+                     [](const auto &entry) {
     return IsLayerColorMetadataValue(entry.second.color);
   });
 }
 
-// Appends the root-level Perastage layer appearance map when layers define colors.
+// Appends the root-level Perastage layer appearance map when layers define
+// colors.
 static void AppendLayerAppearanceMetadata(tinyxml2::XMLDocument &doc,
                                           tinyxml2::XMLElement *perastageData,
                                           const MvrScene &scene) {
@@ -1596,8 +1729,10 @@ static void AppendLayerAppearanceMetadata(tinyxml2::XMLDocument &doc,
     return;
 
   tinyxml2::XMLElement *map = nullptr;
-  for (tinyxml2::XMLElement *existing = perastageData->FirstChildElement("LayerAppearanceMap");
-       existing; existing = existing->NextSiblingElement("LayerAppearanceMap")) {
+  for (tinyxml2::XMLElement *existing =
+           perastageData->FirstChildElement("LayerAppearanceMap");
+       existing;
+       existing = existing->NextSiblingElement("LayerAppearanceMap")) {
     map = existing;
     break;
   }
@@ -1630,7 +1765,8 @@ static bool HasTrussInfoMetadata(const Truss &truss) {
          !truss.crossSection.empty() || !truss.modelFile.empty() ||
          !truss.positionName.empty() ||
          truss.sourceRepresentation != Truss::GeometryRepresentation::Unknown ||
-         !truss.perastageTypeKey.empty() || !truss.perastageAuxGdtfArchivePath.empty();
+         !truss.perastageTypeKey.empty() ||
+         !truss.perastageAuxGdtfArchivePath.empty();
 }
 
 // Appends one root-level Perastage truss metadata entry keyed by exported UUID.
@@ -1672,9 +1808,12 @@ static void AppendTrussInfoMetadata(tinyxml2::XMLDocument &doc,
   addTxt("PositionName", truss.positionName);
   addTxt("HangPos", truss.positionName);
   addTxt("Representation", ToRepresentationText(truss.sourceRepresentation));
-  addTxt("TypeKey", trussTypeKey.empty() ? SanitizeArchiveFileName(truss.perastageTypeKey, "") : trussTypeKey);
-  const std::string exportedAuxGdtf =
-      auxGdtfArchivePath.empty() ? truss.perastageAuxGdtfArchivePath : auxGdtfArchivePath;
+  addTxt("TypeKey", trussTypeKey.empty()
+                        ? SanitizeArchiveFileName(truss.perastageTypeKey, "")
+                        : trussTypeKey);
+  const std::string exportedAuxGdtf = auxGdtfArchivePath.empty()
+                                          ? truss.perastageAuxGdtfArchivePath
+                                          : auxGdtfArchivePath;
   addTxt("AuxGdtf", SanitizeArchiveFileName(exportedAuxGdtf, ""));
   trussInfoMap->InsertEndChild(info);
 }
@@ -1707,7 +1846,8 @@ static void AppendSupportHoistInfoUserData(tinyxml2::XMLDocument &doc,
   addNum("Weight", support.weightKg, "kg");
   addNum("Load", support.loadKg, "kg");
 
-  const std::string hoistFunction = NormalizeHoistFunction(support.hoistFunction);
+  const std::string hoistFunction =
+      NormalizeHoistFunction(support.hoistFunction);
   if (!hoistFunction.empty()) {
     addText("RiggingPoint", hoistFunction);
     addText("Function", hoistFunction); // Compatibility alias for older builds.
@@ -1770,8 +1910,7 @@ static std::string HexToCie(const std::string &hex) {
   unsigned int G = (rgb >> 8) & 0xFF;
   unsigned int B = rgb & 0xFF;
   auto invGamma = [](double c) {
-    return c <= 0.04045 ? c / 12.92
-                        : std::pow((c + 0.055) / 1.055, 2.4);
+    return c <= 0.04045 ? c / 12.92 : std::pow((c + 0.055) / 1.055, 2.4);
   };
   double r = invGamma(R / 255.0);
   double g = invGamma(G / 255.0);
@@ -1890,8 +2029,8 @@ static std::string CreatePatchedGdtf(const std::string &gdtfPath,
       ov.hasWeightKg ? std::optional<float>(ov.weightKg) : std::nullopt;
   const std::optional<float> powerW =
       ov.hasPowerW ? std::optional<float>(ov.powerW) : std::nullopt;
-  patched = GdtfMutationAudit::ApplyPhysicalProperties(
-                ft, doc, weightKg, powerW) ||
+  patched =
+      GdtfMutationAudit::ApplyPhysicalProperties(ft, doc, weightKg, powerW) ||
             patched;
   if (!ov.manufacturer.empty()) {
     ft->SetAttribute("Manufacturer", ov.manufacturer.c_str());
@@ -1921,7 +2060,8 @@ static std::string CreatePatchedGdtf(const std::string &gdtfPath,
 
   if (patched) {
     GdtfMutationAudit::AppendRevision(
-        ft, doc, (ov.hasWeightKg || ov.hasPowerW)
+        ft, doc,
+        (ov.hasWeightKg || ov.hasPowerW)
                      ? kPhysicalPropertiesRevisionText
                      : "Patched fixture metadata for MVR export",
         GdtfMutationAudit::BuildPerastageModifiedBy());
@@ -1934,16 +2074,21 @@ static std::string CreatePatchedGdtf(const std::string &gdtfPath,
   return outPath;
 }
 
-// Serialize the configured scene into a .mvr archive and collect non-fatal export warnings.
+// Serialize the configured scene into a .mvr archive and collect non-fatal
+// export warnings.
 bool MvrExporter::ExportToFile(const std::string &filePath) {
-  return ExportToFile(filePath, mvr::preferences::LoadExportOptions(ConfigManager::Get()));
+  return ExportToFile(
+      filePath, mvr::preferences::LoadExportOptions(ConfigManager::Get()));
 }
 
-// Serialize the configured scene into a .mvr archive with explicit export options.
-bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptions &options) {
+// Serialize the configured scene into a .mvr archive with explicit export
+// options.
+bool MvrExporter::ExportToFile(const std::string &filePath,
+                               const MvrExportOptions &options) {
   m_exportWarnings.clear();
   const auto &scene = ConfigManager::Get().GetScene();
-  const TrussGeometryAuthority trussGeometryAuthority = GetTrussGeometryAuthoritySetting();
+  const TrussGeometryAuthority trussGeometryAuthority =
+      GetTrussGeometryAuthoritySetting();
   std::unordered_map<std::string, std::string> positions;
   std::unordered_map<std::string, std::string> legacyPositionIdToCanonical;
   std::unordered_set<std::string> usedPositionUuids;
@@ -1955,7 +2100,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
     if (out.empty() || usedPositionUuids.contains(out)) {
       int suffix = 0;
       do {
-        out = DeriveDeterministicUuid(seedBase + "#" + std::to_string(suffix++));
+        out =
+            DeriveDeterministicUuid(seedBase + "#" + std::to_string(suffix++));
       } while (usedPositionUuids.contains(out));
     }
     usedPositionUuids.insert(out);
@@ -1978,9 +2124,9 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
     const std::string generated = reserveCanonicalPositionUuid({}, seed);
     positions[generated] = name.empty() ? rawUuid : name;
     legacyPositionIdToCanonical[rawUuid] = generated;
-    LogLegacyPositionUuidWarning(
-        "MVR export converted legacy Position uuid '" + rawUuid +
-        "' to canonical '" + generated + "' (name='" + positions[generated] + "')");
+    LogLegacyPositionUuidWarning("MVR export converted legacy Position uuid '" +
+                                 rawUuid + "' to canonical '" + generated +
+                                 "' (name='" + positions[generated] + "')");
   }
 
   std::unordered_map<std::string, std::string> positionByName;
@@ -1994,7 +2140,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
     auto legacyIt = legacyPositionIdToCanonical.find(positionId);
     if (legacyIt != legacyPositionIdToCanonical.end()) {
       auto existing = positions.find(legacyIt->second);
-      if (existing != positions.end() && !nameHint.empty() && existing->second != nameHint)
+      if (existing != positions.end() && !nameHint.empty() &&
+          existing->second != nameHint)
         existing->second = nameHint;
       if (!nameHint.empty())
         positionByName[nameHint] = legacyIt->second;
@@ -2007,7 +2154,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
       if (it == positions.end()) {
         positions[canonicalId] = nameHint;
       } else if (!nameHint.empty() && it->second != nameHint) {
-        // Refresh the stored name so Hang Position edits are preserved on export.
+        // Refresh the stored name so Hang Position edits are preserved on
+        // export.
         it->second = nameHint;
       }
       if (!nameHint.empty())
@@ -2022,13 +2170,14 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
     if (byName != positionByName.end())
       return;
 
-    std::string newUuid = reserveCanonicalPositionUuid({}, "mvr:position:name:" + nameHint);
+    std::string newUuid =
+        reserveCanonicalPositionUuid({}, "mvr:position:name:" + nameHint);
     positions[newUuid] = nameHint;
     positionByName[nameHint] = newUuid;
     if (!positionId.empty()) {
       LogLegacyPositionUuidWarning(
-          "MVR export normalized legacy Position uuid '" + positionId + "' -> '" +
-          newUuid + "' (name='" + nameHint + "')");
+          "MVR export normalized legacy Position uuid '" + positionId +
+          "' -> '" + newUuid + "' (name='" + nameHint + "')");
     }
   };
 
@@ -2039,7 +2188,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
   for (const auto &[uid, support] : scene.supports)
     ensurePositionEntry(support.position, support.positionName);
 
-  auto resolvePositionReference = [&](const std::string &positionId,
+  auto resolvePositionReference =
+      [&](const std::string &positionId,
                                       const std::string &nameHint) -> std::string {
     auto legacyIt = legacyPositionIdToCanonical.find(positionId);
     if (legacyIt != legacyPositionIdToCanonical.end())
@@ -2055,9 +2205,10 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
         if (!positionId.empty() && byName->second != positionId) {
           Logger::Instance().Log(
               Logger::Level::Info,
-              wxString::Format(
-                  "MVR export remapped non-canonical Position '%s' to '%s' by name '%s'",
-                  positionId.c_str(), byName->second.c_str(), nameHint.c_str())
+              wxString::Format("MVR export remapped non-canonical Position "
+                               "'%s' to '%s' by name '%s'",
+                               positionId.c_str(), byName->second.c_str(),
+                               nameHint.c_str())
                   .ToStdString());
         }
         return byName->second;
@@ -2103,15 +2254,16 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
     if (allowReuseBySource && srcIt != sourceToArchivePath.end())
       return srcIt->second;
 
-    std::string archivePath = EnsureUniqueArchivePath(preferredArchivePath, reservedArchivePaths);
+    std::string archivePath =
+        EnsureUniqueArchivePath(preferredArchivePath, reservedArchivePaths);
     if (allowReuseBySource)
       sourceToArchivePath[normalizedSource] = archivePath;
     resourceEntries.push_back({fs::path(normalizedSource), archivePath});
     return archivePath;
   };
 
-  auto registerGdtfResource = [&](const std::string &objectUuid,
-                                  const std::string &rawGdtfPath,
+  auto registerGdtfResource =
+      [&](const std::string &objectUuid, const std::string &rawGdtfPath,
                                   const std::string &preferredName,
                                   bool allowReuseBySource = true) -> std::string {
     if (rawGdtfPath.empty())
@@ -2127,7 +2279,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
     return archivePath;
   };
 
-  auto registerModelTextureDependencies = [&](const std::string &rawModelSource) {
+  auto registerModelTextureDependencies = [&](const std::string
+                                                  &rawModelSource) {
     if (rawModelSource.empty())
       return;
     const std::string normalizedModelPath = normalizeSourcePath(rawModelSource);
@@ -2141,8 +2294,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
         if (!ResolveTextureDependencyPath(modelPath, textureRef, texturePath))
           continue;
 
-        std::string preferredTextureName =
-            SanitizeArchiveFileName(textureRef, texturePath.filename().generic_string());
+        std::string preferredTextureName = SanitizeArchiveFileName(
+            textureRef, texturePath.filename().generic_string());
         registerResource(texturePath.generic_string(), preferredTextureName);
       }
       return;
@@ -2157,7 +2310,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
         const std::string trimmedRef = TrimAscii(textureRef);
         if (trimmedRef.empty())
           continue;
-        const fs::path candidate = modelDir / PathUtils::PathFromUtf8(trimmedRef);
+        const fs::path candidate =
+            modelDir / PathUtils::PathFromUtf8(trimmedRef);
         if (!fs::exists(candidate))
           continue;
 
@@ -2168,27 +2322,32 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
     }
   };
 
-  auto registerModelResource = [&](const std::string &rawModelSource,
+  auto registerModelResource =
+      [&](const std::string &rawModelSource,
                                    const std::string &fallbackArchiveName) -> std::string {
     std::string archivePath = registerResource(
-        rawModelSource, SanitizeArchiveFileName(rawModelSource, fallbackArchiveName));
+        rawModelSource,
+        SanitizeArchiveFileName(rawModelSource, fallbackArchiveName));
     registerModelTextureDependencies(rawModelSource);
     return archivePath;
   };
 
-  auto registerPrimitiveModelResource = [&](const std::string &modelRef,
+  auto registerPrimitiveModelResource =
+      [&](const std::string &modelRef,
                                             const std::string &objectUuid) -> std::string {
     std::string primitiveToken;
     if (!mvr::ResolvePrimitiveTokenFromModelRef(modelRef, primitiveToken))
       return {};
     const std::string normalizedModelRef = ToLowerAscii(TrimAscii(modelRef));
 
-    auto convertCylinderTokenMillimetersToMeters = [&](const std::string &token) {
+    auto convertCylinderTokenMillimetersToMeters =
+        [&](const std::string &token) {
       std::string normalized = ToLowerAscii(TrimAscii(token));
       if (normalized.rfind("primitive:cylinder", 0) != 0)
         return normalized;
       const size_t separator = normalized.find(';');
-      if (separator == std::string::npos || separator + 1 >= normalized.size())
+          if (separator == std::string::npos ||
+              separator + 1 >= normalized.size())
         return normalized;
 
       std::vector<std::string> fields;
@@ -2248,11 +2407,14 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
       if (primitiveLabel.empty())
         primitiveLabel = "shape";
       const std::size_t primitiveHash = std::hash<std::string>{}(primitiveKey);
-      const std::string tempFileName = wxString::Format(
-          "primitive_%s_%zx.glb", primitiveLabel.c_str(), primitiveHash)
+      const std::string tempFileName =
+          wxString::Format("primitive_%s_%zx.glb", primitiveLabel.c_str(),
+                           primitiveHash)
                                            .ToStdString();
-      fs::path outputPath = PathUtils::PathFromUtf8(primitiveTempDir) / PathUtils::PathFromUtf8(tempFileName);
-      if (!mvr::WritePrimitiveModelForToken(primitiveKey, outputPath.generic_string()))
+      fs::path outputPath = PathUtils::PathFromUtf8(primitiveTempDir) /
+                            PathUtils::PathFromUtf8(tempFileName);
+      if (!mvr::WritePrimitiveModelForToken(primitiveKey,
+                                            outputPath.generic_string()))
         return {};
       sourcePath = outputPath.generic_string();
       primitiveSourceByToken[primitiveKey] = sourcePath;
@@ -2316,10 +2478,12 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
   };
 
   const auto assignedIds = assignIds();
-  const auto assignedUnitNumbers = BuildFixtureUnitNumbersForExport(scene.fixtures);
+  const auto assignedUnitNumbers =
+      BuildFixtureUnitNumbersForExport(scene.fixtures);
 
   tinyxml2::XMLDocument doc;
-  doc.InsertEndChild(doc.NewDeclaration("xml version=\"1.0\" encoding=\"UTF-8\""));
+  doc.InsertEndChild(
+      doc.NewDeclaration("xml version=\"1.0\" encoding=\"UTF-8\""));
 
   auto appendPlaceholderCubeGeometry = [&](tinyxml2::XMLElement *owner,
                                           const std::string &objectUuid,
@@ -2327,7 +2491,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
     const std::string modelArchivePath =
         registerPrimitiveModelResource("primitive:cube", objectUuid);
     if (modelArchivePath.empty()) {
-      Logger::Instance().Log(Logger::Level::Warn,
+      Logger::Instance().Log(
+          Logger::Level::Warn,
                              std::string("MVR export could not create placeholder geometry for ") +
                                  nodeName + " uuid=" + objectUuid);
       return false;
@@ -2346,7 +2511,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
     g3d->InsertEndChild(geoMatrix);
     geos->InsertEndChild(g3d);
     owner->InsertEndChild(geos);
-    Logger::Instance().Log(Logger::Level::Warn,
+    Logger::Instance().Log(
+        Logger::Level::Warn,
                            std::string("MVR export added placeholder cube geometry for ") +
                                nodeName + " uuid=" + objectUuid);
     return true;
@@ -2360,7 +2526,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
   doc.InsertEndChild(root);
 
   if (HasLayerAppearanceMetadata(scene)) {
-    tinyxml2::XMLElement *rootPerastageData = FindOrCreatePerastageDataNode(doc, root);
+    tinyxml2::XMLElement *rootPerastageData =
+        FindOrCreatePerastageDataNode(doc, root);
     AppendLayerAppearanceMetadata(doc, rootPerastageData, scene);
   }
 
@@ -2397,8 +2564,9 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
       SymdefGeometry fallback;
       fallback.file = file;
       auto matIt = scene.symdefMatrices.find(uuid);
-      fallback.transform =
-          (matIt != scene.symdefMatrices.end()) ? matIt->second : MatrixUtils::Identity();
+      fallback.transform = (matIt != scene.symdefMatrices.end())
+                               ? matIt->second
+                               : MatrixUtils::Identity();
       if (tit != scene.symdefTypes.end())
         fallback.geometryType = tit->second;
       geometries.push_back(std::move(fallback));
@@ -2461,18 +2629,22 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
   std::unordered_map<std::string, std::string> trussExportUuids;
   for (const auto &[uuid, truss] : scene.trusses) {
     std::string exportUuid = CanonicalizeUuid(truss.uuid);
-    const std::string seed = "mvr-export-truss:" + truss.uuid + ":" + truss.name + ":" +
+    const std::string seed = "mvr-export-truss:" + truss.uuid + ":" +
+                             truss.name + ":" +
                              MatrixUtils::FormatMatrix(truss.transform);
-    const bool needsRepair = exportUuid.empty() || usedObjectExportUuids.contains(exportUuid);
+    const bool needsRepair =
+        exportUuid.empty() || usedObjectExportUuids.contains(exportUuid);
     if (needsRepair) {
       Logger::Instance().Log(
           Logger::Level::Warn,
           wxString::Format(
-              "Truss '%s' has missing, non-canonical, or conflicting UUID '%s'. Applying deterministic fallback UUID for export.",
+              "Truss '%s' has missing, non-canonical, or conflicting UUID "
+              "'%s'. Applying deterministic fallback UUID for export.",
               truss.name.c_str(), truss.uuid.c_str())
               .ToStdString());
       for (int suffix = 0;; ++suffix) {
-        const std::string candidate = DeriveDeterministicUuid(seed + "#" + std::to_string(suffix));
+        const std::string candidate =
+            DeriveDeterministicUuid(seed + "#" + std::to_string(suffix));
         if (!candidate.empty() && !usedObjectExportUuids.contains(candidate)) {
           exportUuid = candidate;
           break;
@@ -2500,8 +2672,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
     if (stableUuid.empty()) {
       Logger::Instance().Log(
           Logger::Level::Warn,
-          wxString::Format(
-              "Fixture '%s' has non-canonical UUID '%s'. Applying deterministic fallback UUID for export.",
+          wxString::Format("Fixture '%s' has non-canonical UUID '%s'. Applying "
+                           "deterministic fallback UUID for export.",
               f.instanceName.c_str(), f.uuid.c_str())
               .ToStdString());
       stableUuid = DeriveDeterministicUuid(seed);
@@ -2509,8 +2681,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
     if (usedFixtureUuids.contains(stableUuid)) {
       Logger::Instance().Log(
           Logger::Level::Warn,
-          wxString::Format(
-              "Fixture UUID collision detected during export for '%s' (uuid=%s). Applying controlled fallback UUID.",
+          wxString::Format("Fixture UUID collision detected during export for "
+                           "'%s' (uuid=%s). Applying controlled fallback UUID.",
               f.instanceName.c_str(), stableUuid.c_str())
               .ToStdString());
       int suffix = 1;
@@ -2524,8 +2696,9 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
     usedFixtureUuids.insert(stableUuid);
 
     fe->SetAttribute("uuid", stableUuid.c_str());
-    const std::string fixtureExportName =
-        TrimAscii(f.instanceName).empty() ? "Fixture" : TrimAscii(f.instanceName);
+    const std::string fixtureExportName = TrimAscii(f.instanceName).empty()
+                                              ? "Fixture"
+                                              : TrimAscii(f.instanceName);
     fe->SetAttribute("name", fixtureExportName.c_str());
 
     auto addInt = [&](const char *n, int v) {
@@ -2559,16 +2732,18 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
       Logger::Instance().Log(
           Logger::Level::Warn,
           wxString::Format(
-              "Fixture '%s' (uuid=%s) had an empty current GDTF. Recovering preserved original MVR GDTFSpec '%s' for export.",
-              fixtureExportName.c_str(), f.uuid.c_str(), fixtureSourceGdtf.c_str())
+              "Fixture '%s' (uuid=%s) had an empty current GDTF. Recovering "
+              "preserved original MVR GDTFSpec '%s' for export.",
+              fixtureExportName.c_str(), f.uuid.c_str(),
+              fixtureSourceGdtf.c_str())
               .ToStdString());
     }
     bool usedDummyFallbackForFixture = false;
     if (fixtureSourceGdtf.empty()) {
       fixtureSourceGdtf = ResolveFallbackFixtureGdtfPath();
-      const std::string fallbackHint = std::string(kDummyFallbackFixtureGdtfFileName) +
-                                       " (legacy: " +
-                                       kLegacyFallbackFixtureGdtfFileName + ")";
+      const std::string fallbackHint =
+          std::string(kDummyFallbackFixtureGdtfFileName) +
+          " (legacy: " + kLegacyFallbackFixtureGdtfFileName + ")";
       if (fixtureSourceGdtf.empty()) {
         std::ostringstream msg;
         msg << "Fixture '" << fixtureExportName << "' (uuid=" << f.uuid
@@ -2584,14 +2759,16 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
         Logger::Instance().Log(Logger::Level::Info, msg.str());
         usedDummyFallbackForFixture = true;
         if (dummyFallbackFixtureExamples.size() < 5)
-          dummyFallbackFixtureExamples.push_back(fixtureExportName + " (uuid=" + f.uuid + ")");
+          dummyFallbackFixtureExamples.push_back(fixtureExportName +
+                                                 " (uuid=" + f.uuid + ")");
       }
     }
     if (usedDummyFallbackForFixture)
       ++exportedDummyFixtureGdtfCount;
     else if (!fixtureSourceGdtf.empty())
       ++exportedRealFixtureGdtfCount;
-    std::string fixtureName = SanitizeArchiveFileName(fixtureSourceGdtf, "fixture.gdtf");
+    std::string fixtureName =
+        SanitizeArchiveFileName(fixtureSourceGdtf, "fixture.gdtf");
     GdtfOverrides fixtureOverrides;
     const bool needsPhysicalPatch =
         FixtureNeedsPhysicalGdtfPatch(f, fixtureSourceGdtf, fixtureOverrides);
@@ -2599,16 +2776,18 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
       const fs::path archiveName(fixtureName);
       const std::string stem = archiveName.stem().generic_string();
       const std::string extension = archiveName.extension().generic_string();
-      fixtureName = SanitizeArchiveFileName(stem + "_physical_" + f.uuid + extension,
-                                            "fixture_physical.gdtf");
+      fixtureName = SanitizeArchiveFileName(
+          stem + "_physical_" + f.uuid + extension, "fixture_physical.gdtf");
     }
     std::string fixtureGdtfArchivePath;
     if (needsPhysicalPatch) {
       std::ostringstream patchKey;
       patchKey << normalizeSourcePath(fixtureSourceGdtf) << '|'
-               << (fixtureOverrides.hasWeightKg ? fixtureOverrides.weightKg : -1.0f)
+               << (fixtureOverrides.hasWeightKg ? fixtureOverrides.weightKg
+                                                : -1.0f)
                << '|'
-               << (fixtureOverrides.hasPowerW ? fixtureOverrides.powerW : -1.0f);
+               << (fixtureOverrides.hasPowerW ? fixtureOverrides.powerW
+                                              : -1.0f);
       auto patchIt = physicalPatchArchiveByKey.find(patchKey.str());
       if (patchIt != physicalPatchArchiveByKey.end()) {
         fixtureGdtfArchivePath = patchIt->second;
@@ -2624,7 +2803,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
       fixtureGdtfArchivePath =
           registerGdtfResource(f.uuid, fixtureSourceGdtf, fixtureName);
     }
-    MergeFixtureTypeCategoryExport(fixtureTypeCategoryMetadata, f, fixtureGdtfArchivePath);
+    MergeFixtureTypeCategoryExport(fixtureTypeCategoryMetadata, f,
+                                   fixtureGdtfArchivePath);
 
     const Matrix fixtureMatrixToWrite =
         f.parentGroupUuid.empty()
@@ -2639,12 +2819,15 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
     // Keep fixture GDTF payloads byte-preserved unless the user intentionally
     // edits type-level physical properties that must be exported through GDTF.
     addStr("GDTFMode", f.gdtfMode);
+    if (!f.mvrFixtureColorHex.empty())
+      addStr("Color", HexToCie(f.mvrFixtureColorHex));
     if (!f.position.empty() || !f.positionName.empty())
       addStr("Position", resolvePositionReference(f.position, f.positionName));
     addStr("FixtureID", fixtureExportId.text);
     addInt("FixtureIDNumeric", fixtureExportId.numeric);
     auto unitIt = assignedUnitNumbers.find(f.uuid);
-    addInt("UnitNumber", unitIt != assignedUnitNumbers.end() ? unitIt->second : f.unitNumber);
+    addInt("UnitNumber",
+           unitIt != assignedUnitNumbers.end() ? unitIt->second : f.unitNumber);
 
     if (!f.address.empty()) {
       const std::string trimmedAddress = TrimAscii(f.address);
@@ -2660,9 +2843,11 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
       } else {
         Logger::Instance().Log(
             Logger::Level::Warn,
-            wxString::Format(
-                "Skipping invalid DMX patch for fixture '%s' (uuid=%s): '%s' (expected Universe.Address with universe >= 1 and address in [1,512])",
-                f.instanceName.c_str(), f.uuid.c_str(), trimmedAddress.c_str())
+            wxString::Format("Skipping invalid DMX patch for fixture '%s' "
+                             "(uuid=%s): '%s' (expected Universe.Address with "
+                             "universe >= 1 and address in [1,512])",
+                             f.instanceName.c_str(), f.uuid.c_str(),
+                             trimmedAddress.c_str())
                 .ToStdString());
       }
     }
@@ -2673,9 +2858,11 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
   auto exportTruss = [&](tinyxml2::XMLElement *parent, const Truss &t) {
     tinyxml2::XMLElement *te = doc.NewElement("Truss");
     const auto exportUuidIt = trussExportUuids.find(t.uuid);
-    const std::string exportedTrussUuid = exportUuidIt != trussExportUuids.end()
+    const std::string exportedTrussUuid =
+        exportUuidIt != trussExportUuids.end()
                                              ? exportUuidIt->second
-                                             : DeriveDeterministicUuid("mvr-export-truss:" + t.uuid + ":" + t.name);
+            : DeriveDeterministicUuid("mvr-export-truss:" + t.uuid + ":" +
+                                      t.name);
     te->SetAttribute("uuid", exportedTrussUuid.c_str());
     if (!t.name.empty())
       te->SetAttribute("name", t.name.c_str());
@@ -2695,7 +2882,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
       }
     };
     auto idIt = assignedIds.find(t.uuid);
-    int fixtureNumericId = (idIt != assignedIds.end()) ? idIt->second.second : 0;
+    int fixtureNumericId =
+        (idIt != assignedIds.end()) ? idIt->second.second : 0;
     if (fixtureNumericId <= 0)
       fixtureNumericId = 1;
     std::string fixtureId = std::to_string(fixtureNumericId);
@@ -2709,23 +2897,27 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
         gdtfArchiveByObjectUuid[exportedTrussUuid] = trussGdtfArchivePath;
     } else {
       std::string trussSourceGdtf = t.gdtfSpec;
-      if (trussSourceGdtf.empty() && fs::path(t.modelFile).extension() == ".gdtf")
+      if (trussSourceGdtf.empty() &&
+          fs::path(t.modelFile).extension() == ".gdtf")
         trussSourceGdtf = t.modelFile;
 
       const bool importedFromMvrGeometry =
-          t.sourceRepresentation == Truss::GeometryRepresentation::SymbolSymdef ||
+          t.sourceRepresentation ==
+              Truss::GeometryRepresentation::SymbolSymdef ||
           t.sourceRepresentation == Truss::GeometryRepresentation::Geometry3D;
       if (trussSourceGdtf.empty() && !importedFromMvrGeometry) {
-        fs::path tempPath = fs::temp_directory_path() /
-                            ("perastage-truss-export-" + (t.uuid.empty() ? std::string("truss") : t.uuid) + ".gdtf");
+        fs::path tempPath =
+            fs::temp_directory_path() /
+            ("perastage-truss-export-" +
+             (t.uuid.empty() ? std::string("truss") : t.uuid) + ".gdtf");
         std::string conversionError;
         if (BuildTrussGdtfFromInstance(t, tempPath, &conversionError))
           trussSourceGdtf = tempPath.string();
       }
 
       std::string trussPreferredName = BuildTrussGdtfArchiveName(t);
-      trussGdtfArchivePath =
-          registerGdtfResource(exportedTrussUuid, trussSourceGdtf, trussPreferredName, true);
+      trussGdtfArchivePath = registerGdtfResource(
+          exportedTrussUuid, trussSourceGdtf, trussPreferredName, true);
       if (!trussGdtfArchivePath.empty())
         trussArchiveByTypeKey[trussTypeKey] = trussGdtfArchivePath;
     }
@@ -2752,9 +2944,9 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
 
     const bool writeWorldTransform = t.parentGroupUuid.empty();
     const Matrix matrixToWrite =
-        writeWorldTransform ? t.transform
-                            : (t.hasLocalTransform ? t.localTransform
-                                                   : t.transform);
+        writeWorldTransform
+            ? t.transform
+            : (t.hasLocalTransform ? t.localTransform : t.transform);
     std::string mstr = MatrixUtils::FormatMatrix(matrixToWrite);
     tinyxml2::XMLElement *mat = doc.NewElement("Matrix");
     mat->SetText(mstr.c_str());
@@ -2771,10 +2963,12 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
     }
 
     if (trussGeometryAuthority == TrussGeometryAuthority::MvrGeometry) {
-      if (t.sourceRepresentation == Truss::GeometryRepresentation::SymbolSymdef &&
+      if (t.sourceRepresentation ==
+              Truss::GeometryRepresentation::SymbolSymdef &&
           !t.sourceSymdefUuid.empty()) {
         const bool flattenSymbol =
-            options.trussGeometryExportMode == MvrTrussGeometryExportMode::DirectGeometry3DForTrussSymbols;
+            options.trussGeometryExportMode ==
+            MvrTrussGeometryExportMode::DirectGeometry3DForTrussSymbols;
         tinyxml2::XMLElement *geos = doc.NewElement("Geometries");
         if (flattenSymbol) {
           std::vector<SymdefGeometry> geometries;
@@ -2782,11 +2976,14 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
           if (geoIt != scene.symdefGeometries.end())
             geometries = geoIt->second;
           auto fileIt = scene.symdefFiles.find(t.sourceSymdefUuid);
-          if (geometries.empty() && fileIt != scene.symdefFiles.end() && !fileIt->second.empty()) {
+          if (geometries.empty() && fileIt != scene.symdefFiles.end() &&
+              !fileIt->second.empty()) {
             SymdefGeometry fallback;
             fallback.file = fileIt->second;
             auto matIt = scene.symdefMatrices.find(t.sourceSymdefUuid);
-            fallback.transform = (matIt != scene.symdefMatrices.end()) ? matIt->second : MatrixUtils::Identity();
+            fallback.transform = (matIt != scene.symdefMatrices.end())
+                                     ? matIt->second
+                                     : MatrixUtils::Identity();
             auto typeIt = scene.symdefTypes.find(t.sourceSymdefUuid);
             if (typeIt != scene.symdefTypes.end())
               fallback.geometryType = typeIt->second;
@@ -2797,13 +2994,15 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
             if (geo.file.empty())
               continue;
             tinyxml2::XMLElement *g3d = doc.NewElement("Geometry3D");
-            const std::string archivePath = registerModelResource(geo.file, "truss.3ds");
+            const std::string archivePath =
+                registerModelResource(geo.file, "truss.3ds");
             if (archivePath.empty())
               continue;
             g3d->SetAttribute("fileName", archivePath.c_str());
             if (!geo.geometryType.empty())
               g3d->SetAttribute("geometryType", geo.geometryType.c_str());
-            const Matrix composedMatrix = MatrixUtils::Multiply(t.sourceSymbolMatrix, geo.transform);
+            const Matrix composedMatrix =
+                MatrixUtils::Multiply(t.sourceSymbolMatrix, geo.transform);
             tinyxml2::XMLElement *geoMat = doc.NewElement("Matrix");
             geoMat->SetText(MatrixUtils::FormatMatrix(composedMatrix).c_str());
             g3d->InsertEndChild(geoMat);
@@ -2814,15 +3013,19 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
             te->InsertEndChild(geos);
             Logger::Instance().Log(
                 Logger::Level::Info,
-                wxString::Format("MVR export truss flattened Symbol/Symdef geometry uuid=%s symdef=%s",
+                wxString::Format("MVR export truss flattened Symbol/Symdef "
+                                 "geometry uuid=%s symdef=%s",
                                  t.uuid.c_str(), t.sourceSymdefUuid.c_str())
                     .ToStdString());
           } else {
             m_exportWarnings.push_back(
-                "MVR export could not resolve truss Symdef '" + t.sourceSymdefUuid +
-                "' for direct Geometry3D export; preserving Symbol/Symdef representation.");
+                "MVR export could not resolve truss Symdef '" +
+                t.sourceSymdefUuid +
+                "' for direct Geometry3D export; preserving Symbol/Symdef "
+                "representation.");
             tinyxml2::XMLElement *sym = doc.NewElement("Symbol");
-            const std::string symbolMatrixText = MatrixUtils::FormatMatrix(t.sourceSymbolMatrix);
+            const std::string symbolMatrixText =
+                MatrixUtils::FormatMatrix(t.sourceSymbolMatrix);
             const std::string symbolUuid = ResolveExportSymbolUuid(
                 t.sourceSymbolUuid, t.uuid, t.sourceSymdefUuid,
                 "mvr:symbol:truss:" + t.uuid + ":" + t.sourceSymdefUuid + ":" +
@@ -2838,7 +3041,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
           }
         } else {
           tinyxml2::XMLElement *sym = doc.NewElement("Symbol");
-          const std::string symbolMatrixText = MatrixUtils::FormatMatrix(t.sourceSymbolMatrix);
+          const std::string symbolMatrixText =
+              MatrixUtils::FormatMatrix(t.sourceSymbolMatrix);
           const std::string symbolUuid = ResolveExportSymbolUuid(
               t.sourceSymbolUuid, t.uuid, t.sourceSymdefUuid,
               "mvr:symbol:truss:" + t.uuid + ":" + t.sourceSymdefUuid + ":" +
@@ -2853,13 +3057,16 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
           te->InsertEndChild(geos);
           Logger::Instance().Log(
               Logger::Level::Info,
-              wxString::Format("MVR export truss keeps Symbol/Symdef uuid=%s symbol=%s symdef=%s",
-                               t.uuid.c_str(), symbolUuid.c_str(), t.sourceSymdefUuid.c_str())
+              wxString::Format("MVR export truss keeps Symbol/Symdef uuid=%s "
+                               "symbol=%s symdef=%s",
+                               t.uuid.c_str(), symbolUuid.c_str(),
+                               t.sourceSymdefUuid.c_str())
                   .ToStdString());
         }
       } else if (!t.symbolFile.empty()) {
         std::string ext = fs::path(t.symbolFile).extension().string();
-        std::transform(ext.begin(), ext.end(), ext.begin(),
+        std::transform(
+            ext.begin(), ext.end(), ext.begin(),
                        [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
         if (ext == ".3ds" || ext == ".glb") {
           tinyxml2::XMLElement *geos = doc.NewElement("Geometries");
@@ -2870,13 +3077,15 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
           if (!t.sourceGeometryType.empty())
             g3d->SetAttribute("geometryType", t.sourceGeometryType.c_str());
           tinyxml2::XMLElement *geoMat = doc.NewElement("Matrix");
-          geoMat->SetText(MatrixUtils::FormatMatrix(t.sourceGeometryMatrix).c_str());
+          geoMat->SetText(
+              MatrixUtils::FormatMatrix(t.sourceGeometryMatrix).c_str());
           g3d->InsertEndChild(geoMat);
           geos->InsertEndChild(g3d);
           te->InsertEndChild(geos);
           Logger::Instance().Log(
               Logger::Level::Info,
-              wxString::Format("MVR export truss uses direct Geometry3D uuid=%s",
+              wxString::Format(
+                  "MVR export truss uses direct Geometry3D uuid=%s",
                                t.uuid.c_str())
                   .ToStdString());
         }
@@ -2939,7 +3148,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
     for (const auto &geo : s.geometries) {
       if (geo.modelFile.empty())
         continue;
-      std::string modelArchivePath = registerModelResource(geo.modelFile, "support.3ds");
+      std::string modelArchivePath =
+          registerModelResource(geo.modelFile, "support.3ds");
       if (modelArchivePath.empty())
         continue;
       tinyxml2::XMLElement *g3d = doc.NewElement("Geometry3D");
@@ -2950,12 +3160,14 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
       ensureGeometries()->InsertEndChild(g3d);
     }
     if (!geos && !s.modelFile.empty()) {
-      std::string modelArchivePath = registerModelResource(s.modelFile, "support.3ds");
+      std::string modelArchivePath =
+          registerModelResource(s.modelFile, "support.3ds");
       if (!modelArchivePath.empty()) {
         tinyxml2::XMLElement *g3d = doc.NewElement("Geometry3D");
         g3d->SetAttribute("fileName", modelArchivePath.c_str());
         tinyxml2::XMLElement *geoMatrix = doc.NewElement("Matrix");
-        geoMatrix->SetText(MatrixUtils::FormatMatrix(MatrixUtils::Identity()).c_str());
+        geoMatrix->SetText(
+            MatrixUtils::FormatMatrix(MatrixUtils::Identity()).c_str());
         g3d->InsertEndChild(geoMatrix);
         ensureGeometries()->InsertEndChild(g3d);
       }
@@ -2965,7 +3177,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
     } else {
       tinyxml2::XMLElement *emptyGeometries = doc.NewElement("Geometries");
       se->InsertEndChild(emptyGeometries);
-      Logger::Instance().Log(Logger::Level::Warn,
+      Logger::Instance().Log(
+          Logger::Level::Warn,
                              "MVR export kept Support uuid=" + s.uuid +
                                  " with empty Geometries because no source geometry is available");
     }
@@ -2979,7 +3192,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
     chainLength->SetText(std::to_string(std::max(s.chainLength, 0.0f)).c_str());
     se->InsertEndChild(chainLength);
 
-    std::string supportGdtfArchivePath = registerGdtfResource(s.uuid, s.gdtfSpec, "");
+    std::string supportGdtfArchivePath =
+        registerGdtfResource(s.uuid, s.gdtfSpec, "");
     if (!supportGdtfArchivePath.empty()) {
       tinyxml2::XMLElement *e = doc.NewElement("GDTFSpec");
       e->SetText(supportGdtfArchivePath.c_str());
@@ -2992,7 +3206,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
     }
 
     auto supportIdIt = assignedIds.find(s.uuid);
-    int supportNumericId = (supportIdIt != assignedIds.end()) ? supportIdIt->second.second : 0;
+    int supportNumericId =
+        (supportIdIt != assignedIds.end()) ? supportIdIt->second.second : 0;
     if (supportNumericId <= 0)
       supportNumericId = 1;
     tinyxml2::XMLElement *supportId = doc.NewElement("FixtureID");
@@ -3024,7 +3239,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
     addSupportInfo("Function", s.function);
     addSupportInfo("HoistFunction", s.hoistFunction);
     addSupportNum("ChainLength", s.chainLength);
-    addSupportInfo("Position", resolvePositionReference(s.position, s.positionName));
+    addSupportInfo("Position",
+                   resolvePositionReference(s.position, s.positionName));
     addSupportInfo("PositionName", s.positionName);
     if (info->FirstChild())
       data->InsertEndChild(info);
@@ -3107,7 +3323,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
 
     if (!obj.geometries.empty()) {
       tinyxml2::XMLElement *geos = doc.NewElement("Geometries");
-      std::vector<std::pair<std::string, std::string>> primitiveGeometryModelRefs;
+      std::vector<std::pair<std::string, std::string>>
+          primitiveGeometryModelRefs;
       for (const auto &geo : obj.geometries) {
         if (geo.modelFile.empty())
           continue;
@@ -3126,15 +3343,17 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
         Matrix geoMatrixToWrite = geo.localTransform;
 
         CylinderTokenParams cylinderParams;
-        const bool hasCylinderToken = parseCylinderTokenParams(modelRef, cylinderParams);
+        const bool hasCylinderToken =
+            parseCylinderTokenParams(modelRef, cylinderParams);
         const bool hasExplicitCylinderDimensions =
             hasCylinderToken && cylinderParams.hasExplicitDimensions;
         const bool isRoundCylinder =
             hasExplicitCylinderDimensions &&
-            std::fabs(cylinderParams.topRadiusMm - cylinderParams.bottomRadiusMm) < 1e-3f;
+            std::fabs(cylinderParams.topRadiusMm -
+                      cylinderParams.bottomRadiusMm) < 1e-3f;
         if (hasExplicitCylinderDimensions) {
-          // Explicit parametric cylinders already encode final dimensions in the
-          // generated primitive mesh; keep geometry matrix scale neutral.
+          // Explicit parametric cylinders already encode final dimensions in
+          // the generated primitive mesh; keep geometry matrix scale neutral.
           geoMatrixToWrite = MatrixUtils::Identity();
         }
         if (isRoundCylinder) {
@@ -3148,13 +3367,15 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
           if (!modelArchivePath.empty())
             g3d->SetAttribute("fileName", modelArchivePath.c_str());
 
-          // Convert token dimensions (stored in millimeters) to scene meters for
-          // Geometry3D matrix scaling, matching importer expectations in MA3.
+          // Convert token dimensions (stored in millimeters) to scene meters
+          // for Geometry3D matrix scaling, matching importer expectations in
+          // MA3.
           constexpr float kMillimetersPerMeter = 1000.0f;
           const float radialScale = std::max(
-              (cylinderParams.topRadiusMm * 2.0f) / kMillimetersPerMeter, 0.000001f);
-          const float heightScale = std::max(cylinderParams.heightMm / kMillimetersPerMeter,
+              (cylinderParams.topRadiusMm * 2.0f) / kMillimetersPerMeter,
                                              0.000001f);
+          const float heightScale = std::max(
+              cylinderParams.heightMm / kMillimetersPerMeter, 0.000001f);
           if (cylinderParams.axis == 'x') {
             for (float &component : geoMatrixToWrite.u)
               component *= heightScale;
@@ -3180,7 +3401,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
         }
 
         std::string primitiveToken;
-        if (mvr::ResolvePrimitiveTokenFromModelRef(geo.modelFile, primitiveToken)) {
+        if (mvr::ResolvePrimitiveTokenFromModelRef(geo.modelFile,
+                                                   primitiveToken)) {
           // Persist the effective model reference used for Geometry3D so a
           // roundtrip keeps primitive token parameters/axis aligned with the
           // stored geometry matrix.
@@ -3203,11 +3425,13 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
         tinyxml2::XMLElement *data = doc.NewElement("Data");
         data->SetAttribute("provider", "Perastage");
         tinyxml2::XMLElement *map = doc.NewElement("PrimitiveGeometryMap");
-        for (const auto &[archiveFileName, modelRef] : primitiveGeometryModelRefs) {
+        for (const auto &[archiveFileName, modelRef] :
+             primitiveGeometryModelRefs) {
           tinyxml2::XMLElement *entry = doc.NewElement("Entry");
           entry->SetAttribute("fileName", archiveFileName.c_str());
-          // Keep Perastage-specific metadata namespaced to reduce collisions with
-          // third-party MVR parsers that may react to generic attribute names.
+          // Keep Perastage-specific metadata namespaced to reduce collisions
+          // with third-party MVR parsers that may react to generic attribute
+          // names.
           entry->SetAttribute("perastageModelRef", modelRef.c_str());
           map->InsertEndChild(entry);
         }
@@ -3226,7 +3450,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
       if (!modelArchivePath.empty()) {
         g3d->SetAttribute("fileName", modelArchivePath.c_str());
         tinyxml2::XMLElement *geoMatrix = doc.NewElement("Matrix");
-        geoMatrix->SetText(MatrixUtils::FormatMatrix(MatrixUtils::Identity()).c_str());
+        geoMatrix->SetText(
+            MatrixUtils::FormatMatrix(MatrixUtils::Identity()).c_str());
         g3d->InsertEndChild(geoMatrix);
         oe->InsertEndChild(geos);
         geos->InsertEndChild(g3d);
@@ -3307,12 +3532,12 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
       continue;
     tinyxml2::XMLElement *layerElem = doc.NewElement("Layer");
     if (!layerUuid.empty()) {
-      const std::string exportLayerUuid = ExportLayerUuid(layerUuid, layer.name);
+      const std::string exportLayerUuid =
+          ExportLayerUuid(layerUuid, layer.name);
       layerElem->SetAttribute("uuid", exportLayerUuid.c_str());
     }
     if (!layer.name.empty())
       layerElem->SetAttribute("name", layer.name.c_str());
-
 
     tinyxml2::XMLElement *childList = doc.NewElement("ChildList");
 
@@ -3357,24 +3582,29 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
   // Objects with no layer
   tinyxml2::XMLElement *rootChildList = doc.NewElement("ChildList");
   for (const auto &[uid, group] : scene.groupObjects) {
-    if (!(group.layer == DEFAULT_LAYER_NAME || group.layer.empty()) || !group.parentGroupUuid.empty())
+    if (!(group.layer == DEFAULT_LAYER_NAME || group.layer.empty()) ||
+        !group.parentGroupUuid.empty())
       continue;
     exportGroupObject(exportGroupObject, rootChildList, group);
   }
   for (const auto &[uid, f] : scene.fixtures) {
-    if ((f.layer == DEFAULT_LAYER_NAME || f.layer.empty()) && f.parentGroupUuid.empty())
+    if ((f.layer == DEFAULT_LAYER_NAME || f.layer.empty()) &&
+        f.parentGroupUuid.empty())
       exportFixture(rootChildList, f);
   }
   for (const auto &[uid, t] : scene.trusses) {
-    if ((t.layer == DEFAULT_LAYER_NAME || t.layer.empty()) && t.parentGroupUuid.empty())
+    if ((t.layer == DEFAULT_LAYER_NAME || t.layer.empty()) &&
+        t.parentGroupUuid.empty())
       exportTruss(rootChildList, t);
   }
   for (const auto &[uid, s] : scene.supports) {
-    if ((s.layer == DEFAULT_LAYER_NAME || s.layer.empty()) && s.parentGroupUuid.empty())
+    if ((s.layer == DEFAULT_LAYER_NAME || s.layer.empty()) &&
+        s.parentGroupUuid.empty())
       exportSupport(rootChildList, s);
   }
   for (const auto &[uid, obj] : scene.sceneObjects) {
-    if ((obj.layer == DEFAULT_LAYER_NAME || obj.layer.empty()) && obj.parentGroupUuid.empty())
+    if ((obj.layer == DEFAULT_LAYER_NAME || obj.layer.empty()) &&
+        obj.parentGroupUuid.empty())
       exportSceneObject(rootChildList, obj);
   }
   if (rootChildList->FirstChild()) {
@@ -3391,13 +3621,15 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
   }
 
   if (!fixtureTypeCategoryMetadata.empty()) {
-    tinyxml2::XMLElement *rootPerastageDataForFixtures = FindOrCreatePerastageDataNode(doc, root);
+    tinyxml2::XMLElement *rootPerastageDataForFixtures =
+        FindOrCreatePerastageDataNode(doc, root);
     AppendFixtureTypeCategoryMetadata(doc, rootPerastageDataForFixtures,
                                       fixtureTypeCategoryMetadata);
   }
 
   if (trussInfoMap->FirstChild()) {
-    tinyxml2::XMLElement *rootPerastageDataForTrusses = FindOrCreatePerastageDataNode(doc, root);
+    tinyxml2::XMLElement *rootPerastageDataForTrusses =
+        FindOrCreatePerastageDataNode(doc, root);
     rootPerastageDataForTrusses->InsertEndChild(trussInfoMap);
   } else {
     doc.DeleteNode(trussInfoMap);
@@ -3410,7 +3642,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
     tinyxml2::XMLElement *manifest = doc.NewElement("TrussSidecarManifest");
     for (const auto &[typeKey, archivePath] : trussArchiveByTypeKey) {
       const auto exportTypeKeyIt = trussExportTypeKeyByTypeKey.find(typeKey);
-      const std::string exportTypeKey = exportTypeKeyIt != trussExportTypeKeyByTypeKey.end()
+      const std::string exportTypeKey =
+          exportTypeKeyIt != trussExportTypeKeyByTypeKey.end()
                                            ? exportTypeKeyIt->second
                                            : SanitizeArchiveFileName(typeKey, "truss_type");
       tinyxml2::XMLElement *typeNode = doc.NewElement("Type");
@@ -3419,7 +3652,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
       manifest->InsertEndChild(typeNode);
       Logger::Instance().Log(
           Logger::Level::Info,
-          wxString::Format("MVR export generated truss sidecar GDTF typeKey=%s archive=%s",
+          wxString::Format(
+              "MVR export generated truss sidecar GDTF typeKey=%s archive=%s",
                            exportTypeKey.c_str(), archivePath.c_str())
               .ToStdString());
     }
@@ -3430,18 +3664,21 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
       manifest->InsertEndChild(instNode);
       Logger::Instance().Log(
           Logger::Level::Info,
-          wxString::Format("MVR export linked truss instance to sidecar uuid=%s typeKey=%s",
+          wxString::Format(
+              "MVR export linked truss instance to sidecar uuid=%s typeKey=%s",
                            uuid.c_str(), typeKey.c_str())
               .ToStdString());
     }
     data->InsertEndChild(manifest);
   }
 
-  // Prunes non-referenced resources so deleted scene elements do not keep stale payload files.
+  // Prunes non-referenced resources so deleted scene elements do not keep stale
+  // payload files.
   const std::unordered_set<std::string> referencedArchivePaths =
       CollectReferencedArchivePaths(doc);
   std::ostringstream fixtureGdtfExportDiagnostics;
-  fixtureGdtfExportDiagnostics << "MVR export fixture GDTF diagnostics: real="
+  fixtureGdtfExportDiagnostics
+      << "MVR export fixture GDTF diagnostics: real="
                                 << exportedRealFixtureGdtfCount
                                 << ", dummyFallback=" << exportedDummyFixtureGdtfCount
                                 << ", preservedOriginalRecoveries="
@@ -3454,9 +3691,11 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
       fixtureGdtfExportDiagnostics << dummyFallbackFixtureExamples[i];
     }
   }
-  Logger::Instance().Log(Logger::Level::Info, fixtureGdtfExportDiagnostics.str());
+  Logger::Instance().Log(Logger::Level::Info,
+                         fixtureGdtfExportDiagnostics.str());
 
-  const std::vector<ResourceEntry> allResourceEntriesBeforePrune = resourceEntries;
+  const std::vector<ResourceEntry> allResourceEntriesBeforePrune =
+      resourceEntries;
   resourceEntries.erase(
       std::remove_if(resourceEntries.begin(), resourceEntries.end(),
                      [&](const ResourceEntry &entry) {
@@ -3469,16 +3708,19 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
   LogResourcePruneDiagnostics(referencedArchivePaths,
                               allResourceEntriesBeforePrune, resourceEntries);
 
-  // Deduplicate archive resources and keep only the first entry for each archive path.
+  // Deduplicate archive resources and keep only the first entry for each
+  // archive path.
   std::unordered_set<std::string> seenArchivePaths;
   std::vector<ResourceEntry> deduplicatedResources;
   deduplicatedResources.reserve(resourceEntries.size());
   for (const auto &entry : resourceEntries) {
-    const std::string normalizedPath = NormalizeArchiveEntryPath(entry.archivePath);
+    const std::string normalizedPath =
+        NormalizeArchiveEntryPath(entry.archivePath);
     if (normalizedPath.empty())
       continue;
     if (!seenArchivePaths.insert(normalizedPath).second) {
-      m_exportWarnings.push_back("Referenced file '" + normalizedPath +
+      m_exportWarnings.push_back(
+          "Referenced file '" + normalizedPath +
                                  "' appears multiple times; duplicates will be ignored.");
       continue;
     }
@@ -3494,14 +3736,16 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
       continue;
     auto cit = gdtfOverrides.find(entry.archivePath);
     if (cit != gdtfOverrides.end()) {
-      std::string tmp = CreatePatchedGdtf(entry.sourcePath.string(), cit->second);
+      std::string tmp =
+          CreatePatchedGdtf(entry.sourcePath.string(), cit->second);
       if (!tmp.empty())
         entry.sourcePath = fs::path(tmp);
     }
     ++plannedArchiveEntries[entry.archivePath];
   }
 
-  if (!ValidateMvr16Export(doc, gdtfArchiveByObjectUuid, plannedArchiveEntries, &m_exportWarnings)) {
+  if (!ValidateMvr16Export(doc, gdtfArchiveByObjectUuid, plannedArchiveEntries,
+                           &m_exportWarnings)) {
     zip.Close();
     return false;
   }
@@ -3514,7 +3758,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
   std::unordered_set<std::string> writtenArchiveEntries;
   {
     if (!writtenArchiveEntries.insert("GeneralSceneDescription.xml").second) {
-      wxLogError("MVR export failed: duplicate ZIP entry GeneralSceneDescription.xml");
+      wxLogError(
+          "MVR export failed: duplicate ZIP entry GeneralSceneDescription.xml");
       zip.Close();
       return false;
     }
@@ -3529,7 +3774,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
     if (!fs::exists(resource.sourcePath) || resource.archivePath.empty())
       continue;
     if (!writtenArchiveEntries.insert(resource.archivePath).second) {
-      wxLogError("MVR export failed: duplicate ZIP entry %s", resource.archivePath);
+      wxLogError("MVR export failed: duplicate ZIP entry %s",
+                 resource.archivePath);
       zip.Close();
       return false;
     }
@@ -3553,11 +3799,14 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
 
 // Export an MVR into memory by writing a temporary file and reading it back.
 bool MvrExporter::ExportToBuffer(std::vector<uint8_t> &outBytes) {
-  return ExportToBuffer(outBytes, mvr::preferences::LoadExportOptions(ConfigManager::Get()));
+  return ExportToBuffer(
+      outBytes, mvr::preferences::LoadExportOptions(ConfigManager::Get()));
 }
 
-// Export an MVR into memory with explicit options by writing a temporary file and reading it back.
-bool MvrExporter::ExportToBuffer(std::vector<uint8_t> &outBytes, const MvrExportOptions &options) {
+// Export an MVR into memory with explicit options by writing a temporary file
+// and reading it back.
+bool MvrExporter::ExportToBuffer(std::vector<uint8_t> &outBytes,
+                                 const MvrExportOptions &options) {
   outBytes.clear();
   wxFileName tempFile =
       wxFileName::CreateTempFileName("perastage_mvr_export_buffer");

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -93,7 +93,7 @@ struct FixtureExportId {
   int numeric = 0;
 };
 
-struct FixtureTypeCategoryExport {
+struct FixtureTypeInfoExport {
   std::string key;
   std::string gdtfSpec;
   std::string gdtfMode;
@@ -101,6 +101,7 @@ struct FixtureTypeCategoryExport {
   std::string model;
   std::string category;
   std::string categorySource;
+  std::string visualColorHex;
 };
 
 static bool TryParseInt(std::string_view text, int &out);
@@ -114,15 +115,15 @@ static FixtureExportId ResolveFixtureExportId(const Fixture &fixture);
 static std::unordered_map<std::string, int> BuildFixtureUnitNumbersForExport(
     const std::unordered_map<std::string, Fixture> &fixtures);
 static std::string
-BuildFixtureTypeCategoryKey(const Fixture &fixture,
+BuildFixtureTypeInfoKey(const Fixture &fixture,
                                                const std::string &gdtfArchivePath);
 static bool IsManualFixtureCategorySource(const std::string &source);
-static void MergeFixtureTypeCategoryExport(
-    std::map<std::string, FixtureTypeCategoryExport> &metadataByType,
+static void MergeFixtureTypeInfoExport(
+    std::map<std::string, FixtureTypeInfoExport> &metadataByType,
     const Fixture &fixture, const std::string &gdtfArchivePath);
-static void AppendFixtureTypeCategoryMetadata(
+static void AppendFixtureTypeMetadata(
     tinyxml2::XMLDocument &doc, tinyxml2::XMLElement *perastageData,
-    const std::map<std::string, FixtureTypeCategoryExport> &metadataByType);
+    const std::map<std::string, FixtureTypeInfoExport> &metadataByType);
 
 static bool ShouldExportSupportHoistInfo(const Support &support);
 static bool NearlyEqualPhysicalValue(float lhs, float rhs);
@@ -671,7 +672,7 @@ SanitizeArchiveRelativePath(const std::string &input,
 
 // Builds a stable fixture type/profile key for root-level category metadata.
 static std::string
-BuildFixtureTypeCategoryKey(const Fixture &fixture,
+BuildFixtureTypeInfoKey(const Fixture &fixture,
                                                const std::string &gdtfArchivePath) {
   std::ostringstream key;
   key << TrimAscii(gdtfArchivePath) << '|' << TrimAscii(fixture.gdtfMode);
@@ -691,22 +692,22 @@ static bool IsManualFixtureCategorySource(const std::string &source) {
   return ToLowerAscii(TrimAscii(source)) == "manual";
 }
 
-// Merges one fixture's category into the type-level export map
-// deterministically.
-static void MergeFixtureTypeCategoryExport(
-    std::map<std::string, FixtureTypeCategoryExport> &metadataByType,
+// Merges one fixture's shared type metadata into the export map.
+static void MergeFixtureTypeInfoExport(
+    std::map<std::string, FixtureTypeInfoExport> &metadataByType,
     const Fixture &fixture, const std::string &gdtfArchivePath) {
   const std::string category = TrimAscii(fixture.category);
-  if (category.empty())
+  const std::string visualColorHex = TrimAscii(fixture.visualColorHex);
+  if (category.empty() && visualColorHex.empty())
     return;
 
-  const std::string key = BuildFixtureTypeCategoryKey(fixture, gdtfArchivePath);
+  const std::string key = BuildFixtureTypeInfoKey(fixture, gdtfArchivePath);
   if (key.empty())
     return;
 
   const std::string source = TrimAscii(fixture.categorySource);
   auto [it, inserted] = metadataByType.try_emplace(key);
-  FixtureTypeCategoryExport &entry = it->second;
+  FixtureTypeInfoExport &entry = it->second;
   if (inserted) {
     entry.key = key;
     entry.gdtfSpec = TrimAscii(gdtfArchivePath);
@@ -714,6 +715,7 @@ static void MergeFixtureTypeCategoryExport(
     entry.model = TrimAscii(fixture.typeName);
     entry.category = category;
     entry.categorySource = source;
+    entry.visualColorHex = visualColorHex;
     return;
   }
 
@@ -724,12 +726,15 @@ static void MergeFixtureTypeCategoryExport(
     entry.category = category;
     entry.categorySource = source;
   }
+  if (!visualColorHex.empty() &&
+      (entry.visualColorHex.empty() || visualColorHex < entry.visualColorHex))
+    entry.visualColorHex = visualColorHex;
 }
 
-// Appends deduplicated fixture category metadata to root Perastage UserData.
-static void AppendFixtureTypeCategoryMetadata(
+// Appends deduplicated fixture type metadata to root Perastage UserData.
+static void AppendFixtureTypeMetadata(
     tinyxml2::XMLDocument &doc, tinyxml2::XMLElement *perastageData,
-    const std::map<std::string, FixtureTypeCategoryExport> &metadataByType) {
+    const std::map<std::string, FixtureTypeInfoExport> &metadataByType) {
   if (!perastageData || metadataByType.empty())
     return;
 
@@ -746,13 +751,20 @@ static void AppendFixtureTypeCategoryMetadata(
     if (!entry.model.empty())
       info->SetAttribute("model", entry.model.c_str());
 
-    tinyxml2::XMLElement *category = doc.NewElement("Category");
-    category->SetText(entry.category.c_str());
-    info->InsertEndChild(category);
-    if (!entry.categorySource.empty()) {
+    if (!entry.category.empty()) {
+      tinyxml2::XMLElement *category = doc.NewElement("Category");
+      category->SetText(entry.category.c_str());
+      info->InsertEndChild(category);
+    }
+    if (!entry.category.empty() && !entry.categorySource.empty()) {
       tinyxml2::XMLElement *source = doc.NewElement("CategorySource");
       source->SetText(entry.categorySource.c_str());
       info->InsertEndChild(source);
+    }
+    if (!entry.visualColorHex.empty()) {
+      tinyxml2::XMLElement *visualColor = doc.NewElement("VisualColor");
+      visualColor->SetText(entry.visualColorHex.c_str());
+      info->InsertEndChild(visualColor);
     }
     map->InsertEndChild(info);
   }
@@ -2655,7 +2667,7 @@ bool MvrExporter::ExportToFile(const std::string &filePath,
     trussExportUuids[uuid] = exportUuid;
   }
   tinyxml2::XMLElement *trussInfoMap = doc.NewElement("TrussInfoMap");
-  std::map<std::string, FixtureTypeCategoryExport> fixtureTypeCategoryMetadata;
+  std::map<std::string, FixtureTypeInfoExport> fixtureTypeMetadata;
 
   int exportedRealFixtureGdtfCount = 0;
   int exportedDummyFixtureGdtfCount = 0;
@@ -2803,7 +2815,7 @@ bool MvrExporter::ExportToFile(const std::string &filePath,
       fixtureGdtfArchivePath =
           registerGdtfResource(f.uuid, fixtureSourceGdtf, fixtureName);
     }
-    MergeFixtureTypeCategoryExport(fixtureTypeCategoryMetadata, f,
+    MergeFixtureTypeInfoExport(fixtureTypeMetadata, f,
                                    fixtureGdtfArchivePath);
 
     const Matrix fixtureMatrixToWrite =
@@ -3620,11 +3632,11 @@ bool MvrExporter::ExportToFile(const std::string &filePath,
     layersNode->InsertEndChild(defaultLayerElem);
   }
 
-  if (!fixtureTypeCategoryMetadata.empty()) {
+  if (!fixtureTypeMetadata.empty()) {
     tinyxml2::XMLElement *rootPerastageDataForFixtures =
         FindOrCreatePerastageDataNode(doc, root);
-    AppendFixtureTypeCategoryMetadata(doc, rootPerastageDataForFixtures,
-                                      fixtureTypeCategoryMetadata);
+    AppendFixtureTypeMetadata(doc, rootPerastageDataForFixtures,
+                                      fixtureTypeMetadata);
   }
 
   if (trussInfoMap->FirstChild()) {

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -1587,15 +1587,16 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
   };
   parseLayerAppearanceMap(root->FirstChildElement("UserData"));
 
-  struct RootFixtureTypeCategoryInfo {
+  struct RootFixtureTypeInfo {
     std::string category;
     std::string categorySource;
+    std::string visualColorHex;
   };
-  std::unordered_map<std::string, RootFixtureTypeCategoryInfo>
-      rootFixtureCategoryByTypeKey;
+  std::unordered_map<std::string, RootFixtureTypeInfo>
+      rootFixtureTypeInfoByKey;
 
   // Builds the root UserData fixture type key used by Perastage exports.
-  auto buildFixtureTypeCategoryKey = [](const std::string &gdtfSpec,
+  auto buildFixtureTypeInfoKey = [](const std::string &gdtfSpec,
                                         const std::string &gdtfMode,
                                         const std::string &typeName) {
     std::ostringstream key;
@@ -1630,30 +1631,39 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
           std::string key =
               Trim(info->Attribute("key") ? info->Attribute("key") : "");
           if (key.empty()) {
-            key = buildFixtureTypeCategoryKey(
+            key = buildFixtureTypeInfoKey(
                 info->Attribute("gdtfSpec") ? info->Attribute("gdtfSpec") : "",
                 info->Attribute("gdtfMode") ? info->Attribute("gdtfMode") : "",
                 info->Attribute("model") ? info->Attribute("model") : "");
           }
           if (key.empty())
             continue;
-          RootFixtureTypeCategoryInfo categoryInfo;
+          RootFixtureTypeInfo typeInfo;
           if (tinyxml2::XMLElement *category =
                   info->FirstChildElement("Category")) {
             if (const char *txt = category->GetText())
-              categoryInfo.category =
+              typeInfo.category =
                   GdtfFixtureCategory::NormalizeCategory(Trim(txt));
           }
           if (tinyxml2::XMLElement *source =
                   info->FirstChildElement("CategorySource")) {
             if (const char *txt = source->GetText())
-              categoryInfo.categorySource = Trim(txt);
+              typeInfo.categorySource = Trim(txt);
           }
-          if (!categoryInfo.category.empty() &&
-              categoryInfo.categorySource.empty())
-            categoryInfo.categorySource = GdtfFixtureCategory::kManualSource;
-          if (!categoryInfo.category.empty())
-            rootFixtureCategoryByTypeKey[key] = categoryInfo;
+          if (!typeInfo.category.empty() &&
+              typeInfo.categorySource.empty())
+            typeInfo.categorySource = GdtfFixtureCategory::kManualSource;
+          if (tinyxml2::XMLElement *visualColor =
+                  info->FirstChildElement("VisualColor")) {
+            if (const char *txt = visualColor->GetText()) {
+              const std::string value = Trim(txt);
+              if (isHexRgb(value))
+                typeInfo.visualColorHex = value;
+            }
+          }
+          if (!typeInfo.category.empty() ||
+              !typeInfo.visualColorHex.empty())
+            rootFixtureTypeInfoByKey[key] = typeInfo;
         }
       }
     }
@@ -2354,14 +2364,17 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
         fixture.physicalPropertiesDirty = false;
 
         ReadFixtureCategoryFromUserData(node, fixture);
-        const std::string categoryTypeKey = buildFixtureTypeCategoryKey(
+        const std::string fixtureTypeInfoKey = buildFixtureTypeInfoKey(
             rawGdtfSpec, fixture.gdtfMode, fixture.typeName);
-        auto rootCategoryIt =
-            rootFixtureCategoryByTypeKey.find(categoryTypeKey);
-        if (rootCategoryIt != rootFixtureCategoryByTypeKey.end()) {
-          fixture.category = rootCategoryIt->second.category;
-          fixture.categorySource = rootCategoryIt->second.categorySource;
-          fixture.categorySourceReason.clear();
+        auto rootTypeInfoIt =
+            rootFixtureTypeInfoByKey.find(fixtureTypeInfoKey);
+        if (rootTypeInfoIt != rootFixtureTypeInfoByKey.end()) {
+          if (!rootTypeInfoIt->second.category.empty()) {
+            fixture.category = rootTypeInfoIt->second.category;
+            fixture.categorySource = rootTypeInfoIt->second.categorySource;
+            fixture.categorySourceReason.clear();
+          }
+          fixture.visualColorHex = rootTypeInfoIt->second.visualColorHex;
         }
         const std::optional<GdtfDictionary::Entry> &dictionaryEntry =
             getDictionaryEntryCached(fixture.typeName);

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -16,8 +16,8 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "mvrimporter.h"
-#include "filesystem_path_utils.h"
 #include "configmanager.h"
+#include "filesystem_path_utils.h"
 #ifdef PERASTAGE_ENABLE_MVR_GDTF_DOWNLOAD_API
 #include "credentialstore.h"
 #endif
@@ -26,34 +26,33 @@
 #ifdef PERASTAGE_ENABLE_MVR_GDTF_DOWNLOAD_API
 #include "gdtfnet.h"
 #endif
-#include "gdtfloader.h"
-#include "gdtf_catalog_service.h"
-#include "gdtf_import_matching.h"
+#include "fixture_label_overrides.h"
 #include "gdtf_catalog_matcher.h"
+#include "gdtf_catalog_service.h"
 #include "gdtf_fixture_category.h"
+#include "gdtf_import_matching.h"
+#include "gdtfloader.h"
+#include "groupobject.h"
 #include "matrixutils.h"
 #include "primitive_model_resources.h"
 #include "projectutils.h"
 #include "sceneobject.h"
 #include "support.h"
-#include "groupobject.h"
-#include "uuidutils.h"
 #include "trussloader.h"
-#include "fixture_label_overrides.h"
+#include "uuidutils.h"
 
 #include "consolepanel.h"
 #ifdef PERASTAGE_ENABLE_MVR_GDTF_DOWNLOAD_API
 #include "logindialog.h"
 #endif
-#include "logger.h"
 #include "json.hpp"
+#include "logger.h"
 #include <algorithm>
 #include <array>
 #include <atomic>
 #include <cctype>
 #include <cerrno>
 #include <charconv>
-#include <cstdlib>
 #include <chrono>
 #include <cmath>
 #include <cstdio>
@@ -81,9 +80,9 @@
 #include <tinyxml2.h>
 
 // wxWidgets zip support
+#include <wx/listctrl.h>
 #include <wx/wfstream.h>
 #include <wx/wx.h>
-#include <wx/listctrl.h>
 class wxZipStreamLink;
 #include <wx/filename.h>
 #include <wx/stdpaths.h>
@@ -126,7 +125,8 @@ static std::string DecodeLegacyCredentialValue(const std::string &encoded) {
     unsigned int value = 0;
     std::istringstream iss(encoded.substr(i, 2));
     iss >> std::hex >> value;
-    out.push_back(static_cast<char>((static_cast<unsigned char>(value)) ^ kKey));
+    out.push_back(
+        static_cast<char>((static_cast<unsigned char>(value)) ^ kKey));
   }
   return out;
 }
@@ -151,10 +151,10 @@ LoadStoredGdtfShareCredentials() {
   return std::make_pair(username, DecodeLegacyCredentialValue(encodedPassword));
 }
 
-
 static std::string ToLowerCopy(std::string s) {
-  std::transform(s.begin(), s.end(), s.begin(),
-                 [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+  std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) {
+    return static_cast<char>(std::tolower(c));
+  });
   return s;
 }
 
@@ -229,18 +229,20 @@ static bool IsNearlyEqualRelative(float a, float b, float relEps) {
 }
 
 static bool IsGeometryMatrixContext(const std::string &contextTag) {
-  if (contextTag == "SceneObject/Geometry3D" || contextTag == "Truss/Geometry3D" ||
-      contextTag == "Symbol") {
+  if (contextTag == "SceneObject/Geometry3D" ||
+      contextTag == "Truss/Geometry3D" || contextTag == "Symbol") {
     return true;
   }
   return contextTag.find("Geometry3D") != std::string::npos;
 }
 
-static std::string JoinMatrixContextCounts(const std::unordered_map<std::string, size_t> &counts) {
+static std::string
+JoinMatrixContextCounts(const std::unordered_map<std::string, size_t> &counts) {
   if (counts.empty())
     return "none";
 
-  std::vector<std::pair<std::string, size_t>> sorted(counts.begin(), counts.end());
+  std::vector<std::pair<std::string, size_t>> sorted(counts.begin(),
+                                                     counts.end());
   std::sort(sorted.begin(), sorted.end(), [](const auto &lhs, const auto &rhs) {
     if (lhs.second != rhs.second)
       return lhs.second > rhs.second;
@@ -285,9 +287,8 @@ static bool TryParseFloat(const std::string &text, float &out) {
     return false;
 
   const auto first =
-      std::find_if_not(text.begin(), text.end(), [](unsigned char c) {
-        return std::isspace(c);
-      });
+      std::find_if_not(text.begin(), text.end(),
+                       [](unsigned char c) { return std::isspace(c); });
   if (first == text.end())
     return false;
   const auto last =
@@ -327,7 +328,8 @@ static fs::path ResolveSceneRelativePath(const std::string &basePath,
 }
 
 // Compares path components using platform filesystem case-sensitivity rules.
-static bool SameFilesystemPathComponent(const fs::path &lhs, const fs::path &rhs) {
+static bool SameFilesystemPathComponent(const fs::path &lhs,
+                                        const fs::path &rhs) {
 #if defined(_WIN32)
   return ToLowerAscii(lhs.string()) == ToLowerAscii(rhs.string());
 #else
@@ -335,7 +337,8 @@ static bool SameFilesystemPathComponent(const fs::path &lhs, const fs::path &rhs
 #endif
 }
 
-// Returns true when candidate is inside base after both paths have been normalized.
+// Returns true when candidate is inside base after both paths have been
+// normalized.
 static bool IsPathWithinDirectoryByComponents(const fs::path &candidate,
                                               const fs::path &base) {
   auto candidateIt = candidate.begin();
@@ -367,8 +370,10 @@ static fs::path NormalizedAbsolutePathForImport(const fs::path &path,
   return absolute.lexically_normal();
 }
 
-// Converts imported resource paths to scene-relative references only when they stay under scene.basePath.
-static std::string ToSceneRelativePathIfPossible(const std::string &basePath,
+// Converts imported resource paths to scene-relative references only when they
+// stay under scene.basePath.
+static std::string
+ToSceneRelativePathIfPossible(const std::string &basePath,
                                                  const fs::path &candidatePath) {
   if (candidatePath.empty())
     return {};
@@ -411,7 +416,8 @@ static std::string ResolveScenePathForRead(const std::string &basePath,
 
 // Resolves a scene-provided GDTF spec to the real extracted file path.
 // MVR files may omit ".gdtf" in <GDTFSpec> or use a different filename case,
-// so we progressively try exact, extension-appended and case-insensitive matches.
+// so we progressively try exact, extension-appended and case-insensitive
+// matches.
 static std::string ResolveGdtfPath(const std::string &baseDir,
                                    const std::string &spec) {
   const std::string normalizedSpec = NormalizeArchivePathValue(spec);
@@ -420,7 +426,8 @@ static std::string ResolveGdtfPath(const std::string &baseDir,
 
   fs::path candidate = baseDir.empty()
                            ? PathUtils::PathFromUtf8(normalizedSpec)
-                           : PathUtils::PathFromUtf8(baseDir) / PathUtils::PathFromUtf8(normalizedSpec);
+                           : PathUtils::PathFromUtf8(baseDir) /
+                                 PathUtils::PathFromUtf8(normalizedSpec);
 
   std::error_code ec;
   const std::string candidateExt = ToLowerAscii(candidate.extension().string());
@@ -437,7 +444,8 @@ static std::string ResolveGdtfPath(const std::string &baseDir,
   }
 
 #if defined(_WIN32)
-  // Restricts fallback directory scans to the extracted MVR base directory on Windows.
+  // Restricts fallback directory scans to the extracted MVR base directory on
+  // Windows.
   if (baseDir.empty())
     return {};
   fs::path lookupDir = PathUtils::PathFromUtf8(baseDir);
@@ -448,8 +456,8 @@ static std::string ResolveGdtfPath(const std::string &baseDir,
   if (ec || !fs::exists(lookupDir, ec) || ec)
     return {};
 
-  const std::string expectedStem =
-      ToLowerAscii(Trim(PathUtils::PathFromUtf8(normalizedSpec).filename().stem().string()));
+  const std::string expectedStem = ToLowerAscii(
+      Trim(PathUtils::PathFromUtf8(normalizedSpec).filename().stem().string()));
   const std::string normalizedSpecKey = NormalizeGdtfLookupKey(normalizedSpec);
   for (const auto &entry : fs::directory_iterator(lookupDir, ec)) {
     if (ec)
@@ -467,7 +475,8 @@ static std::string ResolveGdtfPath(const std::string &baseDir,
     // Last fallback: compare normalized names ignoring case and extra blanks
     // before extension.
     if (!normalizedSpecKey.empty() &&
-        NormalizeGdtfLookupKey(entryPath.filename().generic_string()) == normalizedSpecKey) {
+        NormalizeGdtfLookupKey(entryPath.filename().generic_string()) ==
+            normalizedSpecKey) {
       return ToString(entryPath.u8string());
     }
   }
@@ -484,8 +493,8 @@ static std::string DescribeTrussForLog(const Truss &truss) {
   return oss.str();
 }
 
-static Truss::GeometryRepresentation ParseTrussRepresentation(
-    const std::string &value) {
+static Truss::GeometryRepresentation
+ParseTrussRepresentation(const std::string &value) {
   const std::string lower = ToLowerCopy(Trim(value));
   if (lower == "symbolsymdef")
     return Truss::GeometryRepresentation::SymbolSymdef;
@@ -512,8 +521,7 @@ static std::string CieToHex(const std::string &cie) {
   double b = 0.0557 * X - 0.2040 * Yv + 1.0570 * Z;
   auto gamma = [](double c) {
     c = std::max(0.0, c);
-    return c <= 0.0031308 ? 12.92 * c
-                          : 1.055 * std::pow(c, 1.0 / 2.4) - 0.055;
+    return c <= 0.0031308 ? 12.92 * c : 1.055 * std::pow(c, 1.0 / 2.4) - 0.055;
   };
   r = gamma(r);
   g = gamma(g);
@@ -525,8 +533,8 @@ static std::string CieToHex(const std::string &cie) {
   int G = static_cast<int>(std::round(g * 255.0));
   int B = static_cast<int>(std::round(b * 255.0));
   std::ostringstream os;
-  os << '#' << std::uppercase << std::hex << std::setfill('0')
-     << std::setw(2) << R << std::setw(2) << G << std::setw(2) << B;
+  os << '#' << std::uppercase << std::hex << std::setfill('0') << std::setw(2)
+     << R << std::setw(2) << G << std::setw(2) << B;
   return os.str();
 }
 
@@ -560,8 +568,7 @@ static void LogMessage(Logger::Level level, const std::string &msg) {
     const std::string suffix = "... (truncated)";
     std::string panelMsg = msg;
     if (panelMsg.size() > kMaxConsoleMessageLength) {
-      size_t keepLength =
-          kMaxConsoleMessageLength > suffix.size()
+      size_t keepLength = kMaxConsoleMessageLength > suffix.size()
               ? kMaxConsoleMessageLength - suffix.size()
               : 0;
       panelMsg = panelMsg.substr(0, keepLength) + suffix;
@@ -612,8 +619,7 @@ PromptGdtfConflicts(const std::vector<GdtfConflict> &conflicts) {
   wxDialog dlg(nullptr, wxID_ANY, "Resolve GDTF source conflicts");
   wxBoxSizer *topSizer = new wxBoxSizer(wxVERTICAL);
   wxStaticText *subtitle = new wxStaticText(
-      &dlg, wxID_ANY,
-      "Choose which source to keep for each fixture type.");
+      &dlg, wxID_ANY, "Choose which source to keep for each fixture type.");
   subtitle->SetForegroundColour(wxColour(145, 145, 145));
   topSizer->Add(subtitle, 0, wxLEFT | wxRIGHT | wxTOP, 10);
 
@@ -638,7 +644,8 @@ PromptGdtfConflicts(const std::vector<GdtfConflict> &conflicts) {
 
   wxButton *selectAllMvrButton = new wxButton(&dlg, wxID_ANY, "Select all");
   wxButton *selectAllAppButton = new wxButton(&dlg, wxID_ANY, "Select all");
-  wxButton *selectAllDownloadButton = new wxButton(&dlg, wxID_ANY, "Select all");
+  wxButton *selectAllDownloadButton =
+      new wxButton(&dlg, wxID_ANY, "Select all");
   grid->Add(new wxStaticText(&dlg, wxID_ANY, wxEmptyString));
   grid->Add(selectAllMvrButton, 0, wxALIGN_CENTER_HORIZONTAL);
   grid->Add(selectAllAppButton, 0, wxALIGN_CENTER_HORIZONTAL);
@@ -677,10 +684,9 @@ PromptGdtfConflicts(const std::vector<GdtfConflict> &conflicts) {
                              }
                              selectAll(existing);
                            });
-  selectAllMvrButton->Bind(wxEVT_BUTTON,
-                           [&mvrBtns, &selectAll](wxCommandEvent &) {
-                             selectAll(mvrBtns);
-                           });
+  selectAllMvrButton->Bind(
+      wxEVT_BUTTON,
+      [&mvrBtns, &selectAll](wxCommandEvent &) { selectAll(mvrBtns); });
   selectAllDownloadButton->Bind(wxEVT_BUTTON,
                                 [&downloadBtns, &selectAll](wxCommandEvent &) {
                                   selectAll(downloadBtns);
@@ -711,7 +717,8 @@ PromptGdtfConflicts(const std::vector<GdtfConflict> &conflicts) {
   return chosen;
 }
 
-// Returns the preferred fallback GDTF path for download conflicts, prioritizing app fixtures over MVR fixtures.
+// Returns the preferred fallback GDTF path for download conflicts, prioritizing
+// app fixtures over MVR fixtures.
 static std::string GetDownloadFallbackPath(const GdtfConflict &conflict) {
   return !conflict.appPath.empty() ? conflict.appPath : conflict.mvrPath;
 }
@@ -804,8 +811,8 @@ ParseGdtfCatalogEntries(const std::string &listData) {
         gdtf_catalog_matcher::GdtfCatalogModeCandidate parsed;
         if (mode.is_object()) {
           parsed.name = jsonToString(mode.value("name", json{}));
-          parsed.footprint =
-              static_cast<int>(jsonToLongLong(mode.value("dmxFootprint", json{})));
+          parsed.footprint = static_cast<int>(
+              jsonToLongLong(mode.value("dmxFootprint", json{})));
         }
         if (!parsed.name.empty() || parsed.footprint > 0)
           modes.push_back(std::move(parsed));
@@ -830,10 +837,10 @@ ParseGdtfCatalogEntries(const std::string &listData) {
   return entries;
 }
 
-
 static void ApplySupportHoistInfoDefaults(Support &support) {
   if (support.dummyProfileId.empty() && !support.dummyPreset.empty()) {
-    const auto profile = DummyProfileLibrary::FindByDisplayName(support.dummyPreset);
+    const auto profile =
+        DummyProfileLibrary::FindByDisplayName(support.dummyPreset);
     if (profile.has_value())
       support.dummyProfileId = profile->id;
   }
@@ -841,16 +848,16 @@ static void ApplySupportHoistInfoDefaults(Support &support) {
   support.hoistFunction = NormalizeHoistFunction(
       support.hoistFunction.empty() ? support.function : support.hoistFunction);
   support.hoistDataSource = NormalizeHoistDataSource(support.hoistDataSource);
-  support.motorNameSource =
-      ResolveHoistFieldDataSource(support.motorNameSource, support.hoistDataSource);
+  support.motorNameSource = ResolveHoistFieldDataSource(
+      support.motorNameSource, support.hoistDataSource);
   support.motorManufacturerSource = ResolveHoistFieldDataSource(
       support.motorManufacturerSource, support.hoistDataSource);
-  support.motorModelSource =
-      ResolveHoistFieldDataSource(support.motorModelSource, support.hoistDataSource);
-  support.capacitySource =
-      ResolveHoistFieldDataSource(support.capacitySource, support.hoistDataSource);
-  support.weightSource =
-      ResolveHoistFieldDataSource(support.weightSource, support.hoistDataSource);
+  support.motorModelSource = ResolveHoistFieldDataSource(
+      support.motorModelSource, support.hoistDataSource);
+  support.capacitySource = ResolveHoistFieldDataSource(support.capacitySource,
+                                                       support.hoistDataSource);
+  support.weightSource = ResolveHoistFieldDataSource(support.weightSource,
+                                                     support.hoistDataSource);
   support.hoistFunctionSource = ResolveHoistFieldDataSource(
       support.hoistFunctionSource, support.hoistDataSource);
   if (support.function.empty())
@@ -873,16 +880,19 @@ static void ReadFixtureCategoryFromUserData(tinyxml2::XMLElement *fixtureNode,
     if (!info)
       continue;
 
-    if (tinyxml2::XMLElement *categoryNode = info->FirstChildElement("Category")) {
+    if (tinyxml2::XMLElement *categoryNode =
+            info->FirstChildElement("Category")) {
       if (const char *txt = categoryNode->GetText())
         fixture.category = GdtfFixtureCategory::NormalizeCategory(Trim(txt));
     }
 
-    if (tinyxml2::XMLElement *sourceNode = info->FirstChildElement("CategorySource")) {
+    if (tinyxml2::XMLElement *sourceNode =
+            info->FirstChildElement("CategorySource")) {
       if (const char *txt = sourceNode->GetText())
         fixture.categorySource = Trim(txt);
     }
-    if (tinyxml2::XMLElement *reasonNode = info->FirstChildElement("CategoryReason")) {
+    if (tinyxml2::XMLElement *reasonNode =
+            info->FirstChildElement("CategoryReason")) {
       if (const char *txt = reasonNode->GetText())
         fixture.categorySourceReason = Trim(txt);
     }
@@ -901,8 +911,8 @@ struct LegacyFixtureIdentity {
 };
 
 // Reads legacy Perastage fixture identity fields used by older MVR exports.
-static LegacyFixtureIdentity ReadLegacyFixtureIdentityFromUserData(
-    tinyxml2::XMLElement *fixtureNode) {
+static LegacyFixtureIdentity
+ReadLegacyFixtureIdentityFromUserData(tinyxml2::XMLElement *fixtureNode) {
   LegacyFixtureIdentity identity;
   if (!fixtureNode)
     return identity;
@@ -934,8 +944,8 @@ static LegacyFixtureIdentity ReadLegacyFixtureIdentityFromUserData(
 
 static void ReadSupportHoistInfoFromUserData(tinyxml2::XMLElement *supportNode,
                                              Support &support) {
-  for (tinyxml2::XMLElement *ud = supportNode->FirstChildElement("UserData"); ud;
-       ud = ud->NextSiblingElement("UserData")) {
+  for (tinyxml2::XMLElement *ud = supportNode->FirstChildElement("UserData");
+       ud; ud = ud->NextSiblingElement("UserData")) {
     for (tinyxml2::XMLElement *data = ud->FirstChildElement("Data"); data;
          data = data->NextSiblingElement("Data")) {
       tinyxml2::XMLElement *info = data->FirstChildElement("HoistInfo");
@@ -965,7 +975,8 @@ static void ReadSupportHoistInfoFromUserData(tinyxml2::XMLElement *supportNode,
       readFloat("Weight", support.weightKg);
       readFloat("Load", support.loadKg);
 
-      std::string hoistFunction = readText("RiggingPoint"); // Canonical in new schema.
+      std::string hoistFunction =
+          readText("RiggingPoint"); // Canonical in new schema.
       if (hoistFunction.empty())
         hoistFunction = readText("Function");
       if (!hoistFunction.empty())
@@ -986,8 +997,8 @@ static void ReadSupportHoistInfoFromUserData(tinyxml2::XMLElement *supportNode,
 
       const std::string useDefaults = ToLowerCopy(readText("UseMotorDefaults"));
       if (!useDefaults.empty()) {
-        support.useMotorDefaults =
-            !(useDefaults == "false" || useDefaults == "0" || useDefaults == "no");
+        support.useMotorDefaults = !(useDefaults == "false" ||
+                                     useDefaults == "0" || useDefaults == "no");
       }
 
       const std::string dummyPreset = readText("DummyPreset");
@@ -1038,28 +1049,29 @@ static void ReadSupportHoistInfoFromUserData(tinyxml2::XMLElement *supportNode,
 }
 // Imports an MVR file into the global application scene.
 bool MvrImporter::ImportFromFile(const std::string &filePath,
-                                 bool promptConflicts,
-                                 bool applyDictionary,
+                                 bool promptConflicts, bool applyDictionary,
                                  ProgressCallback progressCallback) {
   MvrImportResult importResult;
   return ImportFromFile(filePath, importResult, MvrImportMode::ReplaceProject,
                         promptConflicts, applyDictionary, progressCallback);
 }
 
-// Imports an MVR file into an import result and optionally replaces the global project.
+// Imports an MVR file into an import result and optionally replaces the global
+// project.
 bool MvrImporter::ImportFromFile(const std::string &filePath,
                                  MvrImportResult &importResult,
-                                 MvrImportMode mode,
-                                 bool promptConflicts,
+                                 MvrImportMode mode, bool promptConflicts,
                                  bool applyDictionary,
                                  ProgressCallback progressCallback) {
   MvrImportOptions options;
   options.promptConflicts = promptConflicts;
   options.applyDictionary = applyDictionary;
-  return ImportFromFile(filePath, importResult, mode, options, progressCallback);
+  return ImportFromFile(filePath, importResult, mode, options,
+                        progressCallback);
 }
 
-// Imports an MVR file into an import result using explicit import behavior options.
+// Imports an MVR file into an import result using explicit import behavior
+// options.
 bool MvrImporter::ImportFromFile(const std::string &filePath,
                                  MvrImportResult &importResult,
                                  MvrImportMode mode,
@@ -1069,7 +1081,8 @@ bool MvrImporter::ImportFromFile(const std::string &filePath,
                                   progressCallback);
 }
 
-// Imports an MVR file into the provided scene without resetting global configuration.
+// Imports an MVR file into the provided scene without resetting global
+// configuration.
 bool MvrImporter::ImportSceneFromFile(const std::string &filePath,
                                       MvrScene &targetScene,
                                       bool promptConflicts,
@@ -1081,14 +1094,16 @@ bool MvrImporter::ImportSceneFromFile(const std::string &filePath,
   return ImportSceneFromFile(filePath, targetScene, options, progressCallback);
 }
 
-// Imports an MVR file into the provided scene using explicit import behavior options.
+// Imports an MVR file into the provided scene using explicit import behavior
+// options.
 bool MvrImporter::ImportSceneFromFile(const std::string &filePath,
                                       MvrScene &targetScene,
                                       const MvrImportOptions &options,
                                       ProgressCallback progressCallback) {
   MvrImportResult importResult;
-  const bool imported = ImportFromFile(
-      filePath, importResult, MvrImportMode::ParseOnly, options, progressCallback);
+  const bool imported =
+      ImportFromFile(filePath, importResult, MvrImportMode::ParseOnly, options,
+                     progressCallback);
   if (!imported)
     return false;
 
@@ -1097,13 +1112,15 @@ bool MvrImporter::ImportSceneFromFile(const std::string &filePath,
   return true;
 }
 
-// Extracts an MVR package and parses its scene data into an import result payload.
+// Extracts an MVR package and parses its scene data into an import result
+// payload.
 bool MvrImporter::ImportFromFileIntoResult(const std::string &filePath,
                                            MvrImportResult &importResult,
                                            MvrImportMode mode,
                                            const MvrImportOptions &options,
                                            ProgressCallback progressCallback) {
-  auto reportProgress = [&](std::string stage, int completed = 0, int total = 0) {
+  auto reportProgress = [&](std::string stage, int completed = 0,
+                            int total = 0) {
     if (!progressCallback)
       return;
     progressCallback(ProgressState{std::move(stage), completed, total});
@@ -1172,10 +1189,10 @@ bool MvrImporter::ImportFromFileIntoResult(const std::string &filePath,
       ++extractedGdtfEntryCount;
     }
   }
-  LogMessage(Logger::Level::Info,
-             "MVR extraction diagnostics: basePath='" +
-                 ToString(tempPath.u8string()) + "', extractedGdtfEntries=" +
-                 std::to_string(extractedGdtfEntryCount));
+  LogMessage(
+      Logger::Level::Info,
+      "MVR extraction diagnostics: basePath='" + ToString(tempPath.u8string()) +
+          "', extractedGdtfEntries=" + std::to_string(extractedGdtfEntryCount));
 
   fs::path sceneFile = tempPath / "GeneralSceneDescription.xml";
   std::error_code sceneFileEc;
@@ -1207,8 +1224,8 @@ bool MvrImporter::ImportFromFileIntoResult(const std::string &filePath,
 
   std::string scenePath = ToString(sceneFile.u8string());
   reportProgress("Parsing scene data...");
-  const bool parsed = ParseSceneXml(scenePath, importResult, options,
-                                    progressCallback);
+  const bool parsed =
+      ParseSceneXml(scenePath, importResult, options, progressCallback);
   if (!parsed)
     return false;
 
@@ -1222,12 +1239,14 @@ bool MvrImporter::ImportFromFileIntoResult(const std::string &filePath,
 }
 
 // Normalizes an MVR archive path so extracted resources can be found reliably.
-std::string MvrImporter::NormalizeArchivePath(const std::string &archivePath) const {
+std::string
+MvrImporter::NormalizeArchivePath(const std::string &archivePath) const {
   return NormalizeArchivePathValue(archivePath);
 }
 
 // Returns a remapped extraction path for long archive entries when one exists.
-std::string MvrImporter::RemapArchivePathIfNeeded(const std::string &archivePath) const {
+std::string
+MvrImporter::RemapArchivePathIfNeeded(const std::string &archivePath) const {
   const std::string normalized = NormalizeArchivePath(archivePath);
   auto it = pathRemap.find(normalized);
   if (it != pathRemap.end())
@@ -1243,12 +1262,16 @@ std::string MvrImporter::CreateTemporaryDirectory() {
     std::error_code ec;
     if (fs::create_directory(fullPath, ec) && !ec) {
       // Return the path encoded as UTF-8 so it can safely be converted back
-      // using PathUtils::PathFromUtf8 or passed to wxWidgets APIs expecting UTF-8 strings.
+      // using PathUtils::PathFromUtf8 or passed to wxWidgets APIs expecting
+      // UTF-8 strings.
       return ToString(fullPath.u8string());
     }
   }
 
-  fs::path fallback = tempBase / ("ps_" + std::to_string(
+  fs::path fallback =
+      tempBase /
+      ("ps_" +
+       std::to_string(
                                       std::chrono::system_clock::now().time_since_epoch().count()));
   fs::create_directory(fallback);
   return ToString(fallback.u8string());
@@ -1269,7 +1292,8 @@ bool MvrImporter::ExtractMvrZip(const std::string &mvrPath,
   while ((entry.reset(zipStream.GetNextEntry())), entry) {
     // Extract entry names using UTF-8 to preserve special characters
     std::string entryName = entry->GetName().ToUTF8().data();
-    fs::path fullPath = PathUtils::PathFromUtf8(destDir) / PathUtils::PathFromUtf8(entryName);
+    fs::path fullPath =
+        PathUtils::PathFromUtf8(destDir) / PathUtils::PathFromUtf8(entryName);
 
     if (entry->IsDir()) {
       std::string dirUtf8 = ToString(fullPath.u8string());
@@ -1296,9 +1320,12 @@ bool MvrImporter::ExtractMvrZip(const std::string &mvrPath,
 
     if (!output.is_open()) {
       fs::path longDir = PathUtils::PathFromUtf8(destDir) / "_long";
-      std::string extension = PathUtils::PathFromUtf8(entryName).extension().string();
-      std::string hashBase = std::to_string(std::hash<std::string>{}(normalizedEntryName));
-      wxFileName::Mkdir(wxString::FromUTF8(ToString(longDir.u8string()).c_str()),
+      std::string extension =
+          PathUtils::PathFromUtf8(entryName).extension().string();
+      std::string hashBase =
+          std::to_string(std::hash<std::string>{}(normalizedEntryName));
+      wxFileName::Mkdir(
+          wxString::FromUTF8(ToString(longDir.u8string()).c_str()),
                         wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
 
       for (int suffix = 0; suffix < 64 && !output.is_open(); ++suffix) {
@@ -1306,12 +1333,13 @@ bool MvrImporter::ExtractMvrZip(const std::string &mvrPath,
         if (suffix > 0)
           candidateName += "_" + std::to_string(suffix);
         candidateName += extension;
-        fs::path candidatePath = longDir / PathUtils::PathFromUtf8(candidateName);
+        fs::path candidatePath =
+            longDir / PathUtils::PathFromUtf8(candidateName);
         output = tryOpenOutput(candidatePath);
         if (output.is_open()) {
           fullPath = candidatePath;
-          pathRemap[normalizedEntryName] = ToString((fs::path("_long") /
-                                                     PathUtils::PathFromUtf8(candidateName))
+          pathRemap[normalizedEntryName] = ToString(
+              (fs::path("_long") / PathUtils::PathFromUtf8(candidateName))
                                                         .u8string());
           remapped = true;
         }
@@ -1320,8 +1348,8 @@ bool MvrImporter::ExtractMvrZip(const std::string &mvrPath,
 
     if (!output.is_open()) {
       std::ostringstream msg;
-      msg << "Cannot create file while extracting MVR entry. entry='" << entryName
-          << "', path='" << ToString(fullPath.u8string())
+      msg << "Cannot create file while extracting MVR entry. entry='"
+          << entryName << "', path='" << ToString(fullPath.u8string())
           << "', pathLength=" << fullPathLength;
       const std::string loweredEntry = ToLowerAscii(normalizedEntryName);
       const bool isSceneXml =
@@ -1329,13 +1357,13 @@ bool MvrImporter::ExtractMvrZip(const std::string &mvrPath,
           fs::path(loweredEntry).filename().generic_string() ==
               "generalscenedescription.xml";
       if (isSceneXml) {
-        LogMessage(Logger::Level::Error, msg.str() +
-                                           " (required scene XML; aborting import)");
+        LogMessage(Logger::Level::Error,
+                   msg.str() + " (required scene XML; aborting import)");
         return false;
       }
 
-      LogMessage(Logger::Level::Warn, msg.str() +
-                                       " (asset entry skipped, continuing import)");
+      LogMessage(Logger::Level::Warn,
+                 msg.str() + " (asset entry skipped, continuing import)");
       char discardBuffer[4096];
       while (true) {
         zipStream.Read(discardBuffer, sizeof(discardBuffer));
@@ -1369,12 +1397,14 @@ bool MvrImporter::ExtractMvrZip(const std::string &mvrPath,
   return true;
 }
 
-// Parses GeneralSceneDescription.xml and populates the import result scene payload.
+// Parses GeneralSceneDescription.xml and populates the import result scene
+// payload.
 bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                                 MvrImportResult &importResult,
                                 const MvrImportOptions &options,
                                 ProgressCallback progressCallback) {
-  auto reportProgress = [&](std::string stage, int completed = 0, int total = 0) {
+  auto reportProgress = [&](std::string stage, int completed = 0,
+                            int total = 0) {
     if (!progressCallback)
       return;
     progressCallback(ProgressState{std::move(stage), completed, total});
@@ -1395,14 +1425,14 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
 
   MvrScene &scene = importResult.scene;
   scene.Clear();
-  scene.basePath = ToString(PathUtils::PathFromUtf8(sceneXmlPath).parent_path().u8string());
-  LogMessage(Logger::Level::Info,
+  scene.basePath =
+      ToString(PathUtils::PathFromUtf8(sceneXmlPath).parent_path().u8string());
+  LogMessage(
+      Logger::Level::Info,
              std::string("MVR import mode: source=") +
                  DescribeMvrImportSourceKind(options.sourceKind) +
-                 ", promptConflicts=" +
-                 (options.promptConflicts ? "true" : "false") +
-                 ", applyDictionary=" +
-                 (options.applyDictionary ? "true" : "false") +
+          ", promptConflicts=" + (options.promptConflicts ? "true" : "false") +
+          ", applyDictionary=" + (options.applyDictionary ? "true" : "false") +
                  ", basePath='" + scene.basePath + "'.");
 
   root->QueryIntAttribute("verMajor", &scene.versionMajor);
@@ -1449,8 +1479,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
       out = std::atoi(n->GetText());
   };
 
-  auto fixtureIdOf = [&](tinyxml2::XMLElement *parent,
-                         std::string &textOut,
+  auto fixtureIdOf = [&](tinyxml2::XMLElement *parent, std::string &textOut,
                          int &numericOut) {
     textOut = textOf(parent, "FixtureID");
     intOf(parent, "FixtureIDNumeric", numericOut);
@@ -1465,44 +1494,49 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
     if (!userDataNode)
       return false;
     bool found = false;
-    for (tinyxml2::XMLElement *data = userDataNode->FirstChildElement("Data"); data;
-         data = data->NextSiblingElement("Data")) {
+    for (tinyxml2::XMLElement *data = userDataNode->FirstChildElement("Data");
+         data; data = data->NextSiblingElement("Data")) {
       const std::string provider = ToLowerCopy(
           Trim(data->Attribute("provider") ? data->Attribute("provider") : ""));
       if (provider != "perastage")
         continue;
-      if (tinyxml2::XMLElement *manifest = data->FirstChildElement("TrussSidecarManifest")) {
+      if (tinyxml2::XMLElement *manifest =
+              data->FirstChildElement("TrussSidecarManifest")) {
         found = true;
-        for (tinyxml2::XMLElement *type = manifest->FirstChildElement("Type"); type;
-             type = type->NextSiblingElement("Type")) {
+        for (tinyxml2::XMLElement *type = manifest->FirstChildElement("Type");
+             type; type = type->NextSiblingElement("Type")) {
           const char *key = type->Attribute("key");
           const char *path = type->Attribute("gdtf");
           if (key && path)
             perastageTypeToGdtfPath[Trim(key)] = RemapArchivePathIfNeeded(path);
         }
-        for (tinyxml2::XMLElement *inst = manifest->FirstChildElement("Instance"); inst;
-             inst = inst->NextSiblingElement("Instance")) {
+        for (tinyxml2::XMLElement *inst =
+                 manifest->FirstChildElement("Instance");
+             inst; inst = inst->NextSiblingElement("Instance")) {
           const char *uuid = inst->Attribute("uuid");
           const char *key = inst->Attribute("typeKey");
           if (uuid && key)
-            perastageInstanceToTypeKey[CanonicalizeUuid(Trim(uuid))] = Trim(key);
+            perastageInstanceToTypeKey[CanonicalizeUuid(Trim(uuid))] =
+                Trim(key);
         }
       }
     }
     if (found) {
-      LogMessage(Logger::Level::Info,
+      LogMessage(
+          Logger::Level::Info,
                  std::string("MVR import loaded Perastage sidecar manifest from ") +
                      originLabel);
     }
     return found;
   };
 
-  const bool hasRootManifest =
-      parsePerastageManifest(root->FirstChildElement("UserData"), "GeneralSceneDescription/UserData");
+  const bool hasRootManifest = parsePerastageManifest(
+      root->FirstChildElement("UserData"), "GeneralSceneDescription/UserData");
   if (!hasRootManifest &&
-      parsePerastageManifest(sceneNode->FirstChildElement("UserData"), "legacy Scene/UserData")) {
-    LogMessage(Logger::Level::Warn,
-               "MVR import used legacy Scene/UserData fallback for Perastage sidecar manifest");
+      parsePerastageManifest(sceneNode->FirstChildElement("UserData"),
+                             "legacy Scene/UserData")) {
+    LogMessage(Logger::Level::Warn, "MVR import used legacy Scene/UserData "
+                                    "fallback for Perastage sidecar manifest");
   }
 
   std::unordered_map<std::string, std::string> layerColorByUuid;
@@ -1510,28 +1544,28 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
   auto isHexRgb = [](const std::string &color) {
     if (color.size() != 7 || color[0] != '#')
       return false;
-    return std::all_of(color.begin() + 1, color.end(), [](unsigned char ch) {
-      return std::isxdigit(ch) != 0;
-    });
+    return std::all_of(color.begin() + 1, color.end(),
+                       [](unsigned char ch) { return std::isxdigit(ch) != 0; });
   };
   auto parseLayerAppearanceMap = [&](tinyxml2::XMLElement *userDataNode) {
     if (!userDataNode)
       return;
-    for (tinyxml2::XMLElement *data = userDataNode->FirstChildElement("Data"); data;
-         data = data->NextSiblingElement("Data")) {
+    for (tinyxml2::XMLElement *data = userDataNode->FirstChildElement("Data");
+         data; data = data->NextSiblingElement("Data")) {
       const std::string provider = ToLowerCopy(
           Trim(data->Attribute("provider") ? data->Attribute("provider") : ""));
       if (provider != "perastage")
         continue;
-      for (tinyxml2::XMLElement *map = data->FirstChildElement("LayerAppearanceMap"); map;
-           map = map->NextSiblingElement("LayerAppearanceMap")) {
+      for (tinyxml2::XMLElement *map =
+               data->FirstChildElement("LayerAppearanceMap");
+           map; map = map->NextSiblingElement("LayerAppearanceMap")) {
         auto parseAppearanceEntry = [&](tinyxml2::XMLElement *entry) {
           const std::string color =
               Trim(entry->Attribute("color") ? entry->Attribute("color") : "");
           if (!isHexRgb(color))
             return;
-          const std::string uuid =
-              CanonicalizeUuid(Trim(entry->Attribute("uuid") ? entry->Attribute("uuid") : ""));
+          const std::string uuid = CanonicalizeUuid(
+              Trim(entry->Attribute("uuid") ? entry->Attribute("uuid") : ""));
           const std::string name =
               Trim(entry->Attribute("name") ? entry->Attribute("name") : "");
           if (!uuid.empty())
@@ -1540,23 +1574,25 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
             layerColorByName[name] = color;
         };
 
-        for (tinyxml2::XMLElement *entry = map->FirstChildElement("PerastageLayerAppearance");
-             entry; entry = entry->NextSiblingElement("PerastageLayerAppearance"))
+        for (tinyxml2::XMLElement *entry =
+                 map->FirstChildElement("PerastageLayerAppearance");
+             entry;
+             entry = entry->NextSiblingElement("PerastageLayerAppearance"))
           parseAppearanceEntry(entry);
-        for (tinyxml2::XMLElement *entry = map->FirstChildElement("Layer"); entry;
-             entry = entry->NextSiblingElement("Layer"))
+        for (tinyxml2::XMLElement *entry = map->FirstChildElement("Layer");
+             entry; entry = entry->NextSiblingElement("Layer"))
           parseAppearanceEntry(entry);
       }
     }
   };
   parseLayerAppearanceMap(root->FirstChildElement("UserData"));
 
-
   struct RootFixtureTypeCategoryInfo {
     std::string category;
     std::string categorySource;
   };
-  std::unordered_map<std::string, RootFixtureTypeCategoryInfo> rootFixtureCategoryByTypeKey;
+  std::unordered_map<std::string, RootFixtureTypeCategoryInfo>
+      rootFixtureCategoryByTypeKey;
 
   // Builds the root UserData fixture type key used by Perastage exports.
   auto buildFixtureTypeCategoryKey = [](const std::string &gdtfSpec,
@@ -1579,17 +1615,20 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
   auto parseRootFixtureTypeInfoMap = [&](tinyxml2::XMLElement *userDataNode) {
     if (!userDataNode)
       return;
-    for (tinyxml2::XMLElement *data = userDataNode->FirstChildElement("Data"); data;
-         data = data->NextSiblingElement("Data")) {
+    for (tinyxml2::XMLElement *data = userDataNode->FirstChildElement("Data");
+         data; data = data->NextSiblingElement("Data")) {
       const std::string provider = ToLowerCopy(
           Trim(data->Attribute("provider") ? data->Attribute("provider") : ""));
       if (provider != "perastage")
         continue;
-      for (tinyxml2::XMLElement *map = data->FirstChildElement("FixtureTypeInfoMap"); map;
-           map = map->NextSiblingElement("FixtureTypeInfoMap")) {
-        for (tinyxml2::XMLElement *info = map->FirstChildElement("FixtureTypeInfo"); info;
-             info = info->NextSiblingElement("FixtureTypeInfo")) {
-          std::string key = Trim(info->Attribute("key") ? info->Attribute("key") : "");
+      for (tinyxml2::XMLElement *map =
+               data->FirstChildElement("FixtureTypeInfoMap");
+           map; map = map->NextSiblingElement("FixtureTypeInfoMap")) {
+        for (tinyxml2::XMLElement *info =
+                 map->FirstChildElement("FixtureTypeInfo");
+             info; info = info->NextSiblingElement("FixtureTypeInfo")) {
+          std::string key =
+              Trim(info->Attribute("key") ? info->Attribute("key") : "");
           if (key.empty()) {
             key = buildFixtureTypeCategoryKey(
                 info->Attribute("gdtfSpec") ? info->Attribute("gdtfSpec") : "",
@@ -1599,15 +1638,19 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
           if (key.empty())
             continue;
           RootFixtureTypeCategoryInfo categoryInfo;
-          if (tinyxml2::XMLElement *category = info->FirstChildElement("Category")) {
+          if (tinyxml2::XMLElement *category =
+                  info->FirstChildElement("Category")) {
             if (const char *txt = category->GetText())
-              categoryInfo.category = GdtfFixtureCategory::NormalizeCategory(Trim(txt));
+              categoryInfo.category =
+                  GdtfFixtureCategory::NormalizeCategory(Trim(txt));
           }
-          if (tinyxml2::XMLElement *source = info->FirstChildElement("CategorySource")) {
+          if (tinyxml2::XMLElement *source =
+                  info->FirstChildElement("CategorySource")) {
             if (const char *txt = source->GetText())
               categoryInfo.categorySource = Trim(txt);
           }
-          if (!categoryInfo.category.empty() && categoryInfo.categorySource.empty())
+          if (!categoryInfo.category.empty() &&
+              categoryInfo.categorySource.empty())
             categoryInfo.categorySource = GdtfFixtureCategory::kManualSource;
           if (!categoryInfo.category.empty())
             rootFixtureCategoryByTypeKey[key] = categoryInfo;
@@ -1622,16 +1665,16 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
   auto parseRootTrussInfoMap = [&](tinyxml2::XMLElement *userDataNode) {
     if (!userDataNode)
       return;
-    for (tinyxml2::XMLElement *data = userDataNode->FirstChildElement("Data"); data;
-         data = data->NextSiblingElement("Data")) {
+    for (tinyxml2::XMLElement *data = userDataNode->FirstChildElement("Data");
+         data; data = data->NextSiblingElement("Data")) {
       const std::string provider = ToLowerCopy(
           Trim(data->Attribute("provider") ? data->Attribute("provider") : ""));
       if (provider != "perastage")
         continue;
-      for (tinyxml2::XMLElement *map = data->FirstChildElement("TrussInfoMap"); map;
-           map = map->NextSiblingElement("TrussInfoMap")) {
-        for (tinyxml2::XMLElement *info = map->FirstChildElement("TrussInfo"); info;
-             info = info->NextSiblingElement("TrussInfo")) {
+      for (tinyxml2::XMLElement *map = data->FirstChildElement("TrussInfoMap");
+           map; map = map->NextSiblingElement("TrussInfoMap")) {
+        for (tinyxml2::XMLElement *info = map->FirstChildElement("TrussInfo");
+             info; info = info->NextSiblingElement("TrussInfo")) {
           const std::string uuid = CanonicalizeUuid(
               Trim(info->Attribute("uuid") ? info->Attribute("uuid") : ""));
           if (!uuid.empty())
@@ -1654,13 +1697,14 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
       if (canonicalUid.empty()) {
         if (rawUid.empty())
           continue;
-        std::string seed = "mvr:legacy-position:" + rawUid + ":" + (name ? Trim(name) : "");
+        std::string seed =
+            "mvr:legacy-position:" + rawUid + ":" + (name ? Trim(name) : "");
         const std::string generated = DeriveDeterministicUuid(seed);
         legacyPositionIdToCanonical[rawUid] = generated;
         scene.positions[generated] = name ? name : rawUid;
         LogMessage(Logger::Level::Warn,
-                   "MVR import migrated non-canonical Position uuid '" + rawUid + "' -> '" +
-                       generated + "'");
+                   "MVR import migrated non-canonical Position uuid '" +
+                       rawUid + "' -> '" + generated + "'");
       } else {
         if (canonicalUid != rawUid)
           legacyPositionIdToCanonical[rawUid] = canonicalUid;
@@ -1668,11 +1712,14 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
       }
     }
 
-    std::function<void(tinyxml2::XMLElement *, const Matrix &, std::vector<SymdefGeometry> &)> parseSymdefChildList;
+    std::function<void(tinyxml2::XMLElement *, const Matrix &,
+                       std::vector<SymdefGeometry> &)>
+        parseSymdefChildList;
     parseSymdefChildList = [&](tinyxml2::XMLElement *childList,
                                const Matrix &parent,
                                std::vector<SymdefGeometry> &geometries) {
-      for (tinyxml2::XMLElement *child = childList ? childList->FirstChildElement() : nullptr;
+      for (tinyxml2::XMLElement *child =
+               childList ? childList->FirstChildElement() : nullptr;
            child; child = child->NextSiblingElement()) {
         const char *name = child->Name();
         if (!name)
@@ -1743,8 +1790,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
 
   auto parseMatrixOrIdentity = [&](tinyxml2::XMLElement *parent,
                                    const char *elementName,
-                                   const std::string &contextTag,
-                                   Matrix &out,
+                                   const std::string &contextTag, Matrix &out,
                                    bool inspectScale = false) {
     out = MatrixUtils::Identity();
     if (!parent)
@@ -1771,13 +1817,16 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
         const float minNorm = std::min({nu, nv, nw});
         const float maxNorm = std::max({nu, nv, nw});
 
-        const bool finiteNorms = std::isfinite(nu) && std::isfinite(nv) && std::isfinite(nw);
+        const bool finiteNorms =
+            std::isfinite(nu) && std::isfinite(nv) && std::isfinite(nw);
         const bool strictlyPositiveNorms = minNorm > 0.0f;
-        const bool isUniformScale = IsNearlyEqualRelative(nu, nv, kUniformScaleRelativeTolerance) &&
+        const bool isUniformScale =
+            IsNearlyEqualRelative(nu, nv, kUniformScaleRelativeTolerance) &&
                                     IsNearlyEqualRelative(nu, nw, kUniformScaleRelativeTolerance);
         const bool isTinyUniformGeometryScale =
-            finiteNorms && strictlyPositiveNorms && maxNorm <= kTinyScaleMaxNorm &&
-            isUniformScale && IsGeometryMatrixContext(contextTag);
+            finiteNorms && strictlyPositiveNorms &&
+            maxNorm <= kTinyScaleMaxNorm && isUniformScale &&
+            IsGeometryMatrixContext(contextTag);
         if (isTinyUniformGeometryScale) {
           ++matrixScaleAggregation.acceptedTinyUniformScaleCount;
           ++matrixScaleAggregation.acceptedByContext[contextTag];
@@ -1785,15 +1834,18 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
         }
 
         const bool hasInvalidNorm = !finiteNorms || !strictlyPositiveNorms;
-        const bool hasOutlierNorm = minNorm < kMinOutlierNorm || maxNorm > kMaxOutlierNorm;
+        const bool hasOutlierNorm =
+            minNorm < kMinOutlierNorm || maxNorm > kMaxOutlierNorm;
         if (!hasInvalidNorm && !hasOutlierNorm)
           return;
 
         ++matrixScaleAggregation.suspiciousMatrixCount;
         ++matrixScaleAggregation.suspiciousByContext[contextTag];
-        if (matrixScaleAggregation.suspiciousExamples.size() < kMaxSuspiciousExamples) {
+        if (matrixScaleAggregation.suspiciousExamples.size() <
+            kMaxSuspiciousExamples) {
           std::ostringstream oss;
-          oss << contextTag << " (|u|=" << nu << ", |v|=" << nv << ", |w|=" << nw << ")";
+          oss << contextTag << " (|u|=" << nu << ", |v|=" << nv
+              << ", |w|=" << nw << ")";
           matrixScaleAggregation.suspiciousExamples.push_back(oss.str());
         }
       }
@@ -1843,7 +1895,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
   std::unordered_map<std::string, GdtfFixtureCategory::InferenceResult>
       categoryInferenceByResolvedPath;
   const std::string kEmptyResolvedPath;
-  auto resolveGdtfPathCached = [&](const std::string &spec) -> const std::string & {
+  auto resolveGdtfPathCached =
+      [&](const std::string &spec) -> const std::string & {
     const std::string normalized = NormalizeArchivePathValue(spec);
     if (normalized.empty())
       return kEmptyResolvedPath;
@@ -1854,23 +1907,28 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
 
     std::string resolved = ResolveGdtfPath(scene.basePath, normalized);
     if (resolved.empty())
-      resolved = ToString(ResolveSceneRelativePath(scene.basePath, normalized).u8string());
-    return resolvedGdtfPathCache.emplace(normalized, std::move(resolved)).first->second;
+      resolved = ToString(
+          ResolveSceneRelativePath(scene.basePath, normalized).u8string());
+    return resolvedGdtfPathCache.emplace(normalized, std::move(resolved))
+        .first->second;
   };
 
   auto normalizeGdtfSpecForScene = [&](const std::string &spec) {
     const std::string normalized = NormalizeArchivePathValue(spec);
     if (normalized.empty())
       return std::string{};
-    return ToSceneRelativePathIfPossible(scene.basePath, PathUtils::PathFromUtf8(resolveGdtfPathCached(normalized)));
+    return ToSceneRelativePathIfPossible(
+        scene.basePath,
+        PathUtils::PathFromUtf8(resolveGdtfPathCached(normalized)));
   };
 
-  auto getGdtfModesCached = [&](const std::string &gdtfPath)
-      -> const std::vector<std::string> & {
+  auto getGdtfModesCached =
+      [&](const std::string &gdtfPath) -> const std::vector<std::string> & {
     auto cacheIt = gdtfModesCache.find(gdtfPath);
     if (cacheIt != gdtfModesCache.end())
       return cacheIt->second;
-    return gdtfModesCache.emplace(gdtfPath, GetGdtfModes(gdtfPath)).first->second;
+    return gdtfModesCache.emplace(gdtfPath, GetGdtfModes(gdtfPath))
+        .first->second;
   };
 
   auto getGdtfModeChannelCountCached = [&](const std::string &gdtfPath,
@@ -1884,14 +1942,15 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
     return count;
   };
 
-  auto resolveExistingGdtfModeCached = [&](const std::string &gdtfPath,
-                                           const std::string &requestedMode,
+  auto resolveExistingGdtfModeCached =
+      [&](const std::string &gdtfPath, const std::string &requestedMode,
                                            std::optional<int> channelCountHint) {
     const std::vector<std::string> &modes = getGdtfModesCached(gdtfPath);
     if (modes.empty())
       return requestedMode;
 
-    const std::string normalizedRequested = ToLowerAscii(Trim(requestedMode));
+        const std::string normalizedRequested =
+            ToLowerAscii(Trim(requestedMode));
     if (!normalizedRequested.empty()) {
       for (const std::string &mode : modes) {
         if (ToLowerAscii(Trim(mode)) == normalizedRequested)
@@ -1938,8 +1997,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
   };
   std::unordered_map<std::string, GdtfFixtureMetadata> gdtfFixtureMetadataCache;
   const GdtfFixtureMetadata kEmptyFixtureMetadata{};
-  auto getFixtureMetadata = [&](const std::string &resolvedGdtfPath)
-      -> const GdtfFixtureMetadata & {
+  auto getFixtureMetadata =
+      [&](const std::string &resolvedGdtfPath) -> const GdtfFixtureMetadata & {
     if (resolvedGdtfPath.empty())
       return kEmptyFixtureMetadata;
 
@@ -1951,7 +2010,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
     metadata.fixtureName = Trim(GetGdtfFixtureName(resolvedGdtfPath));
     metadata.hasProperties =
         GetGdtfProperties(resolvedGdtfPath, metadata.weightKg, metadata.powerW);
-    return gdtfFixtureMetadataCache.emplace(resolvedGdtfPath, std::move(metadata))
+    return gdtfFixtureMetadataCache
+        .emplace(resolvedGdtfPath, std::move(metadata))
         .first->second;
   };
 
@@ -1965,7 +2025,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
     if (it == trussDefinitionCache.end()) {
       Truss loaded;
       if (LoadTrussDefinition(resolvedGdtfPath, loaded))
-        it = trussDefinitionCache.emplace(resolvedGdtfPath, std::move(loaded)).first;
+        it = trussDefinitionCache.emplace(resolvedGdtfPath, std::move(loaded))
+                 .first;
       else
         it = trussDefinitionCache.emplace(resolvedGdtfPath, std::nullopt).first;
     }
@@ -1976,10 +2037,9 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
     return true;
   };
 
-  auto appendGeometryInstance = [&](std::vector<GeometryInstance> &instances,
-                                    const std::string &fileName,
-                                    const Matrix &localTransform,
-                                    const std::string &instanceKey,
+  auto appendGeometryInstance =
+      [&](std::vector<GeometryInstance> &instances, const std::string &fileName,
+          const Matrix &localTransform, const std::string &instanceKey,
                                     const std::string &sourceSymbolUuid = {},
                                     const std::string &sourceSymdefUuid = {}) {
     std::string normalized = normalizeAndResolveGeometryFileName(fileName);
@@ -2046,19 +2106,21 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
 
   // ---- Helper lambdas for object parsing ----
   int preservedGroupObjectCount = 0;
-  std::function<void(tinyxml2::XMLElement *, const std::string &, const Matrix &, const std::string &)>
+  std::function<void(tinyxml2::XMLElement *, const std::string &,
+                     const Matrix &, const std::string &)>
       parseChildList;
 
-  auto ensurePositionEntry = [&](const std::string &positionId)
-      -> std::string {
+  auto ensurePositionEntry = [&](const std::string &positionId) -> std::string {
     if (positionId.empty())
       return {};
 
     auto legacyIt = legacyPositionIdToCanonical.find(positionId);
-    const std::string remappedId =
-        legacyIt != legacyPositionIdToCanonical.end() ? legacyIt->second : positionId;
+    const std::string remappedId = legacyIt != legacyPositionIdToCanonical.end()
+                                       ? legacyIt->second
+                                       : positionId;
     const std::string canonicalId = CanonicalizeUuid(remappedId);
-    const std::string normalizedId = canonicalId.empty() ? remappedId : canonicalId;
+    const std::string normalizedId =
+        canonicalId.empty() ? remappedId : canonicalId;
 
     auto it = scene.positions.find(normalizedId);
     if (it != scene.positions.end())
@@ -2113,7 +2175,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
         stableUuid = legacyUuid;
       } else if (!rawUuid.empty()) {
         LogMessage(Logger::Level::Warn,
-                   wxString::Format("MVR import: %s UUID '%s' is invalid. Applying deterministic fallback.",
+                   wxString::Format("MVR import: %s UUID '%s' is invalid. "
+                                    "Applying deterministic fallback.",
                                     kind, rawUuid.c_str())
                        .ToStdString());
       }
@@ -2123,13 +2186,15 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
 
     if (usedStableUuids.contains(stableUuid)) {
       LogMessage(Logger::Level::Warn,
-                 wxString::Format("MVR import: UUID collision for %s '%s'. Applying controlled fallback UUID.",
+                 wxString::Format("MVR import: UUID collision for %s '%s'. "
+                                  "Applying controlled fallback UUID.",
                                   kind, stableUuid.c_str())
                      .ToStdString());
       int suffix = 1;
       std::string candidate;
       do {
-        candidate = DeriveDeterministicUuid(seed + "#" + std::to_string(suffix++));
+        candidate =
+            DeriveDeterministicUuid(seed + "#" + std::to_string(suffix++));
       } while (usedStableUuids.contains(candidate));
       stableUuid = std::move(candidate);
     }
@@ -2153,15 +2218,17 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
 
   std::unordered_map<std::string, std::optional<GdtfDictionary::Entry>>
       dictionaryEntryByTypeCache;
-  auto getDictionaryEntryCached =
-      [&](const std::string &typeName) -> const std::optional<GdtfDictionary::Entry> & {
-    static const std::optional<GdtfDictionary::Entry> kEmptyEntry = std::nullopt;
+  auto getDictionaryEntryCached = [&](const std::string &typeName)
+      -> const std::optional<GdtfDictionary::Entry> & {
+    static const std::optional<GdtfDictionary::Entry> kEmptyEntry =
+        std::nullopt;
     if (typeName.empty())
       return kEmptyEntry;
     auto it = dictionaryEntryByTypeCache.find(typeName);
     if (it != dictionaryEntryByTypeCache.end())
       return it->second;
-    return dictionaryEntryByTypeCache.emplace(typeName, GdtfDictionary::Get(typeName))
+    return dictionaryEntryByTypeCache
+        .emplace(typeName, GdtfDictionary::Get(typeName))
         .first->second;
   };
 
@@ -2169,11 +2236,14 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
   int trussSymbolSymdefPreservedCount = 0;
   std::unordered_map<std::string, int> trussSymbolSymdefPreservedBySymdef;
 
-  // Parses a Fixture XML node into scene data while preserving its original matching identity.
-  std::function<void(tinyxml2::XMLElement *, const std::string &, const Matrix &, const Matrix &, const std::string &)>
+  // Parses a Fixture XML node into scene data while preserving its original
+  // matching identity.
+  std::function<void(tinyxml2::XMLElement *, const std::string &,
+                     const Matrix &, const Matrix &, const std::string &)>
       parseFixture = [&](tinyxml2::XMLElement *node,
                          const std::string &layerName,
-                         const Matrix &nodeTransform, const Matrix &localTransform,
+                         const Matrix &nodeTransform,
+                         const Matrix &localTransform,
                          const std::string &parentGroupUuid) {
         Fixture fixture;
         const LegacyFixtureIdentity legacyIdentity =
@@ -2181,9 +2251,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
         const char *rawUuidAttr = node->Attribute("uuid");
         const std::string rawFixtureUuid =
             rawUuidAttr ? Trim(rawUuidAttr) : std::string{};
-        fixture.uuid =
-            resolveStableUuid("Fixture", node, layerName, nodeTransform,
-                              legacyIdentity.stableId);
+        fixture.uuid = resolveStableUuid(
+            "Fixture", node, layerName, nodeTransform, legacyIdentity.stableId);
         if (!rawFixtureUuid.empty() && rawFixtureUuid != fixture.uuid)
           fixtureUuidRemap[rawFixtureUuid] = fixture.uuid;
         fixture.layer = layerName;
@@ -2211,8 +2280,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
         fixture.originalMvrGdtfSpec = rawGdtfSpec;
         fixture.gdtfMode = textOf(node, "GDTFMode");
         fixture.requestedFixtureName =
-            mvr::gdtf_import_matching::SelectRequestedFixtureName(rawFixtureNodeName,
-                                                                 rawGdtfSpec);
+            mvr::gdtf_import_matching::SelectRequestedFixtureName(
+                rawFixtureNodeName, rawGdtfSpec);
         fixture.focus = textOf(node, "Focus");
         fixture.function = textOf(node, "Function");
         fixture.position = CanonicalizeUuid(textOf(node, "Position"));
@@ -2225,7 +2294,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
         if (tinyxml2::XMLElement *colorNode =
                 node->FirstChildElement("Color")) {
           if (const char *txt = colorNode->GetText())
-            fixture.gelColor = CieToHex(txt);
+            fixture.mvrFixtureColorHex = CieToHex(txt);
         }
         float legacyPowerConsumptionW = 0.0f;
         bool hasLegacyPowerConsumption = false;
@@ -2241,8 +2310,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
         }
         float legacyWeightKg = 0.0f;
         bool hasLegacyWeight = false;
-        if (tinyxml2::XMLElement *wNode =
-                node->FirstChildElement("Weight")) {
+        if (tinyxml2::XMLElement *wNode = node->FirstChildElement("Weight")) {
           if (const char *txt = wNode->GetText()) {
             float parsed = 0.0f;
             if (TryParseFloat(txt, parsed)) {
@@ -2254,36 +2322,42 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
         std::string resolvedGdtfPathForFixture;
         if (!fixture.gdtfSpec.empty()) {
           fixture.gdtfSpec = RemapArchivePathIfNeeded(fixture.gdtfSpec);
-          const std::string &resolvedGdtfPath = resolveGdtfPathCached(fixture.gdtfSpec);
+          const std::string &resolvedGdtfPath =
+              resolveGdtfPathCached(fixture.gdtfSpec);
           resolvedGdtfPathForFixture = resolvedGdtfPath;
           fixture.gdtfSpec = normalizeGdtfSpecForScene(fixture.gdtfSpec);
           if (fixture.gdtfSpec.empty() && !rawGdtfSpec.empty())
             fixture.gdtfSpec = RemapArchivePathIfNeeded(rawGdtfSpec);
-          const GdtfFixtureMetadata &metadata = getFixtureMetadata(resolvedGdtfPath);
+          const GdtfFixtureMetadata &metadata =
+              getFixtureMetadata(resolvedGdtfPath);
           fixture.typeName = metadata.fixtureName;
           if (metadata.hasProperties) {
             if (metadata.weightKg > 0.0f)
               fixture.weightKg = metadata.weightKg;
             if (metadata.powerW > 0.0f)
               fixture.powerConsumptionW = metadata.powerW;
-            fixture.physicalPropertiesSource = FixturePhysicalPropertiesSource::Gdtf;
+            fixture.physicalPropertiesSource =
+                FixturePhysicalPropertiesSource::Gdtf;
             fixture.physicalPropertiesDirty = false;
           }
         }
         if (fixture.weightKg <= 0.0f && hasLegacyWeight) {
           fixture.weightKg = legacyWeightKg;
-          fixture.physicalPropertiesSource = FixturePhysicalPropertiesSource::LegacyMvrFixtureNode;
+          fixture.physicalPropertiesSource =
+              FixturePhysicalPropertiesSource::LegacyMvrFixtureNode;
         }
         if (fixture.powerConsumptionW <= 0.0f && hasLegacyPowerConsumption) {
           fixture.powerConsumptionW = legacyPowerConsumptionW;
-          fixture.physicalPropertiesSource = FixturePhysicalPropertiesSource::LegacyMvrFixtureNode;
+          fixture.physicalPropertiesSource =
+              FixturePhysicalPropertiesSource::LegacyMvrFixtureNode;
         }
         fixture.physicalPropertiesDirty = false;
 
         ReadFixtureCategoryFromUserData(node, fixture);
         const std::string categoryTypeKey = buildFixtureTypeCategoryKey(
             rawGdtfSpec, fixture.gdtfMode, fixture.typeName);
-        auto rootCategoryIt = rootFixtureCategoryByTypeKey.find(categoryTypeKey);
+        auto rootCategoryIt =
+            rootFixtureCategoryByTypeKey.find(categoryTypeKey);
         if (rootCategoryIt != rootFixtureCategoryByTypeKey.end()) {
           fixture.category = rootCategoryIt->second.category;
           fixture.categorySource = rootCategoryIt->second.categorySource;
@@ -2338,22 +2412,19 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
             fixture.matrixRaw = txt;
         }
 
-        if (options.applyDictionary && dictionaryEntry && !fixture.typeName.empty()) {
+        if (options.applyDictionary && dictionaryEntry &&
+            !fixture.typeName.empty()) {
           int footprint = 0;
-          if (!resolvedGdtfPathForFixture.empty() && !fixture.gdtfMode.empty()) {
-            footprint = getGdtfModeChannelCountCached(resolvedGdtfPathForFixture,
-                                                      fixture.gdtfMode);
+          if (!resolvedGdtfPathForFixture.empty() &&
+              !fixture.gdtfMode.empty()) {
+            footprint = getGdtfModeChannelCountCached(
+                resolvedGdtfPathForFixture, fixture.gdtfMode);
           }
           pendingGdtfConflictByType.try_emplace(
               fixture.typeName,
-              GdtfConflict{fixture.typeName,
-                           fixture.requestedFixtureName,
-                           fixture.gdtfSpec,
-                           dictionaryEntry->path,
-                           "",
-                           fixture.typeName,
-                           fixture.gdtfMode,
-                           footprint,
+              GdtfConflict{fixture.typeName, fixture.requestedFixtureName,
+                           fixture.gdtfSpec, dictionaryEntry->path, "",
+                           fixture.typeName, fixture.gdtfMode, footprint,
                            true});
         }
 
@@ -2422,15 +2493,18 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
         truss.perastageTypeKey = Trim(tk->GetText());
     if (tinyxml2::XMLElement *ag = info->FirstChildElement("AuxGdtf"))
       if (ag->GetText())
-        truss.perastageAuxGdtfArchivePath = RemapArchivePathIfNeeded(Trim(ag->GetText()));
+        truss.perastageAuxGdtfArchivePath =
+            RemapArchivePathIfNeeded(Trim(ag->GetText()));
   };
 
-  std::function<void(tinyxml2::XMLElement *, const std::string &, const Matrix &, const Matrix &, const std::string &)> parseTruss =
-      [&](tinyxml2::XMLElement *node, const std::string &layerName,
-          const Matrix &nodeTransform, const Matrix &localTransform, const std::string &parentGroupUuid) {
+  std::function<void(tinyxml2::XMLElement *, const std::string &,
+                     const Matrix &, const Matrix &, const std::string &)>
+      parseTruss = [&](tinyxml2::XMLElement *node, const std::string &layerName,
+                       const Matrix &nodeTransform,
+                       const Matrix &localTransform,
+                       const std::string &parentGroupUuid) {
         Truss truss;
-        truss.uuid =
-            resolveStableUuid("Truss", node, layerName, nodeTransform);
+        truss.uuid = resolveStableUuid("Truss", node, layerName, nodeTransform);
         truss.layer = layerName;
         truss.transform = nodeTransform;
         truss.localTransform = localTransform;
@@ -2458,9 +2532,11 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
 
         bool gdtfLoadFailed = false;
         if (!truss.gdtfSpec.empty()) {
-          truss.sourceRepresentation = Truss::GeometryRepresentation::PublicGdtf;
+          truss.sourceRepresentation =
+              Truss::GeometryRepresentation::PublicGdtf;
           truss.gdtfSpec = RemapArchivePathIfNeeded(truss.gdtfSpec);
-          const std::string trussGdtfPath = resolveGdtfPathCached(truss.gdtfSpec);
+          const std::string trussGdtfPath =
+              resolveGdtfPathCached(truss.gdtfSpec);
           truss.gdtfSpec = normalizeGdtfSpecForScene(truss.gdtfSpec);
           Truss gdtfTruss;
           if (loadTrussDefinitionCached(trussGdtfPath, gdtfTruss)) {
@@ -2482,7 +2558,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
             if (gdtfTruss.weightKg > 0.0f)
               truss.weightKg = gdtfTruss.weightKg;
             if (truss.gdtfMode.empty())
-              truss.gdtfMode = gdtfTruss.gdtfMode.empty() ? "Default" : gdtfTruss.gdtfMode;
+              truss.gdtfMode =
+                  gdtfTruss.gdtfMode.empty() ? "Default" : gdtfTruss.gdtfMode;
           } else {
             gdtfLoadFailed = true;
           }
@@ -2492,19 +2569,22 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                 node->FirstChildElement("Geometries")) {
           if (tinyxml2::XMLElement *g3d =
                   geos->FirstChildElement("Geometry3D")) {
-            truss.sourceRepresentation = Truss::GeometryRepresentation::Geometry3D;
+            truss.sourceRepresentation =
+                Truss::GeometryRepresentation::Geometry3D;
             const char *file = g3d->Attribute("fileName");
             if (file)
               truss.symbolFile = normalizeAndResolveGeometryFileName(file);
             Matrix geoMatrix = MatrixUtils::Identity();
-            parseMatrixOrIdentity(g3d, "Matrix", "Truss/Geometry3D", geoMatrix, true);
+            parseMatrixOrIdentity(g3d, "Matrix", "Truss/Geometry3D", geoMatrix,
+                                  true);
             truss.sourceGeometryMatrix = geoMatrix;
             if (const char *type = g3d->Attribute("geometryType"))
               truss.sourceGeometryType = Trim(type);
             truss.transform = MatrixUtils::Multiply(nodeTransform, geoMatrix);
           } else if (tinyxml2::XMLElement *sym =
                          geos->FirstChildElement("Symbol")) {
-            truss.sourceRepresentation = Truss::GeometryRepresentation::SymbolSymdef;
+            truss.sourceRepresentation =
+                Truss::GeometryRepresentation::SymbolSymdef;
             std::vector<SymdefGeometry> symGeometries;
             std::string symType;
             Matrix symMatrix = MatrixUtils::Identity();
@@ -2517,8 +2597,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
             truss.sourceGeometryType = symType;
             Matrix symLocal = symMatrix;
             if (!symGeometries.empty()) {
-              truss.symbolFile =
-                  normalizeAndResolveGeometryFileName(symGeometries.front().file);
+              truss.symbolFile = normalizeAndResolveGeometryFileName(
+                  symGeometries.front().file);
               symLocal = MatrixUtils::Multiply(symMatrix,
                                                symGeometries.front().transform);
             }
@@ -2531,16 +2611,19 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
           }
         }
 
-
-        const bool hasGdtfMetadataAuthority = !truss.gdtfSpec.empty() && !gdtfLoadFailed;
+        const bool hasGdtfMetadataAuthority =
+            !truss.gdtfSpec.empty() && !gdtfLoadFailed;
 
         auto rootTrussInfoIt = rootTrussInfoByUuid.find(truss.uuid);
         if (rootTrussInfoIt != rootTrussInfoByUuid.end()) {
-          applyTrussInfo(rootTrussInfoIt->second, truss, hasGdtfMetadataAuthority);
-        } else if (tinyxml2::XMLElement *ud = node->FirstChildElement("UserData")) {
+          applyTrussInfo(rootTrussInfoIt->second, truss,
+                         hasGdtfMetadataAuthority);
+        } else if (tinyxml2::XMLElement *ud =
+                       node->FirstChildElement("UserData")) {
           for (tinyxml2::XMLElement *data = ud->FirstChildElement("Data"); data;
                data = data->NextSiblingElement("Data")) {
-            if (tinyxml2::XMLElement *info = data->FirstChildElement("TrussInfo")) {
+            if (tinyxml2::XMLElement *info =
+                    data->FirstChildElement("TrussInfo")) {
               applyTrussInfo(info, truss, hasGdtfMetadataAuthority);
               break;
             }
@@ -2553,9 +2636,11 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
           auto typeIt = perastageTypeToGdtfPath.find(truss.perastageTypeKey);
           if (typeIt != perastageTypeToGdtfPath.end()) {
             truss.perastageAuxGdtfArchivePath = typeIt->second;
-            fs::path auxPath = scene.basePath.empty()
+            fs::path auxPath =
+                scene.basePath.empty()
                                    ? PathUtils::PathFromUtf8(typeIt->second)
-                                   : PathUtils::PathFromUtf8(scene.basePath) / PathUtils::PathFromUtf8(typeIt->second);
+                    : PathUtils::PathFromUtf8(scene.basePath) /
+                          PathUtils::PathFromUtf8(typeIt->second);
             Truss sidecar;
             if (LoadTrussDefinition(ToString(auxPath.u8string()), sidecar)) {
               if (truss.manufacturer.empty())
@@ -2576,11 +2661,12 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
 
         const fs::path resolvedSymbolPath =
             ResolveSceneRelativePath(scene.basePath, truss.symbolFile);
-        const bool symbolRenderable = IsRenderableTrussGeometry(truss.symbolFile);
+        const bool symbolRenderable =
+            IsRenderableTrussGeometry(truss.symbolFile);
         std::error_code symbolExistsEc;
         const bool symbolExists =
-            symbolRenderable && fs::exists(resolvedSymbolPath, symbolExistsEc) &&
-            !symbolExistsEc;
+            symbolRenderable &&
+            fs::exists(resolvedSymbolPath, symbolExistsEc) && !symbolExistsEc;
         if (!symbolExists) {
           std::ostringstream reason;
           if (truss.symbolFile.empty()) {
@@ -2603,10 +2689,14 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
         scene.trusses[truss.uuid] = truss;
       };
 
-  // Parses a Support XML node into scene data while preserving group-local transforms.
-  std::function<void(tinyxml2::XMLElement *, const std::string &, const Matrix &, const Matrix &, const std::string &)> parseSupport =
-      [&](tinyxml2::XMLElement *node, const std::string &layerName,
-          const Matrix &nodeTransform, const Matrix &localTransform,
+  // Parses a Support XML node into scene data while preserving group-local
+  // transforms.
+  std::function<void(tinyxml2::XMLElement *, const std::string &,
+                     const Matrix &, const Matrix &, const std::string &)>
+      parseSupport = [&](tinyxml2::XMLElement *node,
+                         const std::string &layerName,
+                         const Matrix &nodeTransform,
+                         const Matrix &localTransform,
           const std::string &parentGroupUuid) {
         Support support;
         support.uuid =
@@ -2662,14 +2752,17 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
         if (supportPosIt != legacyPositionIdToCanonical.end())
           support.position = supportPosIt->second;
 
-        if (tinyxml2::XMLElement *geos = node->FirstChildElement("Geometries")) {
-          for (tinyxml2::XMLElement *g3d = geos->FirstChildElement("Geometry3D"); g3d;
-               g3d = g3d->NextSiblingElement("Geometry3D")) {
+        if (tinyxml2::XMLElement *geos =
+                node->FirstChildElement("Geometries")) {
+          for (tinyxml2::XMLElement *g3d =
+                   geos->FirstChildElement("Geometry3D");
+               g3d; g3d = g3d->NextSiblingElement("Geometry3D")) {
             const char *file = g3d->Attribute("fileName");
             if (!file)
               continue;
             Matrix geoMatrix = MatrixUtils::Identity();
-            parseMatrixOrIdentity(g3d, "Matrix", "Support/Geometry3D", geoMatrix, true);
+            parseMatrixOrIdentity(g3d, "Matrix", "Support/Geometry3D",
+                                  geoMatrix, true);
             appendGeometryInstance(support.geometries, Trim(file), geoMatrix,
                                    BuildSceneObjectGeometryInstanceKey(
                                        support.uuid, "support-geometry3d",
@@ -2677,8 +2770,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
           }
 
           size_t symbolIndex = 0;
-          for (tinyxml2::XMLElement *sym = geos->FirstChildElement("Symbol"); sym;
-               sym = sym->NextSiblingElement("Symbol"), ++symbolIndex) {
+          for (tinyxml2::XMLElement *sym = geos->FirstChildElement("Symbol");
+               sym; sym = sym->NextSiblingElement("Symbol"), ++symbolIndex) {
             std::vector<SymdefGeometry> symGeometries;
             Matrix symMatrix = MatrixUtils::Identity();
             std::string symGeometryType;
@@ -2686,7 +2779,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                 Trim(sym->Attribute("uuid") ? sym->Attribute("uuid") : "");
             const std::string sourceSymdefUuid =
                 Trim(sym->Attribute("symdef") ? sym->Attribute("symdef") : "");
-            resolveSymdefReference(sym, symGeometries, symGeometryType, symMatrix);
+            resolveSymdefReference(sym, symGeometries, symGeometryType,
+                                   symMatrix);
             size_t symGeometryIndex = 0;
             for (const auto &geo : symGeometries) {
               appendGeometryInstance(
@@ -2694,7 +2788,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                   MatrixUtils::Multiply(symMatrix, geo.transform),
                   BuildSceneObjectGeometryInstanceKey(
                       support.uuid, "support-symbol", symbolIndex,
-                      sourceSymdefUuid + "/" + std::to_string(symGeometryIndex)),
+                      sourceSymdefUuid + "/" +
+                          std::to_string(symGeometryIndex)),
                   sourceSymbolUuid, sourceSymdefUuid);
               ++symGeometryIndex;
             }
@@ -2712,11 +2807,15 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
         scene.supports[support.uuid] = support;
       };
 
-  // Parses a SceneObject XML node into scene data while preserving group-local transforms.
-  std::function<void(tinyxml2::XMLElement *, const std::string &, const Matrix &, const Matrix &, const std::string &)>
+  // Parses a SceneObject XML node into scene data while preserving group-local
+  // transforms.
+  std::function<void(tinyxml2::XMLElement *, const std::string &,
+                     const Matrix &, const Matrix &, const std::string &)>
       parseSceneObj = [&](tinyxml2::XMLElement *node,
                           const std::string &layerName,
-                          const Matrix &nodeTransform, const Matrix &localTransform, const std::string &parentGroupUuid) {
+                          const Matrix &nodeTransform,
+                          const Matrix &localTransform,
+                          const std::string &parentGroupUuid) {
         SceneObject obj;
         obj.uuid =
             resolveStableUuid("SceneObject", node, layerName, nodeTransform);
@@ -2729,26 +2828,31 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
           obj.name = nameAttr;
 
         std::string geometryType;
-        std::unordered_map<std::string, std::string> primitiveModelRefByArchiveFile;
+        std::unordered_map<std::string, std::string>
+            primitiveModelRefByArchiveFile;
 
         for (tinyxml2::XMLElement *ud = node->FirstChildElement("UserData"); ud;
              ud = ud->NextSiblingElement("UserData")) {
           for (tinyxml2::XMLElement *data = ud->FirstChildElement("Data"); data;
                data = data->NextSiblingElement("Data")) {
             const std::string provider = ToLowerCopy(
-                Trim(data->Attribute("provider") ? data->Attribute("provider") : ""));
+                Trim(data->Attribute("provider") ? data->Attribute("provider")
+                                                 : ""));
             if (provider != "perastage")
               continue;
-            if (tinyxml2::XMLElement *map = data->FirstChildElement("PrimitiveGeometryMap")) {
-              for (tinyxml2::XMLElement *entry = map->FirstChildElement("Entry"); entry;
-                   entry = entry->NextSiblingElement("Entry")) {
+            if (tinyxml2::XMLElement *map =
+                    data->FirstChildElement("PrimitiveGeometryMap")) {
+              for (tinyxml2::XMLElement *entry =
+                       map->FirstChildElement("Entry");
+                   entry; entry = entry->NextSiblingElement("Entry")) {
                 const char *fileName = entry->Attribute("fileName");
                 const char *modelRef = entry->Attribute("perastageModelRef");
                 if (!modelRef)
                   modelRef = entry->Attribute("modelRef");
                 if (!fileName || !modelRef)
                   continue;
-                primitiveModelRefByArchiveFile[ToLowerCopy(Trim(fileName))] = Trim(modelRef);
+                primitiveModelRefByArchiveFile[ToLowerCopy(Trim(fileName))] =
+                    Trim(modelRef);
               }
             }
           }
@@ -2759,8 +2863,9 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
 
         if (tinyxml2::XMLElement *geos =
                 node->FirstChildElement("Geometries")) {
-          for (tinyxml2::XMLElement *g3d = geos->FirstChildElement("Geometry3D"); g3d;
-               g3d = g3d->NextSiblingElement("Geometry3D")) {
+          for (tinyxml2::XMLElement *g3d =
+                   geos->FirstChildElement("Geometry3D");
+               g3d; g3d = g3d->NextSiblingElement("Geometry3D")) {
             const char *file = g3d->Attribute("fileName");
             if (!file)
               continue;
@@ -2769,7 +2874,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
               geometryType = Trim(type);
 
             Matrix geoMatrix = MatrixUtils::Identity();
-            parseMatrixOrIdentity(g3d, "Matrix", "SceneObject/Geometry3D", geoMatrix, true);
+            parseMatrixOrIdentity(g3d, "Matrix", "SceneObject/Geometry3D",
+                                  geoMatrix, true);
             std::string fileName = Trim(file);
             auto mappedModelRefIt =
                 primitiveModelRefByArchiveFile.find(ToLowerCopy(fileName));
@@ -2781,15 +2887,17 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
               instance.localTransform = geoMatrix;
               obj.geometries.push_back(std::move(instance));
             } else {
-              const std::string instanceKey = BuildSceneObjectGeometryInstanceKey(
-                  obj.uuid, "geometry3d", obj.geometries.size());
-              appendGeometryInstance(obj.geometries, fileName, geoMatrix, instanceKey);
+              const std::string instanceKey =
+                  BuildSceneObjectGeometryInstanceKey(obj.uuid, "geometry3d",
+                                                      obj.geometries.size());
+              appendGeometryInstance(obj.geometries, fileName, geoMatrix,
+                                     instanceKey);
             }
           }
 
           size_t symbolIndex = 0;
-          for (tinyxml2::XMLElement *sym = geos->FirstChildElement("Symbol"); sym;
-               sym = sym->NextSiblingElement("Symbol"), ++symbolIndex) {
+          for (tinyxml2::XMLElement *sym = geos->FirstChildElement("Symbol");
+               sym; sym = sym->NextSiblingElement("Symbol"), ++symbolIndex) {
             std::vector<SymdefGeometry> symGeometries;
             Matrix symMatrix = MatrixUtils::Identity();
             std::string symGeometryType;
@@ -2797,18 +2905,23 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                 Trim(sym->Attribute("uuid") ? sym->Attribute("uuid") : "");
             const std::string sourceSymdefUuid =
                 Trim(sym->Attribute("symdef") ? sym->Attribute("symdef") : "");
-            resolveSymdefReference(sym, symGeometries, symGeometryType, symMatrix);
+            resolveSymdefReference(sym, symGeometries, symGeometryType,
+                                   symMatrix);
             if (!symGeometryType.empty())
               geometryType = symGeometryType;
 
             size_t symGeometryIndex = 0;
             for (const auto &geo : symGeometries) {
-              Matrix localTransform = MatrixUtils::Multiply(symMatrix, geo.transform);
-              const std::string instanceKey = BuildSceneObjectGeometryInstanceKey(
+              Matrix localTransform =
+                  MatrixUtils::Multiply(symMatrix, geo.transform);
+              const std::string instanceKey =
+                  BuildSceneObjectGeometryInstanceKey(
                   obj.uuid, "symbol", symbolIndex,
-                  sourceSymdefUuid + "/" + std::to_string(symGeometryIndex));
-              appendGeometryInstance(obj.geometries, geo.file, localTransform, instanceKey,
-                                     sourceSymbolUuid, sourceSymdefUuid);
+                      sourceSymdefUuid + "/" +
+                          std::to_string(symGeometryIndex));
+              appendGeometryInstance(obj.geometries, geo.file, localTransform,
+                                     instanceKey, sourceSymbolUuid,
+                                     sourceSymdefUuid);
               std::ostringstream geometryLog;
               geometryLog << "SceneObject geometry resolved: sceneObject='"
                           << obj.name << "' sceneUuid=" << obj.uuid
@@ -2851,47 +2964,59 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
           support.parentGroupUuid = obj.parentGroupUuid;
           support.modelFile = obj.modelFile;
           support.geometries = obj.geometries;
-          for (tinyxml2::XMLElement *ud = node->FirstChildElement("UserData"); ud;
-               ud = ud->NextSiblingElement("UserData")) {
-            for (tinyxml2::XMLElement *data = ud->FirstChildElement("Data"); data;
-                 data = data->NextSiblingElement("Data")) {
+          for (tinyxml2::XMLElement *ud = node->FirstChildElement("UserData");
+               ud; ud = ud->NextSiblingElement("UserData")) {
+            for (tinyxml2::XMLElement *data = ud->FirstChildElement("Data");
+                 data; data = data->NextSiblingElement("Data")) {
               const std::string provider = ToLowerCopy(
-                  Trim(data->Attribute("provider") ? data->Attribute("provider") : ""));
+                  Trim(data->Attribute("provider") ? data->Attribute("provider")
+                                                   : ""));
               if (provider != "perastage")
                 continue;
-              if (tinyxml2::XMLElement *info = data->FirstChildElement("SupportInfo")) {
-                if (tinyxml2::XMLElement *n = info->FirstChildElement("GDTFSpec");
+              if (tinyxml2::XMLElement *info =
+                      data->FirstChildElement("SupportInfo")) {
+                if (tinyxml2::XMLElement *n =
+                        info->FirstChildElement("GDTFSpec");
                     n && n->GetText()) {
-                  support.gdtfSpec = RemapArchivePathIfNeeded(Trim(n->GetText()));
+                  support.gdtfSpec =
+                      RemapArchivePathIfNeeded(Trim(n->GetText()));
                 }
-                if (tinyxml2::XMLElement *n = info->FirstChildElement("GDTFMode");
+                if (tinyxml2::XMLElement *n =
+                        info->FirstChildElement("GDTFMode");
                     n && n->GetText()) {
                   support.gdtfMode = Trim(n->GetText());
                 }
-                if (tinyxml2::XMLElement *n = info->FirstChildElement("Function");
+                if (tinyxml2::XMLElement *n =
+                        info->FirstChildElement("Function");
                     n && n->GetText()) {
                   support.function = Trim(n->GetText());
                 }
-                if (tinyxml2::XMLElement *n = info->FirstChildElement("HoistFunction");
+                if (tinyxml2::XMLElement *n =
+                        info->FirstChildElement("HoistFunction");
                     n && n->GetText()) {
-                  support.hoistFunction = NormalizeHoistFunction(Trim(n->GetText()));
+                  support.hoistFunction =
+                      NormalizeHoistFunction(Trim(n->GetText()));
                 }
-                if (tinyxml2::XMLElement *n = info->FirstChildElement("ChainLength");
+                if (tinyxml2::XMLElement *n =
+                        info->FirstChildElement("ChainLength");
                     n && n->GetText()) {
                   float parsed = 0.0f;
                   if (TryParseFloat(Trim(n->GetText()), parsed))
                     support.chainLength = parsed;
                 }
-                if (tinyxml2::XMLElement *n = info->FirstChildElement("Position");
+                if (tinyxml2::XMLElement *n =
+                        info->FirstChildElement("Position");
                     n && n->GetText()) {
                   support.position = Trim(n->GetText());
                 }
-                if (tinyxml2::XMLElement *n = info->FirstChildElement("PositionName");
+                if (tinyxml2::XMLElement *n =
+                        info->FirstChildElement("PositionName");
                     n && n->GetText()) {
                   support.positionName = Trim(n->GetText());
                 }
                 LogMessage(Logger::Level::Info,
-                           "MVR import reconstructed Support from SceneObject fallback uuid='" +
+                           "MVR import reconstructed Support from SceneObject "
+                           "fallback uuid='" +
                                support.uuid + "'");
               }
             }
@@ -2926,17 +3051,19 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
         if (!childList)
           return 0;
         int count = 0;
-        for (tinyxml2::XMLElement *child = childList->FirstChildElement(); child;
-             child = child->NextSiblingElement()) {
+        for (tinyxml2::XMLElement *child = childList->FirstChildElement();
+             child; child = child->NextSiblingElement()) {
           const char *name = child->Name();
           if (!name)
             continue;
           const std::string nodeName = name;
-          if (nodeName == "Fixture" || nodeName == "Truss" || nodeName == "Support" ||
-              nodeName == "SceneObject" || nodeName == "GroupObject") {
+          if (nodeName == "Fixture" || nodeName == "Truss" ||
+              nodeName == "Support" || nodeName == "SceneObject" ||
+              nodeName == "GroupObject") {
             ++count;
           }
-          if (tinyxml2::XMLElement *inner = child->FirstChildElement("ChildList"))
+          if (tinyxml2::XMLElement *inner =
+                  child->FirstChildElement("ChildList"))
             count += countImportSceneNodes(inner);
         }
         return count;
@@ -2949,7 +3076,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
   }
   for (tinyxml2::XMLElement *layer = layersNode->FirstChildElement("Layer");
        layer; layer = layer->NextSiblingElement("Layer")) {
-    totalImportNodes += countImportSceneNodes(layer->FirstChildElement("ChildList"));
+    totalImportNodes +=
+        countImportSceneNodes(layer->FirstChildElement("ChildList"));
   }
 
   int importedNodes = 0;
@@ -2966,7 +3094,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
   };
 
   parseChildList = [&](tinyxml2::XMLElement *cl, const std::string &layerName,
-                       const Matrix &parentTransform, const std::string &parentGroupUuid) {
+                       const Matrix &parentTransform,
+                       const std::string &parentGroupUuid) {
     for (tinyxml2::XMLElement *child = cl->FirstChildElement(); child;
          child = child->NextSiblingElement()) {
       const char *name = child->Name();
@@ -2974,7 +3103,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
         continue;
 
       Matrix local = MatrixUtils::Identity();
-      parseMatrixOrIdentity(child, "Matrix", std::string("Child/") + name, local, true);
+      parseMatrixOrIdentity(child, "Matrix", std::string("Child/") + name,
+                            local, true);
       Matrix nodeTransform = MatrixUtils::Multiply(parentTransform, local);
 
       std::string nodeName = name;
@@ -2983,21 +3113,26 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
         reportNodeProgress("Fixture");
         if (!parentGroupUuid.empty()) {
           scene.groupObjects[parentGroupUuid].children.push_back(
-              {MvrNodeType::Fixture, referenceUuidForNode("Fixture", child, layerName, nodeTransform)});
+              {MvrNodeType::Fixture,
+               referenceUuidForNode("Fixture", child, layerName,
+                                    nodeTransform)});
         }
       } else if (nodeName == "Truss") {
         parseTruss(child, layerName, nodeTransform, local, parentGroupUuid);
         reportNodeProgress("Truss");
         if (!parentGroupUuid.empty()) {
           scene.groupObjects[parentGroupUuid].children.push_back(
-              {MvrNodeType::Truss, referenceUuidForNode("Truss", child, layerName, nodeTransform)});
+              {MvrNodeType::Truss,
+               referenceUuidForNode("Truss", child, layerName, nodeTransform)});
         }
       } else if (nodeName == "Support") {
         parseSupport(child, layerName, nodeTransform, local, parentGroupUuid);
         reportNodeProgress("Support");
         if (!parentGroupUuid.empty()) {
           scene.groupObjects[parentGroupUuid].children.push_back(
-              {MvrNodeType::Support, referenceUuidForNode("Support", child, layerName, nodeTransform)});
+              {MvrNodeType::Support,
+               referenceUuidForNode("Support", child, layerName,
+                                    nodeTransform)});
         }
       } else if (nodeName == "SceneObject") {
         parseSceneObj(child, layerName, nodeTransform, local, parentGroupUuid);
@@ -3005,11 +3140,13 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
         if (!parentGroupUuid.empty()) {
           scene.groupObjects[parentGroupUuid].children.push_back(
               {MvrNodeType::SceneObject,
-               referenceUuidForNode("SceneObject", child, layerName, nodeTransform)});
+               referenceUuidForNode("SceneObject", child, layerName,
+                                    nodeTransform)});
         }
       } else if (nodeName == "GroupObject") {
         GroupObject group;
-        group.uuid = resolveStableUuid("GroupObject", child, layerName, nodeTransform);
+        group.uuid =
+            resolveStableUuid("GroupObject", child, layerName, nodeTransform);
         group.layer = layerName;
         group.transform = nodeTransform;
         group.localTransform = local;
@@ -3065,7 +3202,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                        layer->FirstChildElement("Color")) {
           if (const char *txt = colorNode->GetText()) {
             const std::string legacyColor = Trim(txt);
-            l.color = isHexRgb(legacyColor) ? legacyColor : CieToHex(legacyColor);
+            l.color =
+                isHexRgb(legacyColor) ? legacyColor : CieToHex(legacyColor);
           }
         }
       }
@@ -3124,7 +3262,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
       if (conflict.modeName.empty())
         conflict.modeName = f.gdtfMode;
       if (conflict.footprint <= 0) {
-        const std::string resolvedGdtfPath = resolveFixtureGdtfPathForRead(f.gdtfSpec);
+        const std::string resolvedGdtfPath =
+            resolveFixtureGdtfPathForRead(f.gdtfSpec);
         if (!resolvedGdtfPath.empty() && !f.gdtfMode.empty())
           conflict.footprint =
               getGdtfModeChannelCountCached(resolvedGdtfPath, f.gdtfMode);
@@ -3152,7 +3291,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
         reportProgress("Conflict dialog:hide");
         if (!choices.empty()) {
           std::unordered_map<std::string, std::string> selectedPathByType;
-          std::unordered_map<std::string, std::string> downloadFallbackPathByType;
+          std::unordered_map<std::string, std::string>
+              downloadFallbackPathByType;
           std::unordered_map<std::string, std::string> selectedModeByType;
           std::vector<GdtfConflict> downloadRequests;
           for (const auto &conflict : gdtfConflicts) {
@@ -3164,31 +3304,37 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
               selectedPathByType[conflict.type] = conflict.mvrPath;
             } else {
               downloadRequests.push_back(conflict);
-              const std::string fallbackPath = GetDownloadFallbackPath(conflict);
+              const std::string fallbackPath =
+                  GetDownloadFallbackPath(conflict);
               selectedPathByType[conflict.type] = fallbackPath;
               downloadFallbackPathByType[conflict.type] = fallbackPath;
             }
           }
 
           if (!downloadRequests.empty()) {
-            auto parseAddressToAbsoluteChannel = [](const std::string &address) {
+            auto parseAddressToAbsoluteChannel =
+                [](const std::string &address) {
               const std::string trimmed = Trim(address);
               const size_t dotPos = trimmed.find('.');
               if (dotPos == std::string::npos)
                 return -1;
-              const int universe = std::atoi(trimmed.substr(0, dotPos).c_str());
-              const int channel = std::atoi(trimmed.substr(dotPos + 1).c_str());
+                  const int universe =
+                      std::atoi(trimmed.substr(0, dotPos).c_str());
+                  const int channel =
+                      std::atoi(trimmed.substr(dotPos + 1).c_str());
               if (universe <= 0 || channel <= 0)
                 return -1;
               return (universe - 1) * 512 + channel;
             };
-            auto inferFootprintFromAddresses = [&](const std::string &typeName) {
+            auto inferFootprintFromAddresses =
+                [&](const std::string &typeName) {
               std::vector<int> channels;
               for (const auto &[fixtureUuid, fixture] : scene.fixtures) {
                 (void)fixtureUuid;
                 if (fixture.typeName != typeName)
                   continue;
-                const int absolute = parseAddressToAbsoluteChannel(fixture.address);
+                    const int absolute =
+                        parseAddressToAbsoluteChannel(fixture.address);
                 if (absolute > 0)
                   channels.push_back(absolute);
               }
@@ -3210,10 +3356,12 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
             std::optional<CredentialStore::Credentials> activeCredentials =
                 CredentialStore::Load();
             auto requestCredentials = [&]() -> bool {
-              const std::string initialUser =
-                  activeCredentials ? activeCredentials->username : std::string();
-              const std::string initialPass =
-                  activeCredentials ? activeCredentials->password : std::string();
+              const std::string initialUser = activeCredentials
+                                                  ? activeCredentials->username
+                                                  : std::string();
+              const std::string initialPass = activeCredentials
+                                                  ? activeCredentials->password
+                                                  : std::string();
               GdtfLoginDialog loginDlg(nullptr, initialUser, initialPass);
               if (loginDlg.ShowModal() != wxID_OK)
                 return false;
@@ -3227,7 +3375,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
               return true;
             };
 
-            wxString cookieFileWx = wxFileName::CreateTempFileName("gdtf_mvr_import_");
+            wxString cookieFileWx =
+                wxFileName::CreateTempFileName("gdtf_mvr_import_");
             if (wxFileExists(cookieFileWx))
               wxRemoveFile(cookieFileWx);
             const std::string cookieFile = cookieFileWx.ToStdString();
@@ -3248,7 +3397,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
               wxWindow *dialogParent =
                   wxTheApp ? wxDynamicCast(wxTheApp->GetTopWindow(), wxWindow)
                            : nullptr;
-              wxDialog downloadInfoDialog(dialogParent, wxID_ANY, "GDTF download queue",
+              wxDialog downloadInfoDialog(dialogParent, wxID_ANY,
+                                          "GDTF download queue",
                                           wxDefaultPosition, wxSize(1140, 580));
               wxBoxSizer *infoSizer = new wxBoxSizer(wxVERTICAL);
               enum class DownloadRowState {
@@ -3282,32 +3432,36 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
               summaryFont.SetWeight(wxFONTWEIGHT_BOLD);
               summaryText->SetFont(summaryFont);
               infoSizer->Add(summaryText, 0, wxLEFT | wxRIGHT | wxTOP, 8);
-              wxStaticText *progressPhaseText =
-                  new wxStaticText(&downloadInfoDialog, wxID_ANY,
-                                   "Preparing download queue...");
+              wxStaticText *progressPhaseText = new wxStaticText(
+                  &downloadInfoDialog, wxID_ANY, "Preparing download queue...");
               progressPhaseText->SetForegroundColour(wxColour(140, 140, 140));
               infoSizer->Add(progressPhaseText, 0, wxLEFT | wxRIGHT | wxTOP, 8);
-              wxGauge *progressGauge =
-                  new wxGauge(&downloadInfoDialog, wxID_ANY,
-                              100,
-                              wxDefaultPosition, wxSize(-1, 6),
-                              wxGA_HORIZONTAL | wxGA_SMOOTH);
+              wxGauge *progressGauge = new wxGauge(
+                  &downloadInfoDialog, wxID_ANY, 100, wxDefaultPosition,
+                  wxSize(-1, 6), wxGA_HORIZONTAL | wxGA_SMOOTH);
               progressGauge->SetForegroundColour(wxColour(80, 145, 90));
               progressGauge->SetBackgroundColour(wxColour(52, 52, 52));
               progressGauge->SetValue(0);
-              infoSizer->Add(progressGauge, 0, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, 8);
+              infoSizer->Add(progressGauge, 0,
+                             wxEXPAND | wxLEFT | wxRIGHT | wxTOP, 8);
 
               wxListCtrl *downloadInfoList = new wxListCtrl(
-                  &downloadInfoDialog, wxID_ANY, wxDefaultPosition, wxDefaultSize,
+                  &downloadInfoDialog, wxID_ANY, wxDefaultPosition,
+                  wxDefaultSize,
                   wxLC_REPORT | wxLC_SINGLE_SEL | wxLC_HRULES | wxLC_VRULES);
-              downloadInfoList->InsertColumn(0, "Fixture type", wxLIST_FORMAT_LEFT, 260);
-              downloadInfoList->InsertColumn(1, "Selected GDTF", wxLIST_FORMAT_LEFT, 460);
-              downloadInfoList->InsertColumn(2, "Status", wxLIST_FORMAT_LEFT, 170);
-              downloadInfoList->InsertColumn(3, "Progress", wxLIST_FORMAT_LEFT, 220);
-              downloadInfoList->InsertColumn(4, "Details", wxLIST_FORMAT_LEFT, 180);
+              downloadInfoList->InsertColumn(0, "Fixture type",
+                                             wxLIST_FORMAT_LEFT, 260);
+              downloadInfoList->InsertColumn(1, "Selected GDTF",
+                                             wxLIST_FORMAT_LEFT, 460);
+              downloadInfoList->InsertColumn(2, "Status", wxLIST_FORMAT_LEFT,
+                                             170);
+              downloadInfoList->InsertColumn(3, "Progress", wxLIST_FORMAT_LEFT,
+                                             220);
+              downloadInfoList->InsertColumn(4, "Details", wxLIST_FORMAT_LEFT,
+                                             180);
               infoSizer->Add(downloadInfoList, 1, wxEXPAND | wxALL, 8);
-              wxStaticText *footerSummary =
-                  new wxStaticText(&downloadInfoDialog, wxID_ANY,
+              wxStaticText *footerSummary = new wxStaticText(
+                  &downloadInfoDialog, wxID_ANY,
                                    "0 processed  |  0 downloaded  |  0 fallback");
               footerSummary->SetForegroundColour(wxColour(100, 100, 100));
               infoSizer->Add(footerSummary, 0, wxLEFT | wxRIGHT, 8);
@@ -3318,7 +3472,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
               wxBoxSizer *actionSizer = new wxBoxSizer(wxHORIZONTAL);
               wxButton *cancelButton =
                   new wxButton(&downloadInfoDialog, wxID_CANCEL, "Cancel");
-              wxButton *ackButton = new wxButton(&downloadInfoDialog, wxID_OK, "OK");
+              wxButton *ackButton =
+                  new wxButton(&downloadInfoDialog, wxID_OK, "OK");
               ackButton->Disable();
               actionSizer->Add(cancelButton, 0, wxRIGHT, 8);
               actionSizer->Add(ackButton, 0);
@@ -3346,7 +3501,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
               cancelButton->Bind(wxEVT_BUTTON, [&](wxCommandEvent &) {
                 cancelRequested.store(true);
                 cancelButton->Disable();
-                progressPhaseText->SetLabel("Cancel requested. Finishing current transfer...");
+                progressPhaseText->SetLabel(
+                    "Cancel requested. Finishing current transfer...");
               });
               ackButton->Bind(wxEVT_BUTTON, [&](wxCommandEvent &) {
                 downloadUiActive->store(false);
@@ -3359,7 +3515,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                 long long downloadedBytes = 0;
                 long long totalBytes = -1;
               };
-              std::unordered_map<std::string, DownloadProgressStats> rowProgressByType;
+              std::unordered_map<std::string, DownloadProgressStats>
+                  rowProgressByType;
               const auto queueStartTime = std::chrono::steady_clock::now();
               auto formatBytes = [](long long bytes) -> wxString {
                 if (bytes < 0)
@@ -3401,9 +3558,10 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                   }
                 }
                 footerSummary->SetLabel(
-                    wxString::Format("%d/%zu processed  |  %d downloaded  |  %d fallback  |  %d canceled",
-                                     processed, rowStateByType.size(), downloaded, fallback,
-                                     canceled));
+                    wxString::Format("%d/%zu processed  |  %d downloaded  |  "
+                                     "%d fallback  |  %d canceled",
+                                     processed, rowStateByType.size(),
+                                     downloaded, fallback, canceled));
               };
               auto refreshBytesSummary = [&]() {
                 long long downloaded = 0;
@@ -3411,7 +3569,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                 bool hasUnknownTotal = false;
                 for (const auto &[typeKey, progress] : rowProgressByType) {
                   (void)typeKey;
-                  downloaded += std::max<long long>(0, progress.downloadedBytes);
+                  downloaded +=
+                      std::max<long long>(0, progress.downloadedBytes);
                   if (progress.totalBytes > 0) {
                     knownTotal += progress.totalBytes;
                   } else {
@@ -3425,10 +3584,10 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                     std::chrono::duration_cast<std::chrono::seconds>(
                         std::chrono::steady_clock::now() - queueStartTime)
                         .count();
-                if (!hasUnknownTotal && knownTotal > downloaded && elapsed > 0 &&
-                    downloaded > 0) {
-                  const double speed =
-                      static_cast<double>(downloaded) / static_cast<double>(elapsed);
+                if (!hasUnknownTotal && knownTotal > downloaded &&
+                    elapsed > 0 && downloaded > 0) {
+                  const double speed = static_cast<double>(downloaded) /
+                                       static_cast<double>(elapsed);
                   if (speed > 0.0) {
                     const long long remainingSeconds = static_cast<long long>(
                         static_cast<double>(knownTotal - downloaded) / speed);
@@ -3462,7 +3621,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                 bool hasUnknownTotal = false;
                 for (const auto &[typeKey, progress] : rowProgressByType) {
                   (void)typeKey;
-                  downloaded += std::max<long long>(0, progress.downloadedBytes);
+                  downloaded +=
+                      std::max<long long>(0, progress.downloadedBytes);
                   if (progress.totalBytes > 0) {
                     knownTotal += progress.totalBytes;
                   } else {
@@ -3490,9 +3650,11 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                 const int safeTotal = std::max(1, total);
                 progressGauge->SetValue((finished * 100) / safeTotal);
               };
-              // Schedules progress updates on the UI thread without blocking worker callbacks.
+              // Schedules progress updates on the UI thread without blocking
+              // worker callbacks.
               auto runOnUiThread = [&](std::function<void()> task) {
-                // Drops worker-thread progress updates to avoid deferred UI races during teardown.
+                // Drops worker-thread progress updates to avoid deferred UI
+                // races during teardown.
                 if (!wxThread::IsMain())
                   return;
                 if (!downloadUiActive->load())
@@ -3504,12 +3666,15 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
               wxYieldIfNeeded();
               for (const GdtfConflict &req : downloadRequests) {
                 const long row = downloadInfoList->InsertItem(
-                    downloadInfoList->GetItemCount(), wxString::FromUTF8(req.type));
+                    downloadInfoList->GetItemCount(),
+                    wxString::FromUTF8(req.type));
                 downloadInfoList->SetItem(row, 1, "-");
                 downloadInfoList->SetItem(row, 2, "Pending");
                 downloadInfoList->SetItem(row, 3, "0 B / ? B");
-                downloadInfoList->SetItem(row, 4, "Waiting to match catalog entry");
-                downloadInfoList->SetItemTextColour(row, rowTextColor(DownloadRowState::Pending));
+                downloadInfoList->SetItem(row, 4,
+                                          "Waiting to match catalog entry");
+                downloadInfoList->SetItemTextColour(
+                    row, rowTextColor(DownloadRowState::Pending));
                 rowByType[req.type] = row;
                 rowStateByType[req.type] = DownloadRowState::Pending;
                 rowProgressByType[req.type] = DownloadProgressStats{};
@@ -3538,24 +3703,28 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
               if (catalogResult.snapshot) {
                 listPayload = catalogResult.snapshot->listData;
               }
-              reportProgress(
-                  wxString::Format("[METRIC] GDTF import catalog cache_hit=%d cache_miss=%d cache_age_s=%lld refresh_attempted=%d refresh_succeeded=%d",
+              reportProgress(wxString::Format(
+                                 "[METRIC] GDTF import catalog cache_hit=%d "
+                                 "cache_miss=%d cache_age_s=%lld "
+                                 "refresh_attempted=%d refresh_succeeded=%d",
                                    catalogResult.metrics.cacheHit ? 1 : 0,
                                    catalogResult.metrics.cacheMiss ? 1 : 0,
-                                   static_cast<long long>(catalogResult.metrics.cacheAgeSeconds),
+                                 static_cast<long long>(
+                                     catalogResult.metrics.cacheAgeSeconds),
                                    catalogResult.metrics.refreshAttempted ? 1 : 0,
                                    catalogResult.metrics.refreshSucceeded ? 1 : 0)
                       .ToStdString());
 
-              std::vector<gdtf_catalog_matcher::GdtfCatalogEntry> catalogEntries;
+              std::vector<gdtf_catalog_matcher::GdtfCatalogEntry>
+                  catalogEntries;
               std::string catalogFailureReason;
               if (!listPayload.empty()) {
                 catalogEntries = ParseGdtfCatalogEntries(listPayload);
               }
 
               if (catalogEntries.empty()) {
-                reportProgress(
-                    "[INFO] Cached catalog did not provide usable entries; forcing online refresh.");
+                reportProgress("[INFO] Cached catalog did not provide usable "
+                               "entries; forcing online refresh.");
                 const GdtfCatalogRefreshResult forcedCatalogResult =
                     catalogService.RefreshCatalogIfStale(
                         [&](std::string &onlineListData) {
@@ -3563,14 +3732,15 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                                              &listHttpCode) &&
                                  listHttpCode == 200;
                         },
-                        refreshNowUtc,
-                        0);
+                        refreshNowUtc, 0);
                 if (forcedCatalogResult.snapshot) {
                   listPayload = forcedCatalogResult.snapshot->listData;
                   catalogEntries = ParseGdtfCatalogEntries(listPayload);
                 }
                 reportProgress(
-                    wxString::Format("[METRIC] GDTF import forced_refresh attempted=%d succeeded=%d entries=%zu",
+                    wxString::Format(
+                        "[METRIC] GDTF import forced_refresh attempted=%d "
+                        "succeeded=%d entries=%zu",
                                      forcedCatalogResult.metrics.refreshAttempted ? 1 : 0,
                                      forcedCatalogResult.metrics.refreshSucceeded ? 1 : 0,
                                      catalogEntries.size())
@@ -3578,21 +3748,24 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
               }
 
               if (catalogEntries.empty()) {
-                const std::string preview =
-                    listPayload.substr(0, std::min<size_t>(listPayload.size(), 180));
+                const std::string preview = listPayload.substr(
+                    0, std::min<size_t>(listPayload.size(), 180));
                 catalogFailureReason =
-                    wxString::Format("Catalog fetch/parsing failed (HTTP %ld, bytes=%zu)",
+                    wxString::Format(
+                        "Catalog fetch/parsing failed (HTTP %ld, bytes=%zu)",
                                      listHttpCode, listPayload.size())
                         .ToStdString();
                 reportProgress("[WARN] " + catalogFailureReason);
                 if (!preview.empty()) {
-                  reportProgress("[WARN] GDTF catalog payload preview: " + preview);
+                  reportProgress("[WARN] GDTF catalog payload preview: " +
+                                 preview);
                 }
               }
 
               if (!catalogEntries.empty()) {
-                summaryText->SetLabel(wxString::Format(
-                    "Selected fixture types for download (catalog entries: %zu)",
+                summaryText->SetLabel(
+                    wxString::Format("Selected fixture types for download "
+                                     "(catalog entries: %zu)",
                     catalogEntries.size()));
                 progressGauge->SetValue(25);
                 progressPhaseText->SetLabel("Downloading selected fixtures...");
@@ -3600,27 +3773,32 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                   if (cancelRequested.load()) {
                     break;
                   }
-                  reportProgress("Downloading selected GDTFs: matching " + req.type + "...");
+                  reportProgress("Downloading selected GDTFs: matching " +
+                                 req.type + "...");
                   if (req.footprint <= 0)
                     req.footprint = inferFootprintFromAddresses(req.type);
-                  const auto bestMatch = gdtf_catalog_matcher::SelectBestDownloadMatch(
-                      req.requestedFixtureName, req.type, req.modeName, req.manufacturer,
-                      req.footprint, catalogEntries);
+                  const auto bestMatch =
+                      gdtf_catalog_matcher::SelectBestDownloadMatch(
+                          req.requestedFixtureName, req.type, req.modeName,
+                          req.manufacturer, req.footprint, catalogEntries);
 
                   if (!bestMatch.found || bestMatch.rid.empty()) {
                     const wxString progressText =
                         rowProgressByType[req.type].totalBytes > 0
-                            ? formatBytes(rowProgressByType[req.type].downloadedBytes) +
+                            ? formatBytes(
+                                  rowProgressByType[req.type].downloadedBytes) +
                                   " / " +
-                                  formatBytes(rowProgressByType[req.type].totalBytes)
+                                  formatBytes(
+                                      rowProgressByType[req.type].totalBytes)
                             : wxString("0 B / ? B");
                     const bool fallsBackToApp =
                         downloadFallbackPathByType[req.type] == req.appPath &&
                         !req.appPath.empty();
-                    updateStatusRow(req.type, "-", fallsBackToApp ? "Fallback to App"
+                    updateStatusRow(req.type, "-",
+                                    fallsBackToApp ? "Fallback to App"
                                                                    : "Fallback to MVR",
-                                    progressText,
-                                    "No catalog match found", DownloadRowState::Fallback);
+                                    progressText, "No catalog match found",
+                                    DownloadRowState::Fallback);
                     updateProgressGauge();
                     wxYieldIfNeeded();
                     continue;
@@ -3630,23 +3808,28 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
 #ifdef NDEBUG
                       ProjectUtils::GetWritableLibraryPath("fixtures");
 #else
-                      (PathUtils::PathFromUtf8(
-                           wxStandardPaths::Get().GetExecutablePath().ToStdString())
+                      (PathUtils::PathFromUtf8(wxStandardPaths::Get()
+                                                   .GetExecutablePath()
+                                                   .ToStdString())
                            .parent_path() /
                        "library" / "fixtures")
                           .string();
 #endif
                   fs::create_directories(baseFixturesPath);
                   const std::string filePath =
-                      (fs::path(baseFixturesPath) / (req.type + ".gdtf")).string();
+                      (fs::path(baseFixturesPath) / (req.type + ".gdtf"))
+                          .string();
                   long downloadHttpCode = 0;
                   wxString selectedFixtureName = wxString::FromUTF8(req.type);
                   for (const auto &entry : catalogEntries) {
                     if (entry.rid == bestMatch.rid) {
-                      wxString manufacturer = wxString::FromUTF8(entry.manufacturer);
-                      wxString fixtureName = wxString::FromUTF8(entry.fixtureName);
+                      wxString manufacturer =
+                          wxString::FromUTF8(entry.manufacturer);
+                      wxString fixtureName =
+                          wxString::FromUTF8(entry.fixtureName);
                       if (!manufacturer.empty() && !fixtureName.empty()) {
-                        selectedFixtureName = manufacturer + " / " + fixtureName;
+                        selectedFixtureName =
+                            manufacturer + " / " + fixtureName;
                       } else if (!fixtureName.empty()) {
                         selectedFixtureName = fixtureName;
                       }
@@ -3654,39 +3837,45 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                     }
                   }
                   updateStatusRow(req.type, selectedFixtureName, "Downloading",
-                                  "0 B / ? B",
-                                  "Fetching fixture package",
+                                  "0 B / ? B", "Fetching fixture package",
                                   DownloadRowState::Downloading);
-                  reportProgress("Downloading selected GDTFs: downloading " + req.type + "...");
-                  auto formatRowProgress = [&](const DownloadProgressStats &stats,
+                  reportProgress("Downloading selected GDTFs: downloading " +
+                                 req.type + "...");
+                  auto formatRowProgress =
+                      [&](const DownloadProgressStats &stats,
                                                double percent) -> wxString {
-                    wxString totalText =
-                        stats.totalBytes > 0 ? formatBytes(stats.totalBytes)
+                    wxString totalText = stats.totalBytes > 0
+                                             ? formatBytes(stats.totalBytes)
                                              : wxString("? B");
                     wxString bytesText =
                         formatBytes(stats.downloadedBytes) + " / " + totalText;
                     if (stats.totalBytes > 0) {
-                      bytesText += wxString::Format(" (%.0f%%)", std::clamp(percent, 0.0, 100.0));
+                      bytesText += wxString::Format(
+                          " (%.0f%%)", std::clamp(percent, 0.0, 100.0));
                     }
                     return bytesText;
                   };
-                  if (GdtfDownload(bestMatch.rid, filePath, cookieFile,
-                                   downloadHttpCode,
+                  if (GdtfDownload(
+                          bestMatch.rid, filePath, cookieFile, downloadHttpCode,
                                    [&](const GdtfDownloadProgress &progress) {
                                      const long long downloadedBytes =
-                                         std::max<long long>(0, progress.downloadedBytes);
+                                std::max<long long>(0,
+                                                    progress.downloadedBytes);
                                      const long long totalBytes =
-                                         progress.totalBytes > 0 ? progress.totalBytes : -1;
+                                progress.totalBytes > 0 ? progress.totalBytes
+                                                        : -1;
                                      const double percentage = progress.percentage;
                                      const std::string typeKey = req.type;
                                      const wxString selectedFixtureNameCopy =
                                          selectedFixtureName;
-                                     runOnUiThread([=, &rowProgressByType, &updateStatusRow,
-                                                    &formatRowProgress, &updateProgressGauge]() {
+                            runOnUiThread([=, &rowProgressByType,
+                                           &updateStatusRow, &formatRowProgress,
+                                           &updateProgressGauge]() {
                                        auto &stats = rowProgressByType[typeKey];
                                        stats.downloadedBytes = downloadedBytes;
                                        stats.totalBytes = totalBytes;
-                                       updateStatusRow(typeKey, selectedFixtureNameCopy,
+                              updateStatusRow(
+                                  typeKey, selectedFixtureNameCopy,
                                                        "Downloading",
                                                        formatRowProgress(stats, percentage),
                                                        "Fetching fixture package",
@@ -3701,40 +3890,48 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                       selectedModeByType[req.type] = bestMatch.modeName;
                     wxString details = "Downloaded and assigned";
                     if (!bestMatch.modeName.empty())
-                      details += " (Mode: " + wxString::FromUTF8(bestMatch.modeName) + ")";
+                      details +=
+                          " (Mode: " + wxString::FromUTF8(bestMatch.modeName) +
+                          ")";
                     if (!bestMatch.selectionReason.empty())
-                      details += " [" + wxString::FromUTF8(bestMatch.selectionReason) + "]";
+                      details += " [" +
+                                 wxString::FromUTF8(bestMatch.selectionReason) +
+                                 "]";
                     auto &stats = rowProgressByType[req.type];
                     if (stats.totalBytes > 0) {
                       stats.downloadedBytes = stats.totalBytes;
                     }
-                    updateStatusRow(req.type, selectedFixtureName, "Success",
+                    updateStatusRow(
+                        req.type, selectedFixtureName, "Success",
                                     formatRowProgress(rowProgressByType[req.type], 100.0),
-                                    details,
-                                    DownloadRowState::Downloaded);
+                        details, DownloadRowState::Downloaded);
                   } else if (cancelRequested.load()) {
                     const wxString totalText =
                         rowProgressByType[req.type].totalBytes > 0
-                            ? formatBytes(rowProgressByType[req.type].totalBytes)
+                            ? formatBytes(
+                                  rowProgressByType[req.type].totalBytes)
                             : wxString("? B");
-                    updateStatusRow(req.type, selectedFixtureName, "Canceled",
-                                    formatBytes(rowProgressByType[req.type].downloadedBytes) +
+                    updateStatusRow(
+                        req.type, selectedFixtureName, "Canceled",
+                        formatBytes(
+                            rowProgressByType[req.type].downloadedBytes) +
                                         " / " + totalText,
-                                    "Canceled by user",
-                                    DownloadRowState::Canceled);
+                        "Canceled by user", DownloadRowState::Canceled);
                     break;
                   } else {
                     const wxString totalText =
                         rowProgressByType[req.type].totalBytes > 0
-                            ? formatBytes(rowProgressByType[req.type].totalBytes)
+                            ? formatBytes(
+                                  rowProgressByType[req.type].totalBytes)
                             : wxString("? B");
                     const bool fallsBackToApp =
                         downloadFallbackPathByType[req.type] == req.appPath &&
                         !req.appPath.empty();
-                    updateStatusRow(req.type, selectedFixtureName,
-                                    fallsBackToApp ? "Fallback to App"
-                                                   : "Fallback to MVR",
-                                    formatBytes(rowProgressByType[req.type].downloadedBytes) +
+                    updateStatusRow(
+                        req.type, selectedFixtureName,
+                        fallsBackToApp ? "Fallback to App" : "Fallback to MVR",
+                        formatBytes(
+                            rowProgressByType[req.type].downloadedBytes) +
                                         " / " + totalText,
                                     "Download failed", DownloadRowState::Fallback);
                   }
@@ -3749,29 +3946,34 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                                       DownloadRowState::Canceled);
                     }
                   }
-                  progressPhaseText->SetLabel("Queue canceled. Keeping downloaded fixtures.");
+                  progressPhaseText->SetLabel(
+                      "Queue canceled. Keeping downloaded fixtures.");
                 } else {
                   progressPhaseText->SetLabel("Queue finished.");
                 }
               } else {
                 if (catalogFailureReason.empty())
                   catalogFailureReason = "Catalog fetch/parsing failed.";
-                summaryText->SetLabel("Selected fixture types for download (catalog load failed: " +
-                                      wxString::FromUTF8(catalogFailureReason) + ")");
+                summaryText->SetLabel("Selected fixture types for download "
+                                      "(catalog load failed: " +
+                                      wxString::FromUTF8(catalogFailureReason) +
+                                      ")");
                 for (const GdtfConflict &req : downloadRequests) {
-                  updateStatusRow(req.type, "-", "Fallback to MVR",
-                                  "0 B / ? B",
-                                  "Failed to load catalog list", DownloadRowState::Fallback);
+                  updateStatusRow(req.type, "-", "Fallback to MVR", "0 B / ? B",
+                                  "Failed to load catalog list",
+                                  DownloadRowState::Fallback);
                 }
                 updateProgressGauge();
-                progressPhaseText->SetLabel("Catalog load failed. " +
+                progressPhaseText->SetLabel(
+                    "Catalog load failed. " +
                                             wxString::FromUTF8(catalogFailureReason) +
                                             ". Keeping MVR originals.");
               }
               isDownloadInfoFinished = true;
               downloadUiActive->store(false);
               cancelButton->Disable();
-              summaryText->SetLabel(summaryText->GetLabel() + " - queue finished");
+              summaryText->SetLabel(summaryText->GetLabel() +
+                                    " - queue finished");
               ackButton->Enable();
               downloadInfoDialog.Hide();
             } else {
@@ -3781,7 +3983,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
             if (wxFileExists(cookieFileWx))
               wxRemoveFile(cookieFileWx);
 #else
-            wxMessageBox("GDTF Share download is unavailable in this build target.",
+            wxMessageBox(
+                "GDTF Share download is unavailable in this build target.",
                          "GDTF Share download", wxOK | wxICON_WARNING);
 #endif
             reportProgress("Conflict dialog:hide");
@@ -3795,7 +3998,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
           ++appliedFixturesForConflictApply;
           if (totalFixturesForConflictApply > 0 &&
               (appliedFixturesForConflictApply == 1 ||
-               appliedFixturesForConflictApply == totalFixturesForConflictApply ||
+                 appliedFixturesForConflictApply ==
+                     totalFixturesForConflictApply ||
                appliedFixturesForConflictApply % 50 == 0)) {
             reportProgress("Applying GDTF conflict selection...",
                            appliedFixturesForConflictApply,
@@ -3808,16 +4012,19 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                 resolveFixtureGdtfPathForRead(f.gdtfSpec);
             const int previousChannelCount =
                 (!resolvedGdtfPath.empty() && !f.gdtfMode.empty())
-                    ? getGdtfModeChannelCountCached(resolvedGdtfPath, f.gdtfMode)
+                      ? getGdtfModeChannelCountCached(resolvedGdtfPath,
+                                                      f.gdtfMode)
                     : -1;
               const auto selectedPathIt = selectedPathByType.find(typeKey);
               if (selectedPathIt == selectedPathByType.end())
                 continue;
               f.gdtfSpec = selectedPathIt->second;
             f.gdtfSpec = ToSceneRelativePathIfPossible(
-                scene.basePath, PathUtils::PathFromUtf8(resolveFixtureGdtfPathForRead(f.gdtfSpec)));
-            std::string parsed =
-                Trim(GetGdtfFixtureName(resolveFixtureGdtfPathForRead(f.gdtfSpec)));
+                  scene.basePath,
+                  PathUtils::PathFromUtf8(
+                      resolveFixtureGdtfPathForRead(f.gdtfSpec)));
+              std::string parsed = Trim(GetGdtfFixtureName(
+                  resolveFixtureGdtfPathForRead(f.gdtfSpec)));
             if (!parsed.empty())
               f.typeName = parsed;
             const auto &dictEntry = getDictionaryEntryCached(typeKey);
@@ -3830,7 +4037,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                 f.gdtfMode = selectedModeIt->second;
               f.gdtfMode = resolveExistingGdtfModeCached(
                   resolveFixtureGdtfPathForRead(f.gdtfSpec), f.gdtfMode,
-                  previousChannelCount > 0 ? std::optional<int>(previousChannelCount)
+                  previousChannelCount > 0
+                      ? std::optional<int>(previousChannelCount)
                                            : std::nullopt);
             }
           }
@@ -3843,7 +4051,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
           ++appliedFixturesForDictionaryApply;
           if (totalFixturesForDictionaryApply > 0 &&
               (appliedFixturesForDictionaryApply == 1 ||
-               appliedFixturesForDictionaryApply == totalFixturesForDictionaryApply ||
+               appliedFixturesForDictionaryApply ==
+                   totalFixturesForDictionaryApply ||
                appliedFixturesForDictionaryApply % 50 == 0)) {
             reportProgress("Applying dictionary GDTF mappings...",
                            appliedFixturesForDictionaryApply,
@@ -3855,11 +4064,13 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                 resolveFixtureGdtfPathForRead(dictEntry->path);
             std::error_code dictionaryPathEc;
             if (dictionaryResolvedPath.empty() ||
-                !fs::exists(PathUtils::PathFromUtf8(dictionaryResolvedPath), dictionaryPathEc) ||
+                !fs::exists(PathUtils::PathFromUtf8(dictionaryResolvedPath),
+                            dictionaryPathEc) ||
                 dictionaryPathEc) {
               LogMessage(Logger::Level::Warn,
                          "Skipping dictionary GDTF mapping for fixture '" +
-                             f.instanceName + "' because the mapped path is unavailable: " +
+                             f.instanceName +
+                             "' because the mapped path is unavailable: " +
                              dictEntry->path);
               continue;
             }
@@ -3867,17 +4078,21 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                 resolveFixtureGdtfPathForRead(f.gdtfSpec);
             const int previousChannelCount =
                 (!resolvedGdtfPath.empty() && !f.gdtfMode.empty())
-                    ? getGdtfModeChannelCountCached(resolvedGdtfPath, f.gdtfMode)
+                    ? getGdtfModeChannelCountCached(resolvedGdtfPath,
+                                                    f.gdtfMode)
                     : -1;
             f.gdtfSpec = ToSceneRelativePathIfPossible(
-                scene.basePath, PathUtils::PathFromUtf8(dictionaryResolvedPath));
+                scene.basePath,
+                PathUtils::PathFromUtf8(dictionaryResolvedPath));
             if (f.gdtfMode.empty())
               f.gdtfMode = dictEntry->mode;
             f.gdtfMode = resolveExistingGdtfModeCached(
                 dictionaryResolvedPath, f.gdtfMode,
-                previousChannelCount > 0 ? std::optional<int>(previousChannelCount)
+                previousChannelCount > 0
+                    ? std::optional<int>(previousChannelCount)
                                          : std::nullopt);
-            std::string parsed = Trim(GetGdtfFixtureName(dictionaryResolvedPath));
+            std::string parsed =
+                Trim(GetGdtfFixtureName(dictionaryResolvedPath));
             if (!parsed.empty())
               f.typeName = parsed;
           }
@@ -3887,7 +4102,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
   }
 
   reportProgress("Applying fixture categories...");
-  const int totalFixturesForCategoryApply = static_cast<int>(scene.fixtures.size());
+  const int totalFixturesForCategoryApply =
+      static_cast<int>(scene.fixtures.size());
   int appliedFixturesForCategoryApply = 0;
   int autoFallbackAppliedCount = 0;
   std::unordered_map<std::string, int> autoFallbackReasons;
@@ -3931,7 +4147,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
     }
 
     if (fixture.category.empty() && !fixture.gdtfSpec.empty()) {
-      std::string resolvedCategoryPath = resolveFixtureGdtfPathForRead(fixture.gdtfSpec);
+      std::string resolvedCategoryPath =
+          resolveFixtureGdtfPathForRead(fixture.gdtfSpec);
       if (!resolvedCategoryPath.empty()) {
         resolvedCategoryPath =
             ResolveScenePathForRead(scene.basePath, resolvedCategoryPath);
@@ -3948,23 +4165,26 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
           inferred = inferenceCacheIt->second;
         } else {
           inferred = GdtfFixtureCategory::InferFromGdtf(resolvedCategoryPath);
-          categoryInferenceByResolvedPath.emplace(resolvedCategoryPath, inferred);
+          categoryInferenceByResolvedPath.emplace(resolvedCategoryPath,
+                                                  inferred);
         }
       } else {
         inferred = GdtfFixtureCategory::InferFromGdtf(resolvedCategoryPath);
       }
 
-      fixture.category = GdtfFixtureCategory::NormalizeCategory(inferred.category);
+      fixture.category =
+          GdtfFixtureCategory::NormalizeCategory(inferred.category);
       if (fixture.category.empty())
         fixture.category = GdtfFixtureCategory::kUnknown;
       fixture.categorySource = GdtfFixtureCategory::kAutoFallbackSource;
       fixture.categorySourceReason = inferred.reason;
       ++autoFallbackAppliedCount;
-      ++autoFallbackReasons[inferred.reason.empty() ? "unknown" : inferred.reason];
+      ++autoFallbackReasons[inferred.reason.empty() ? "unknown"
+                                                    : inferred.reason];
       ++autoFallbackCategories[fixture.category];
       if (!categoryKey.empty()) {
-        categoryByTypeKey[categoryKey] =
-            {fixture.category, fixture.categorySource, inferred.reason};
+        categoryByTypeKey[categoryKey] = {
+            fixture.category, fixture.categorySource, inferred.reason};
       }
       LogMessage(Logger::Level::Debug,
                  "Auto category fallback: " + fixture.instanceName + " -> " +
@@ -3983,10 +4203,12 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
       pendingCategoryUpdatesByType[fixture.typeName] = fixture.category;
     }
   }
-  auto formatBreakdown = [](const std::unordered_map<std::string, int> &counts) {
+  auto formatBreakdown =
+      [](const std::unordered_map<std::string, int> &counts) {
     if (counts.empty())
       return std::string("none");
-    std::vector<std::pair<std::string, int>> sortedCounts(counts.begin(), counts.end());
+        std::vector<std::pair<std::string, int>> sortedCounts(counts.begin(),
+                                                              counts.end());
     std::sort(sortedCounts.begin(), sortedCounts.end(),
               [](const auto &lhs, const auto &rhs) {
                 if (lhs.second != rhs.second)
@@ -4006,9 +4228,9 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
   };
   LogMessage(Logger::Level::Info,
              "Auto category fallback applied to " +
-                 std::to_string(autoFallbackAppliedCount) + " fixtures; reasons: " +
-                 formatBreakdown(autoFallbackReasons) + "; categories: " +
-                 formatBreakdown(autoFallbackCategories));
+                 std::to_string(autoFallbackAppliedCount) +
+                 " fixtures; reasons: " + formatBreakdown(autoFallbackReasons) +
+                 "; categories: " + formatBreakdown(autoFallbackCategories));
   GdtfDictionary::UpdateCategoriesBulk(pendingCategoryUpdatesByType);
 
   reportProgress("Building fixtures, trusses, and objects...");
@@ -4022,8 +4244,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
         (resolvedFixturesForModeResolve == 1 ||
          resolvedFixturesForModeResolve == totalFixturesForModeResolve ||
          resolvedFixturesForModeResolve % 50 == 0)) {
-      reportProgress("Resolving GDTF modes...",
-                     resolvedFixturesForModeResolve,
+      reportProgress("Resolving GDTF modes...", resolvedFixturesForModeResolve,
                      totalFixturesForModeResolve);
     }
     if (fixture.gdtfSpec.empty())
@@ -4065,13 +4286,15 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
 
   if (matrixScaleAggregation.suspiciousMatrixCount > 0) {
     std::ostringstream oss;
-    oss << "MVR import matrix anomalies: " << matrixScaleAggregation.suspiciousMatrixCount
+    oss << "MVR import matrix anomalies: "
+        << matrixScaleAggregation.suspiciousMatrixCount
         << " suspicious matrices detected. Contexts: "
         << JoinMatrixContextCounts(matrixScaleAggregation.suspiciousByContext);
     LogMessage(Logger::Level::Warn, oss.str());
 
     for (const std::string &example : matrixScaleAggregation.suspiciousExamples)
-      LogMessage(Logger::Level::Warn, "MVR import suspicious matrix example: " + example);
+      LogMessage(Logger::Level::Warn,
+                 "MVR import suspicious matrix example: " + example);
   }
 
   if (trussSymbolSymdefPreservedCount > 0) {
@@ -4093,7 +4316,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
       for (size_t i = 0; i < sortedSymdefCounts.size(); ++i) {
         if (i > 0)
           oss << ", ";
-        oss << "'" << sortedSymdefCounts[i].first << "'=" << sortedSymdefCounts[i].second;
+        oss << "'" << sortedSymdefCounts[i].first
+            << "'=" << sortedSymdefCounts[i].second;
       }
     }
     LogMessage(Logger::Level::Info, oss.str());
@@ -4110,9 +4334,11 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
     if (preservedSpec.empty())
       continue;
     ++fixturesWithGdtfSpec;
-    const std::string resolvedGdtf = resolveFixtureGdtfPathForRead(preservedSpec);
+    const std::string resolvedGdtf =
+        resolveFixtureGdtfPathForRead(preservedSpec);
     std::error_code resolvedEc;
-    if (!resolvedGdtf.empty() && fs::exists(PathUtils::PathFromUtf8(resolvedGdtf), resolvedEc) &&
+    if (!resolvedGdtf.empty() &&
+        fs::exists(PathUtils::PathFromUtf8(resolvedGdtf), resolvedEc) &&
         !resolvedEc) {
       ++fixturesWithResolvedGdtf;
     } else if (unresolvedGdtfExamples.size() < 5) {
@@ -4121,7 +4347,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
   }
 
   std::ostringstream importDiagnostics;
-  importDiagnostics << "MVR import GDTF diagnostics: basePath='" << scene.basePath
+  importDiagnostics << "MVR import GDTF diagnostics: basePath='"
+                    << scene.basePath
                     << "', fixturesWithGdtfSpec=" << fixturesWithGdtfSpec
                     << ", resolvedFixtureGdtfs=" << fixturesWithResolvedGdtf
                     << ", unresolvedFixtureGdtfs="
@@ -4148,10 +4375,10 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
   return true;
 }
 
-// Imports an MVR file and migrates labels after replacing the active project scene.
+// Imports an MVR file and migrates labels after replacing the active project
+// scene.
 bool MvrImporter::ImportAndRegister(const std::string &filePath,
-                                    bool promptConflicts,
-                                    bool applyDictionary,
+                                    bool promptConflicts, bool applyDictionary,
                                     ProgressCallback progressCallback) {
   MvrImportOptions options;
   options.promptConflicts = promptConflicts;
@@ -4165,9 +4392,9 @@ bool MvrImporter::ImportAndRegister(const std::string &filePath,
                                     ProgressCallback progressCallback) {
   MvrImporter importer;
   MvrImportResult importResult;
-  const bool imported = importer.ImportFromFile(
-      filePath, importResult, MvrImportMode::ReplaceProject, options,
-      progressCallback);
+  const bool imported = importer.ImportFromFile(filePath, importResult,
+                                                MvrImportMode::ReplaceProject,
+                                                options, progressCallback);
   if (!imported)
     return false;
 

--- a/tests/gdtf_dictionary_color_mode_propagation_test.cpp
+++ b/tests/gdtf_dictionary_color_mode_propagation_test.cpp
@@ -1,8 +1,8 @@
 /*
  * This file is part of Perastage.
  */
-#include <cassert>
 #include "filesystem_path_utils.h"
+#include <cassert>
 #include <filesystem>
 #include <fstream>
 #include <sstream>
@@ -42,77 +42,80 @@ int main() {
   std::filesystem::create_directories(fixturesDir);
   const std::filesystem::path dictPath = fixturesDir / "gdtf_dictionary.json";
   const bool hadOriginal = std::filesystem::exists(dictPath);
-  const std::string originalContent = hadOriginal ? ReadFile(dictPath) : std::string{};
+  const std::string originalContent =
+      hadOriginal ? ReadFile(dictPath) : std::string{};
 
-  const std::filesystem::path fixtureFile = fixturesDir / "mode_shared_fixture.gdtf";
+  const std::filesystem::path fixtureFile =
+      fixturesDir / "mode_shared_fixture.gdtf";
   WriteFile(fixtureFile, "fixture");
-  const std::filesystem::path fixtureFileNew = fixturesDir / "mode_shared_fixture_new.gdtf";
+  const std::filesystem::path fixtureFileNew =
+      fixturesDir / "mode_shared_fixture_new.gdtf";
   WriteFile(fixtureFileNew, "fixture-new");
 
   nlohmann::json entries = nlohmann::json::object();
-  entries["TypeA"] = {{"file", fixtureFile.string()},
-                      {"mode", "Mode A"},
-                      {"color", "#000001"}};
-  entries["TypeB"] = {{"file", fixtureFile.string()},
-                      {"mode", "Mode_B"},
-                      {"color", "#000002"}};
-  entries["TypeC"] = {{"file", fixtureFile.string()},
-                      {"mode", "mode-a"},
-                      {"color", "#000003"}};
-  WriteFile(dictPath,
+  entries["TypeA"] = {
+      {"file", fixtureFile.string()}, {"mode", "Mode A"}, {"color", "#000001"}};
+  entries["TypeB"] = {
+      {"file", fixtureFile.string()}, {"mode", "Mode_B"}, {"color", "#000002"}};
+  entries["TypeC"] = {
+      {"file", fixtureFile.string()}, {"mode", "mode-a"}, {"color", "#000003"}};
+  WriteFile(
+      dictPath,
             DictionaryJsonContract::MakeRoot("fixtures", std::move(entries)).dump(4));
 
-  GdtfDictionary::UpdateColorForFile("TypeA", fixtureFile.string(), "MODE-A", "#ABCDEF");
+  GdtfDictionary::UpdateVisualColorForFile("TypeA", fixtureFile.string(),
+                                           "MODE-A", "#ABCDEF");
 
   auto dictAfterExplicitModeOpt = GdtfDictionary::Load();
   assert(dictAfterExplicitModeOpt.has_value());
   const auto &dictAfterExplicitMode = *dictAfterExplicitModeOpt;
-  assert(dictAfterExplicitMode.at("TypeA").color == "#ABCDEF");
-  assert(dictAfterExplicitMode.at("TypeC").color == "#ABCDEF");
-  assert(dictAfterExplicitMode.at("TypeB").color == "#000002");
+  assert(dictAfterExplicitMode.at("TypeA").visualColorHex == "#ABCDEF");
+  assert(dictAfterExplicitMode.at("TypeC").visualColorHex == "#ABCDEF");
+  assert(dictAfterExplicitMode.at("TypeB").visualColorHex == "#000002");
 
-  GdtfDictionary::UpdateColorForFile("TypeA", fixtureFile.string(), {}, "#FEDCBA");
+  GdtfDictionary::UpdateVisualColorForFile("TypeA", fixtureFile.string(), {},
+                                           "#FEDCBA");
 
   auto dictAfterEntryModeOpt = GdtfDictionary::Load();
   assert(dictAfterEntryModeOpt.has_value());
   const auto &dictAfterEntryMode = *dictAfterEntryModeOpt;
-  assert(dictAfterEntryMode.at("TypeA").color == "#FEDCBA");
-  assert(dictAfterEntryMode.at("TypeC").color == "#FEDCBA");
-  assert(dictAfterEntryMode.at("TypeB").color == "#000002");
+  assert(dictAfterEntryMode.at("TypeA").visualColorHex == "#FEDCBA");
+  assert(dictAfterEntryMode.at("TypeC").visualColorHex == "#FEDCBA");
+  assert(dictAfterEntryMode.at("TypeB").visualColorHex == "#000002");
 
-  GdtfDictionary::UpdateColorForFile("TypeNotInDictionary", fixtureFile.string(),
-                                     "mode_a", "#123456");
+  GdtfDictionary::UpdateVisualColorForFile(
+      "TypeNotInDictionary", fixtureFile.string(), "mode_a", "#123456");
 
   auto dictAfterNewTypeOpt = GdtfDictionary::Load();
   assert(dictAfterNewTypeOpt.has_value());
   const auto &dictAfterNewType = *dictAfterNewTypeOpt;
-  assert(dictAfterNewType.at("TypeA").color == "#123456");
-  assert(dictAfterNewType.at("TypeC").color == "#123456");
-  assert(dictAfterNewType.at("TypeB").color == "#000002");
-  assert(dictAfterNewType.at("TypeNotInDictionary").color == "#123456");
+  assert(dictAfterNewType.at("TypeA").visualColorHex == "#123456");
+  assert(dictAfterNewType.at("TypeC").visualColorHex == "#123456");
+  assert(dictAfterNewType.at("TypeB").visualColorHex == "#000002");
+  assert(dictAfterNewType.at("TypeNotInDictionary").visualColorHex ==
+         "#123456");
 
   nlohmann::json migratedEntries = nlohmann::json::object();
-  migratedEntries["TypeA"] = {{"file", fixtureFile.string()},
-                              {"mode", "Mode A"},
-                              {"color", "#100000"}};
-  migratedEntries["TypeB"] = {{"file", fixtureFile.string()},
-                              {"mode", "Mode_B"},
-                              {"color", "#200000"}};
+  migratedEntries["TypeA"] = {
+      {"file", fixtureFile.string()}, {"mode", "Mode A"}, {"color", "#100000"}};
+  migratedEntries["TypeB"] = {
+      {"file", fixtureFile.string()}, {"mode", "Mode_B"}, {"color", "#200000"}};
   migratedEntries["TypeC"] = {{"file", fixtureFileNew.string()},
                               {"mode", "Mode A"},
                               {"color", "#300000"}};
-  WriteFile(dictPath, DictionaryJsonContract::MakeRoot("fixtures", std::move(migratedEntries))
+  WriteFile(dictPath, DictionaryJsonContract::MakeRoot(
+                          "fixtures", std::move(migratedEntries))
                          .dump(4));
 
-  GdtfDictionary::UpdateColorForFile("TypeA", fixtureFileNew.string(), "Mode A",
-                                     "#654321");
+  GdtfDictionary::UpdateVisualColorForFile("TypeA", fixtureFileNew.string(),
+                                           "Mode A", "#654321");
   auto dictAfterPathRefreshOpt = GdtfDictionary::Load();
   assert(dictAfterPathRefreshOpt.has_value());
   const auto &dictAfterPathRefresh = *dictAfterPathRefreshOpt;
   assert(dictAfterPathRefresh.at("TypeA").path == fixtureFileNew.string());
-  assert(dictAfterPathRefresh.at("TypeA").color == "#654321");
-  assert(dictAfterPathRefresh.at("TypeC").color == "#654321");
-  assert(dictAfterPathRefresh.at("TypeB").color == "#200000");
+  assert(dictAfterPathRefresh.at("TypeA").visualColorHex == "#654321");
+  assert(dictAfterPathRefresh.at("TypeC").visualColorHex == "#654321");
+  assert(dictAfterPathRefresh.at("TypeB").visualColorHex == "#200000");
 
   nlohmann::json inconsistentEntries = nlohmann::json::object();
   inconsistentEntries["TypeWithColor"] = {{"file", fixtureFileNew.string()},
@@ -122,16 +125,18 @@ int main() {
                                              {"mode", "mode-a"}};
   inconsistentEntries["TypeOtherMode"] = {{"file", fixtureFileNew.string()},
                                           {"mode", "Mode B"}};
-  WriteFile(dictPath,
-            DictionaryJsonContract::MakeRoot("fixtures", std::move(inconsistentEntries))
+  WriteFile(dictPath, DictionaryJsonContract::MakeRoot(
+                          "fixtures", std::move(inconsistentEntries))
                 .dump(4));
 
   auto dictAfterLoadHarmonizationOpt = GdtfDictionary::Load();
   assert(dictAfterLoadHarmonizationOpt.has_value());
   const auto &dictAfterLoadHarmonization = *dictAfterLoadHarmonizationOpt;
-  assert(dictAfterLoadHarmonization.at("TypeWithColor").color == "#0F0F0F");
-  assert(dictAfterLoadHarmonization.at("TypeWithoutColor").color == "#0F0F0F");
-  assert(dictAfterLoadHarmonization.at("TypeOtherMode").color.empty());
+  assert(dictAfterLoadHarmonization.at("TypeWithColor").visualColorHex ==
+         "#0F0F0F");
+  assert(dictAfterLoadHarmonization.at("TypeWithoutColor").visualColorHex ==
+         "#0F0F0F");
+  assert(dictAfterLoadHarmonization.at("TypeOtherMode").visualColorHex.empty());
 
   std::filesystem::remove(fixtureFileNew);
   std::filesystem::remove(fixtureFile);

--- a/tests/gdtf_dictionary_color_roundtrip_test.cpp
+++ b/tests/gdtf_dictionary_color_roundtrip_test.cpp
@@ -1,8 +1,8 @@
 /*
  * This file is part of Perastage.
  */
-#include <cassert>
 #include "filesystem_path_utils.h"
+#include <cassert>
 #include <filesystem>
 #include <fstream>
 #include <sstream>
@@ -43,7 +43,8 @@ int main() {
   const std::filesystem::path dictPath = fixturesDir / "gdtf_dictionary.json";
 
   const bool hadOriginal = std::filesystem::exists(dictPath);
-  const std::string originalContent = hadOriginal ? ReadFile(dictPath) : std::string{};
+  const std::string originalContent =
+      hadOriginal ? ReadFile(dictPath) : std::string{};
 
   const std::filesystem::path fixtureFile = fixturesDir / "color_fixture.gdtf";
   WriteFile(fixtureFile, "fixture");
@@ -54,7 +55,8 @@ int main() {
                          {"mode", "ModeA"},
                          {"category", "Wash"},
                          {"color", "#ABCDEF"}};
-  WriteFile(dictPath,
+  WriteFile(
+      dictPath,
             DictionaryJsonContract::MakeRoot("fixtures", std::move(entries)).dump(4));
 
   auto loadedOpt = GdtfDictionary::Load();
@@ -62,12 +64,12 @@ int main() {
 
   const auto colorOnlyIt = loadedOpt->find("ColorOnlyType");
   assert(colorOnlyIt != loadedOpt->end());
-  assert(colorOnlyIt->second.color == "#112233");
+  assert(colorOnlyIt->second.visualColorHex == "#112233");
   assert(colorOnlyIt->second.path.empty());
 
   const auto fullIt = loadedOpt->find("FullType");
   assert(fullIt != loadedOpt->end());
-  assert(fullIt->second.color == "#ABCDEF");
+  assert(fullIt->second.visualColorHex == "#ABCDEF");
 
   assert(GdtfDictionary::Save(*loadedOpt));
 
@@ -79,8 +81,10 @@ int main() {
   }
 
   assert(savedRoot.contains("entries"));
-  assert(savedRoot["entries"]["ColorOnlyType"]["color"] == "#112233");
-  assert(savedRoot["entries"]["FullType"]["color"] == "#ABCDEF");
+  assert(savedRoot["entries"]["ColorOnlyType"]["visual_color"] == "#112233");
+  assert(savedRoot["entries"]["FullType"]["visual_color"] == "#ABCDEF");
+  assert(!savedRoot["entries"]["ColorOnlyType"].contains("color"));
+  assert(!savedRoot["entries"]["FullType"].contains("color"));
 
   std::filesystem::remove(fixtureFile);
   if (hadOriginal)

--- a/tests/mvr_exporter_compliance_test.cpp
+++ b/tests/mvr_exporter_compliance_test.cpp
@@ -3,9 +3,9 @@
  */
 #include <algorithm>
 #include <cassert>
+#include <cctype>
 #include <filesystem>
 #include <fstream>
-#include <cctype>
 #include <set>
 #include <string>
 #include <unordered_map>
@@ -17,15 +17,15 @@
 #include <wx/wfstream.h>
 #include <wx/zipstrm.h>
 
-#include "configmanager.h"
 #include "app_version.h"
+#include "configmanager.h"
 #include "fixture.h"
 #include "matrixutils.h"
 #include "mvrexporter.h"
 #include "mvrimporter.h"
 #include "sceneobject.h"
-#include "truss.h"
 #include "support.h"
+#include "truss.h"
 #include "uuidutils.h"
 
 namespace fs = std::filesystem;
@@ -93,7 +93,8 @@ static bool GdtfHasRenderable3DModel(const fs::path &gdtfPath) {
   if (modelNames.empty())
     return false;
 
-  tinyxml2::XMLElement *geometries = fixtureType->FirstChildElement("Geometries");
+  tinyxml2::XMLElement *geometries =
+      fixtureType->FirstChildElement("Geometries");
   if (!geometries)
     return false;
 
@@ -121,8 +122,8 @@ static bool GdtfHasRenderable3DModel(const fs::path &gdtfPath) {
 }
 
 // Finds an exported Fixture XML element by UUID.
-static tinyxml2::XMLElement *FindFixtureElementByUuid(tinyxml2::XMLElement *root,
-                                                      const std::string &uuid) {
+static tinyxml2::XMLElement *
+FindFixtureElementByUuid(tinyxml2::XMLElement *root, const std::string &uuid) {
   for (tinyxml2::XMLElement *node = root->FirstChildElement(); node;
        node = node->NextSiblingElement()) {
     std::vector<tinyxml2::XMLElement *> stack{node};
@@ -144,7 +145,8 @@ static tinyxml2::XMLElement *FindFixtureElementByUuid(tinyxml2::XMLElement *root
 }
 
 // Reads the exported UnitNumber for a fixture UUID.
-static int ReadFixtureUnitNumber(tinyxml2::XMLElement *root, const std::string &uuid) {
+static int ReadFixtureUnitNumber(tinyxml2::XMLElement *root,
+                                 const std::string &uuid) {
   tinyxml2::XMLElement *fixture = FindFixtureElementByUuid(root, uuid);
   assert(fixture != nullptr);
   tinyxml2::XMLElement *unitNumber = fixture->FirstChildElement("UnitNumber");
@@ -184,7 +186,8 @@ static void AssertGeneratedGdtfVersioning(const fs::path &gdtfPath) {
   assert(revisions != nullptr);
   tinyxml2::XMLElement *revision = revisions->FirstChildElement("Revision");
   assert(revision != nullptr);
-  const std::string expectedModifiedBy = std::string("Perastage ") + app::kVersion;
+  const std::string expectedModifiedBy =
+      std::string("Perastage ") + app::kVersion;
   assert(std::string(revision->Attribute("ModifiedBy")) == expectedModifiedBy);
 }
 
@@ -215,8 +218,10 @@ int main() {
   std::ofstream(tempDir / "models" / "support_model.3ds") << "support";
 
   const std::string longToken(320, "x"[0]);
-  const fs::path longNamedGdtf = tempDir / ("VeryLongGeneratedName_" + longToken + ".gdtf");
-  const fs::path duplicateLongNamedGdtf = tempDir / "C" / ("VeryLongGeneratedName_" + longToken + ".gdtf");
+  const fs::path longNamedGdtf =
+      tempDir / ("VeryLongGeneratedName_" + longToken + ".gdtf");
+  const fs::path duplicateLongNamedGdtf =
+      tempDir / "C" / ("VeryLongGeneratedName_" + longToken + ".gdtf");
   std::ofstream(longNamedGdtf) << "LONG";
   std::ofstream(duplicateLongNamedGdtf) << "LONG2";
 
@@ -249,7 +254,7 @@ int main() {
   f2.fixtureIdNumeric = 0;
   f2.unitNumber = 0;
   f2.address = "3.1";
-  f2.color = "#445566";
+  f2.visualColorHex = "#445566";
   scene.fixtures[f2.uuid] = f2;
 
   Fixture f3;
@@ -257,7 +262,7 @@ int main() {
   f3.instanceName = "Floor Wash";
   f3.gdtfSpec = (tempDir / "A" / "Same.gdtf").generic_string();
   f3.address = "6.121";
-  f3.gelColor = "#00FF00";
+  f3.mvrFixtureColorHex = "#00FF00";
   f3.weightKg = 12.5f;
   f3.powerConsumptionW = 450.0f;
   scene.fixtures[f3.uuid] = f3;
@@ -356,7 +361,8 @@ int main() {
   unitExistingMissingA.uuid = "unit-existing-missing-a";
   unitExistingMissingA.instanceName = "Existing Unit Missing A";
   unitExistingMissingA.typeName = "Existing Unit Type";
-  unitExistingMissingA.gdtfSpec = (tempDir / "A" / "Same.gdtf").generic_string();
+  unitExistingMissingA.gdtfSpec =
+      (tempDir / "A" / "Same.gdtf").generic_string();
   unitExistingMissingA.transform.o = {0.0f, -10.0f, 0.0f};
   unitExistingMissingA.address = "15.1";
   scene.fixtures[unitExistingMissingA.uuid] = unitExistingMissingA;
@@ -365,7 +371,8 @@ int main() {
   unitExistingMissingB.uuid = "unit-existing-missing-b";
   unitExistingMissingB.instanceName = "Existing Unit Missing B";
   unitExistingMissingB.typeName = "Existing Unit Type";
-  unitExistingMissingB.gdtfSpec = (tempDir / "A" / "Same.gdtf").generic_string();
+  unitExistingMissingB.gdtfSpec =
+      (tempDir / "A" / "Same.gdtf").generic_string();
   unitExistingMissingB.transform.o = {0.0f, 10.0f, 0.0f};
   unitExistingMissingB.address = "16.1";
   scene.fixtures[unitExistingMissingB.uuid] = unitExistingMissingB;
@@ -439,7 +446,8 @@ int main() {
   sup.positionName = "SCREEN";
   sup.chainLength = 1.0f;
   GeometryInstance supportGeometry;
-  supportGeometry.modelFile = (tempDir / "models" / "support_model.3ds").string();
+  supportGeometry.modelFile =
+      (tempDir / "models" / "support_model.3ds").string();
   supportGeometry.localTransform = MatrixUtils::Identity();
   sup.geometries.push_back(supportGeometry);
   scene.supports[sup.uuid] = sup;
@@ -493,7 +501,8 @@ int main() {
   int caseOnlyEntryCount = 0;
   for (const std::string &entryName : entries) {
     std::string lowerEntry = entryName;
-    std::transform(lowerEntry.begin(), lowerEntry.end(), lowerEntry.begin(),
+    std::transform(
+        lowerEntry.begin(), lowerEntry.end(), lowerEntry.begin(),
                    [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
     if (lowerEntry == "caseonly.gdtf" || lowerEntry == "caseonly_2.gdtf")
       ++caseOnlyEntryCount;
@@ -532,20 +541,26 @@ int main() {
 
   MvrExporter deterministicExporter;
   fs::path deterministicMvrPath = tempDir / "Test1_repeat.mvr";
-  assert(deterministicExporter.ExportToFile(deterministicMvrPath.generic_string()));
-  const auto deterministicEntries = ReadArchiveTextEntries(deterministicMvrPath);
-  auto deterministicXmlIt = deterministicEntries.find("GeneralSceneDescription.xml");
+  assert(deterministicExporter.ExportToFile(
+      deterministicMvrPath.generic_string()));
+  const auto deterministicEntries =
+      ReadArchiveTextEntries(deterministicMvrPath);
+  auto deterministicXmlIt =
+      deterministicEntries.find("GeneralSceneDescription.xml");
   assert(deterministicXmlIt != deterministicEntries.end());
   tinyxml2::XMLDocument deterministicDoc;
-  assert(deterministicDoc.Parse(deterministicXmlIt->second.c_str()) == tinyxml2::XML_SUCCESS);
+  assert(deterministicDoc.Parse(deterministicXmlIt->second.c_str()) ==
+         tinyxml2::XML_SUCCESS);
   tinyxml2::XMLElement *deterministicRoot =
       deterministicDoc.FirstChildElement("GeneralSceneDescription");
   assert(deterministicRoot != nullptr);
   assert(ReadFixtureUnitNumber(deterministicRoot, "unit-order-bottom") == 1);
   assert(ReadFixtureUnitNumber(deterministicRoot, "unit-order-left") == 2);
   assert(ReadFixtureUnitNumber(deterministicRoot, "unit-order-right") == 3);
-  assert(ReadFixtureUnitNumber(deterministicRoot, "unit-existing-missing-a") == 2);
-  assert(ReadFixtureUnitNumber(deterministicRoot, "unit-existing-missing-b") == 3);
+  assert(ReadFixtureUnitNumber(deterministicRoot, "unit-existing-missing-a") ==
+         2);
+  assert(ReadFixtureUnitNumber(deterministicRoot, "unit-existing-missing-b") ==
+         3);
 
   std::unordered_set<int> numericIds;
   std::unordered_map<std::string, int> gdtfCount;
@@ -585,10 +600,12 @@ int main() {
         if (std::string(cur->Name()) == tagName) {
           auto *idNode = cur->FirstChildElement("FixtureID");
           auto *numNode = cur->FirstChildElement("FixtureIDNumeric");
-          assert(idNode && idNode->GetText() && std::string(idNode->GetText()).size() > 0);
+          assert(idNode && idNode->GetText() &&
+                 std::string(idNode->GetText()).size() > 0);
           assert(numNode && numNode->GetText());
           std::string fixtureIdText = idNode->GetText();
-          assert(std::all_of(fixtureIdText.begin(), fixtureIdText.end(),
+          assert(std::all_of(
+              fixtureIdText.begin(), fixtureIdText.end(),
                              [](unsigned char c) { return std::isdigit(c) != 0; }));
           int value = std::stoi(numNode->GetText());
           assert(value > 0);
@@ -613,7 +630,8 @@ int main() {
             if (fixtureUuid == f3.uuid) {
               assert(colorNode != nullptr);
               assert(colorNode->GetText() != nullptr);
-              assert(std::string(colorNode->GetText()) == "0.300000,0.600000,0.715200");
+              assert(std::string(colorNode->GetText()) ==
+                     "0.300000,0.600000,0.715200");
               sawFixtureGelColor = true;
             }
 
@@ -652,7 +670,8 @@ int main() {
             assert(addr->GetText() != nullptr);
             const std::string addressText = addr->GetText();
             assert(!addressText.empty());
-            assert(std::all_of(addressText.begin(), addressText.end(),
+            assert(std::all_of(
+                addressText.begin(), addressText.end(),
                                [](unsigned char c) { return std::isdigit(c) != 0; }));
             const int absoluteAddress = std::stoi(addressText);
             if (absoluteAddress == ComputeAbsoluteDmx(1, 1))
@@ -689,7 +708,8 @@ int main() {
             assert(gdtfOut.is_open());
             gdtfOut << mvrGeometryEntries.at(trussGdtfSpec);
             gdtfOut.close();
-            const bool hasRenderableGdtf = GdtfHasRenderable3DModel(trussGdtfPath);
+            const bool hasRenderableGdtf =
+                GdtfHasRenderable3DModel(trussGdtfPath);
             assert(hasRenderableGdtf);
             if (hasRenderableGdtf)
               ++mvrGeometryTrussesWithRenderableGdtf;
@@ -708,15 +728,18 @@ int main() {
                   cur->FirstChildElement("CustomIdType") != nullptr;
             }
             const char *trussName = cur->Attribute("name");
-            if (trussName != nullptr && std::string(trussName) == trNonNumeric.name) {
-              sawInvalidTrussUuidRepaired = std::string(trussUuid) != trNonNumeric.uuid;
+            if (trussName != nullptr &&
+                std::string(trussName) == trNonNumeric.name) {
+              sawInvalidTrussUuidRepaired =
+                  std::string(trussUuid) != trNonNumeric.uuid;
               repairedInvalidTrussUuid = trussUuid;
               sawNonNumericTrussNameFixtureIdConsistency =
                   fixtureIdText == std::to_string(value);
             }
           }
 
-          if (auto *gdtf = cur->FirstChildElement("GDTFSpec"); gdtf && gdtf->GetText()) {
+          if (auto *gdtf = cur->FirstChildElement("GDTFSpec");
+              gdtf && gdtf->GetText()) {
             std::string spec = gdtf->GetText();
             const fs::path specPath(spec);
             assert(specPath.filename().generic_string().size() <= 120);
@@ -750,12 +773,14 @@ int main() {
             auto *g3d = geometries->FirstChildElement("Geometry3D");
             assert(g3d != nullptr);
             const char *fileName = g3d->Attribute("fileName");
-            assert(fileName != nullptr && std::string(fileName).find("sphere") != std::string::npos);
+            assert(fileName != nullptr &&
+                   std::string(fileName).find("sphere") != std::string::npos);
             assert(mvrGeometryEntries.count(fileName) == 1);
             auto *geoMatrix = g3d->FirstChildElement("Matrix");
             assert(geoMatrix != nullptr && geoMatrix->GetText() != nullptr);
             Matrix parsedGeoMatrix = MatrixUtils::Identity();
-            assert(MatrixUtils::ParseMatrix(geoMatrix->GetText(), parsedGeoMatrix));
+            assert(MatrixUtils::ParseMatrix(geoMatrix->GetText(),
+                                            parsedGeoMatrix));
             const Matrix identity = MatrixUtils::Identity();
             assert(parsedGeoMatrix.u == identity.u);
             assert(parsedGeoMatrix.v == identity.v);
@@ -766,9 +791,11 @@ int main() {
 
           if (std::string(sceneObjectUuid) == primitivePipe.uuid) {
             auto *objMatrixNode = cur->FirstChildElement("Matrix");
-            assert(objMatrixNode != nullptr && objMatrixNode->GetText() != nullptr);
+            assert(objMatrixNode != nullptr &&
+                   objMatrixNode->GetText() != nullptr);
             Matrix parsedObjMatrix = MatrixUtils::Identity();
-            assert(MatrixUtils::ParseMatrix(objMatrixNode->GetText(), parsedObjMatrix));
+            assert(MatrixUtils::ParseMatrix(objMatrixNode->GetText(),
+                                            parsedObjMatrix));
             if (parsedObjMatrix.u == primitivePipe.transform.u &&
                 parsedObjMatrix.v == primitivePipe.transform.v &&
                 parsedObjMatrix.w == primitivePipe.transform.w) {
@@ -783,7 +810,8 @@ int main() {
             auto *geoMatrix = g3d->FirstChildElement("Matrix");
             assert(geoMatrix != nullptr && geoMatrix->GetText() != nullptr);
             Matrix parsedGeoMatrix = MatrixUtils::Identity();
-            assert(MatrixUtils::ParseMatrix(geoMatrix->GetText(), parsedGeoMatrix));
+            assert(MatrixUtils::ParseMatrix(geoMatrix->GetText(),
+                                            parsedGeoMatrix));
             const Matrix identity = MatrixUtils::Identity();
             if (parsedGeoMatrix.u == identity.u &&
                 parsedGeoMatrix.v == identity.v &&
@@ -795,9 +823,11 @@ int main() {
 
           if (std::string(sceneObjectUuid) == primitivePipeBaked.uuid) {
             auto *objMatrixNode = cur->FirstChildElement("Matrix");
-            assert(objMatrixNode != nullptr && objMatrixNode->GetText() != nullptr);
+            assert(objMatrixNode != nullptr &&
+                   objMatrixNode->GetText() != nullptr);
             Matrix parsedObjMatrix = MatrixUtils::Identity();
-            assert(MatrixUtils::ParseMatrix(objMatrixNode->GetText(), parsedObjMatrix));
+            assert(MatrixUtils::ParseMatrix(objMatrixNode->GetText(),
+                                            parsedObjMatrix));
             if (parsedObjMatrix.u == primitivePipe.transform.u &&
                 parsedObjMatrix.v == primitivePipe.transform.v &&
                 parsedObjMatrix.w == primitivePipe.transform.w) {
@@ -853,8 +883,8 @@ int main() {
   assert(layersNode != nullptr);
   bool sawDefaultLayerNode = false;
   bool sawSphereInDefaultLayer = false;
-  for (tinyxml2::XMLElement *layerOrOther = layersNode->FirstChildElement(); layerOrOther;
-       layerOrOther = layerOrOther->NextSiblingElement()) {
+  for (tinyxml2::XMLElement *layerOrOther = layersNode->FirstChildElement();
+       layerOrOther; layerOrOther = layerOrOther->NextSiblingElement()) {
     assert(std::string(layerOrOther->Name()) == "Layer");
     const char *layerName = layerOrOther->Attribute("name");
     const std::string layerNameText = layerName ? layerName : "";
@@ -864,13 +894,16 @@ int main() {
     if (layerNameText == "Default")
       sawDefaultLayerNode = true;
 
-    tinyxml2::XMLElement *childList = layerOrOther->FirstChildElement("ChildList");
-    for (tinyxml2::XMLElement *child = childList ? childList->FirstChildElement() : nullptr; child;
-         child = child->NextSiblingElement()) {
+    tinyxml2::XMLElement *childList =
+        layerOrOther->FirstChildElement("ChildList");
+    for (tinyxml2::XMLElement *child =
+             childList ? childList->FirstChildElement() : nullptr;
+         child; child = child->NextSiblingElement()) {
       if (std::string(child->Name()) != "SceneObject")
         continue;
       const char *uuidAttr = child->Attribute("uuid");
-      if (uuidAttr != nullptr && std::string(uuidAttr) == primitiveSphere.uuid &&
+      if (uuidAttr != nullptr &&
+          std::string(uuidAttr) == primitiveSphere.uuid &&
           layerNameText == "Default") {
         sawSphereInDefaultLayer = true;
       }
@@ -883,16 +916,16 @@ int main() {
   bool sawRootTrussInfoMap = false;
   bool sawRepairedTrussInfo = false;
   bool sawCanonicalTrussInfo = false;
-  for (tinyxml2::XMLElement *data = rootUserData->FirstChildElement("Data"); data;
-       data = data->NextSiblingElement("Data")) {
+  for (tinyxml2::XMLElement *data = rootUserData->FirstChildElement("Data");
+       data; data = data->NextSiblingElement("Data")) {
     const char *provider = data->Attribute("provider");
     if (provider == nullptr || std::string(provider) != "Perastage")
       continue;
-    for (tinyxml2::XMLElement *map = data->FirstChildElement("TrussInfoMap"); map;
-         map = map->NextSiblingElement("TrussInfoMap")) {
+    for (tinyxml2::XMLElement *map = data->FirstChildElement("TrussInfoMap");
+         map; map = map->NextSiblingElement("TrussInfoMap")) {
       sawRootTrussInfoMap = true;
-      for (tinyxml2::XMLElement *info = map->FirstChildElement("TrussInfo"); info;
-           info = info->NextSiblingElement("TrussInfo")) {
+      for (tinyxml2::XMLElement *info = map->FirstChildElement("TrussInfo");
+           info; info = info->NextSiblingElement("TrussInfo")) {
         const char *uuid = info->Attribute("uuid");
         assert(uuid != nullptr);
         assert(CanonicalizeUuid(uuid) == std::string(uuid));
@@ -954,7 +987,8 @@ int main() {
   assert(capacityNode != nullptr && capacityNode->GetText() != nullptr &&
          std::string(capacityNode->GetText()) == "1000.000000");
   auto *supportPositionNode = supportInfo->FirstChildElement("Position");
-  assert(supportPositionNode != nullptr && supportPositionNode->GetText() != nullptr);
+  assert(supportPositionNode != nullptr &&
+         supportPositionNode->GetText() != nullptr);
   assert(CanonicalizeUuid(supportPositionNode->GetText()) ==
          std::string(supportPositionNode->GetText()));
 
@@ -967,34 +1001,39 @@ int main() {
     gdtfOut << mvrGeometryEntries.at(gdtfSpec);
     gdtfOut.close();
     AssertGeneratedGdtfVersioning(trussGdtfPath);
-    fixtureTypeIdByTrussUuid[trussUuid] = ReadFixtureTypeIdFromGdtf(trussGdtfPath);
+    fixtureTypeIdByTrussUuid[trussUuid] =
+        ReadFixtureTypeIdFromGdtf(trussGdtfPath);
   }
-  assert(fixtureTypeIdByTrussUuid.at(tr.uuid) == fixtureTypeIdByTrussUuid.at(trNonNumeric.uuid));
+  assert(fixtureTypeIdByTrussUuid.at(tr.uuid) ==
+         fixtureTypeIdByTrussUuid.at(trNonNumeric.uuid));
   assert(fixtureTypeIdByTrussUuid.at(tr.uuid) !=
          fixtureTypeIdByTrussUuid.at(trDifferentType.uuid));
-
 
   cfg.SetFloat("mvr_truss_geometry_authority", 1.0f);
   fs::path mvrPathGdtfAuthority = tempDir / "Test2_GdtfAuthority.mvr";
   assert(exporter.ExportToFile(mvrPathGdtfAuthority.generic_string()));
 
-  const auto gdtfAuthorityEntries = ReadArchiveTextEntries(mvrPathGdtfAuthority);
-  auto xmlGdtfAuthorityIt = gdtfAuthorityEntries.find("GeneralSceneDescription.xml");
+  const auto gdtfAuthorityEntries =
+      ReadArchiveTextEntries(mvrPathGdtfAuthority);
+  auto xmlGdtfAuthorityIt =
+      gdtfAuthorityEntries.find("GeneralSceneDescription.xml");
   assert(xmlGdtfAuthorityIt != gdtfAuthorityEntries.end());
   std::string xmlGdtfAuthority = xmlGdtfAuthorityIt->second;
 
   assert(!xmlGdtfAuthority.empty());
   tinyxml2::XMLDocument docGdtfAuthority;
-  assert(docGdtfAuthority.Parse(xmlGdtfAuthority.c_str()) == tinyxml2::XML_SUCCESS);
-  tinyxml2::XMLElement *rootGdtfAuthority = docGdtfAuthority.FirstChildElement("GeneralSceneDescription");
+  assert(docGdtfAuthority.Parse(xmlGdtfAuthority.c_str()) ==
+         tinyxml2::XML_SUCCESS);
+  tinyxml2::XMLElement *rootGdtfAuthority =
+      docGdtfAuthority.FirstChildElement("GeneralSceneDescription");
   assert(rootGdtfAuthority != nullptr);
 
   bool sawTrussWithGdtfSpec = false;
   int gdtfAuthorityTrussCount = 0;
   int gdtfAuthorityTrussesWithGeometry3d = 0;
   int gdtfAuthorityTrussesWithRenderableGdtf = 0;
-  for (tinyxml2::XMLElement *node = rootGdtfAuthority->FirstChildElement(); node;
-       node = node->NextSiblingElement()) {
+  for (tinyxml2::XMLElement *node = rootGdtfAuthority->FirstChildElement();
+       node; node = node->NextSiblingElement()) {
     std::vector<tinyxml2::XMLElement *> stack{node};
     while (!stack.empty()) {
       tinyxml2::XMLElement *cur = stack.back();
@@ -1006,8 +1045,10 @@ int main() {
         const std::string trussGdtfSpec = gdtfSpec->GetText();
         sawTrussWithGdtfSpec = true;
         auto *geometries = cur->FirstChildElement("Geometries");
-        assert(geometries == nullptr || geometries->FirstChildElement("Geometry3D") == nullptr);
-        if (geometries != nullptr && geometries->FirstChildElement("Geometry3D") != nullptr)
+        assert(geometries == nullptr ||
+               geometries->FirstChildElement("Geometry3D") == nullptr);
+        if (geometries != nullptr &&
+            geometries->FirstChildElement("Geometry3D") != nullptr)
           ++gdtfAuthorityTrussesWithGeometry3d;
 
         assert(gdtfAuthorityEntries.count(trussGdtfSpec) == 1);
@@ -1040,8 +1081,10 @@ int main() {
     wxZipOutputStream legacyZip(legacyOut);
     const std::string legacyXml =
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-        "<GeneralSceneDescription verMajor=\"1\" verMinor=\"6\" provider=\"Perastage\" providerVersion=\"" +
-        std::string(app::kVersion) + "\">"
+        "<GeneralSceneDescription verMajor=\"1\" verMinor=\"6\" "
+        "provider=\"Perastage\" providerVersion=\"" +
+        std::string(app::kVersion) +
+        "\">"
         "<UserData><Data provider=\"Perastage\" ver=\"" +
         std::string(kPerastageUserDataSchemaVersion) +
         "\"><TrussSidecarManifest/></Data></UserData>"
@@ -1071,15 +1114,16 @@ int main() {
   const MvrScene &importedScene = ConfigManager::Get().GetScene();
   assert(!importedScene.fixtures.empty());
   const Fixture &legacyFixture = importedScene.fixtures.begin()->second;
-  assert(importedScene.fixtures.count("11111111-1111-4111-8111-111111111111") == 1);
+  assert(importedScene.fixtures.count("11111111-1111-4111-8111-111111111111") ==
+         1);
   assert(legacyFixture.uuid == "11111111-1111-4111-8111-111111111111");
   assert(legacyFixture.instanceName == "Legacy Fixture Name");
   assert(!legacyFixture.position.empty());
   assert(legacyFixture.position != "LX1");
   assert(CanonicalizeUuid(legacyFixture.position) == legacyFixture.position);
   assert(importedScene.positions.count(legacyFixture.position) == 1);
-  assert(legacyFixture.color.empty());
-  assert(!legacyFixture.gelColor.empty());
+  assert(legacyFixture.visualColorHex.empty());
+  assert(!legacyFixture.mvrFixtureColorHex.empty());
 
   fs::remove_all(tempDir);
   return 0;

--- a/tests/mvr_fixture_category_roundtrip_test.cpp
+++ b/tests/mvr_fixture_category_roundtrip_test.cpp
@@ -98,6 +98,7 @@ int main() {
   fixture.gdtfMode = "ModeA";
   fixture.category = "Spot";
   fixture.categorySource = "Manual";
+  fixture.visualColorHex = "#336699";
   scene.fixtures[fixture.uuid] = fixture;
 
   Fixture fixtureTwo = fixture;
@@ -124,8 +125,14 @@ int main() {
   assert(rootUserData != nullptr);
   auto *fixtureTypeMap = rootUserData->FirstChildElement("Data")->FirstChildElement("FixtureTypeInfoMap");
   assert(fixtureTypeMap != nullptr);
-  assert(fixtureTypeMap->FirstChildElement("FixtureTypeInfo") != nullptr);
-  assert(fixtureTypeMap->FirstChildElement("FixtureTypeInfo")->NextSiblingElement("FixtureTypeInfo") == nullptr);
+  auto *fixtureTypeInfo =
+      fixtureTypeMap->FirstChildElement("FixtureTypeInfo");
+  assert(fixtureTypeInfo != nullptr);
+  assert(fixtureTypeInfo->NextSiblingElement("FixtureTypeInfo") == nullptr);
+  assert(fixtureTypeInfo->FirstChildElement("VisualColor") != nullptr);
+  assert(std::string(
+             fixtureTypeInfo->FirstChildElement("VisualColor")->GetText()) ==
+         "#336699");
 
   int exportedFixtureCount = 0;
   for (auto *layerNode = root->FirstChildElement("Scene")->FirstChildElement("Layers")->FirstChildElement("Layer");
@@ -155,7 +162,10 @@ int main() {
   assert(loaded.size() == 2);
   const Fixture &loadedFixture = loaded.at("11111111-1111-1111-1111-111111111111");
   assert(loadedFixture.category == "Spot");
+  assert(loadedFixture.visualColorHex == "#336699");
   assert(loaded.at("22222222-2222-2222-2222-222222222222").category == "Spot");
+  assert(loaded.at("22222222-2222-2222-2222-222222222222")
+             .visualColorHex == "#336699");
 
   // Dictionary should be updated with scene (MVR) priority category.
   auto entry = GdtfDictionary::Get("FixtureType");

--- a/tests/save_load_roundtrip_test.cpp
+++ b/tests/save_load_roundtrip_test.cpp
@@ -21,14 +21,14 @@
 #include <wx/init.h>
 
 #include "configmanager.h"
-#include "gdtfdictionary.h"
-#include "projectutils.h"
 #include "fixture.h"
-#include "truss.h"
-#include "sceneobject.h"
-#include "layer.h"
-#include "support.h"
 #include "fixture_label_overrides.h"
+#include "gdtfdictionary.h"
+#include "layer.h"
+#include "projectutils.h"
+#include "sceneobject.h"
+#include "support.h"
+#include "truss.h"
 #include "uuidutils.h"
 
 int main() {
@@ -39,11 +39,15 @@ int main() {
     cfg.Reset();
     MvrScene &scene = cfg.GetScene();
 
-    Layer layer; layer.uuid = "layer1"; layer.name = "Layer1"; layer.color = "#112233";
+  Layer layer;
+  layer.uuid = "layer1";
+  layer.name = "Layer1";
+  layer.visualColorHex = "#112233";
     scene.layers[layer.uuid] = layer;
 
     // Prepare dummy GDTF files
-    std::filesystem::path tempDir = std::filesystem::temp_directory_path() / "gdtf_roundtrip";
+  std::filesystem::path tempDir =
+      std::filesystem::temp_directory_path() / "gdtf_roundtrip";
     std::filesystem::create_directories(tempDir);
     std::ofstream(tempDir / "orig.gdtf") << "orig";
     std::ofstream(tempDir / "dict.gdtf") << "dict";
@@ -60,13 +64,15 @@ int main() {
     assert(fixtureTypeSpaced.has_value());
     assert(fixtureTypeSpaced->path == fixtureTypeCanonical->path);
     std::ofstream(tempDir / "Dummy 1ch.gdtf") << "dummy";
-    GdtfDictionary::Update("Dummy 1ch", (tempDir / "Dummy 1ch.gdtf").string(), "");
+  GdtfDictionary::Update("Dummy 1ch", (tempDir / "Dummy 1ch.gdtf").string(),
+                         "");
     auto dummyEntry = GdtfDictionary::Get("Dummy 1ch");
     assert(!dummyEntry.has_value());
     GdtfDictionary::Update("Dummy 1ch", (tempDir / "dict.gdtf").string(), "");
     dummyEntry = GdtfDictionary::Get("Dummy 1ch");
     assert(!dummyEntry.has_value());
-    GdtfDictionary::Update("Some Type", (tempDir / "Dummy 1ch.gdtf").string(), "");
+  GdtfDictionary::Update("Some Type", (tempDir / "Dummy 1ch.gdtf").string(),
+                         "");
     auto dummyPathEntry = GdtfDictionary::Get("Some Type");
     assert(!dummyPathEntry.has_value());
     GdtfDictionary::UpdateCategory("TextOnlyType", "Spot");
@@ -74,11 +80,17 @@ int main() {
     assert(textOnlyEntry.has_value());
     assert(textOnlyEntry->category == "Spot");
     assert(textOnlyEntry->path.empty());
-    std::unordered_map<std::string, GdtfDictionary::Entry> categoryPropagationDict;
+  std::unordered_map<std::string, GdtfDictionary::Entry>
+      categoryPropagationDict;
     categoryPropagationDict["Type A"] = {
         (tempDir / "shared.gdtf").string(), "Mode A", "OldA", "", "", ""};
     categoryPropagationDict["Type B"] = {
-        (tempDir / "subdir" / "shared.gdtf").string(), "Mode B", "OldB", "", "", ""};
+      (tempDir / "subdir" / "shared.gdtf").string(),
+      "Mode B",
+      "OldB",
+      "",
+      "",
+      ""};
     assert(GdtfDictionary::Save(categoryPropagationDict));
     GdtfDictionary::UpdateCategoriesBulk({{"Type A", "Wash"}});
     const auto categoryPropagationA = GdtfDictionary::Get("Type A");
@@ -88,20 +100,67 @@ int main() {
     assert(categoryPropagationA->category == "Wash");
     assert(categoryPropagationB->category == "Wash");
 
-    Fixture f; f.uuid = "fx1"; f.instanceName = "Fixture"; f.layer = layer.name; f.typeName = "FixtureType"; f.gdtfSpec = "orig.gdtf"; f.color = "#445566"; f.fixtureIdText = "S101A"; f.fixtureIdNumeric = 101; f.fixtureId = 101; scene.fixtures[f.uuid] = f;
-    Fixture f2; f2.uuid = "fx2"; f2.instanceName = "Fixture 2"; f2.layer = layer.name; f2.typeName = "FixtureType"; f2.gdtfSpec = "orig.gdtf"; f2.fixtureIdText = "S101B"; f2.fixtureIdNumeric = 101; f2.fixtureId = 101; scene.fixtures[f2.uuid] = f2;
-    const std::string nonCanonicalFixtureUuid = "A0B1C2D3-E4F5-4678-9ABC-DEF012345678";
-    Fixture f3; f3.uuid = nonCanonicalFixtureUuid; f3.instanceName = "Fixture 3"; f3.layer = layer.name; f3.typeName = "FixtureType"; f3.gdtfSpec = "orig.gdtf"; f3.fixtureIdText = "S101C"; f3.fixtureIdNumeric = 101; f3.fixtureId = 101; scene.fixtures[f3.uuid] = f3;
-    Fixture f4; f4.uuid = "fx-edited-id"; f4.instanceName = "Edited ID Fixture"; f4.layer = layer.name; f4.typeName = "FixtureType"; f4.gdtfSpec = "orig.gdtf"; f4.fixtureIdText = "Imported ID"; f4.fixtureIdNumeric = 44; f4.fixtureId = 707; scene.fixtures[f4.uuid] = f4;
+  Fixture f;
+  f.uuid = "fx1";
+  f.instanceName = "Fixture";
+  f.layer = layer.name;
+  f.typeName = "FixtureType";
+  f.gdtfSpec = "orig.gdtf";
+  f.visualColorHex = "#445566";
+  f.fixtureIdText = "S101A";
+  f.fixtureIdNumeric = 101;
+  f.fixtureId = 101;
+  scene.fixtures[f.uuid] = f;
+  Fixture f2;
+  f2.uuid = "fx2";
+  f2.instanceName = "Fixture 2";
+  f2.layer = layer.name;
+  f2.typeName = "FixtureType";
+  f2.gdtfSpec = "orig.gdtf";
+  f2.fixtureIdText = "S101B";
+  f2.fixtureIdNumeric = 101;
+  f2.fixtureId = 101;
+  scene.fixtures[f2.uuid] = f2;
+  const std::string nonCanonicalFixtureUuid =
+      "A0B1C2D3-E4F5-4678-9ABC-DEF012345678";
+  Fixture f3;
+  f3.uuid = nonCanonicalFixtureUuid;
+  f3.instanceName = "Fixture 3";
+  f3.layer = layer.name;
+  f3.typeName = "FixtureType";
+  f3.gdtfSpec = "orig.gdtf";
+  f3.fixtureIdText = "S101C";
+  f3.fixtureIdNumeric = 101;
+  f3.fixtureId = 101;
+  scene.fixtures[f3.uuid] = f3;
+  Fixture f4;
+  f4.uuid = "fx-edited-id";
+  f4.instanceName = "Edited ID Fixture";
+  f4.layer = layer.name;
+  f4.typeName = "FixtureType";
+  f4.gdtfSpec = "orig.gdtf";
+  f4.fixtureIdText = "Imported ID";
+  f4.fixtureIdNumeric = 44;
+  f4.fixtureId = 707;
+  scene.fixtures[f4.uuid] = f4;
     viewer2d::ApplyShowLabelNameOverride(cfg, {nonCanonicalFixtureUuid}, 0, true);
-    Truss t; t.uuid = "tr1"; t.name = "Truss"; t.layer = layer.name; scene.trusses[t.uuid] = t;
-    SceneObject o; o.uuid = "obj1"; o.name = "Object"; o.layer = layer.name; scene.sceneObjects[o.uuid] = o;
+  Truss t;
+  t.uuid = "tr1";
+  t.name = "Truss";
+  t.layer = layer.name;
+  scene.trusses[t.uuid] = t;
+  SceneObject o;
+  o.uuid = "obj1";
+  o.name = "Object";
+  o.layer = layer.name;
+  scene.sceneObjects[o.uuid] = o;
     SceneObject cylinderObj;
     cylinderObj.uuid = "obj-cylinder";
     cylinderObj.name = "Cylinder";
     cylinderObj.layer = layer.name;
     GeometryInstance cylinderGeometry;
-    cylinderGeometry.modelFile = "primitive:cylinder;top=200.000000;bottom=450.000000;height=1200.000000";
+  cylinderGeometry.modelFile =
+      "primitive:cylinder;top=200.000000;bottom=450.000000;height=1200.000000";
     cylinderObj.geometries.push_back(cylinderGeometry);
     cylinderObj.modelFile = cylinderGeometry.modelFile;
     scene.sceneObjects[cylinderObj.uuid] = cylinderObj;
@@ -120,16 +179,34 @@ int main() {
     legacyPipeObj.transform.o = {0.0f, 0.0f, 0.0f};
     scene.sceneObjects[legacyPipeObj.uuid] = legacyPipeObj;
 
-    Support sManual; sManual.uuid = "sup-manual"; sManual.name = "Manual Hoist"; sManual.layer = layer.name;
-    sManual.motorName = "ChainMaster D8+"; sManual.motorManufacturer = "ChainMaster"; sManual.motorModel = "D8+"; sManual.dummyPreset = "D8+ 1000kg";
-    sManual.hoistDataSource = "Manual"; sManual.hoistFunction = "Audio";
-    sManual.capacityKg = 700.0f; sManual.weightKg = 40.0f; sManual.loadKg = 325.0f; scene.supports[sManual.uuid] = sManual;
+  Support sManual;
+  sManual.uuid = "sup-manual";
+  sManual.name = "Manual Hoist";
+  sManual.layer = layer.name;
+  sManual.motorName = "ChainMaster D8+";
+  sManual.motorManufacturer = "ChainMaster";
+  sManual.motorModel = "D8+";
+  sManual.dummyPreset = "D8+ 1000kg";
+  sManual.hoistDataSource = "Manual";
+  sManual.hoistFunction = "Audio";
+  sManual.capacityKg = 700.0f;
+  sManual.weightKg = 40.0f;
+  sManual.loadKg = 325.0f;
+  scene.supports[sManual.uuid] = sManual;
 
-    Support sInherited; sInherited.uuid = "sup-inherited"; sInherited.name = "Inherited Hoist"; sInherited.layer = layer.name;
-    sInherited.motorName = "CM Lodestar"; sInherited.motorFixtureUuid = "fx1"; sInherited.useMotorDefaults = false; sInherited.dummyPreset = "Lodestar 500kg";
-    sInherited.hoistDataSource = "Inherited"; scene.supports[sInherited.uuid] = sInherited;
+  Support sInherited;
+  sInherited.uuid = "sup-inherited";
+  sInherited.name = "Inherited Hoist";
+  sInherited.layer = layer.name;
+  sInherited.motorName = "CM Lodestar";
+  sInherited.motorFixtureUuid = "fx1";
+  sInherited.useMotorDefaults = false;
+  sInherited.dummyPreset = "Lodestar 500kg";
+  sInherited.hoistDataSource = "Inherited";
+  scene.supports[sInherited.uuid] = sInherited;
 
-    std::filesystem::path temp = std::filesystem::temp_directory_path() / "roundtrip_test.pera";
+  std::filesystem::path temp =
+      std::filesystem::temp_directory_path() / "roundtrip_test.pera";
     assert(cfg.SaveProject(temp.string()));
 
     cfg.Reset();
@@ -153,7 +230,7 @@ int main() {
     const std::string loadedLegacyPipeToken =
         scene2.sceneObjects.at("obj-legacy-pipe").geometries.front().modelFile;
     assert(loadedLegacyPipeToken == "primitive:cylinder");
-    assert(scene2.fixtures.at("fx1").color == "#445566");
+  assert(scene2.fixtures.at("fx1").visualColorHex == "#445566");
     assert(scene2.fixtures.at("fx1").fixtureIdText == "S101A");
     assert(scene2.fixtures.at("fx1").fixtureIdNumeric == 101);
     assert(scene2.fixtures.at("fx2").fixtureIdText == "S101B");
@@ -161,7 +238,8 @@ int main() {
     assert(scene2.fixtures.at("fx-edited-id").fixtureId == 707);
     assert(scene2.fixtures.at("fx-edited-id").fixtureIdNumeric == 707);
     assert(scene2.fixtures.at("fx-edited-id").fixtureIdText == "707");
-    const std::string canonicalFixtureUuid = CanonicalizeUuid(nonCanonicalFixtureUuid);
+  const std::string canonicalFixtureUuid =
+      CanonicalizeUuid(nonCanonicalFixtureUuid);
     assert(!canonicalFixtureUuid.empty());
     assert(scene2.fixtures.count(canonicalFixtureUuid) == 1);
     const auto fixtureOverrides = viewer2d::LoadFixtureLabelOverrides(cfg);
@@ -169,7 +247,7 @@ int main() {
     const auto &fixture3Override = fixtureOverrides.at(canonicalFixtureUuid);
     assert(fixture3Override.showLabelName[0].has_value());
     assert(*fixture3Override.showLabelName[0]);
-    assert(scene2.layers.at("layer1").color == "#112233");
+  assert(scene2.layers.at("layer1").visualColorHex == "#112233");
 
     const auto &loadedManual = scene2.supports.at("sup-manual");
     assert(loadedManual.motorName == "ChainMaster D8+");
@@ -190,10 +268,12 @@ int main() {
 
     const auto &loaded = scene2.fixtures.at("fx1");
     assert(std::filesystem::path(loaded.gdtfSpec).filename() == "orig.gdtf");
-    assert(std::filesystem::path(loaded.originalMvrGdtfSpec).filename() == "orig.gdtf");
+  assert(std::filesystem::path(loaded.originalMvrGdtfSpec).filename() ==
+         "orig.gdtf");
 
     std::filesystem::remove(temp);
-    std::filesystem::remove(ProjectUtils::GetDefaultLibraryPath("fixtures") + "/dict.gdtf");
+  std::filesystem::remove(ProjectUtils::GetDefaultLibraryPath("fixtures") +
+                          "/dict.gdtf");
     GdtfDictionary::Save({});
     std::filesystem::remove_all(tempDir);
     return 0;

--- a/tests/save_load_roundtrip_test.cpp
+++ b/tests/save_load_roundtrip_test.cpp
@@ -39,10 +39,10 @@ int main() {
     cfg.Reset();
     MvrScene &scene = cfg.GetScene();
 
-  Layer layer;
-  layer.uuid = "layer1";
-  layer.name = "Layer1";
-  layer.visualColorHex = "#112233";
+    Layer layer;
+    layer.uuid = "layer1";
+    layer.name = "Layer1";
+    layer.color = "#112233";
     scene.layers[layer.uuid] = layer;
 
     // Prepare dummy GDTF files
@@ -247,7 +247,7 @@ int main() {
     const auto &fixture3Override = fixtureOverrides.at(canonicalFixtureUuid);
     assert(fixture3Override.showLabelName[0].has_value());
     assert(*fixture3Override.showLabelName[0]);
-  assert(scene2.layers.at("layer1").visualColorHex == "#112233");
+    assert(scene2.layers.at("layer1").color == "#112233");
 
     const auto &loadedManual = scene2.supports.at("sup-manual");
     assert(loadedManual.motorName == "ChainMaster D8+");

--- a/viewer3d/render/opaque_fixture_pass.cpp
+++ b/viewer3d/render/opaque_fixture_pass.cpp
@@ -806,7 +806,7 @@ void OpaqueFixturePass::Render(
       g = c[1];
       b = c[2];
     } else if (mode == Viewer2DRenderMode::ByFixtureType) {
-      auto c = getTypeColor(f.gdtfSpec, f.color);
+      auto c = getTypeColor(f.gdtfSpec, f.visualColorHex);
       r = c[0];
       g = c[1];
       b = c[2];


### PR DESCRIPTION
### Motivation
- Remove ambiguity between the Perastage visual/type color and the standards MVR/GDTF fixture color so UI, dictionary, import/export and rendering use the correct source of truth.
- Match MVR/GDTF semantics: keep Perastage display defaults local to the app and treat `Fixture/Color` as the official MVR/GDTF CIE color stored per fixture instance.
- Preserve compatibility and avoid data loss by reading legacy keys/fields while writing new canonical keys and names.

### Description
- Model: renamed ambiguous fields to `visualColorHex` (Perastage visual/type color) and `mvrFixtureColorHex` (official MVR Fixture/Color stored in hex and converted to/from CIE when serializing). (`models/fixture.h`)
- Dictionary: read legacy `color` but prefer `visual_color` when present; saves now emit `visual_color`; API surface renamed to `GetDefaultVisualColorForFixture`, `UpdateVisualColorForFile`, etc. (`core/gdtfdictionary.*`, `core/dictionary_bundle.cpp`)
- Fixture table / editor: added adjacent columns `Type Color` (visual) and `MVR Color` (official) using the named column system; table renderers, edit flows and propagate/update rules updated so `Type Color` drives visuals and `MVR Color` is metadata/export-only. (`gui/fixturetable/*`, `gui/fixtureeditdialog.*`, `gui/fixturetablepanel.cpp`)
- MVR import/export: importer populates `mvrFixtureColorHex` from `<Color>` and does not touch `visualColorHex`; exporter emits `<Color>` only when `mvrFixtureColorHex` is set and converts from hex to CIE as before. (`mvr/mvrimporter.cpp`, `mvr/mvrexporter.cpp`)
- Summaries/legends/viewers/layouts: all UI/legend/summary rendering and layout hashes now use `visualColorHex` exclusively; layout cache/scene hash uses visual color for rendering determinism. (`gui/summarypanel.cpp`, `gui/layoutlegenditems.cpp`, `gui/layout_view_cache_archive.cpp`, `viewer3d/*`) 
- Tests and docs: updated and added tests and test expectations for dictionary round-trip and MVR export/import behavior, and updated `docs/features.md` and `docs/release-notes-draft.md` to describe Type Color vs MVR Color behavior. (`tests/*`, `docs/*`)

### Testing
- Ran project architectural checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both passed.
- Ran `git diff --check` and repository whitespace/syntax checks used in CI; no residual `GetDefaultColorForFixture`/legacy `color` getters left active where the new names were required.
- Updated/added unit test sources that exercise dictionary migration and MVR import/export semantics (dictionary roundtrip and MVR exporter compliance tests were updated to assert `visual_color` persistence and `mvrFixtureColorHex` behavior); full unit test execution requiring a configured build was not possible in this environment because the system lacks the `wxWidgets` development libraries, so a full `cmake` configure/build and test run could not complete here.
- Manual grep/search safety checks were run to ensure no remaining accidental uses of the old ambiguous fields remain in the GUI rendering paths; these checks passed in the repository snapshot.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a339f1bfaf48324adc1642d127729d7)