### PR TITLE
Fix cube primitive face normals

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -107,6 +107,7 @@ This release addresses dozens of issues across importing, snapping, editing and 
 - **Command-bar parsing** - improved parsing of `t` and `thru` sequences distributes position/rotation values as expected.
 - **Truss and support export/import** - MVR exports no longer embed local file paths, preserve layer colour metadata in a standards-compliant UserData block, and store fixture colours as gel/filter data only when intended.  Round-trip exports retain support objects, keep support-specific hoist metadata in root-level Perastage UserData instead of under Support nodes, write fixture, truss, support and scene-object children in the correct schema order, and preserve deterministic scene-object IDs for standards-compliant MVR 1.6 exchange.
 - **Geometry models** - GLB/3DS trusses remain visible even when metadata is missing, and unsupported formats are rejected clearly.  Newly added scene objects reuse existing primitive data immediately.
+- **Cube primitive lighting** - corrected cube triangle winding so generated cube primitives produce outward-facing normals for all faces.
 - **Dimension labels** - 3D truss height labels now show both value and unit suffix in the selected project distance units.
 - **Picking and selection** - hollow/U-shaped meshes are selected by their geometry rather than by bounding boxes, and quick-click fixture selection works even if the precise release pick misses.
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1231,6 +1231,11 @@ add_test(NAME RiderImportBenchmark COMMAND rider_import_benchmark
 set_library_env(RiderImportBenchmark)
 
 
+add_executable(meshprimitives_cube_normals_test meshprimitives_cube_normals_test.cpp
+               ../viewer3d/meshprimitives.cpp)
+target_include_directories(meshprimitives_cube_normals_test PRIVATE ../viewer3d)
+add_test(NAME MeshPrimitivesCubeNormals COMMAND meshprimitives_cube_normals_test)
+
 add_executable(gdtfloader_primitive_test gdtfloader_primitive_test.cpp
                ../viewer3d/gdtfloader.cpp
                ../core/gdtf_canonicalizer.cpp

--- a/tests/meshprimitives_cube_normals_test.cpp
+++ b/tests/meshprimitives_cube_normals_test.cpp
@@ -1,0 +1,72 @@
+#include "meshprimitives.h"
+
+#include <array>
+#include <cassert>
+#include <cmath>
+
+namespace {
+
+struct ExpectedFaceNormal {
+    size_t triangleOffset;
+    std::array<float, 3> normal;
+};
+
+// Computes the normalized geometric normal for an indexed triangle.
+std::array<float, 3> TriangleNormal(const Mesh& mesh, size_t triangleOffset)
+{
+    const uint32_t i0 = mesh.indices[triangleOffset];
+    const uint32_t i1 = mesh.indices[triangleOffset + 1];
+    const uint32_t i2 = mesh.indices[triangleOffset + 2];
+
+    const float v0x = mesh.vertices[i0 * 3];
+    const float v0y = mesh.vertices[i0 * 3 + 1];
+    const float v0z = mesh.vertices[i0 * 3 + 2];
+    const float v1x = mesh.vertices[i1 * 3];
+    const float v1y = mesh.vertices[i1 * 3 + 1];
+    const float v1z = mesh.vertices[i1 * 3 + 2];
+    const float v2x = mesh.vertices[i2 * 3];
+    const float v2y = mesh.vertices[i2 * 3 + 1];
+    const float v2z = mesh.vertices[i2 * 3 + 2];
+
+    float nx = (v1y - v0y) * (v2z - v0z) - (v1z - v0z) * (v2y - v0y);
+    float ny = (v1z - v0z) * (v2x - v0x) - (v1x - v0x) * (v2z - v0z);
+    float nz = (v1x - v0x) * (v2y - v0y) - (v1y - v0y) * (v2x - v0x);
+
+    const float length = std::sqrt(nx * nx + ny * ny + nz * nz);
+    assert(length > 0.0f);
+    return {nx / length, ny / length, nz / length};
+}
+
+// Verifies that two normal vectors match within a small tolerance.
+void AssertNormal(const std::array<float, 3>& actual, const std::array<float, 3>& expected)
+{
+    constexpr float kTolerance = 0.0001f;
+    assert(std::fabs(actual[0] - expected[0]) < kTolerance);
+    assert(std::fabs(actual[1] - expected[1]) < kTolerance);
+    assert(std::fabs(actual[2] - expected[2]) < kTolerance);
+}
+
+}
+
+// Verifies cube primitive triangle winding generates outward face normals.
+int main()
+{
+    const Mesh mesh = BuildCubeMesh(2.0f, 4.0f, 6.0f);
+    assert(mesh.indices.size() == 36);
+
+    const ExpectedFaceNormal expectedFaces[] = {
+        {0, {0.0f, 0.0f, -1.0f}},
+        {6, {0.0f, 0.0f, 1.0f}},
+        {12, {0.0f, -1.0f, 0.0f}},
+        {24, {0.0f, 1.0f, 0.0f}},
+        {30, {-1.0f, 0.0f, 0.0f}},
+        {18, {1.0f, 0.0f, 0.0f}},
+    };
+
+    for (const ExpectedFaceNormal& face : expectedFaces) {
+        AssertNormal(TriangleNormal(mesh, face.triangleOffset), face.normal);
+        AssertNormal(TriangleNormal(mesh, face.triangleOffset + 3), face.normal);
+    }
+
+    return 0;
+}

--- a/viewer3d/meshprimitives.cpp
+++ b/viewer3d/meshprimitives.cpp
@@ -26,6 +26,7 @@
 namespace {
 constexpr float kPi = 3.14159265358979323846f;
 
+// Returns a lower-case copy of a primitive type string.
 std::string ToLower(std::string value)
 {
     std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) {
@@ -34,6 +35,7 @@ std::string ToLower(std::string value)
     return value;
 }
 
+// Appends one position vertex to a mesh.
 void AddVertex(Mesh& mesh, float x, float y, float z)
 {
     mesh.vertices.push_back(x);
@@ -42,6 +44,7 @@ void AddVertex(Mesh& mesh, float x, float y, float z)
 }
 }
 
+// Builds a cube mesh with outward-facing triangle winding.
 Mesh BuildCubeMesh(float sizeX, float sizeY, float sizeZ)
 {
     Mesh mesh;
@@ -61,23 +64,25 @@ Mesh BuildCubeMesh(float sizeX, float sizeY, float sizeZ)
     };
 
     mesh.indices = {
-        0, 1, 2, 0, 2, 3,
-        4, 6, 5, 4, 7, 6,
-        0, 4, 5, 0, 5, 1,
-        1, 5, 6, 1, 6, 2,
-        2, 6, 7, 2, 7, 3,
-        3, 7, 4, 3, 4, 0,
+        0, 2, 1, 0, 3, 2,
+        4, 5, 6, 4, 6, 7,
+        0, 5, 4, 0, 1, 5,
+        1, 6, 5, 1, 2, 6,
+        2, 7, 6, 2, 3, 7,
+        3, 4, 7, 3, 0, 4,
     };
 
     ComputeNormals(mesh);
     return mesh;
 }
 
+// Builds a cylinder mesh with matching top and bottom radii.
 Mesh BuildCylinderMesh(float radius, float height, int segments)
 {
     return BuildCylinderMesh(radius, radius, height, segments);
 }
 
+// Builds a cylinder or truncated cone mesh around the Z axis.
 Mesh BuildCylinderMesh(float topRadius, float bottomRadius, float height, int segments)
 {
     Mesh mesh;
@@ -126,6 +131,7 @@ Mesh BuildCylinderMesh(float topRadius, float bottomRadius, float height, int se
     return mesh;
 }
 
+// Builds a UV sphere mesh centered at the origin.
 Mesh BuildSphereMesh(float radius, int rings, int segments)
 {
     Mesh mesh;
@@ -164,6 +170,7 @@ Mesh BuildSphereMesh(float radius, int rings, int segments)
     return mesh;
 }
 
+// Builds a supported primitive mesh from a primitive type string.
 bool BuildPrimitiveMesh(const std::string& primitiveType, Mesh& outMesh)
 {
     const std::string type = ToLower(primitiveType);


### PR DESCRIPTION
### Motivation
- Ensure cube primitives generate outward-facing normals so lighting and shading behave correctly across all faces. 
- The existing index winding produced inward/outward inconsistencies that caused incorrect face normals from `ComputeNormals(mesh)`.

### Description
- Reordered the triangle indices in `BuildCubeMesh(float sizeX, float sizeY, float sizeZ)` so each triangle uses outward-facing winding compatible with `ComputeNormals(mesh)`; change is in `viewer3d/meshprimitives.cpp`.
- Added short one-line English comments above the touched C++ function definitions to satisfy the code-style policy (`ToLower`, `AddVertex`, `BuildCubeMesh`, `BuildCylinderMesh`, `BuildSphereMesh`, `BuildPrimitiveMesh`).
- Added a focused regression test `tests/meshprimitives_cube_normals_test.cpp` that verifies the six cube face normals (`-Z`, `+Z`, `-Y`, `+Y`, `-X`, `+X`).
- Registered the test in `tests/CMakeLists.txt` and updated `docs/release-notes-draft.md` with a release-note entry describing the fix.

### Testing
- Compiled and ran the new test: `g++ -std=c++17 -Iviewer3d tests/meshprimitives_cube_normals_test.cpp viewer3d/meshprimitives.cpp -o /tmp/meshprimitives_cube_normals_test && /tmp/meshprimitives_cube_normals_test`, which executed successfully.
- Ran the mandatory repository checks: `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both returned OK.
- Ran `git diff --check` to validate no whitespace/errors were introduced, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38528333e08324a176a8439206a3b9)