### PR TITLE
fix: harden 3D picking coordinates and Windows crash dumps

### DIFF
--- a/core/diagnostics/CrashHandler.cpp
+++ b/core/diagnostics/CrashHandler.cpp
@@ -18,11 +18,15 @@
 #if defined(_WIN32)
 #include <windows.h>
 #include <minidumpapiset.h>
+#include <iomanip>
 #endif
 
 namespace diagnostics {
 namespace {
 std::atomic_flag g_handlingCrash = ATOMIC_FLAG_INIT;
+#if defined(_WIN32)
+void *g_vectoredExceptionHandler = nullptr;
+#endif
 
 // Returns a human-readable signal name for crash reports.
 const char *SignalName(int signalNumber) {
@@ -88,6 +92,101 @@ bool WriteWindowsMinidump(const std::filesystem::path &dumpPath,
   CloseHandle(file);
   return ok == TRUE;
 }
+
+// Returns true when a Windows exception represents a serious native crash.
+bool IsSeriousWindowsException(DWORD exceptionCode) {
+  switch (exceptionCode) {
+  case EXCEPTION_ACCESS_VIOLATION:
+  case EXCEPTION_ILLEGAL_INSTRUCTION:
+  case EXCEPTION_STACK_OVERFLOW:
+  case EXCEPTION_ARRAY_BOUNDS_EXCEEDED:
+  case EXCEPTION_DATATYPE_MISALIGNMENT:
+  case EXCEPTION_FLT_DIVIDE_BY_ZERO:
+  case EXCEPTION_INT_DIVIDE_BY_ZERO:
+    return true;
+  default:
+    return false;
+  }
+}
+
+// Resolves the module path that contains a faulting Windows instruction address.
+std::string ResolveFaultingModulePath(void *address) {
+  if (!address)
+    return {};
+
+  HMODULE module = nullptr;
+  if (!GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                              GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                          reinterpret_cast<LPCWSTR>(address), &module)) {
+    return {};
+  }
+
+  wchar_t path[MAX_PATH] = {};
+  const DWORD length = GetModuleFileNameW(module, path, MAX_PATH);
+  if (length == 0)
+    return {};
+
+  const int utf8Length = WideCharToMultiByte(CP_UTF8, 0, path, -1, nullptr, 0,
+                                            nullptr, nullptr);
+  if (utf8Length <= 0)
+    return {};
+
+  std::string utf8(static_cast<std::size_t>(utf8Length - 1), '\0');
+  WideCharToMultiByte(CP_UTF8, 0, path, -1, utf8.data(), utf8Length, nullptr,
+                      nullptr);
+  return utf8;
+}
+
+// Appends Windows exception metadata to crash report details.
+void AppendWindowsExceptionDetails(std::ostringstream &details,
+                                   EXCEPTION_POINTERS *exceptionInfo) {
+  if (!exceptionInfo || !exceptionInfo->ExceptionRecord) {
+    details << "\nWindows exception context: unavailable";
+    return;
+  }
+
+  EXCEPTION_RECORD *record = exceptionInfo->ExceptionRecord;
+  details << "\nWindows exception context: available";
+  details << "\nException code: 0x" << std::hex << std::setw(8)
+          << std::setfill('0') << record->ExceptionCode << std::dec;
+  details << "\nException address: " << record->ExceptionAddress;
+  const std::string modulePath =
+      ResolveFaultingModulePath(record->ExceptionAddress);
+  if (!modulePath.empty())
+    details << "\nFaulting module: " << modulePath;
+}
+
+// Writes a Windows crash report after an already-attempted native minidump capture.
+void WriteWindowsExceptionCrashReport(const std::filesystem::path &reportPath,
+                                      const std::filesystem::path &dumpPath,
+                                      bool dumpWritten,
+                                      const std::string &dumpError,
+                                      EXCEPTION_POINTERS *exceptionInfo) {
+  std::ostringstream details;
+  details << "Unhandled structured exception";
+  AppendWindowsExceptionDetails(details, exceptionInfo);
+  details << "\nMinidump exception context: "
+          << (exceptionInfo ? "real Windows exception context" : "unavailable");
+  if (dumpWritten) {
+    details << "\nWindows minidump: " << dumpPath.string();
+    DiagnosticLogger::Error("Windows minidump written: " + dumpPath.string());
+  } else {
+    details << "\nWindows minidump unavailable: " << dumpError;
+    DiagnosticLogger::Error("Unable to write Windows minidump: " + dumpError);
+  }
+  details << "\nText stack trace: best-effort backward-cpp capture";
+
+  std::ofstream out(reportPath, std::ios::out | std::ios::trunc);
+  if (out.is_open()) {
+    out << DiagnosticReport::BuildTextReport(
+        "Unhandled structured exception", details.str(), CaptureStackTrace());
+    out.close();
+    DiagnosticLogger::Error("Crash report written: " + reportPath.string());
+  } else {
+    DiagnosticLogger::Error("Unable to write crash report file.");
+  }
+  DiagnosticLogger::Flush();
+}
 #endif
 
 // Writes a crash report without involving GUI objects.
@@ -113,6 +212,9 @@ void WriteCrashReport(const std::string &reason, const std::string &details,
           dumpError)) {
     enrichedDetails += enrichedDetails.empty() ? "" : "\n";
     enrichedDetails += "Windows minidump: " + dumpPath.string();
+    enrichedDetails += "\nMinidump exception context: " +
+                       std::string(exceptionInfo ? "real Windows exception context"
+                                                 : "unavailable");
     DiagnosticLogger::Error("Windows minidump written: " + dumpPath.string());
   } else {
     enrichedDetails += enrichedDetails.empty() ? "" : "\n";
@@ -135,22 +237,44 @@ void WriteCrashReport(const std::string &reason, const std::string &details,
 }
 
 #if defined(_WIN32)
+// Handles a serious Windows exception by writing a dump before text stack capture.
+LONG HandleWindowsException(EXCEPTION_POINTERS *exceptionInfo, LONG handledResult) {
+  if (g_handlingCrash.test_and_set())
+    return handledResult;
+
+  if (!exceptionInfo || !exceptionInfo->ExceptionRecord ||
+      !IsSeriousWindowsException(exceptionInfo->ExceptionRecord->ExceptionCode)) {
+    g_handlingCrash.clear();
+    return EXCEPTION_CONTINUE_SEARCH;
+  }
+
+  std::string directoryError;
+  if (!DiagnosticPaths::EnsureDirectory(DiagnosticPaths::CrashReportsDirectory(),
+                                        &directoryError)) {
+    DiagnosticLogger::Error("Unable to create crash report directory: " +
+                            directoryError);
+    DiagnosticLogger::Flush();
+    return handledResult;
+  }
+
+  const std::filesystem::path reportPath = DiagnosticPaths::NewCrashReportFile();
+  const std::filesystem::path dumpPath = reportPath.parent_path() /
+                                        reportPath.stem().concat(".dmp");
+  std::string dumpError;
+  const bool dumpWritten = WriteWindowsMinidump(dumpPath, exceptionInfo, dumpError);
+  WriteWindowsExceptionCrashReport(reportPath, dumpPath, dumpWritten, dumpError,
+                                   exceptionInfo);
+  return handledResult;
+}
+
 // Handles Windows structured exceptions by creating a local crash report.
 LONG WINAPI HandleWindowsUnhandledException(EXCEPTION_POINTERS *exceptionInfo) {
-  if (g_handlingCrash.test_and_set())
-    return EXCEPTION_EXECUTE_HANDLER;
+  return HandleWindowsException(exceptionInfo, EXCEPTION_EXECUTE_HANDLER);
+}
 
-  std::ostringstream details;
-  details << "Unhandled structured exception";
-  if (exceptionInfo && exceptionInfo->ExceptionRecord) {
-    details << "\nException code: 0x" << std::hex
-            << exceptionInfo->ExceptionRecord->ExceptionCode;
-    details << "\nException address: "
-            << exceptionInfo->ExceptionRecord->ExceptionAddress;
-  }
-  WriteCrashReport("Unhandled structured exception", details.str(),
-                   CaptureStackTrace(), exceptionInfo);
-  return EXCEPTION_EXECUTE_HANDLER;
+// Handles first-chance Windows exceptions before CRT signal translation can lose context.
+LONG WINAPI HandleWindowsVectoredException(EXCEPTION_POINTERS *exceptionInfo) {
+  return HandleWindowsException(exceptionInfo, EXCEPTION_CONTINUE_SEARCH);
 }
 #endif
 
@@ -200,6 +324,9 @@ void CrashHandler::Initialize() {
   (void)backwardSignalHandling;
   InstallSignalHandlers();
 #if defined(_WIN32)
+  if (!g_vectoredExceptionHandler)
+    g_vectoredExceptionHandler =
+        AddVectoredExceptionHandler(1, HandleWindowsVectoredException);
   SetUnhandledExceptionFilter(HandleWindowsUnhandledException);
 #endif
   std::set_terminate(HandleTerminate);

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -19,6 +19,9 @@ Changes since **v1.4.0**.
 
 ## Stability and diagnostics
 
+- Hardened 3D picking coordinate validation to avoid unsafe OpenGL reads near viewport edges and during zero-sized or out-of-range viewer states.
+- Improved Windows crash dumps so native access violations are captured from the original exception context before best-effort text stack reporting.
+
 ## Build, packaging and CI
 
 ## Documentation

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1501,6 +1501,12 @@ foreach(PERASTAGE_TEST_TARGET IN LISTS PERASTAGE_TEST_TARGETS)
     endif()
 endforeach()
 
+add_executable(picking_coordinate_utils_test
+               picking_coordinate_utils_test.cpp
+               ../viewer3d/picking/picking_coordinate_utils.cpp)
+target_include_directories(picking_coordinate_utils_test PRIVATE ../viewer3d/picking)
+add_test(NAME PickingCoordinateUtils COMMAND picking_coordinate_utils_test)
+
 add_executable(pick_mesh_validation_test
                pick_mesh_validation_test.cpp
                ../viewer3d/render/pick_mesh_validation.cpp)

--- a/tests/picking_coordinate_utils_test.cpp
+++ b/tests/picking_coordinate_utils_test.cpp
@@ -1,0 +1,56 @@
+#include "picking_coordinate_utils.h"
+
+#include <cstdlib>
+#include <iostream>
+
+namespace {
+
+// Verifies a valid mouse coordinate conversion result.
+void ExpectConvert(int mouseX, int mouseY, int width, int height, int expectedX,
+                   int expectedY) {
+  int framebufferX = -1;
+  int framebufferY = -1;
+  if (!TryConvertMouseToFramebufferPoint(mouseX, mouseY, width, height,
+                                         framebufferX, framebufferY)) {
+    std::cerr << "Expected conversion to succeed for mouse=(" << mouseX << ','
+              << mouseY << ") size=(" << width << ',' << height << ")\n";
+    std::exit(1);
+  }
+  if (framebufferX != expectedX || framebufferY != expectedY) {
+    std::cerr << "Unexpected framebuffer point: got=(" << framebufferX << ','
+              << framebufferY << ") expected=(" << expectedX << ','
+              << expectedY << ")\n";
+    std::exit(1);
+  }
+}
+
+// Verifies that an invalid mouse coordinate conversion is rejected.
+void ExpectReject(int mouseX, int mouseY, int width, int height) {
+  int framebufferX = 123;
+  int framebufferY = 456;
+  if (TryConvertMouseToFramebufferPoint(mouseX, mouseY, width, height,
+                                        framebufferX, framebufferY)) {
+    std::cerr << "Expected conversion to fail for mouse=(" << mouseX << ','
+              << mouseY << ") size=(" << width << ',' << height << ")\n";
+    std::exit(1);
+  }
+}
+
+} // namespace
+
+// Exercises edge and invalid coordinate conversion cases.
+int main() {
+  ExpectConvert(0, 0, 640, 480, 0, 479);
+  ExpectConvert(0, 479, 640, 480, 0, 0);
+  ExpectConvert(639, 0, 640, 480, 639, 479);
+  ExpectConvert(639, 479, 640, 480, 639, 0);
+
+  ExpectReject(-1, 0, 640, 480);
+  ExpectReject(0, -1, 640, 480);
+  ExpectReject(640, 0, 640, 480);
+  ExpectReject(0, 480, 640, 480);
+  ExpectReject(0, 0, 0, 480);
+  ExpectReject(0, 0, 640, 0);
+
+  return 0;
+}

--- a/viewer3d/CMakeLists.txt
+++ b/viewer3d/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/meshprimitives.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/picking/selectionsystem.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/picking/id_pick_pass.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/picking/picking_coordinate_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/gl_primitive_renderer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/glew_init_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/base_pass_framebuffer_cache.cpp

--- a/viewer3d/picking/id_pick_pass.cpp
+++ b/viewer3d/picking/id_pick_pass.cpp
@@ -1,5 +1,7 @@
 #include "id_pick_pass.h"
 
+#include "picking_coordinate_utils.h"
+
 #include <GL/glew.h>
 #ifdef __APPLE__
 #define GL_SILENCE_DEPRECATION
@@ -203,14 +205,25 @@ bool IdPickPass::ReadUuidAt(int mouseX, int mouseY, int width, int height,
                             const std::unordered_set<std::string> &hiddenLayers,
                             std::string &outUuid) {
   RebuildIfNeeded(width, height, hiddenLayers);
-  if (m_fbo == 0 || !m_framebufferUsable || mouseX < 0 || mouseY < 0 ||
-      mouseX >= width || mouseY >= height)
+  if (m_fbo == 0 || !m_framebufferUsable)
     return false;
 
-  const int sampleY = height - mouseY;
+  int framebufferX = 0;
+  int framebufferY = 0;
+  if (!TryConvertMouseToFramebufferPoint(mouseX, mouseY, width, height,
+                                         framebufferX, framebufferY)) {
+    if (!m_loggedInvalidReadCoordinates) {
+      wxLogWarning(
+          "Viewer3D ID picking skipped an out-of-range read at mouse=(%d,%d), framebuffer=(%d,%d).",
+          mouseX, mouseY, width, height);
+      m_loggedInvalidReadCoordinates = true;
+    }
+    return false;
+  }
+
   unsigned char pixel[3] = {0, 0, 0};
   glBindFramebuffer(GL_FRAMEBUFFER, m_fbo);
-  glReadPixels(mouseX, sampleY, 1, 1, GL_RGB, GL_UNSIGNED_BYTE, pixel);
+  glReadPixels(framebufferX, framebufferY, 1, 1, GL_RGB, GL_UNSIGNED_BYTE, pixel);
   glBindFramebuffer(GL_FRAMEBUFFER, 0);
 
   const uint32_t pickId = (static_cast<uint32_t>(pixel[0]) << 16) |

--- a/viewer3d/picking/id_pick_pass.h
+++ b/viewer3d/picking/id_pick_pass.h
@@ -35,6 +35,7 @@ private:
   bool m_dirty = true;
   bool m_framebufferUsable = false;
   bool m_loggedFramebufferFailure = false;
+  bool m_loggedInvalidReadCoordinates = false;
   size_t m_lastSceneVersion = static_cast<size_t>(-1);
   std::unordered_set<std::string> m_lastHiddenLayers;
   std::array<int, 4> m_lastViewport = {0, 0, 0, 0};

--- a/viewer3d/picking/picking_coordinate_utils.cpp
+++ b/viewer3d/picking/picking_coordinate_utils.cpp
@@ -1,0 +1,20 @@
+#include "picking_coordinate_utils.h"
+
+// Converts a top-left-origin mouse point into bottom-left-origin framebuffer coordinates.
+bool TryConvertMouseToFramebufferPoint(int mouseX, int mouseY,
+                                       int framebufferWidth,
+                                       int framebufferHeight,
+                                       int &framebufferX,
+                                       int &framebufferY) {
+  if (framebufferWidth <= 0 || framebufferHeight <= 0)
+    return false;
+  if (mouseX < 0 || mouseY < 0 || mouseX >= framebufferWidth ||
+      mouseY >= framebufferHeight) {
+    return false;
+  }
+
+  framebufferX = mouseX;
+  framebufferY = framebufferHeight - 1 - mouseY;
+  return framebufferX >= 0 && framebufferY >= 0 &&
+         framebufferX < framebufferWidth && framebufferY < framebufferHeight;
+}

--- a/viewer3d/picking/picking_coordinate_utils.h
+++ b/viewer3d/picking/picking_coordinate_utils.h
@@ -1,0 +1,8 @@
+#pragma once
+
+// Converts window mouse coordinates to validated OpenGL framebuffer coordinates.
+bool TryConvertMouseToFramebufferPoint(int mouseX, int mouseY,
+                                       int framebufferWidth,
+                                       int framebufferHeight,
+                                       int &framebufferX,
+                                       int &framebufferY);

--- a/viewer3d/picking/selectionsystem.cpp
+++ b/viewer3d/picking/selectionsystem.cpp
@@ -1,5 +1,7 @@
 #include "selectionsystem.h"
 
+#include "picking_coordinate_utils.h"
+
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
@@ -136,10 +138,18 @@ bool ProjectBoundingBox(const ISelectionContext::BoundingBox &bb,
   return visible;
 }
 
+// Builds a world-space ray from validated mouse coordinates.
 bool BuildMouseRay(int mouseX, int mouseY, int screenHeight,
                    const ProjectionSnapshot &projection, Ray &outRay) {
-  const double winX = static_cast<double>(mouseX);
-  const double winY = static_cast<double>(screenHeight - mouseY);
+  int framebufferX = 0;
+  int framebufferY = 0;
+  if (!TryConvertMouseToFramebufferPoint(mouseX, mouseY, projection.viewport[2],
+                                         screenHeight, framebufferX,
+                                         framebufferY)) {
+    return false;
+  }
+  const double winX = static_cast<double>(framebufferX);
+  const double winY = static_cast<double>(framebufferY);
 
   double nearX = 0.0;
   double nearY = 0.0;
@@ -169,17 +179,26 @@ bool BuildMouseRay(int mouseX, int mouseY, int screenHeight,
   return true;
 }
 
+// Reads and unprojects the depth value under a validated mouse coordinate.
 bool ReadWorldPointFromDepth(int mouseX, int mouseY, int screenHeight,
                              const ProjectionSnapshot &projection,
                              std::array<double, 3> &outWorldPoint) {
-  const int sampleY = screenHeight - mouseY;
+  int framebufferX = 0;
+  int framebufferY = 0;
+  if (!TryConvertMouseToFramebufferPoint(mouseX, mouseY, projection.viewport[2],
+                                         screenHeight, framebufferX,
+                                         framebufferY)) {
+    return false;
+  }
+
   float depth = 1.0f;
-  glReadPixels(mouseX, sampleY, 1, 1, GL_DEPTH_COMPONENT, GL_FLOAT, &depth);
+  glReadPixels(framebufferX, framebufferY, 1, 1, GL_DEPTH_COMPONENT, GL_FLOAT,
+               &depth);
   if (depth >= 1.0f)
     return false;
 
-  const double winX = static_cast<double>(mouseX);
-  const double winY = static_cast<double>(sampleY);
+  const double winX = static_cast<double>(framebufferX);
+  const double winY = static_cast<double>(framebufferY);
   double worldX = 0.0;
   double worldY = 0.0;
   double worldZ = 0.0;


### PR DESCRIPTION
### Motivation
- Prevent crashes caused by unsafe mouse-to-framebuffer conversions and out-of-range OpenGL reads during 3D picking. 
- Ensure Windows minidumps are generated from the original exception context so post-mortem analysis resolves the real faulting address rather than the crash-reporter code. 

### Description
- Add `TryConvertMouseToFramebufferPoint(...)` in `viewer3d/picking` to validate framebuffer size and convert Y using `framebufferHeight - 1 - mouseY`, and register it in `viewer3d/CMakeLists.txt`.
- Use the helper in `IdPickPass::ReadUuidAt` (`viewer3d/picking/id_pick_pass.cpp`) and in selection paths (`viewer3d/picking/selectionsystem.cpp`) so `glReadPixels` and `gluUnProject` are only called with validated framebuffer coordinates, and add a one-time diagnostic warning flag for invalid read coordinates.
- Improve Windows crash handling in `core/diagnostics/CrashHandler.cpp` by installing a first-priority vectored exception handler, detecting serious native exception codes, writing a `.dmp` with the original `EXCEPTION_POINTERS` via `MiniDumpWriteDump` before backward-cpp text capture, and appending exception metadata (code, address, faulting module) to the text report.
- Add unit test `tests/picking_coordinate_utils_test.cpp` and CTest registration to cover corners (top-left/bottom-left/top-right/bottom-right), out-of-range negatives, width/height boundary cases, and zero framebuffer dimensions, and update `docs/release-notes-draft.md` with brief release notes entries.

### Testing
- Ran and passed the standalone coordinate conversion unit `picking_coordinate_utils_test` compiled with `g++` (test returned success).
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, and both checks succeeded.
- Ran `git diff --check` with no whitespace errors reported.
- `cmake` configuration for the full `tests` tree could not complete in this environment because wxWidgets development files are not available, so full CTest execution and a Windows binary validation of minidump contents remain to be performed on Windows (manual validation steps are documented).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a2f6303948324a6da932ef7d66bb4)