### PR TITLE
Fix Perastage Updates dialog buttons and preserve suppression checkbox

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -10,6 +10,8 @@ Changes since **v1.4.0**.
 
 ## Fixes
 
+- Fixed the Perastage Updates dialog so Yes and No close the prompt correctly and the per-version reminder suppression can be saved from the startup update prompt.
+
 ## Stability and diagnostics
 
 ## Build, packaging and CI

--- a/gui/update/update_notification_dialog.cpp
+++ b/gui/update/update_notification_dialog.cpp
@@ -2,6 +2,7 @@
 
 #include <wx/button.h>
 #include <wx/checkbox.h>
+#include <wx/event.h>
 #include <wx/dialog.h>
 #include <wx/sizer.h>
 #include <wx/stattext.h>
@@ -47,6 +48,12 @@ UpdateNotificationChoice ShowAvailableUpdateDialog(
   buttonSizer->AddStretchSpacer(1);
   wxButton *yesButton = new wxButton(&dialog, wxID_YES, "Yes");
   wxButton *noButton = new wxButton(&dialog, wxID_NO, "No");
+  yesButton->Bind(wxEVT_BUTTON, [&dialog](wxCommandEvent &) {
+    dialog.EndModal(wxID_YES);
+  });
+  noButton->Bind(wxEVT_BUTTON, [&dialog](wxCommandEvent &) {
+    dialog.EndModal(wxID_NO);
+  });
   buttonSizer->Add(yesButton, 0, wxRIGHT, 8);
   buttonSizer->Add(noButton, 0);
   topSizer->Add(buttonSizer, 0, wxLEFT | wxRIGHT | wxBOTTOM | wxEXPAND, 12);


### PR DESCRIPTION
### Motivation
- The update notification modal did not close when the user clicked the Yes or No buttons and the per-version suppression could not be reliably persisted, so the user experience and the startup-dismissal flow needed to be fixed.

### Description
- Wire the Yes/No buttons in `gui/update/update_notification_dialog.cpp` to explicitly end the dialog modal with `dialog.EndModal(wxID_YES)` and `dialog.EndModal(wxID_NO)` and add the required `<wx/event.h>` include.
- Preserve the existing return semantics so the caller still receives `suppressVersionReminder` and can persist the dismissed version via the existing preferences API.
- Add a brief user-facing entry to `docs/release-notes-draft.md` describing the fix.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed successfully.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed successfully.
- Ran `git diff --check` to ensure no style/whitespace issues, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38f75badc08324b6baca3aa71bc02f)