### PR TITLE
Fix mode-aware GDTF geometry root rendering

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -71,6 +71,10 @@ Perastage v1.4.0 delivers a long-anticipated refresh of the modelling and riggin
 
 This release addresses dozens of issues across importing, snapping, editing and export workflows, including:
 
+- **GDTF fixture geometry placement** - fixtures that use top-level geometry
+  definitions through `GeometryReference` now render those parts only at their
+  referenced hierarchy position. Fixture-specific DMX modes also select the
+  correct geometry root without sharing incompatible cached geometry.
 - **Truss creation from scene types** - Add Truss now lists each available
   truss type once instead of showing every placed instance, and reliably
   reuses the original GDTF, GTruss, GLB, or 3DS definition even when the

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1247,6 +1247,20 @@ target_link_libraries(gdtfloader_channel_modes_test PRIVATE ${wxWidgets_LIBRARIE
 add_test(NAME GdtfLoaderChannelModeSummaries COMMAND gdtfloader_channel_modes_test)
 set_library_env(GdtfLoaderChannelModeSummaries)
 
+add_executable(gdtfloader_geometry_roots_test gdtfloader_geometry_roots_test.cpp
+               ../viewer3d/gdtfloader.cpp
+               ../core/gdtf_mutation_audit.cpp
+               ../viewer3d/loader3ds.cpp
+               ../viewer3d/loaderglb.cpp
+               ../viewer3d/meshprimitives.cpp
+               consolepanel_stub.cpp)
+target_include_directories(gdtfloader_geometry_roots_test PRIVATE
+                           . ../viewer3d ../models ../gui ../third_party)
+target_link_libraries(gdtfloader_geometry_roots_test PRIVATE
+                      ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
+add_test(NAME GdtfLoaderGeometryRoots COMMAND gdtfloader_geometry_roots_test)
+set_library_env(GdtfLoaderGeometryRoots)
+
 add_executable(gdtfloader_set_properties_test gdtfloader_set_properties_test.cpp
                ../viewer3d/gdtfloader.cpp
                ../core/gdtf_mutation_audit.cpp

--- a/tests/gdtfloader_geometry_roots_test.cpp
+++ b/tests/gdtfloader_geometry_roots_test.cpp
@@ -1,0 +1,98 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2026 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+#include "gdtfloader.h"
+
+#include <cassert>
+#include <cmath>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include <wx/filename.h>
+#include <wx/wfstream.h>
+class wxZipStreamLink;
+#include <wx/zipstrm.h>
+
+namespace {
+
+// Creates a minimal GDTF with a top-level beam definition referenced beneath Head.
+std::string MakeReferencedGeometryGdtf()
+{
+    wxFileName tempName(wxFileName::CreateTempFileName("gdtf_geometry_roots_"));
+    const std::string outPath = tempName.GetFullPath().ToStdString() + ".gdtf";
+    wxRemoveFile(tempName.GetFullPath());
+
+    wxFFileOutputStream fileOut(outPath);
+    assert(fileOut.IsOk());
+    wxZipOutputStream zipOut(fileOut);
+    zipOut.PutNextEntry("description.xml");
+    const std::string xml =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        "<GDTF DataVersion=\"1.2\">"
+        "<FixtureType Name=\"ReferencedGeometryFixture\">"
+        "<Models>"
+        "<Model Name=\"BaseModel\" PrimitiveType=\"Cube\" Length=\"1\" Width=\"1\" Height=\"1\"/>"
+        "<Model Name=\"BeamModel\" PrimitiveType=\"Cylinder\" Length=\"0.2\" Width=\"0.2\" Height=\"0.2\"/>"
+        "</Models>"
+        "<Geometries>"
+        "<Geometry Name=\"Base\" Model=\"BaseModel\">"
+        "<Geometry Name=\"Head\" Position=\"{1,0,0,1}{0,1,0,0}{0,0,1,0}{0,0,0,1}\">"
+        "<GeometryReference Name=\"MountedBeam\" Geometry=\"BeamLED\" "
+        "Position=\"{1,0,0,2}{0,1,0,0}{0,0,1,0}{0,0,0,1}\"/>"
+        "</Geometry>"
+        "</Geometry>"
+        "<Beam Name=\"BeamLED\" Model=\"BeamModel\"/>"
+        "</Geometries>"
+        "<DMXModes>"
+        "<DMXMode Name=\"Standard\" Geometry=\"Base\"/>"
+        "</DMXModes>"
+        "</FixtureType>"
+        "</GDTF>";
+    zipOut.Write(xml.data(), xml.size());
+    zipOut.Close();
+    return outPath;
+}
+
+// Compares floating-point transform components with a small tolerance.
+bool NearlyEqual(float lhs, float rhs)
+{
+    return std::fabs(lhs - rhs) < 0.0001f;
+}
+
+} // namespace
+
+// Verifies that referenced top-level geometry is rendered only through its reference.
+int main()
+{
+    const std::string gdtfPath = MakeReferencedGeometryGdtf();
+
+    std::vector<GdtfObject> objects;
+    std::string loadError;
+    assert(LoadGdtf(gdtfPath, objects, "Standard", &loadError));
+    assert(objects.size() == 2);
+    assert(NearlyEqual(objects[0].transform.o[0], 0.0f));
+    assert(NearlyEqual(objects[1].transform.o[0], 3.0f));
+
+    GdtfGeometryTree tree;
+    assert(LoadGdtfGeometryTree(gdtfPath, tree, "Standard", &loadError));
+    assert(tree.emitterNodeIndices.size() == 1);
+    const GdtfNode3D& emitter = tree.nodes[tree.emitterNodeIndices.front()];
+    assert(emitter.parentIndex >= 0);
+    assert(NearlyEqual(emitter.worldTransform.o[0], 3.0f));
+
+    std::vector<GdtfObject> defaultModeObjects;
+    assert(LoadGdtf(gdtfPath, defaultModeObjects, &loadError));
+    assert(defaultModeObjects.size() == 2);
+    assert(NearlyEqual(defaultModeObjects[1].transform.o[0], 3.0f));
+
+    std::error_code ec;
+    std::filesystem::remove(gdtfPath, ec);
+    return 0;
+}

--- a/viewer3d/culling/bounds_cache_system.cpp
+++ b/viewer3d/culling/bounds_cache_system.cpp
@@ -144,9 +144,10 @@ void BoundsCacheSystem::RebuildIfDirty(
         gdtfPathIt->second.attempted) {
       gdtfPath = gdtfPathIt->second.resolvedPath;
     }
-    auto itg = context.resourceSyncState.loadedGdtf.find(gdtfPath);
+    const std::string resourceKey = BuildGdtfResourceKey(gdtfPath, f.gdtfMode);
+    auto itg = context.resourceSyncState.loadedGdtf.find(resourceKey);
     if (itg != context.resourceSyncState.loadedGdtf.end()) {
-      auto bit = context.modelBounds.find(gdtfPath);
+      auto bit = context.modelBounds.find(resourceKey);
       if (bit == context.modelBounds.end()) {
         Viewer3DBoundingBox local;
         local.min = {FLT_MAX, FLT_MAX, FLT_MAX};
@@ -169,7 +170,7 @@ void BoundsCacheSystem::RebuildIfDirty(
           }
         }
         if (localFound)
-          bit = context.modelBounds.emplace(gdtfPath, local).first;
+          bit = context.modelBounds.emplace(resourceKey, local).first;
       }
       if (bit != context.modelBounds.end()) {
         bb = TransformBounds(bit->second, fix);

--- a/viewer3d/culling/visibilitysystem.cpp
+++ b/viewer3d/culling/visibilitysystem.cpp
@@ -19,6 +19,7 @@
 
 #include "configmanager.h"
 #include "matrixutils.h"
+#include "resource_sync_system.h"
 #include "scenedatamanager.h"
 
 #include <algorithm>
@@ -225,9 +226,11 @@ bool VisibilitySystem::EnsureBoundsComputed(
     if (gdtfIt != m_controller.GetResourceSyncState().resolvedGdtfSpecs.end() &&
         gdtfIt->second.attempted)
       gdtfPath = gdtfIt->second.resolvedPath;
-    auto itg = m_controller.GetResourceSyncState().loadedGdtf.find(gdtfPath);
+    const std::string resourceKey =
+        BuildGdtfResourceKey(gdtfPath, fit->second.gdtfMode);
+    auto itg = m_controller.GetResourceSyncState().loadedGdtf.find(resourceKey);
     if (itg != m_controller.GetResourceSyncState().loadedGdtf.end()) {
-      auto bit = m_controller.GetModelBounds().find(gdtfPath);
+      auto bit = m_controller.GetModelBounds().find(resourceKey);
       if (bit == m_controller.GetModelBounds().end()) {
         IVisibilityContext::BoundingBox local;
         local.min = {FLT_MAX, FLT_MAX, FLT_MAX};
@@ -249,7 +252,7 @@ bool VisibilitySystem::EnsureBoundsComputed(
           }
         }
         if (localFound)
-          bit = m_controller.GetModelBounds().emplace(gdtfPath, local).first;
+          bit = m_controller.GetModelBounds().emplace(resourceKey, local).first;
       }
       if (bit != m_controller.GetModelBounds().end()) {
         bb = transformBounds(bit->second, fix);

--- a/viewer3d/gdtfloader.cpp
+++ b/viewer3d/gdtfloader.cpp
@@ -1447,8 +1447,108 @@ static void ParseGeometry(tinyxml2::XMLElement* node,
     }
 }
 
+// Collects GeometryReference targets from a geometry subtree.
+static void CollectReferencedGeometryNames(tinyxml2::XMLElement* node,
+                                           std::unordered_set<std::string>& referencedNames)
+{
+    if (!node)
+        return;
+    if (std::string_view(node->Name()) == "GeometryReference") {
+        if (const char* geometry = node->Attribute("Geometry"); geometry && !IsBlank(geometry))
+            referencedNames.insert(geometry);
+    }
+    for (tinyxml2::XMLElement* child = node->FirstChildElement(); child;
+         child = child->NextSiblingElement()) {
+        CollectReferencedGeometryNames(child, referencedNames);
+    }
+}
+
+// Resolves render roots from the selected DMX mode and standards-based fallbacks.
+static std::vector<tinyxml2::XMLElement*> ResolveGeometryRoots(
+    tinyxml2::XMLElement* fixtureType,
+    tinyxml2::XMLElement* geometries,
+    const std::unordered_map<std::string, tinyxml2::XMLElement*>& geometryMap,
+    const std::string& modeName)
+{
+    auto resolveModeRoot = [&](tinyxml2::XMLElement* mode) -> tinyxml2::XMLElement* {
+        if (!mode)
+            return nullptr;
+        const char* geometry = mode->Attribute("Geometry");
+        if (!geometry || IsBlank(geometry))
+            return nullptr;
+        auto geometryIt = geometryMap.find(geometry);
+        return geometryIt != geometryMap.end() ? geometryIt->second : nullptr;
+    };
+
+    tinyxml2::XMLElement* dmxModes = fixtureType->FirstChildElement("DMXModes");
+    if (dmxModes && !modeName.empty()) {
+        for (tinyxml2::XMLElement* mode = dmxModes->FirstChildElement("DMXMode"); mode;
+             mode = mode->NextSiblingElement("DMXMode")) {
+            const char* name = mode->Attribute("Name");
+            if (name && modeName == name) {
+                if (tinyxml2::XMLElement* root = resolveModeRoot(mode))
+                    return {root};
+                break;
+            }
+        }
+    }
+
+    if (dmxModes) {
+        for (tinyxml2::XMLElement* mode = dmxModes->FirstChildElement("DMXMode"); mode;
+             mode = mode->NextSiblingElement("DMXMode")) {
+            if (tinyxml2::XMLElement* root = resolveModeRoot(mode))
+                return {root};
+        }
+    }
+
+    std::unordered_set<std::string> referencedNames;
+    for (tinyxml2::XMLElement* geometry = geometries->FirstChildElement(); geometry;
+         geometry = geometry->NextSiblingElement()) {
+        CollectReferencedGeometryNames(geometry, referencedNames);
+    }
+
+    std::vector<tinyxml2::XMLElement*> roots;
+    for (tinyxml2::XMLElement* geometry = geometries->FirstChildElement(); geometry;
+         geometry = geometry->NextSiblingElement()) {
+        const char* name = geometry->Attribute("Name");
+        if (!name || referencedNames.find(name) == referencedNames.end())
+            roots.push_back(geometry);
+    }
+    if (!roots.empty())
+        return roots;
+
+    for (tinyxml2::XMLElement* geometry = geometries->FirstChildElement(); geometry;
+         geometry = geometry->NextSiblingElement()) {
+        roots.push_back(geometry);
+    }
+    return roots;
+}
+
+// Builds the complete top-level geometry lookup used by GeometryReference nodes.
+static std::unordered_map<std::string, tinyxml2::XMLElement*> BuildGeometryMap(
+    tinyxml2::XMLElement* geometries)
+{
+    std::unordered_map<std::string, tinyxml2::XMLElement*> geometryMap;
+    for (tinyxml2::XMLElement* geometry = geometries->FirstChildElement(); geometry;
+         geometry = geometry->NextSiblingElement()) {
+        if (const char* name = geometry->Attribute("Name"); name && !IsBlank(name))
+            geometryMap[name] = geometry;
+    }
+    return geometryMap;
+}
+
+// Loads the default GDTF geometry hierarchy using the first usable DMX mode.
 bool LoadGdtfGeometryTree(const std::string& gdtfPath,
                           GdtfGeometryTree& outTree,
+                          std::string* outError)
+{
+    return LoadGdtfGeometryTree(gdtfPath, outTree, std::string(), outError);
+}
+
+// Loads the GDTF geometry hierarchy for the requested DMX mode.
+bool LoadGdtfGeometryTree(const std::string& gdtfPath,
+                          GdtfGeometryTree& outTree,
+                          const std::string& modeName,
                           std::string* outError)
 {
     std::lock_guard<std::recursive_mutex> lock(g_gdtfCacheMutex);
@@ -1458,7 +1558,7 @@ bool LoadGdtfGeometryTree(const std::string& gdtfPath,
     outTree.emitterNodeIndices.clear();
 
     std::vector<GdtfObject> outObjects;
-    const bool ok = LoadGdtf(gdtfPath, outObjects, outError);
+    const bool ok = LoadGdtf(gdtfPath, outObjects, modeName, outError);
     if (!ok)
         return false;
 
@@ -1505,14 +1605,9 @@ bool LoadGdtfGeometryTree(const std::string& gdtfPath,
     std::unordered_set<std::string>* failedModelLoads = &entry->failedModelLoads;
 
     if (tinyxml2::XMLElement* geoms = ft->FirstChildElement("Geometries")) {
-        std::unordered_map<std::string, tinyxml2::XMLElement*> geomMap;
-        for (tinyxml2::XMLElement* g = geoms->FirstChildElement(); g;
-             g = g->NextSiblingElement()) {
-            if (const char* n = g->Attribute("Name"))
-                geomMap[n] = g;
-        }
-        for (tinyxml2::XMLElement* g = geoms->FirstChildElement(); g;
-             g = g->NextSiblingElement()) {
+        const auto geomMap = BuildGeometryMap(geoms);
+        const auto roots = ResolveGeometryRoots(ft, geoms, geomMap, modeName);
+        for (tinyxml2::XMLElement* g : roots) {
             ParseGeometry(g, MatrixUtils::Identity(), models, entry->extractedDir,
                           geomMap, meshCache, outTree, missingModels, failedModelLoads,
                           -1, nullptr, false);
@@ -1522,8 +1617,18 @@ bool LoadGdtfGeometryTree(const std::string& gdtfPath,
     return !outTree.nodes.empty();
 }
 
+// Loads the default GDTF models using the first usable DMX mode.
 bool LoadGdtf(const std::string& gdtfPath,
               std::vector<GdtfObject>& outObjects,
+              std::string* outError)
+{
+    return LoadGdtf(gdtfPath, outObjects, std::string(), outError);
+}
+
+// Loads the GDTF models for the requested DMX mode.
+bool LoadGdtf(const std::string& gdtfPath,
+              std::vector<GdtfObject>& outObjects,
+              const std::string& modeName,
               std::string* outError)
 {
     std::lock_guard<std::recursive_mutex> lock(g_gdtfCacheMutex);
@@ -1607,12 +1712,9 @@ bool LoadGdtf(const std::string& gdtfPath,
     std::unordered_set<std::string>* failedModelLoads = &entry->failedModelLoads;
     GdtfGeometryTree geometryTree;
     if (tinyxml2::XMLElement* geoms = ft->FirstChildElement("Geometries")) {
-        std::unordered_map<std::string, tinyxml2::XMLElement*> geomMap;
-        for (tinyxml2::XMLElement* g = geoms->FirstChildElement(); g; g = g->NextSiblingElement()) {
-            if (const char* n = g->Attribute("Name"))
-                geomMap[n] = g;
-        }
-        for (tinyxml2::XMLElement* g = geoms->FirstChildElement(); g; g = g->NextSiblingElement()) {
+        const auto geomMap = BuildGeometryMap(geoms);
+        const auto roots = ResolveGeometryRoots(ft, geoms, geomMap, modeName);
+        for (tinyxml2::XMLElement* g : roots) {
             ParseGeometry(g, MatrixUtils::Identity(), models, entry->extractedDir, geomMap,
                           meshCache, geometryTree, missingModels, failedModelLoads, -1);
         }

--- a/viewer3d/gdtfloader.h
+++ b/viewer3d/gdtfloader.h
@@ -45,11 +45,23 @@ bool LoadGdtf(const std::string& gdtfPath,
               std::vector<GdtfObject>& outObjects,
               std::string* outError = nullptr);
 
+// Loads the models for a selected GDTF DMX mode while preserving the legacy API.
+bool LoadGdtf(const std::string& gdtfPath,
+              std::vector<GdtfObject>& outObjects,
+              const std::string& modeName,
+              std::string* outError = nullptr);
+
 // Loads the geometry hierarchy defined by a GDTF file preserving each node's
 // local transform and exposing stable node names for geometry, axis and
 // emitter nodes.
 bool LoadGdtfGeometryTree(const std::string& gdtfPath,
                           GdtfGeometryTree& outTree,
+                          std::string* outError = nullptr);
+
+// Loads the geometry hierarchy for a selected GDTF DMX mode.
+bool LoadGdtfGeometryTree(const std::string& gdtfPath,
+                          GdtfGeometryTree& outTree,
+                          const std::string& modeName,
                           std::string* outError = nullptr);
 
 // Returns the DMX footprint (highest occupied offset) of the given mode in a

--- a/viewer3d/render/opaque_fixture_pass.cpp
+++ b/viewer3d/render/opaque_fixture_pass.cpp
@@ -658,7 +658,9 @@ void OpaqueFixturePass::Render(
           gdtfPathIt->second.attempted)
         gdtfPath = gdtfPathIt->second.resolvedPath;
 
-      auto gdtfIt = controller.m_resourceSyncState.loadedGdtf.find(gdtfPath);
+      const std::string resourceKey =
+          BuildGdtfResourceKey(gdtfPath, fixture.gdtfMode);
+      auto gdtfIt = controller.m_resourceSyncState.loadedGdtf.find(resourceKey);
       if (gdtfIt != controller.m_resourceSyncState.loadedGdtf.end()) {
         for (const auto &obj : gdtfIt->second) {
           float localMatrix[16];
@@ -837,7 +839,9 @@ void OpaqueFixturePass::Render(
         BuildFixtureSymbolModelKey(f, normalizedGdtfPath);
     const std::string svgSourcePath = normalizedGdtfPath;
 
-    auto itg = controller.m_resourceSyncState.loadedGdtf.find(gdtfPath);
+    const std::string resourceKey =
+        BuildGdtfResourceKey(gdtfPath, f.gdtfMode);
+    auto itg = controller.m_resourceSyncState.loadedGdtf.find(resourceKey);
 
     bool renderedPerastageSvg = false;
     const bool captureRecordingActive =

--- a/viewer3d/resources/mesh_processing.cpp
+++ b/viewer3d/resources/mesh_processing.cpp
@@ -17,7 +17,7 @@ namespace {
 
 constexpr uint32_t kMeshCacheMagic = 0x4843534Du; // MSCH
 constexpr uint32_t kGdtfCacheMagic = 0x48434747u; // GGCH
-constexpr uint32_t kCacheVersion = 2u;
+constexpr uint32_t kCacheVersion = 3u;
 constexpr float kOverdrawThreshold = 1.05f;
 
 struct CacheHeader {
@@ -65,8 +65,27 @@ bool ReadVector(std::ifstream &in, std::vector<T> &values) {
   return in.good();
 }
 
+// Builds the disk cache path for a source asset.
 std::string BuildCachePath(const std::string &sourcePath) {
   return sourcePath + ".cache";
+}
+
+// Builds a stable hash for mode-specific GDTF disk cache names.
+uint64_t HashCacheToken(const std::string &value) {
+  uint64_t hash = 1469598103934665603ull;
+  for (unsigned char c : value) {
+    hash ^= c;
+    hash *= 1099511628211ull;
+  }
+  return hash;
+}
+
+// Builds the disk cache path for a GDTF mode selection.
+std::string BuildGdtfCachePath(const std::string &sourcePath,
+                               const std::string &modeName) {
+  if (modeName.empty())
+    return BuildCachePath(sourcePath);
+  return sourcePath + "." + std::to_string(HashCacheToken(modeName)) + ".cache";
 }
 
 int64_t GetSourceTimestampNs(const std::string &sourcePath) {
@@ -177,9 +196,11 @@ bool TrySaveMeshCache(const std::string &sourcePath, const Mesh &mesh) {
   return WriteRaw(out, header) && WriteMesh(out, mesh);
 }
 
+// Loads mode-specific GDTF objects from a valid disk cache.
 bool TryLoadGdtfCache(const std::string &gdtfPath,
+                      const std::string &modeName,
                       std::vector<GdtfObject> &outObjects) {
-  std::ifstream in(BuildCachePath(gdtfPath), std::ios::binary);
+  std::ifstream in(BuildGdtfCachePath(gdtfPath, modeName), std::ios::binary);
   if (!in.is_open())
     return false;
 
@@ -204,13 +225,16 @@ bool TryLoadGdtfCache(const std::string &gdtfPath,
   return true;
 }
 
+// Saves mode-specific GDTF objects to the disk cache.
 bool TrySaveGdtfCache(const std::string &gdtfPath,
+                      const std::string &modeName,
                       const std::vector<GdtfObject> &objects) {
   const int64_t sourceTimestampNs = GetSourceTimestampNs(gdtfPath);
   if (sourceTimestampNs < 0)
     return false;
 
-  std::ofstream out(BuildCachePath(gdtfPath), std::ios::binary | std::ios::trunc);
+  std::ofstream out(BuildGdtfCachePath(gdtfPath, modeName),
+                    std::ios::binary | std::ios::trunc);
   if (!out.is_open())
     return false;
 

--- a/viewer3d/resources/mesh_processing.h
+++ b/viewer3d/resources/mesh_processing.h
@@ -21,8 +21,10 @@ bool TryLoadMeshCache(const std::string &sourcePath, Mesh &outMesh);
 bool TrySaveMeshCache(const std::string &sourcePath, const Mesh &mesh);
 
 bool TryLoadGdtfCache(const std::string &gdtfPath,
+                      const std::string &modeName,
                       std::vector<GdtfObject> &outObjects);
 bool TrySaveGdtfCache(const std::string &gdtfPath,
+                      const std::string &modeName,
                       const std::vector<GdtfObject> &objects);
 
 } // namespace viewer3d::resources

--- a/viewer3d/resources/resource_sync_system.cpp
+++ b/viewer3d/resources/resource_sync_system.cpp
@@ -650,6 +650,12 @@ void ReleaseGdtfMeshBuffers(ResourceSyncState &state,
 
 } // namespace
 
+// Builds the mode-aware key used for loaded GDTF resources.
+std::string BuildGdtfResourceKey(const std::string &resolvedPath,
+                                 const std::string &modeName) {
+  return resolvedPath + "\nmode=" + modeName;
+}
+
 // Synchronizes visible scene resources with cached models, GDTFs, and fixture nodes.
 ResourceSyncResult ResourceSyncSystem::Sync(
     const std::string &basePath,
@@ -717,6 +723,7 @@ ResourceSyncResult ResourceSyncSystem::Sync(
     const auto &[uuid, f] = *entry;
     sceneSignature = HashCombine(sceneSignature, HashString(uuid));
     sceneSignature = HashCombine(sceneSignature, HashString(f.gdtfSpec));
+    sceneSignature = HashCombine(sceneSignature, HashString(f.gdtfMode));
     sceneSignature = HashCombine(sceneSignature, HashMatrix(f.transform));
   }
 
@@ -886,31 +893,32 @@ ResourceSyncResult ResourceSyncSystem::Sync(
       continue;
     }
 
-    auto failedIt = state.failedGdtfReasons.find(gdtfPath);
+    const std::string resourceKey = BuildGdtfResourceKey(gdtfPath, f.gdtfMode);
+    auto failedIt = state.failedGdtfReasons.find(resourceKey);
     if (failedIt != state.failedGdtfReasons.end()) {
-      const size_t attempts = state.failedGdtfAttemptCounts[gdtfPath];
+      const size_t attempts = state.failedGdtfAttemptCounts[resourceKey];
       if (attempts >= 3) {
-        ++gdtfErrorCounts[gdtfPath];
-        gdtfErrorReasons[gdtfPath] = failedIt->second;
+        ++gdtfErrorCounts[resourceKey];
+        gdtfErrorReasons[resourceKey] = failedIt->second;
         continue;
       }
       state.failedGdtfReasons.erase(failedIt);
     }
 
-    if (!processedGdtfPaths.insert(gdtfPath).second)
+    if (!processedGdtfPaths.insert(resourceKey).second)
       continue;
 
-    if (state.loadedGdtf.find(gdtfPath) == state.loadedGdtf.end()) {
+    if (state.loadedGdtf.find(resourceKey) == state.loadedGdtf.end()) {
       std::vector<GdtfObject> objs;
       std::string gdtfError;
       try {
         if (meshProcessingOptions.enableDiskCache &&
-            viewer3d::resources::TryLoadGdtfCache(gdtfPath, objs)) {
-        } else if (LoadGdtf(gdtfPath, objs, &gdtfError)) {
+            viewer3d::resources::TryLoadGdtfCache(gdtfPath, f.gdtfMode, objs)) {
+        } else if (LoadGdtf(gdtfPath, objs, f.gdtfMode, &gdtfError)) {
           if (meshProcessingOptions.enableMeshOptimization)
             viewer3d::resources::OptimizeGdtfObjectsForRuntime(objs);
           if (meshProcessingOptions.enableDiskCache)
-            viewer3d::resources::TrySaveGdtfCache(gdtfPath, objs);
+            viewer3d::resources::TrySaveGdtfCache(gdtfPath, f.gdtfMode, objs);
         }
       } catch (const std::exception &ex) {
         gdtfError = ex.what();
@@ -920,26 +928,27 @@ ResourceSyncResult ResourceSyncSystem::Sync(
 
       if (!objs.empty()) {
         SetupGdtfMeshBuffers(objs, callbacks);
-        state.loadedGdtf[gdtfPath] = std::move(objs);
-        state.failedGdtfAttemptCounts.erase(gdtfPath);
+        state.loadedGdtf[resourceKey] = std::move(objs);
+        state.failedGdtfAttemptCounts.erase(resourceKey);
 
         GdtfGeometryTree geometryTree;
         std::string geometryTreeError;
-        if (LoadGdtfGeometryTree(gdtfPath, geometryTree, &geometryTreeError)) {
+        if (LoadGdtfGeometryTree(gdtfPath, geometryTree, f.gdtfMode,
+                                 &geometryTreeError)) {
           const size_t geometryTreeVersion = HashGeometryTreeVersion(geometryTree);
-          state.loadedGdtfGeometryTrees[gdtfPath] = std::move(geometryTree);
-          state.geometryTreeVersionByResolvedGdtfPath[gdtfPath] = geometryTreeVersion;
+          state.loadedGdtfGeometryTrees[resourceKey] = std::move(geometryTree);
+          state.geometryTreeVersionByResolvedGdtfPath[resourceKey] = geometryTreeVersion;
         } else {
-          state.geometryTreeVersionByResolvedGdtfPath.erase(gdtfPath);
+          state.geometryTreeVersionByResolvedGdtfPath.erase(resourceKey);
         }
 
         result.assetsChanged = true;
       } else {
         std::string reason = gdtfError.empty() ? "Failed to load GDTF" : gdtfError;
-        state.failedGdtfReasons[gdtfPath] = reason;
-        ++state.failedGdtfAttemptCounts[gdtfPath];
-        ++gdtfErrorCounts[gdtfPath];
-        gdtfErrorReasons[gdtfPath] = reason;
+        state.failedGdtfReasons[resourceKey] = reason;
+        ++state.failedGdtfAttemptCounts[resourceKey];
+        ++gdtfErrorCounts[resourceKey];
+        gdtfErrorReasons[resourceKey] = reason;
         result.assetsChanged = true;
       }
     }
@@ -980,7 +989,9 @@ ResourceSyncResult ResourceSyncSystem::Sync(
       continue;
     }
 
-    auto treeIt = state.loadedGdtfGeometryTrees.find(gdtfPathIt->second.resolvedPath);
+    const std::string resourceKey =
+        BuildGdtfResourceKey(gdtfPathIt->second.resolvedPath, fixture.gdtfMode);
+    auto treeIt = state.loadedGdtfGeometryTrees.find(resourceKey);
     if (treeIt == state.loadedGdtfGeometryTrees.end()) {
       state.fixtureNodeRegistry.erase(uuid);
       state.fixtureAnchorRegistry.erase(uuid);
@@ -989,12 +1000,12 @@ ResourceSyncResult ResourceSyncSystem::Sync(
     }
 
     auto versionIt = state.geometryTreeVersionByResolvedGdtfPath.find(
-        gdtfPathIt->second.resolvedPath);
+        resourceKey);
     const size_t geometryTreeVersion = versionIt != state.geometryTreeVersionByResolvedGdtfPath.end()
                                            ? versionIt->second
                                            : HashGeometryTreeVersion(treeIt->second);
     const size_t fixtureSignature = BuildFixtureRegistrySignature(
-        uuid, gdtfPathIt->second.resolvedPath, fixture.transform, geometryTreeVersion);
+        uuid, resourceKey, fixture.transform, geometryTreeVersion);
 
     auto signatureIt = state.fixtureRegistrySignatureByUuid.find(uuid);
     const bool hasStableRegistry = signatureIt != state.fixtureRegistrySignatureByUuid.end() &&

--- a/viewer3d/resources/resource_sync_system.h
+++ b/viewer3d/resources/resource_sync_system.h
@@ -71,6 +71,10 @@ struct ResourceSyncResult {
   bool hasSceneSignature = false;
 };
 
+// Builds the mode-aware key used for loaded GDTF resources.
+std::string BuildGdtfResourceKey(const std::string &resolvedPath,
+                                 const std::string &modeName);
+
 class ResourceSyncSystem {
 public:
   static ResourceSyncResult


### PR DESCRIPTION
### Motivation

- Prevent top-level geometry definitions that exist only to be referenced via `GeometryReference` from being rendered as independent root objects at identity, which produced duplicate emitter/beam geometry (e.g., Martin MAC Aura case).
- Respect the selected DMX mode when choosing the geometry root so mode-specific geometry is loaded and cached correctly, avoiding collisions when the same GDTF file is used with different `Fixture::gdtfMode` values.
- Preserve existing `ParseGeometry(...)` transform-accumulation and `GeometryReference` resolution behavior while adding a safe, standards-based selection/fallback for render roots.

### Description

- Added helpers in `viewer3d/gdtfloader.cpp`: `CollectReferencedGeometryNames`, `BuildGeometryMap`, and `ResolveGeometryRoots` to choose which top-level `<Geometries>` entries should be parsed as render roots according to the DMX mode and standards-based fallbacks.  
- Introduced mode-aware overloads `LoadGdtf(..., const std::string& modeName, ...)` and `LoadGdtfGeometryTree(..., const std::string& modeName, ...)` while preserving the existing no-mode APIs that call the new overloads with an empty mode.  
- Changed parsing to only call `ParseGeometry(...)` for the resolved root geometry nodes while keeping the full `geomMap` so `GeometryReference` nodes still resolve and are parsed at the accumulated parent transform.  
- Made resource, geometry-tree, bounds and disk caches mode-aware by adding `BuildGdtfResourceKey(...)`, including `fixture.gdtfMode` in the scene signature, using mode-aware keys when storing `loadedGdtf`/`loadedGdtfGeometryTrees`/`modelBounds`, and passing `fixture.gdtfMode` through to loader and cache calls.  
- Updated disk cache helpers in `viewer3d/resources/mesh_processing.{h,cpp}` to accept a `modeName`, introduced stable mode hashing for cache filenames, and bumped the cache version to invalidate old all-mode caches.  
- Updated callers in rendering and culling layers (`opaque_fixture_pass.cpp`, `bounds_cache_system.cpp`, `visibilitysystem.cpp`) to use the mode-aware resource key.  
- Added a regression test `tests/gdtfloader_geometry_roots_test.cpp` and registered it in `tests/CMakeLists.txt` that builds a tiny GDTF archive (primitive-only models) asserting there is no extra identity-mounted beam and that the referenced emitter has the accumulated Head transform, and updated `docs/release-notes-draft.md` with the fix.  

### Testing

- Ran mandatory repository checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both succeeded.  
- Ran `git diff --check` and ensured there are no whitespace/git-diff issues.  
- Attempted to configure and build the new test with CMake, but the execution environment lacks the `wxWidgets` development libraries so the test binary could not be built or executed here; the test is added and will run in CI where `wxWidgets` is available.  
- Committed the changes (message: `Fix GDTF geometry root selection`) and prepared this PR; the change preserves legacy API behavior when `modeName` is not provided and uses safe fallbacks for files without DMX mode roots.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3452e14da08324a567924a399d517c)