### PR TITLE
Synchronize viewport movement toggles and persist preferences on change

### DIFF
--- a/core/configmanager.cpp
+++ b/core/configmanager.cpp
@@ -20,8 +20,10 @@
 #include "LayoutManager.h"
 #include "LayoutImageResourceRegistry.h"
 #include "logger.h"
+#include "magnet_snap.h"
 #include "mvrexporter.h"
 #include "mvrimporter.h"
+#include "selection_movement_settings.h"
 #include <filesystem>
 #include <fstream>
 #include <iostream>
@@ -38,6 +40,39 @@
 
 namespace {
 constexpr const char *kHiddenLayersConfigKey = "view_hidden_layers";
+
+struct RestoredUserPreference {
+  const char *key = nullptr;
+  std::optional<std::string> value;
+};
+
+// Captures user-level interaction preferences before project config loading.
+std::vector<RestoredUserPreference> CaptureUserInteractionPreferences(
+    const ConfigManager &config) {
+  return {
+      {magnet_snap::kMagnetEnabledConfigKey,
+       config.GetValue(magnet_snap::kMagnetEnabledConfigKey)},
+      {selection_movement_settings::kAxisConstrainedMovementConfigKey,
+       config.GetValue(
+           selection_movement_settings::kAxisConstrainedMovementConfigKey)},
+      {selection_movement_settings::kLeftDragSelectionMovementConfigKey,
+       config.GetValue(
+           selection_movement_settings::kLeftDragSelectionMovementConfigKey)}};
+}
+
+// Restores user-level interaction preferences after project config loading.
+void RestoreUserInteractionPreferences(
+    ConfigManager &config,
+    const std::vector<RestoredUserPreference> &preferences) {
+  for (const auto &preference : preferences) {
+    if (!preference.key)
+      continue;
+    if (preference.value)
+      config.SetValue(preference.key, *preference.value);
+    else
+      config.RemoveKey(preference.key);
+  }
+}
 constexpr const char *kHiddenFixtureTypesConfigKey = "view_hidden_fixture_types";
 constexpr const char *kLayoutsConfigKey = "layouts_collection";
 
@@ -540,12 +575,15 @@ bool ConfigManager::LoadProject(const std::string &path,
 
   const bool hasUserView2dDarkMode = HasKey("view2d_dark_mode");
   const float userView2dDarkMode = GetFloat("view2d_dark_mode");
+  const auto userInteractionPreferences =
+      CaptureUserInteractionPreferences(*this);
   auto restoreUserPreferences = [this, hasUserView2dDarkMode,
-                                 userView2dDarkMode]() {
-    if (!hasUserView2dDarkMode)
-      return;
+                                 userView2dDarkMode,
+                                 userInteractionPreferences]() {
     RevisionGuard guard(*this);
-    SetFloat("view2d_dark_mode", userView2dDarkMode);
+    if (hasUserView2dDarkMode)
+      SetFloat("view2d_dark_mode", userView2dDarkMode);
+    RestoreUserInteractionPreferences(*this, userInteractionPreferences);
   };
 
   bool ok = projectSession.LoadProject(

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -102,6 +102,7 @@ This release addresses dozens of issues across importing, snapping, editing and 
 - **Scene object naming** - edited names in the Data View persist across saves and are exported through MVR, supporting technical naming workflows like cable waypoints.  Fixture IDs remain as edited instead of reverting when reopening or exporting projects.
 - **Magnet snapping** - fixture-to-truss snaps align to the actual truss edge height, stay aligned when the snapped truss or group moves, and only snap after an intentional drag starts.  Truss runs can snap to loose trusses using run bounds while ignoring attached fixtures.
 - **Drag feedback** - the X/Y/Z status display remains visible and changes colour reliably while moving objects in 2D/3D.
+- **Viewport movement toggles** - Drag Move, Axis Lock and Magnet now keep their saved state synchronized with the active 2D/3D viewers when opening projects or switching saved layouts.
 - **Command-bar parsing** - improved parsing of `t` and `thru` sequences distributes position/rotation values as expected.
 - **Truss export/import** - MVR exports no longer embed local file paths, preserve layer colour metadata in a standards-compliant UserData block, and store fixture colours as gel/filter data only when intended.  Round-trip exports retain support objects and write truss children in the correct schema order.
 - **Geometry models** - GLB/3DS trusses remain visible even when metadata is missing, and unsupported formats are rejected clearly.  Newly added scene objects reuse existing primitive data immediately.

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -118,6 +118,7 @@ using json = nlohmann::json;
 #include "ridertextdialog.h"
 #include "riggingpanel.h"
 #include "sceneobjecttablepanel.h"
+#include "selection_movement_settings.h"
 #include "selectfixturetypedialog.h"
 #include "selectnamedialog.h"
 #include "simplecrypt.h"
@@ -279,6 +280,9 @@ const std::vector<std::string> &GetPreferencesDialogConfigKeys() {
       "rider_lx2_margin",        "rider_lx3_margin",
       "rider_lx4_margin",        "rider_lx5_margin",
       "rider_lx6_margin",
+      magnet_snap::kMagnetEnabledConfigKey,
+      selection_movement_settings::kAxisConstrainedMovementConfigKey,
+      selection_movement_settings::kLeftDragSelectionMovementConfigKey,
   };
   return kKeys;
 }
@@ -534,6 +538,7 @@ void MainWindow::Ensure3DViewport() {
 
   if (summaryPanel)
     summaryPanel->SetVisibleRefreshTargets(viewport2DPanel, viewportPanel);
+  ApplyViewportMovementToolState();
 }
 
 void MainWindow::Ensure2DViewport() {
@@ -586,6 +591,7 @@ void MainWindow::Ensure2DViewport() {
 
   if (summaryPanel)
     summaryPanel->SetVisibleRefreshTargets(viewport2DPanel, viewportPanel);
+  ApplyViewportMovementToolState();
 
   auiManager->Update();
 
@@ -941,6 +947,7 @@ bool MainWindow::LoadProjectFromPath(const std::string &path,
   }
   if (viewport2DRenderPanel)
     viewport2DRenderPanel->ApplyConfig();
+  ApplyViewportMovementToolState();
   if (layerPanel)
     layerPanel->ReloadLayers();
 
@@ -1508,13 +1515,7 @@ void MainWindow::OnProjectLoaded(wxCommandEvent &event) {
     }
     if (viewport2DRenderPanel)
       viewport2DRenderPanel->ApplyConfig();
-    const bool magnetEnabled =
-        GetDefaultGuiConfigServices().Preferences().GetValue(
-            magnet_snap::kMagnetEnabledConfigKey) == "1";
-    if (viewportPanel)
-      viewportPanel->SetMagnetEnabled(magnetEnabled);
-    if (viewport2DPanel)
-      viewport2DPanel->SetMagnetEnabled(magnetEnabled);
+    ApplyViewportMovementToolState();
     SyncViewportToolToggleState(
         (viewport2DPanel && viewport2DPanel->IsMeasureToolEnabled()) ||
         (viewportPanel && viewportPanel->IsMeasureToolEnabled()));
@@ -1599,6 +1600,7 @@ void MainWindow::RefreshAfterFixtureSymbolUpdate() {
     viewport2DPanel->UpdateScene(true);
     viewport2DPanel->Refresh();
   }
+  ApplyViewportMovementToolState();
   if (layoutViewerPanel)
     layoutViewerPanel->RefreshAfterFixtureSymbolUpdate();
 }

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -87,6 +87,7 @@ public:
   void SyncViewportToolToggleState(bool measureEnabled);
   void SyncAxisConstraintToolToggleState();
   void SyncLeftDragMoveToolToggleState();
+  void ApplyViewportMovementToolState();
   void Ensure2DViewportAvailable();
   Viewer2DPanel *GetLayoutCapturePanel() const;
   Viewer2DOffscreenRenderer *GetOffscreenRenderer();

--- a/gui/mainwindow_view_shortcuts.cpp
+++ b/gui/mainwindow_view_shortcuts.cpp
@@ -8,6 +8,7 @@
 
 namespace {
 
+// Returns whether the named AUI pane is currently visible.
 bool IsPaneShown(wxAuiManager *manager, const char *name) {
   if (!manager)
     return false;
@@ -15,6 +16,7 @@ bool IsPaneShown(wxAuiManager *manager, const char *name) {
   return pane.IsOk() && pane.IsShown();
 }
 
+// Returns whether a window is the same as or contained by another window.
 bool IsChildOrSame(const wxWindow *root, const wxWindow *window) {
   if (!root || !window)
     return false;
@@ -29,14 +31,17 @@ bool IsChildOrSame(const wxWindow *root, const wxWindow *window) {
 
 } // namespace
 
+// Applies the top view shortcut to the active viewport.
 void MainWindow::OnViewportTopView(wxCommandEvent &WXUNUSED(event)) {
   ApplyViewportShortcut(Viewer2DView::Top);
 }
 
+// Applies the front view shortcut to the active viewport.
 void MainWindow::OnViewportFrontView(wxCommandEvent &WXUNUSED(event)) {
   ApplyViewportShortcut(Viewer2DView::Front);
 }
 
+// Applies the side view shortcut to the active viewport.
 void MainWindow::OnViewportSideView(wxCommandEvent &WXUNUSED(event)) {
   ApplyViewportShortcut(Viewer2DView::Side);
 }
@@ -110,6 +115,7 @@ void MainWindow::OnViewportAxisConstraint(wxCommandEvent &WXUNUSED(event)) {
   preferences.SetValue(
       selection_movement_settings::kAxisConstrainedMovementConfigKey,
       axisConstraintEnabled ? "0" : "1");
+  preferences.SaveUserConfig();
   SyncAxisConstraintToolToggleState();
 }
 
@@ -123,9 +129,11 @@ void MainWindow::OnViewportLeftDragMove(wxCommandEvent &WXUNUSED(event)) {
   preferences.SetValue(
       selection_movement_settings::kLeftDragSelectionMovementConfigKey,
       enabled ? "0" : "1");
+  preferences.SaveUserConfig();
   SyncLeftDragMoveToolToggleState();
 }
 
+// Fits the viewport that currently owns keyboard focus.
 bool MainWindow::ApplyFitShortcut() {
   const wxWindow *focusedWindow = wxWindow::FindFocus();
   const bool focusIn2D = IsChildOrSame(viewport2DPanel, focusedWindow) ||
@@ -140,6 +148,7 @@ bool MainWindow::ApplyFitShortcut() {
   return false;
 }
 
+// Applies a standard view shortcut to the active or only visible viewport.
 void MainWindow::ApplyViewportShortcut(Viewer2DView view) {
   const bool is2DShown = IsPaneShown(auiManager, "2DViewport");
   const bool is3DShown = IsPaneShown(auiManager, "3DViewport");

--- a/gui/mainwindow_view_shortcuts.cpp
+++ b/gui/mainwindow_view_shortcuts.cpp
@@ -1,5 +1,6 @@
 #include "mainwindow.h"
 
+#include "viewer2dpanel.h"
 #include "viewer2drenderpanel.h"
 #include "viewer3dpanel.h"
 #include "selection_movement_settings.h"
@@ -52,12 +53,7 @@ void MainWindow::SyncViewportToolToggleState(bool measureEnabled) {
     return;
   layoutViewsToolBar->ToggleTool(ID_View_Viewport_SelectTool, !measureEnabled);
   layoutViewsToolBar->ToggleTool(ID_View_Viewport_MeasureTool, measureEnabled);
-  SyncAxisConstraintToolToggleState();
-  SyncLeftDragMoveToolToggleState();
-  layoutViewsToolBar->ToggleTool(
-      ID_View_Viewport_Magnet,
-      GetDefaultGuiConfigServices().Preferences().GetValue(
-          magnet_snap::kMagnetEnabledConfigKey) == "1");
+  ApplyViewportMovementToolState();
   layoutViewsToolBar->Refresh();
 }
 
@@ -81,6 +77,38 @@ void MainWindow::SyncLeftDragMoveToolToggleState() {
       GetDefaultGuiConfigServices().Preferences().GetValue(
           selection_movement_settings::kLeftDragSelectionMovementConfigKey) ==
           "1");
+}
+
+// Applies the persisted movement tool state to the toolbar and active viewports.
+void MainWindow::ApplyViewportMovementToolState() {
+  auto &preferences = GetDefaultGuiConfigServices().Preferences();
+  const bool axisConstraintEnabled =
+      preferences.GetValue(
+          selection_movement_settings::kAxisConstrainedMovementConfigKey) !=
+      "0";
+  const bool leftDragMoveEnabled =
+      preferences.GetValue(
+          selection_movement_settings::kLeftDragSelectionMovementConfigKey) ==
+      "1";
+  const bool magnetEnabled =
+      preferences.GetValue(magnet_snap::kMagnetEnabledConfigKey) == "1";
+
+  if (viewport2DPanel) {
+    viewport2DPanel->SetAxisConstrainedMovementEnabled(axisConstraintEnabled);
+    viewport2DPanel->SetLeftDragSelectionMovementEnabled(leftDragMoveEnabled);
+    viewport2DPanel->SetMagnetEnabled(magnetEnabled, false);
+  }
+  if (viewportPanel) {
+    viewportPanel->SetAxisConstrainedMovementEnabled(axisConstraintEnabled);
+    viewportPanel->SetLeftDragSelectionMovementEnabled(leftDragMoveEnabled);
+    viewportPanel->SetMagnetEnabled(magnetEnabled, false);
+  }
+  SyncAxisConstraintToolToggleState();
+  SyncLeftDragMoveToolToggleState();
+  if (layoutViewsToolBar) {
+    layoutViewsToolBar->ToggleTool(ID_View_Viewport_Magnet, magnetEnabled);
+    layoutViewsToolBar->Refresh();
+  }
 }
 
 // Switches the viewport interaction back to standard selection mode.
@@ -116,7 +144,7 @@ void MainWindow::OnViewportAxisConstraint(wxCommandEvent &WXUNUSED(event)) {
       selection_movement_settings::kAxisConstrainedMovementConfigKey,
       axisConstraintEnabled ? "0" : "1");
   preferences.SaveUserConfig();
-  SyncAxisConstraintToolToggleState();
+  ApplyViewportMovementToolState();
 }
 
 // Toggles project-level left-click selection dragging.
@@ -130,7 +158,7 @@ void MainWindow::OnViewportLeftDragMove(wxCommandEvent &WXUNUSED(event)) {
       selection_movement_settings::kLeftDragSelectionMovementConfigKey,
       enabled ? "0" : "1");
   preferences.SaveUserConfig();
-  SyncLeftDragMoveToolToggleState();
+  ApplyViewportMovementToolState();
 }
 
 // Fits the viewport that currently owns keyboard focus.
@@ -177,11 +205,8 @@ void MainWindow::OnViewportMagnet(wxCommandEvent &WXUNUSED(event)) {
   auto &preferences = GetDefaultGuiConfigServices().Preferences();
   const bool enabled =
       preferences.GetValue(magnet_snap::kMagnetEnabledConfigKey) != "1";
-  if (viewport2DPanel)
-    viewport2DPanel->SetMagnetEnabled(enabled);
-  if (viewportPanel)
-    viewportPanel->SetMagnetEnabled(enabled);
-  SyncViewportToolToggleState(
-      (viewport2DPanel && viewport2DPanel->IsMeasureToolEnabled()) ||
-      (viewportPanel && viewportPanel->IsMeasureToolEnabled()));
+  preferences.SetValue(magnet_snap::kMagnetEnabledConfigKey,
+                       enabled ? "1" : "0");
+  preferences.SaveUserConfig();
+  ApplyViewportMovementToolState();
 }

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -490,6 +490,12 @@ Viewer2DPanel::Viewer2DPanel(wxWindow *parent, bool allowOffscreenRender,
   m_controller.SetSelectionOutlineEnabled(m_enableSelection);
   m_magnetEnabled = ConfigManager::Get().GetValue(
                         magnet_snap::kMagnetEnabledConfigKey) == "1";
+  m_leftDragSelectionMovementEnabled =
+      selection_movement_settings::IsLeftDragSelectionMovementEnabled(
+          ConfigManager::Get());
+  m_axisConstrainedMovementEnabled =
+      selection_movement_settings::IsAxisConstrainedMovementEnabled(
+          ConfigManager::Get());
   m_glContext = new wxGLContext(this);
   if (m_enableSelection) {
     StartDragTableUpdateWorker();
@@ -749,12 +755,26 @@ void Viewer2DPanel::SetMeasureToolEnabled(bool enabled) {
 }
 
 // Enables or disables Magnet snapping for selection dragging.
-void Viewer2DPanel::SetMagnetEnabled(bool enabled) {
+void Viewer2DPanel::SetMagnetEnabled(bool enabled, bool persist) {
   m_magnetEnabled = enabled;
   m_pendingMagnetSnap.reset();
+  if (!persist)
+    return;
   ConfigManager::Get().SetValue(magnet_snap::kMagnetEnabledConfigKey,
                                 enabled ? "1" : "0");
   ConfigManager::Get().SaveUserConfig();
+}
+
+// Enables or disables left-click selection dragging.
+void Viewer2DPanel::SetLeftDragSelectionMovementEnabled(bool enabled) {
+  m_leftDragSelectionMovementEnabled = enabled;
+}
+
+// Enables or disables axis-constrained selection movement.
+void Viewer2DPanel::SetAxisConstrainedMovementEnabled(bool enabled) {
+  m_axisConstrainedMovementEnabled = enabled;
+  if (!enabled)
+    m_dragAxis = DragAxis::None;
 }
 
 // Converts a mouse position in window coordinates into the current 2D world position.
@@ -2747,10 +2767,6 @@ void Viewer2DPanel::OnMouseDown(wxMouseEvent &event) {
     if (!m_enableSelection || !IsShownOnScreen())
       return;
 
-    const bool leftDragSelectionMovement =
-        selection_movement_settings::IsLeftDragSelectionMovementEnabled(
-            ConfigManager::Get());
-
     if (event.ControlDown()) {
       m_dragMode = DragMode::RectSelection;
       m_rectSelecting = true;
@@ -2760,7 +2776,7 @@ void Viewer2DPanel::OnMouseDown(wxMouseEvent &event) {
       return;
     }
 
-    if (!leftDragSelectionMovement)
+    if (!m_leftDragSelectionMovementEnabled)
       return;
 
     const RenderSize renderSize = ResolveRenderSize(this);
@@ -3405,8 +3421,7 @@ void Viewer2DPanel::OnMouseMove(wxMouseEvent &event) {
     } else {
       int dx = pos.x - m_lastMousePos.x;
       int dy = pos.y - m_lastMousePos.y;
-      if (selection_movement_settings::IsAxisConstrainedMovementEnabled(
-              ConfigManager::Get())) {
+      if (m_axisConstrainedMovementEnabled) {
         if (m_dragAxis == DragAxis::None &&
             (std::abs(dx) >= kSelectionDragStartThresholdPx ||
              std::abs(dy) >= kSelectionDragStartThresholdPx)) {
@@ -3462,10 +3477,7 @@ void Viewer2DPanel::OnMouseMove(wxMouseEvent &event) {
       return;
 
     if (dx != 0 || dy != 0) {
-      const bool axisConstrainedMovement =
-          selection_movement_settings::IsAxisConstrainedMovementEnabled(
-              ConfigManager::Get());
-      if (axisConstrainedMovement) {
+      if (m_axisConstrainedMovementEnabled) {
         if (m_dragAxis == DragAxis::None) {
           int absDx = std::abs(dx);
           int absDy = std::abs(dy);

--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -152,8 +152,18 @@ public:
       const std::optional<Viewer2DRenderOverrides> &overrides);
   void SetMeasureToolEnabled(bool enabled);
   bool IsMeasureToolEnabled() const { return m_measureToolState.enabled; }
-  void SetMagnetEnabled(bool enabled);
+  void SetMagnetEnabled(bool enabled, bool persist = true);
   bool IsMagnetEnabled() const { return m_magnetEnabled; }
+  void SetLeftDragSelectionMovementEnabled(bool enabled);
+  // Returns whether left-click selection dragging is enabled.
+  bool IsLeftDragSelectionMovementEnabled() const {
+    return m_leftDragSelectionMovementEnabled;
+  }
+  void SetAxisConstrainedMovementEnabled(bool enabled);
+  // Returns whether selection movement is constrained to axes.
+  bool IsAxisConstrainedMovementEnabled() const {
+    return m_axisConstrainedMovementEnabled;
+  }
   void BeginContinuousPlacement(ContinuousPlacementType type,
                                 const std::string &elementUuid);
   bool UndoContinuousPlacement();
@@ -308,6 +318,8 @@ private:
   bool m_dragSelectionMoved = false;
   bool m_dragSelectionPushedUndo = false;
   bool m_magnetEnabled = false;
+  bool m_leftDragSelectionMovementEnabled = false;
+  bool m_axisConstrainedMovementEnabled = true;
   std::optional<magnet_snap::SnapResult> m_pendingMagnetSnap;
   bool m_draggedSincePress = false;
   bool m_continuousPlacementActive = false;

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -868,6 +868,12 @@ Viewer3DPanel::Viewer3DPanel(wxWindow* parent)
 {
     m_magnetEnabled = ConfigManager::Get().GetValue(
                           magnet_snap::kMagnetEnabledConfigKey) == "1";
+    m_leftDragSelectionMovementEnabled =
+        selection_movement_settings::IsLeftDragSelectionMovementEnabled(
+            ConfigManager::Get());
+    m_axisConstrainedMovementEnabled =
+        selection_movement_settings::IsAxisConstrainedMovementEnabled(
+            ConfigManager::Get());
     SetBackgroundStyle(wxBG_STYLE_CUSTOM);
     Bind(wxEVT_THREAD, &Viewer3DPanel::OnThreadRefresh, this, wxEVT_VIEWER_REFRESH);
     m_zoomInteractionTimer.SetOwner(this);
@@ -1707,8 +1713,7 @@ void Viewer3DPanel::OnMouseDown(wxMouseEvent& event)
 
         if (event.LeftDown() && !event.ShiftDown() && !event.MiddleDown() &&
             !event.RightDown() &&
-            selection_movement_settings::IsLeftDragSelectionMovementEnabled(
-                ConfigManager::Get())) {
+            m_leftDragSelectionMovementEnabled) {
             if (PrepareSelectionDrag(event.GetPosition())) {
                 m_lastMousePos = event.GetPosition();
                 m_draggedSincePress = false;
@@ -2176,13 +2181,29 @@ void Viewer3DPanel::OnRightUp(wxMouseEvent& event)
 
 
 // Enables or disables Magnet snapping for 3D selection dragging.
-void Viewer3DPanel::SetMagnetEnabled(bool enabled)
+void Viewer3DPanel::SetMagnetEnabled(bool enabled, bool persist)
 {
     m_magnetEnabled = enabled;
     m_pendingMagnetSnap.reset();
+    if (!persist)
+        return;
     ConfigManager::Get().SetValue(magnet_snap::kMagnetEnabledConfigKey,
                                   enabled ? "1" : "0");
     ConfigManager::Get().SaveUserConfig();
+}
+
+// Enables or disables left-click selection dragging in the 3D viewport.
+void Viewer3DPanel::SetLeftDragSelectionMovementEnabled(bool enabled)
+{
+    m_leftDragSelectionMovementEnabled = enabled;
+}
+
+// Enables or disables axis-constrained selection movement in the 3D viewport.
+void Viewer3DPanel::SetAxisConstrainedMovementEnabled(bool enabled)
+{
+    m_axisConstrainedMovementEnabled = enabled;
+    if (!enabled)
+        m_selectionDragAxis = viewer3d::SelectionDragAxis::None;
 }
 
 // Resets interaction state after wxWidgets reports lost mouse capture.
@@ -3073,8 +3094,7 @@ void Viewer3DPanel::OnMouseMove(wxMouseEvent& event)
             ApplyCameraMatrices(renderSize);
             const int dx = pos.x - m_lastMousePos.x;
             const int dy = pos.y - m_lastMousePos.y;
-            if (selection_movement_settings::IsAxisConstrainedMovementEnabled(
-                    ConfigManager::Get())) {
+            if (m_axisConstrainedMovementEnabled) {
                 const auto projectedAxes = BuildProjectedDragAxes(renderSize);
                 if (m_selectionDragAxis ==
                         viewer3d::SelectionDragAxis::None &&
@@ -3151,8 +3171,7 @@ void Viewer3DPanel::OnMouseMove(wxMouseEvent& event)
             if (renderSize.IsValid() &&
                 TryBindGlContextForInteraction("OnMouseMove")) {
                 ApplyCameraMatrices(renderSize);
-                if (selection_movement_settings::IsAxisConstrainedMovementEnabled(
-                        ConfigManager::Get())) {
+                if (m_axisConstrainedMovementEnabled) {
                     const auto projectedAxes = BuildProjectedDragAxes(renderSize);
                     if (m_selectionDragAxis == viewer3d::SelectionDragAxis::None) {
                         m_selectionDragAxis = viewer3d::SelectDragAxisFromMouseDelta(

--- a/viewer3d/viewer3dpanel.h
+++ b/viewer3d/viewer3dpanel.h
@@ -84,9 +84,19 @@ public:
     // Returns whether the 3D measure tool is currently enabled.
     bool IsMeasureToolEnabled() const { return m_measureToolEnabled; }
     // Enables or disables Magnet snapping for 3D selection dragging.
-    void SetMagnetEnabled(bool enabled);
+    void SetMagnetEnabled(bool enabled, bool persist = true);
     // Returns whether Magnet snapping is currently enabled for 3D selection dragging.
     bool IsMagnetEnabled() const { return m_magnetEnabled; }
+    void SetLeftDragSelectionMovementEnabled(bool enabled);
+    // Returns whether left-click selection dragging is enabled in the 3D viewport.
+    bool IsLeftDragSelectionMovementEnabled() const {
+        return m_leftDragSelectionMovementEnabled;
+    }
+    void SetAxisConstrainedMovementEnabled(bool enabled);
+    // Returns whether 3D selection movement is constrained to axes.
+    bool IsAxisConstrainedMovementEnabled() const {
+        return m_axisConstrainedMovementEnabled;
+    }
     void BeginContinuousPlacement(ContinuousPlacementType type,
                                   const std::string& elementUuid);
     bool UndoContinuousPlacement();
@@ -113,6 +123,8 @@ private:
     bool m_selectionDragMoved = false;
     bool m_selectionDragUndoPushed = false;
     bool m_magnetEnabled = false;
+    bool m_leftDragSelectionMovementEnabled = false;
+    bool m_axisConstrainedMovementEnabled = true;
     std::optional<magnet_snap::SnapResult> m_pendingMagnetSnap;
     wxLongLong m_selectionDragPressTime = 0;
     HoverTargetTable m_selectionDragTarget = HoverTargetTable::None;


### PR DESCRIPTION
### Motivation
- Users reported that Magnet, Axis Lock and Drag-Move toolbar toggles could be out-of-sync after opening a project or switching saved layouts, requiring a manual re-toggle to restore expected behavior.
- The change aims to keep viewer interaction toggles consistent with the active 2D/3D view and to persist toggle changes immediately so user preferences survive restarts.

### Description
- Capture and restore user interaction preferences (`magnet_snap::kMagnetEnabledConfigKey`, `selection_movement_settings::kAxisConstrainedMovementConfigKey`, `selection_movement_settings::kLeftDragSelectionMovementConfigKey`) around project config loading by adding `CaptureUserInteractionPreferences` and `RestoreUserInteractionPreferences` and invoking them from `ConfigManager::LoadProject` in `core/configmanager.cpp`.
- Ensure Axis Lock and Left-Drag Move toolbar toggles persist immediately by calling `preferences.SaveUserConfig()` after toggling the values in `MainWindow::OnViewportAxisConstraint` and `MainWindow::OnViewportLeftDragMove` in `gui/mainwindow_view_shortcuts.cpp`.
- Add concise single-line comments above several GUI shortcut functions to improve readability and satisfy code comment guidance in C++ files.
- Update `docs/release-notes-draft.md` to document that Drag Move, Axis Lock and Magnet now remain synchronized with active viewports when loading projects or saved layouts.

### Testing
- Ran `git diff --check` and found no whitespace or patch errors (success).
- Ran `tests/check_perastage_tree_modules.sh` (success) and `tests/check_no_configmanager_get_in_gui.sh` (success) to ensure module layout and no forbidden `ConfigManager::Get()` usage in GUI code.
- Attempted an out-of-tree `cmake` configure/build (`cmake -S . -B /tmp/perastage-build -DCMAKE_BUILD_TYPE=Debug && cmake --build /tmp/perastage-build --target Perastage -j2`) which could not complete due to missing system wxWidgets development files in the execution environment (configure blocked).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a362ee838188324b25200ce49c63021)