### PR TITLE
Unify GDTF derivative export behavior

### DIFF
--- a/core/gdtfdictionary.cpp
+++ b/core/gdtfdictionary.cpp
@@ -249,7 +249,7 @@ std::string NormalizeTypeKey(const std::string &type) {
 
 // Returns true when the filename optional-comment segment marks a
 // Perastage-authored GDTF.
-bool IsPerastageNamedGdtfFile(const std::filesystem::path &path) {
+bool IsPerastageNamedGdtfFilePath(const std::filesystem::path &path) {
   const std::string stem = path.stem().string();
   const size_t firstAt = stem.find('@');
   if (firstAt == std::string::npos)
@@ -321,7 +321,7 @@ BuildPerastageCanonicalGdtfFileName(const std::filesystem::path &sourcePath) {
                                      fixtureTypeName);
 
   if (manufacturerName.empty())
-    manufacturerName = "Unknow";
+    manufacturerName = "Unknown";
   if (fixtureTypeName.empty())
     fixtureTypeName = sourcePath.stem().string();
 
@@ -332,7 +332,7 @@ BuildPerastageCanonicalGdtfFileName(const std::filesystem::path &sourcePath) {
   manufacturerName = TrimAsciiWhitespace(manufacturerName);
   fixtureTypeName = TrimAsciiWhitespace(fixtureTypeName);
   if (manufacturerName.empty())
-    manufacturerName = "Unknow";
+    manufacturerName = "Unknown";
   if (fixtureTypeName.empty())
     fixtureTypeName = sourcePath.stem().string();
   return manufacturerName + "@" + fixtureTypeName + "@Perastage.gdtf";
@@ -962,6 +962,18 @@ void UpdateDictionaryEntry(const std::string &type, const Entry &entry) {
   Save(dict);
 }
 
+// Builds the canonical @Perastage derivative filename for a GDTF file.
+std::string BuildPerastageCanonicalGdtfFileName(const std::string &gdtfPath) {
+  return BuildPerastageCanonicalGdtfFileName(PathUtils::PathFromUtf8(gdtfPath));
+}
+
+// Returns true when a GDTF path already has canonical Perastage derivative naming.
+bool IsPerastageNamedGdtfFile(const std::string &gdtfPath) {
+  if (gdtfPath.empty())
+    return false;
+  return IsPerastageNamedGdtfFilePath(PathUtils::PathFromUtf8(gdtfPath));
+}
+
 // Creates or refreshes a stable @Perastage derivative for a library-owned GDTF.
 std::optional<Entry> CreateOrUpdatePerastageLibraryDerivative(
     const std::string &type, const std::string &gdtfPath,
@@ -982,9 +994,10 @@ std::optional<Entry> CreateOrUpdatePerastageLibraryDerivative(
     return std::nullopt;
 
   const fs::path dest =
-      IsPerastageNamedGdtfFile(src)
-                            ? file.parent_path() / src.filename()
-                            : file.parent_path() / BuildPerastageCanonicalGdtfFileName(src);
+      IsPerastageNamedGdtfFilePath(src)
+          ? file.parent_path() / src.filename()
+          : file.parent_path() /
+                BuildPerastageCanonicalGdtfFileName(src.string());
   const auto copyResult = FileImportUtils::CopyWithConflictPolicy(
       src, dest, FileImportUtils::ConflictPolicy::Overwrite);
   if (!copyResult.success)

--- a/core/gdtfdictionary.h
+++ b/core/gdtfdictionary.h
@@ -67,6 +67,10 @@ namespace GdtfDictionary {
         const std::string& mode);
     // Copies a user-selected GDTF into the fixtures library and updates the dictionary.
     void Update(const std::string& type, const std::string& gdtfPath, const std::string& mode = {}, const std::string& category = {});
+    // Builds the stable @Perastage derivative filename for a GDTF path.
+    std::string BuildPerastageCanonicalGdtfFileName(const std::string& gdtfPath);
+    // Returns true when a GDTF filename already uses Perastage derivative naming.
+    bool IsPerastageNamedGdtfFile(const std::string& gdtfPath);
     // Creates or overwrites the stable @Perastage derivative for a library fixture and updates the dictionary.
     std::optional<Entry> CreateOrUpdatePerastageLibraryDerivative(
         const std::string& type, const std::string& gdtfPath,

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -71,6 +71,7 @@ Perastage v1.4.0 delivers a long-anticipated refresh of the modelling and riggin
 
 This release addresses dozens of issues across importing, snapping, editing and export workflows, including:
 
+- **GDTF derivative export consistency** - fixture export now uses Perastage-processed derivatives when required, defaults to the canonical `Manufacturer@FixtureType@Perastage.gdtf` filename, preserves original GDTF library assets by default, and warns before overwriting an original file.
 - **GroupObject layer ownership** - fixtures added to truss-based groups now immediately adopt the truss/group layer, while existing trusses and groups keep their original layer across save, reopen, MVR import and MVR export.
 - **GDTF fixture geometry placement** - fixtures that use top-level geometry
   definitions through `GeometryReference` now render those parts only at their

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -71,7 +71,7 @@ Perastage v1.4.0 delivers a long-anticipated refresh of the modelling and riggin
 
 This release addresses dozens of issues across importing, snapping, editing and export workflows, including:
 
-- **GDTF derivative export consistency** - fixture export now uses Perastage-processed derivatives when required, defaults to the canonical `Manufacturer@FixtureType@Perastage.gdtf` filename, preserves original GDTF library assets by default, and warns before overwriting an original file.
+- **GDTF derivative export consistency** - fixture export now uses Perastage-processed derivatives when required, defaults to the canonical `Manufacturer@FixtureType@Perastage.gdtf` filename, preserves original GDTF library assets by default, warns before overwriting an original file, and refreshes fixture table references after derivative promotion.
 - **GroupObject layer ownership** - fixtures added to truss-based groups now immediately adopt the truss/group layer, while existing trusses and groups keep their original layer across save, reopen, MVR import and MVR export.
 - **GDTF fixture geometry placement** - fixtures that use top-level geometry
   definitions through `GeometryReference` now render those parts only at their

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -71,7 +71,7 @@ Perastage v1.4.0 delivers a long-anticipated refresh of the modelling and riggin
 
 This release addresses dozens of issues across importing, snapping, editing and export workflows, including:
 
-- **GDTF derivative export consistency** - fixture export now uses Perastage-processed derivatives when required, defaults to the canonical `Manufacturer@FixtureType@Perastage.gdtf` filename, preserves original GDTF library assets by default, warns before overwriting an original file, and refreshes fixture table references after derivative promotion.
+- **GDTF derivative export consistency** - fixture export now uses Perastage-processed derivatives when required, defaults to the canonical `Manufacturer@FixtureType@Perastage.gdtf` filename, preserves original GDTF library assets by default, warns before overwriting an original file, refreshes fixture table references after derivative promotion, and safely handles exporting to the already-current derivative file.
 - **GroupObject layer ownership** - fixtures added to truss-based groups now immediately adopt the truss/group layer, while existing trusses and groups keep their original layer across save, reopen, MVR import and MVR export.
 - **GDTF fixture geometry placement** - fixtures that use top-level geometry
   definitions through `GeometryReference` now render those parts only at their

--- a/gui/mainwindow_io.cpp
+++ b/gui/mainwindow_io.cpp
@@ -50,6 +50,8 @@
 #include "fixture_label_overrides.h"
 #include "fixturetablepanel.h"
 #include "gdtf_mutation_audit.h"
+#include "gdtfdictionary.h"
+#include "gdtfloader.h"
 #include "hoisttablepanel.h"
 #include "layoutviewerpanel.h"
 #include "mvrexporter.h"
@@ -574,60 +576,11 @@ void MainWindow::OnExportTruss(wxCommandEvent &WXUNUSED(event)) {
                wxOK | wxICON_INFORMATION);
 }
 
+// Exports the effective current GDTF for a selected fixture type.
 void MainWindow::OnExportFixture(wxCommandEvent &WXUNUSED(event)) {
   namespace fs = std::filesystem;
-  auto createTempDir = []() {
-    auto now = std::chrono::system_clock::now().time_since_epoch().count();
-    std::string folderName = "GDTF_" + std::to_string(now);
-    fs::path base = fs::temp_directory_path();
-    fs::path full = base / folderName;
-    fs::create_directory(full);
-    return full.string();
-  };
-  auto extractZip = [](const std::string &zipPath, const std::string &destDir) {
-    if (!fs::exists(zipPath)) {
-      if (ConsolePanel::Instance()) {
-        wxString msg = "GDTF: cannot open " + wxString::FromUTF8(zipPath);
-        ConsolePanel::Instance()->AppendMessage(msg);
-      }
-      return false;
-    }
-    wxLogNull logNo;
-    wxFileInputStream input(zipPath);
-    if (!input.IsOk()) {
-      if (ConsolePanel::Instance()) {
-        wxString msg = "GDTF: cannot open " + wxString::FromUTF8(zipPath);
-        ConsolePanel::Instance()->AppendMessage(msg);
-      }
-      return false;
-    }
-    wxZipInputStream zipStream(input);
-    std::unique_ptr<wxZipEntry> entry;
-    while ((entry.reset(zipStream.GetNextEntry())), entry) {
-      std::string filename = entry->GetName().ToStdString();
-      std::string fullPath = destDir + "/" + filename;
-      if (entry->IsDir()) {
-        wxFileName::Mkdir(fullPath, wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
-        continue;
-      }
-      wxFileName::Mkdir(wxFileName(fullPath).GetPath(), wxS_DIR_DEFAULT,
-                        wxPATH_MKDIR_FULL);
-      std::ofstream output(fullPath, std::ios::binary);
-      if (!output.is_open())
-        return false;
-      char buffer[4096];
-      while (true) {
-        zipStream.Read(buffer, sizeof(buffer));
-        size_t bytes = zipStream.LastRead();
-        if (bytes == 0)
-          break;
-        output.write(buffer, bytes);
-      }
-      output.close();
-    }
-    return true;
-  };
-  const auto &fixtures = GetDefaultGuiConfigServices().LegacyConfigManager().GetScene().fixtures;
+  auto &scene = GetDefaultGuiConfigServices().LegacyConfigManager().GetScene();
+  const auto &fixtures = scene.fixtures;
   std::set<std::string> types;
   for (const auto &[uuid, f] : fixtures)
     if (!f.typeName.empty())
@@ -653,85 +606,89 @@ void MainWindow::OnExportFixture(wxCommandEvent &WXUNUSED(event)) {
   if (!chosen || chosen->gdtfSpec.empty())
     return;
 
-  fs::path src = chosen->gdtfSpec;
-  const std::string &base = GetDefaultGuiConfigServices().LegacyConfigManager().GetScene().basePath;
-  if (src.is_relative() && !base.empty())
-    src = fs::path(base) / src;
-  if (!fs::exists(src)) {
+  const std::string chosenTypeName = chosen->typeName;
+  const std::string chosenGdtfSpec = chosen->gdtfSpec;
+  fs::path originalSrc = PathUtils::PathFromUtf8(chosenGdtfSpec);
+  const std::string &base = scene.basePath;
+  if (originalSrc.is_relative() && !base.empty())
+    originalSrc = fs::path(base) / originalSrc;
+  if (!fs::exists(originalSrc)) {
     wxMessageBox("GDTF file not found.", "Error", wxOK | wxICON_ERROR);
     return;
   }
 
+  fs::path effectiveSrc = originalSrc;
+  bool usingDerivative =
+      GdtfDictionary::IsPerastageNamedGdtfFile(effectiveSrc.string());
+  if (!usingDerivative &&
+      (chosen->weightKg != 0.0f || chosen->powerConsumptionW != 0.0f)) {
+    auto derivative = GdtfDictionary::CreateOrUpdatePerastageLibraryDerivative(
+        chosenTypeName, effectiveSrc.string(), chosen->gdtfMode,
+        chosen->category);
+    if (!derivative || derivative->path.empty()) {
+      wxMessageBox("Could not create the Perastage fixture derivative.",
+                   "Export Fixture", wxOK | wxICON_ERROR);
+      return;
+    }
+    effectiveSrc = PathUtils::PathFromUtf8(derivative->path);
+    usingDerivative = true;
+    if (!SetGdtfProperties(effectiveSrc.string(), chosen->weightKg,
+                           chosen->powerConsumptionW,
+                           GdtfMutationAudit::BuildPerastageModifiedBy())) {
+      wxMessageBox("Could not update the Perastage fixture derivative.",
+                   "Export Fixture", wxOK | wxICON_ERROR);
+      return;
+    }
+    const std::string derivativeSpec = effectiveSrc.filename().string();
+    for (auto &[uuid, fixture] : scene.fixtures) {
+      if (fixture.typeName == chosenTypeName &&
+          fixture.gdtfSpec == chosenGdtfSpec)
+        fixture.gdtfSpec = derivativeSpec;
+    }
+    if (fixtureTablePanel)
+      fixtureTablePanel->ReloadData();
+    RefreshAfterSceneChange();
+  }
+
   wxString fixDir =
       wxString::FromUTF8(ProjectUtils::GetWritableLibraryPath("fixtures"));
+  const std::string defaultName =
+      usingDerivative ? effectiveSrc.filename().string()
+                      : PathUtils::PathFromUtf8(chosenGdtfSpec)
+                            .filename()
+                            .string();
   wxFileDialog saveDlg(this, "Save Fixture", fixDir,
-                       wxString::FromUTF8(sel) + ".gdtf", "*.gdtf",
+                       wxString::FromUTF8(defaultName), "*.gdtf",
                        wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
   if (saveDlg.ShowModal() != wxID_OK)
     return;
 
-  std::string tempDir = createTempDir();
-  if (!extractZip(src.string(), tempDir)) {
-    wxMessageBox("Failed to read GDTF.", "Error", wxOK | wxICON_ERROR);
+  const fs::path target =
+      PathUtils::PathFromUtf8(std::string(saveDlg.GetPath().ToUTF8()));
+  std::error_code equivalentError;
+  if (fs::exists(target, equivalentError) &&
+      fs::equivalent(target, originalSrc, equivalentError)) {
+    const int answer = wxMessageBox(
+        "This will overwrite the original GDTF library asset. Perastage "
+        "normally preserves originals and exports a derived copy instead.\n\n"
+        "Do you want to overwrite the original GDTF file?",
+        "Overwrite Original GDTF", wxYES_NO | wxNO_DEFAULT | wxICON_WARNING,
+        this);
+    if (answer != wxYES)
+      return;
+  }
+
+  std::error_code copyError;
+  fs::create_directories(target.parent_path(), copyError);
+  copyError.clear();
+  fs::copy_file(effectiveSrc, target, fs::copy_options::overwrite_existing,
+                copyError);
+  if (copyError) {
+    wxMessageBox(
+        "Failed to write file: " + wxString::FromUTF8(copyError.message()),
+        "Error", wxOK | wxICON_ERROR);
     return;
   }
-
-  fs::path descPath = fs::path(tempDir) / "description.xml";
-  tinyxml2::XMLDocument doc;
-  if (doc.LoadFile(descPath.string().c_str()) != tinyxml2::XML_SUCCESS) {
-    fs::remove_all(tempDir);
-    wxMessageBox("Failed to parse description.xml.", "Error",
-                 wxOK | wxICON_ERROR);
-    return;
-  }
-
-  tinyxml2::XMLElement *ft = GdtfMutationAudit::EnsureFixtureType(doc);
-  if (!ft) {
-    fs::remove_all(tempDir);
-    wxMessageBox("Invalid GDTF file.", "Error", wxOK | wxICON_ERROR);
-    return;
-  }
-
-  const std::optional<float> weightKg =
-      (chosen->weightKg != 0.0f) ? std::optional<float>(chosen->weightKg)
-                                 : std::nullopt;
-  const std::optional<float> powerConsumptionW =
-      (chosen->powerConsumptionW != 0.0f)
-          ? std::optional<float>(chosen->powerConsumptionW)
-          : std::nullopt;
-  GdtfMutationAudit::ApplyPhysicalPropertiesWithAudit(
-      ft, doc, weightKg, powerConsumptionW,
-      "Exported fixture with updated physical properties from Perastage",
-      GdtfMutationAudit::BuildPerastageModifiedBy());
-
-  doc.SaveFile(descPath.string().c_str());
-
-  wxFileOutputStream out(std::string(saveDlg.GetPath().mb_str()));
-  if (!out.IsOk()) {
-    fs::remove_all(tempDir);
-    wxMessageBox("Failed to write file.", "Error", wxOK | wxICON_ERROR);
-    return;
-  }
-  wxZipOutputStream zip(out);
-  for (auto &p : fs::recursive_directory_iterator(tempDir)) {
-    if (!p.is_regular_file())
-      continue;
-    std::string rel = fs::relative(p.path(), tempDir).string();
-    auto *entry = new wxZipEntry(rel);
-    entry->SetMethod(wxZIP_METHOD_DEFLATE);
-    zip.PutNextEntry(entry);
-    std::ifstream in(p.path(), std::ios::binary);
-    char buf[4096];
-    while (in.good()) {
-      in.read(buf, sizeof(buf));
-      std::streamsize s = in.gcount();
-      if (s > 0)
-        zip.Write(buf, s);
-    }
-    zip.CloseEntry();
-  }
-  zip.Close();
-  fs::remove_all(tempDir);
 
   wxMessageBox("Fixture exported successfully.", "Export Fixture",
                wxOK | wxICON_INFORMATION);

--- a/gui/mainwindow_io.cpp
+++ b/gui/mainwindow_io.cpp
@@ -645,8 +645,8 @@ void MainWindow::OnExportFixture(wxCommandEvent &WXUNUSED(event)) {
           fixture.gdtfSpec == chosenGdtfSpec)
         fixture.gdtfSpec = derivativeSpec;
     }
-    if (fixtureTablePanel)
-      fixtureTablePanel->ReloadData();
+    if (fixturePanel)
+      fixturePanel->ReloadData();
     RefreshAfterSceneChange();
   }
 

--- a/gui/mainwindow_io.cpp
+++ b/gui/mainwindow_io.cpp
@@ -679,15 +679,20 @@ void MainWindow::OnExportFixture(wxCommandEvent &WXUNUSED(event)) {
   }
 
   std::error_code copyError;
-  fs::create_directories(target.parent_path(), copyError);
-  copyError.clear();
-  fs::copy_file(effectiveSrc, target, fs::copy_options::overwrite_existing,
-                copyError);
-  if (copyError) {
-    wxMessageBox(
-        "Failed to write file: " + wxString::FromUTF8(copyError.message()),
-        "Error", wxOK | wxICON_ERROR);
-    return;
+  const bool targetIsEffectiveSource =
+      fs::exists(target, copyError) &&
+      fs::equivalent(target, effectiveSrc, copyError);
+  if (!targetIsEffectiveSource) {
+    fs::create_directories(target.parent_path(), copyError);
+    copyError.clear();
+    fs::copy_file(effectiveSrc, target, fs::copy_options::overwrite_existing,
+                  copyError);
+    if (copyError) {
+      wxMessageBox(
+          "Failed to write file: " + wxString::FromUTF8(copyError.message()),
+          "Error", wxOK | wxICON_ERROR);
+      return;
+    }
   }
 
   wxMessageBox("Fixture exported successfully.", "Export Fixture",

--- a/tests/gdtf_dictionary_color_roundtrip_test.cpp
+++ b/tests/gdtf_dictionary_color_roundtrip_test.cpp
@@ -47,7 +47,9 @@ int main() {
       hadOriginal ? ReadFile(dictPath) : std::string{};
 
   const std::filesystem::path fixtureFile = fixturesDir / "color_fixture.gdtf";
+  const std::filesystem::path unknownFixtureFile = fixturesDir / "mystery_fixture.gdtf";
   WriteFile(fixtureFile, "fixture");
+  WriteFile(unknownFixtureFile, "not a zip archive");
 
   nlohmann::json entries = nlohmann::json::object();
   entries["ColorOnlyType"] = {{"color", "#112233"}};
@@ -71,6 +73,12 @@ int main() {
   assert(fullIt != loadedOpt->end());
   assert(fullIt->second.visualColorHex == "#ABCDEF");
 
+  assert(GdtfDictionary::BuildPerastageCanonicalGdtfFileName(
+             unknownFixtureFile.string()) ==
+         "Unknown@mystery_fixture@Perastage.gdtf");
+  assert(GdtfDictionary::IsPerastageNamedGdtfFile(
+      "Manufacturer@Fixture@Perastage.gdtf"));
+
   assert(GdtfDictionary::Save(*loadedOpt));
 
   nlohmann::json savedRoot;
@@ -87,6 +95,7 @@ int main() {
   assert(!savedRoot["entries"]["FullType"].contains("color"));
 
   std::filesystem::remove(fixtureFile);
+  std::filesystem::remove(unknownFixtureFile);
   if (hadOriginal)
     WriteFile(dictPath, originalContent);
   else


### PR DESCRIPTION
### Motivation
- Make Perastage's handling of modified GDTF fixtures consistent so exported fixtures, UI displays, and dictionary entries point to the actual Perastage-processed derivative when applicable.
- Preserve original GDTF library assets by default and require an explicit, warned overwrite when the user chooses to replace an original.
- Fix a small fallback spelling bug in the canonical Perastage filename generation (`Unknow` → `Unknown`).

### Description
- Expose canonical derivative helpers in `GdtfDictionary`: `BuildPerastageCanonicalGdtfFileName(const std::string&)` and `IsPerastageNamedGdtfFile(const std::string&)`, and keep the existing path-based logic private (`IsPerastageNamedGdtfFilePath`).
- Fix fallback manufacturer name from `"Unknow"` to `"Unknown"` in `BuildPerastageCanonicalGdtfFileName` to ensure consistent canonical names.
- Update `MainWindow::OnExportFixture` to resolve the effective GDTF for the selected fixture, create/update a stable `Manufacturer@FixtureType@Perastage.gdtf` derivative when Perastage mutations (e.g., physical property edits) are required, apply mutations to the derivative via existing helpers, refresh scene entries to reference the derivative, default the Save dialog filename to the effective Perastage filename, and show a clear warning if the user attempts to overwrite the original library asset.
- Refresh fixture table data after promoting/creating a derivative (use `ReloadData()`), add small safety checks around path resolution, and reuse the centralized `GdtfDictionary` helpers to avoid duplicated naming/path logic.
- Add a small test assertion in `tests/gdtf_dictionary_color_roundtrip_test.cpp` covering the canonical fallback name and derivative-name detection, and update `docs/release-notes-draft.md` with the user-visible fix note.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded.
- Ran repository checks for the old misspelling (`rg -n 'Unknow(?!n)' ...`) and confirmed no remaining `Unknow` occurrences.
- Performed `git diff --check` and repository hygiene checks; nothing blocking was found.
- Attempted to configure/build the unit test target (`gdtf_dictionary_color_roundtrip_test`) but CMake failed to configure in the container because `wxWidgets` dev libraries/headers are not available; as a result the compiled test was not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3695fc8b148324a0408f2c1fbc3a8e)