### PR TITLE
Fix creation from existing truss types

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -71,6 +71,10 @@ Perastage v1.4.0 delivers a long-anticipated refresh of the modelling and riggin
 
 This release addresses dozens of issues across importing, snapping, editing and export workflows, including:
 
+- **Truss creation from scene types** - Add Truss now lists each available
+  truss type once instead of showing every placed instance, and reliably
+  reuses the original GDTF, GTruss, GLB, or 3DS definition even when the
+  existing trusses are grouped or use extracted symbol resources.
 - **Continuous fixture placement** - subsequent fixtures now remain directly
   under the pointer after confirming a Magnet-snapped fixture instead of
   inheriting the previous fixture's grouping offset. Placement also responds

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -98,6 +98,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/splashscreen.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/summarypanel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tableprinter.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/truss_creation_source.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/trusstablepanel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/update/app_update_service.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/update/update_check_preferences.cpp

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -88,6 +88,7 @@
 #include "scene_grouping.h"
 #include "scene_object_primitive_creation.h"
 #include "scene_object_primitive_dialogs.h"
+#include "truss_creation_source.h"
 #include "sceneobjecttablepanel.h"
 #include "selectfixturetypedialog.h"
 #include "selection_movement_settings.h"
@@ -1350,14 +1351,12 @@ void MainWindow::OnAddTruss(wxCommandEvent &WXUNUSED(event)) {
   std::string defaultName;
 
   if (!scene.trusses.empty()) {
-    std::map<std::string, std::string> nameToFile;
-    for (const auto &[uuid, t] : scene.trusses)
-      if (!t.name.empty() && !t.symbolFile.empty())
-        nameToFile.try_emplace(t.name, t.symbolFile);
+    const std::vector<gui::TrussCreationSource> trussSources =
+        gui::CollectTrussCreationSources(scene.trusses, scene.basePath);
     std::vector<std::string> names;
-    names.reserve(nameToFile.size());
-    for (const auto &[n, _] : nameToFile)
-      names.push_back(n);
+    names.reserve(trussSources.size());
+    for (const gui::TrussCreationSource &source : trussSources)
+      names.push_back(source.displayName);
 
     SelectNameDialog chooseDlg(this, names, "Select Truss", "Choose a truss:");
     int dlgRes = chooseDlg.ShowModal();
@@ -1379,8 +1378,8 @@ void MainWindow::OnAddTruss(wxCommandEvent &WXUNUSED(event)) {
       int sel = chooseDlg.GetSelection();
       if (sel < 0 || sel >= static_cast<int>(names.size()))
         return;
-      defaultName = names[sel];
-      path = nameToFile[defaultName];
+      defaultName = trussSources[sel].displayName;
+      path = trussSources[sel].definitionPath;
     }
   } else {
     wxString trussDir =

--- a/gui/truss_creation_source.cpp
+++ b/gui/truss_creation_source.cpp
@@ -1,0 +1,67 @@
+#include "truss_creation_source.h"
+
+#include <filesystem>
+#include <map>
+
+#include "filesystem_path_utils.h"
+#include "trussloader.h"
+
+namespace gui {
+namespace {
+
+// Returns the stable type label shown when reusing a truss from the scene.
+std::string GetTrussTypeDisplayName(const Truss &truss) {
+  if (!truss.model.empty())
+    return truss.model;
+  if (!truss.perastageTypeKey.empty())
+    return truss.perastageTypeKey;
+  return truss.name;
+}
+
+// Resolves a supported truss definition reference against the scene directory.
+std::string ResolveDefinitionPath(const std::string &reference,
+                                  const std::filesystem::path &sceneBasePath) {
+  if (reference.empty() || !IsSupportedTrussDefinitionExtension(reference))
+    return {};
+
+  std::filesystem::path path = PathUtils::PathFromUtf8(reference);
+  if (path.is_relative())
+    path = sceneBasePath / path;
+  return PathUtils::PathToUtf8(path.lexically_normal());
+}
+
+// Finds the best reusable definition reference stored on a scene truss.
+std::string GetTrussDefinitionPath(const Truss &truss,
+                                   const std::filesystem::path &sceneBasePath) {
+  for (const std::string *reference :
+       {&truss.gdtfSpec, &truss.modelFile, &truss.symbolFile}) {
+    std::string path = ResolveDefinitionPath(*reference, sceneBasePath);
+    if (!path.empty())
+      return path;
+  }
+  return {};
+}
+
+} // namespace
+
+// Collects one reusable creation entry per available truss type.
+std::vector<TrussCreationSource> CollectTrussCreationSources(
+    const std::unordered_map<std::string, Truss> &trusses,
+    const std::string &sceneBasePath) {
+  const std::filesystem::path basePath = PathUtils::PathFromUtf8(sceneBasePath);
+  std::map<std::string, std::string> sourceByType;
+  for (const auto &[uuid, truss] : trusses) {
+    const std::string displayName = GetTrussTypeDisplayName(truss);
+    const std::string definitionPath = GetTrussDefinitionPath(truss, basePath);
+    if (!displayName.empty() && !definitionPath.empty())
+      sourceByType.try_emplace(displayName, definitionPath);
+  }
+
+  std::vector<TrussCreationSource> sources;
+  sources.reserve(sourceByType.size());
+  for (const auto &[displayName, definitionPath] : sourceByType)
+    sources.push_back({displayName, definitionPath});
+  return sources;
+}
+
+} // namespace gui

--- a/gui/truss_creation_source.h
+++ b/gui/truss_creation_source.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "truss.h"
+
+namespace gui {
+
+struct TrussCreationSource {
+  std::string displayName;
+  std::string definitionPath;
+};
+
+std::vector<TrussCreationSource> CollectTrussCreationSources(
+    const std::unordered_map<std::string, Truss> &trusses,
+    const std::string &sceneBasePath);
+
+} // namespace gui

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -77,6 +77,20 @@ target_link_libraries(trussloader_validation_test PRIVATE
                       ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
 add_test(NAME TrussLoaderValidation COMMAND trussloader_validation_test)
 
+add_executable(truss_creation_source_test
+               truss_creation_source_test.cpp
+               ../gui/truss_creation_source.cpp
+               ../core/trussloader.cpp
+               ../core/truss_gdtf_builder.cpp
+               ../core/logger.cpp
+               ../core/filesystem_path_utils.cpp
+               ../models/truss.cpp)
+target_include_directories(truss_creation_source_test PRIVATE
+                           . ../core ../gui ../models ../third_party)
+target_link_libraries(truss_creation_source_test PRIVATE
+                      ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
+add_test(NAME TrussCreationSource COMMAND truss_creation_source_test)
+
 
 add_executable(mvr_merge_analyzer_applier_test
                mvr_merge_analyzer_applier_test.cpp

--- a/tests/truss_creation_source_test.cpp
+++ b/tests/truss_creation_source_test.cpp
@@ -1,0 +1,54 @@
+#include <cassert>
+#include <filesystem>
+#include <string>
+#include <unordered_map>
+
+#include "truss_creation_source.h"
+
+namespace fs = std::filesystem;
+
+// Verifies that scene instances collapse into reusable truss-type entries.
+int main() {
+  std::unordered_map<std::string, Truss> trusses;
+
+  Truss first;
+  first.name = "FK40Q H-300 1";
+  first.model = "FK40Q H-300";
+  first.gdtfSpec = "trusses/FK40Q_H-300.gdtf";
+  first.symbolFile = "cache/main.svg";
+  trusses.emplace("first", first);
+
+  Truss second = first;
+  second.name = "FK40Q H-300 2";
+  trusses.emplace("second", second);
+
+  Truss third = first;
+  third.name = "FK40Q H-300 3";
+  third.parentGroupUuid = "bridge";
+  trusses.emplace("third", third);
+
+  Truss directModel;
+  directModel.name = "Custom truss 1";
+  directModel.model = "Custom truss";
+  directModel.modelFile = "models/custom.glb";
+  directModel.symbolFile = "cache/custom.svg";
+  trusses.emplace("direct", directModel);
+
+  Truss unusable;
+  unusable.name = "Unusable";
+  unusable.model = "Unusable type";
+  unusable.symbolFile = "cache/unusable.svg";
+  trusses.emplace("unusable", unusable);
+
+  const fs::path sceneBase = fs::path("projects") / "show";
+  const auto sources =
+      gui::CollectTrussCreationSources(trusses, sceneBase.generic_string());
+
+  assert(sources.size() == 2);
+  assert(sources[0].displayName == "Custom truss");
+  assert(fs::path(sources[0].definitionPath) ==
+         sceneBase / "models" / "custom.glb");
+  assert(sources[1].displayName == "FK40Q H-300");
+  assert(fs::path(sources[1].definitionPath) ==
+         sceneBase / "trusses" / "FK40Q_H-300.gdtf");
+}


### PR DESCRIPTION
### Motivation

- The Add Truss flow listed each placed truss instance and reused `symbolFile` entries that are often extracted resources, which caused "Unsupported or unreadable truss file" errors when trying to recreate a truss from an instance.
- The selector should present reusable truss *types* (e.g. `FK40Q H-300`) and preserve a valid definition path (`.gdtf`, `.gtruss`, `.glb`, `.3ds`) resolved against the project rather than instance-only symbol artifacts.

### Description

- Add `gui/truss_creation_source.{h,cpp}` implementing `gui::CollectTrussCreationSources(...)` which deduplicates scene trusses by type and selects a reusable definition path preferring `gdtfSpec`, then `modelFile`, then `symbolFile` when the extension is supported.
- Update `MainWindow::OnAddTruss` to use `CollectTrussCreationSources(...)` so the Add Truss dialog shows one entry per truss type and uses the resolved definition path when creating a truss.
- Register the new helper in `gui/CMakeLists.txt` and add a focused regression test `tests/truss_creation_source_test.cpp` covering duplicate instances, grouped trusses, project-relative definitions and direct model files.
- Update `docs/release-notes-draft.md` with the visible user-facing fix about truss creation selection behavior.

### Testing

- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh` and both returned OK.
- Ran `git diff --check` to ensure no whitespace/format issues and it reported no problems.
- Built and executed a focused standalone test by compiling `truss_creation_source` test with a loader-format stub and the test passed locally.
- Full CMake test configuration could not be completed in this environment because the system does not have the wxWidgets development libraries installed, so full `tests` target runs were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3450dc6f108324a8d51c144fe9bce7)