### PR TITLE
Fix GroupObject layer ownership

### DIFF
--- a/core/scene_grouping.cpp
+++ b/core/scene_grouping.cpp
@@ -23,6 +23,7 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <optional>
 #include <set>
 #include <unordered_set>
 
@@ -192,6 +193,107 @@ CommonParentGroupUuid(const std::vector<SelectedObjectRef> &objects) {
   return parent;
 }
 
+// Returns the layer owned by a scene node when the node exists.
+std::optional<std::string> LayerForObject(const MvrScene &scene,
+                                          const MvrNodeType type,
+                                          const std::string &uuid) {
+  switch (type) {
+  case MvrNodeType::Fixture: {
+    auto it = scene.fixtures.find(uuid);
+    return it == scene.fixtures.end() ? std::nullopt
+                                      : std::optional<std::string>(it->second.layer);
+  }
+  case MvrNodeType::Truss: {
+    auto it = scene.trusses.find(uuid);
+    return it == scene.trusses.end() ? std::nullopt
+                                     : std::optional<std::string>(it->second.layer);
+  }
+  case MvrNodeType::Support: {
+    auto it = scene.supports.find(uuid);
+    return it == scene.supports.end() ? std::nullopt
+                                      : std::optional<std::string>(it->second.layer);
+  }
+  case MvrNodeType::SceneObject: {
+    auto it = scene.sceneObjects.find(uuid);
+    return it == scene.sceneObjects.end()
+               ? std::nullopt
+               : std::optional<std::string>(it->second.layer);
+  }
+  case MvrNodeType::GroupObject: {
+    auto it = scene.groupObjects.find(uuid);
+    return it == scene.groupObjects.end() ? std::nullopt
+                                          : std::optional<std::string>(it->second.layer);
+  }
+  }
+  return std::nullopt;
+}
+
+// Returns the authoritative layer for a GroupObject-based grouping operation.
+std::string AuthoritativeGroupLayer(const MvrScene &scene,
+                                    const std::vector<SelectedObjectRef> &objects,
+                                    const std::string &parentGroupUuid) {
+  if (!parentGroupUuid.empty()) {
+    auto parentIt = scene.groupObjects.find(parentGroupUuid);
+    if (parentIt != scene.groupObjects.end())
+      return parentIt->second.layer;
+  }
+  for (const auto &object : objects) {
+    if (object.type == MvrNodeType::Truss)
+      return object.layer;
+  }
+  for (const auto &object : objects) {
+    if (object.type == MvrNodeType::GroupObject) {
+      auto layer = LayerForObject(scene, object.type, object.uuid);
+      if (layer)
+        return *layer;
+    }
+  }
+  return objects.empty() ? std::string{} : objects.front().layer;
+}
+
+// Applies the authoritative parent GroupObject layer to one child node.
+bool ApplyGroupLayerToChild(MvrScene &scene, const GroupObjectChildRef &child,
+                            const std::string &layer) {
+  switch (child.type) {
+  case MvrNodeType::Fixture: {
+    auto it = scene.fixtures.find(child.uuid);
+    if (it == scene.fixtures.end() || it->second.layer == layer)
+      return false;
+    it->second.layer = layer;
+    return true;
+  }
+  case MvrNodeType::Truss: {
+    auto it = scene.trusses.find(child.uuid);
+    if (it == scene.trusses.end() || it->second.layer == layer)
+      return false;
+    it->second.layer = layer;
+    return true;
+  }
+  case MvrNodeType::Support: {
+    auto it = scene.supports.find(child.uuid);
+    if (it == scene.supports.end() || it->second.layer == layer)
+      return false;
+    it->second.layer = layer;
+    return true;
+  }
+  case MvrNodeType::SceneObject: {
+    auto it = scene.sceneObjects.find(child.uuid);
+    if (it == scene.sceneObjects.end() || it->second.layer == layer)
+      return false;
+    it->second.layer = layer;
+    return true;
+  }
+  case MvrNodeType::GroupObject: {
+    auto it = scene.groupObjects.find(child.uuid);
+    if (it == scene.groupObjects.end() || it->second.layer == layer)
+      return false;
+    it->second.layer = layer;
+    return true;
+  }
+  }
+  return false;
+}
+
 // Updates an object's parent group and local transform fields.
 void ApplyParentAndLocalTransform(MvrScene &scene,
                                   const SelectedObjectRef &object,
@@ -243,6 +345,34 @@ void ApplyParentAndLocalTransform(MvrScene &scene,
     break;
   }
   }
+}
+
+// Moves the newly grouped object to the parent GroupObject layer.
+void ApplyParentAndLayer(MvrScene &scene, const SelectedObjectRef &object,
+                         const std::string &parentGroupUuid,
+                         const Matrix &localTransform,
+                         const std::string &parentLayer) {
+  ApplyParentAndLocalTransform(scene, object, parentGroupUuid, localTransform);
+  ApplyGroupLayerToChild(scene, {object.type, object.uuid}, parentLayer);
+}
+
+// Recursively applies parent group layer ownership through nested groups.
+std::size_t SynchronizeGroupObjectLayerOwnershipFrom(MvrScene &scene,
+                                                     const std::string &groupUuid) {
+  auto groupIt = scene.groupObjects.find(groupUuid);
+  if (groupIt == scene.groupObjects.end())
+    return 0;
+
+  std::size_t repairedCount = 0;
+  const std::string groupLayer = groupIt->second.layer;
+  const std::vector<GroupObjectChildRef> children = groupIt->second.children;
+  for (const auto &child : children) {
+    if (ApplyGroupLayerToChild(scene, child, groupLayer))
+      ++repairedCount;
+    if (child.type == MvrNodeType::GroupObject)
+      repairedCount += SynchronizeGroupObjectLayerOwnershipFrom(scene, child.uuid);
+  }
+  return repairedCount;
 }
 
 // Adds an affected child UUID to the operation result for selection
@@ -580,6 +710,18 @@ void UngroupRootTarget(MvrScene &scene, const std::string &groupUuid,
   result.changed = true;
 }
 
+// Repairs GroupObject child layers so parent group ownership stays authoritative.
+std::size_t SynchronizeGroupObjectLayerOwnership(MvrScene &scene) {
+  std::size_t repairedCount = 0;
+  for (auto &[groupUuid, group] : scene.groupObjects) {
+    if (group.parentGroupUuid.empty()) {
+      repairedCount +=
+          SynchronizeGroupObjectLayerOwnershipFrom(scene, groupUuid);
+    }
+  }
+  return repairedCount;
+}
+
 // Creates a new GroupObject and reparents the selected scene entities.
 OperationResult GroupSelection(MvrScene &scene,
                                const ObjectSelection &selection) {
@@ -607,7 +749,7 @@ OperationResult GroupSelection(MvrScene &scene,
   GroupObject group;
   group.uuid = GenerateUuid();
   group.name = "Group " + std::to_string(scene.groupObjects.size() + 1);
-  group.layer = objects.front().layer;
+  group.layer = AuthoritativeGroupLayer(scene, objects, parentGroupUuid);
   group.parentGroupUuid = parentGroupUuid;
   group.transform = groupWorldTransform;
   group.localTransform =
@@ -624,7 +766,7 @@ OperationResult GroupSelection(MvrScene &scene,
     RemoveChildFromGroups(scene, object.type, object.uuid);
     const Matrix localTransform = MatrixUtils::Multiply(
         inverseGroupWorldTransform, object.worldTransform);
-    ApplyParentAndLocalTransform(scene, object, group.uuid, localTransform);
+    ApplyParentAndLayer(scene, object, group.uuid, localTransform, group.layer);
     group.children.push_back({object.type, object.uuid});
     AppendAffectedTarget(result, scene, object.type, object.uuid);
   }
@@ -661,7 +803,8 @@ OperationResult AddSelectionToGroup(MvrScene &scene,
     RemoveChildFromGroups(scene, object.type, object.uuid);
     const Matrix localTransform = MatrixUtils::Multiply(
         InverseMatrix(groupIt->second.transform), object.worldTransform);
-    ApplyParentAndLocalTransform(scene, object, groupUuid, localTransform);
+    ApplyParentAndLayer(scene, object, groupUuid, localTransform,
+                        groupIt->second.layer);
     groupIt->second.children.push_back({object.type, object.uuid});
     AppendAffectedTarget(result, scene, object.type, object.uuid);
     result.changed = true;

--- a/core/scene_grouping.h
+++ b/core/scene_grouping.h
@@ -20,6 +20,7 @@
 #include "mvrscene.h"
 
 #include <array>
+#include <cstddef>
 #include <string>
 #include <vector>
 
@@ -45,6 +46,9 @@ struct OperationResult {
   std::vector<std::string> affectedSupports;
   std::vector<std::string> affectedSceneObjects;
 };
+
+// Synchronizes GroupObject children to the layer owned by their parent group.
+std::size_t SynchronizeGroupObjectLayerOwnership(MvrScene &scene);
 
 // Creates one MVR-compatible GroupObject from the selected scene entities.
 OperationResult GroupSelection(MvrScene &scene,

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -71,6 +71,7 @@ Perastage v1.4.0 delivers a long-anticipated refresh of the modelling and riggin
 
 This release addresses dozens of issues across importing, snapping, editing and export workflows, including:
 
+- **GroupObject layer ownership** - fixtures added to truss-based groups now immediately adopt the truss/group layer, while existing trusses and groups keep their original layer across save, reopen, MVR import and MVR export.
 - **GDTF fixture geometry placement** - fixtures that use top-level geometry
   definitions through `GeometryReference` now render those parts only at their
   referenced hierarchy position. Fixture-specific DMX modes also select the

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -36,6 +36,7 @@
 #include "matrixutils.h"
 #include "primitive_model_resources.h"
 #include "projectutils.h"
+#include "scene_grouping.h"
 #include "sceneobject.h"
 #include "support.h"
 #include "trussloader.h"
@@ -3239,6 +3240,14 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
     LogMessage(Logger::Level::Info,
                "MVR import preserved GroupObject count=" +
                    std::to_string(preservedGroupObjectCount));
+  }
+  const std::size_t repairedGroupLayerCount =
+      scene_grouping::SynchronizeGroupObjectLayerOwnership(scene);
+  if (repairedGroupLayerCount > 0) {
+    LogMessage(Logger::Level::Info,
+               "MVR import repaired " +
+                   std::to_string(repairedGroupLayerCount) +
+                   " GroupObject child layer assignment(s)");
   }
 
   auto resolveFixtureGdtfPathForRead = [&](const std::string &spec) {

--- a/tests/magnet_snap_test.cpp
+++ b/tests/magnet_snap_test.cpp
@@ -133,6 +133,7 @@ int main() {
 
   Fixture fixture;
   fixture.uuid = "fixture";
+  fixture.layer = "MAC500";
   fixture.transform = Translated(1510.0f, 160.0f, 0.0f);
   scene.fixtures[fixture.uuid] = fixture;
   auto fixtureSnap = magnet_snap::FindSnap(
@@ -156,6 +157,9 @@ int main() {
 
   assert(magnet_snap::ApplyCommittedSnapGrouping(scene, *fixtureSnap));
   assert(scene.fixtures[fixture.uuid].parentGroupUuid == groupUuid);
+  assert(scene.fixtures[fixture.uuid].layer ==
+         scene.groupObjects[groupUuid].layer);
+  assert(scene.trusses["target"].layer == scene.groupObjects[groupUuid].layer);
 
   SceneObject object;
   object.uuid = "object";

--- a/tests/scene_grouping_test.cpp
+++ b/tests/scene_grouping_test.cpp
@@ -27,7 +27,7 @@ int main() {
 
   Fixture fixture;
   fixture.uuid = "fixture-a";
-  fixture.layer = "No Layer";
+  fixture.layer = "MAC500";
   fixture.position = "lx1-position";
   fixture.positionName = "LX1";
   fixture.transform = Translated(1000.0f, 0.0f, 0.0f);
@@ -35,7 +35,7 @@ int main() {
 
   Truss truss;
   truss.uuid = "truss-a";
-  truss.layer = "No Layer";
+  truss.layer = "LX1";
   truss.position = "lx1-position";
   truss.positionName = "LX1";
   truss.transform = Translated(3000.0f, 0.0f, 0.0f);
@@ -51,6 +51,9 @@ int main() {
   assert(scene.groupObjects.size() == 1);
   assert(scene.fixtures[fixture.uuid].parentGroupUuid == groupResult.groupUuid);
   assert(scene.trusses[truss.uuid].parentGroupUuid == groupResult.groupUuid);
+  assert(scene.groupObjects[groupResult.groupUuid].layer == "LX1");
+  assert(scene.fixtures[fixture.uuid].layer == "LX1");
+  assert(scene.trusses[truss.uuid].layer == "LX1");
   assert(scene.fixtures[fixture.uuid].positionName == "LX1");
   assert(scene.trusses[truss.uuid].positionName == "LX1");
   assert(NearlyEqual(scene.fixtures[fixture.uuid].transform.o[0], 1000.0f));
@@ -66,6 +69,8 @@ int main() {
   assert(scene.groupObjects.empty());
   assert(scene.fixtures[fixture.uuid].parentGroupUuid.empty());
   assert(scene.trusses[truss.uuid].parentGroupUuid.empty());
+  assert(scene.fixtures[fixture.uuid].layer == "LX1");
+  assert(scene.trusses[truss.uuid].layer == "LX1");
   assert(scene.fixtures[fixture.uuid].positionName == "LX1");
   assert(scene.trusses[truss.uuid].positionName == "LX1");
   assert(NearlyEqual(scene.fixtures[fixture.uuid].transform.o[0], 1000.0f));
@@ -135,6 +140,47 @@ int main() {
                      1100.0f));
   assert(NearlyEqual(groupedDragScene.trusses[groupedTruss.uuid].transform.o[0],
                      3100.0f));
+
+  MvrScene existingGroupScene;
+  Fixture addedFixture;
+  addedFixture.uuid = "added-fixture";
+  addedFixture.layer = "MAC500";
+  addedFixture.transform = Translated(500.0f, 0.0f, 0.0f);
+  existingGroupScene.fixtures[addedFixture.uuid] = addedFixture;
+  Truss existingTruss;
+  existingTruss.uuid = "existing-truss";
+  existingTruss.layer = "LX1";
+  existingTruss.transform = Translated(1500.0f, 0.0f, 0.0f);
+  existingGroupScene.trusses[existingTruss.uuid] = existingTruss;
+  scene_grouping::ObjectSelection existingGroupSelection;
+  existingGroupSelection.trusses = {existingTruss.uuid};
+  const scene_grouping::OperationResult existingGroupResult =
+      scene_grouping::GroupSelection(existingGroupScene, existingGroupSelection);
+  assert(!existingGroupResult.changed);
+  GroupObject existingGroup;
+  existingGroup.uuid = "existing-group";
+  existingGroup.layer = "LX1";
+  existingGroup.transform = Translated(1500.0f, 0.0f, 0.0f);
+  existingGroup.children.push_back({MvrNodeType::Truss, existingTruss.uuid});
+  existingGroupScene.groupObjects[existingGroup.uuid] = existingGroup;
+  existingGroupScene.trusses[existingTruss.uuid].parentGroupUuid =
+      existingGroup.uuid;
+  scene_grouping::ObjectSelection addFixtureSelection;
+  addFixtureSelection.fixtures = {addedFixture.uuid};
+  assert(scene_grouping::AddSelectionToGroup(existingGroupScene,
+                                             addFixtureSelection,
+                                             existingGroup.uuid)
+             .changed);
+  assert(existingGroupScene.fixtures[addedFixture.uuid].layer == "LX1");
+  assert(existingGroupScene.trusses[existingTruss.uuid].layer == "LX1");
+  assert(NearlyEqual(existingGroupScene.fixtures[addedFixture.uuid]
+                         .transform.o[0],
+                     500.0f));
+
+  existingGroupScene.fixtures[addedFixture.uuid].layer = "MAC500";
+  assert(scene_grouping::SynchronizeGroupObjectLayerOwnership(
+             existingGroupScene) == 1);
+  assert(existingGroupScene.fixtures[addedFixture.uuid].layer == "LX1");
 
   const scene_grouping::OperationResult fixtureDetachResult =
       scene_grouping::RemoveSelectionFromGroup(scene, childSelection);


### PR DESCRIPTION
### Motivation
- Grouping using MVR `GroupObject` incorrectly allowed trusses/groups to be moved to a fixture's previous layer when a fixture from another layer was added, causing inconsistent layer ownership after save/reopen.
- The intent is to make group/truss layer authoritative for `GroupObject`-based grouping and ensure newly added fixtures adopt the group's layer immediately while preserving transforms and metadata.

### Description
- Add a shared core helper `SynchronizeGroupObjectLayerOwnership` (and internal recursive helper) that enforces parent `GroupObject` layer ownership and repairs nested group children when needed.
- Make grouping paths adopt the authoritative group layer by introducing `AuthoritativeGroupLayer` and `ApplyParentAndLayer`, and use them from `GroupSelection` and `AddSelectionToGroup` so newly added objects immediately inherit the target group/truss layer while preserving local/world transforms.
- Call the synchronization helper from the MVR importer to repair imported scenes where GroupObject children have inconsistent layers, and log a concise info message only when repairs are applied.
- Add/extend unit tests in `tests/scene_grouping_test.cpp` and `tests/magnet_snap_test.cpp` to cover cross-layer fixture-to-truss grouping, adding a fixture to an existing truss group, synchronization/repair, and magnet-snap grouping behavior; update release notes in `docs/release-notes-draft.md` to document the user-visible fix.

### Testing
- Built and ran `scene_grouping_test` with: `g++ -std=c++20 -Icore -Imodels tests/scene_grouping_test.cpp core/scene_grouping.cpp core/uuidutils.cpp models/mvrscene.cpp -o /tmp/scene_grouping_test && /tmp/scene_grouping_test`, and it passed.
- Built and ran `magnet_snap_test` with: `g++ -std=c++20 -Icore -Imodels tests/magnet_snap_test.cpp core/magnet_snap.cpp core/scene_grouping.cpp core/uuidutils.cpp models/mvrscene.cpp -o /tmp/magnet_snap_test && /tmp/magnet_snap_test`, and it passed.
- Ran repository checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, and both succeeded.
- Attempting a full CMake test build from `tests/` failed in this environment because wxWidgets development files are unavailable, so `cmake -S tests -B /tmp/perastage-tests` could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3626fe7a408324a7bf87821aae5134)