### PR TITLE
Harden 3D picking/highlight OpenGL state and guard glReadPixels

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -19,7 +19,7 @@ Changes since **v1.4.0**.
 
 ## Stability and diagnostics
 
-- Hardened 3D hover picking and highlight rendering to avoid unsafe OpenGL pixel reads and restore critical render state after hover highlights on Intel Windows drivers and macOS.
+- Hardened 3D hover picking plus hover, group, and selected highlight rendering to avoid unsafe OpenGL pixel reads and restore critical render state after overlay highlights on Intel Windows drivers and macOS.
 - Hardened 3D picking coordinate validation to avoid unsafe OpenGL reads near viewport edges and during zero-sized or out-of-range viewer states.
 - Improved Windows crash dumps so native access violations are captured from the original exception context before best-effort text stack reporting.
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -19,6 +19,7 @@ Changes since **v1.4.0**.
 
 ## Stability and diagnostics
 
+- Hardened 3D hover picking and highlight rendering to avoid unsafe OpenGL pixel reads and restore critical render state after hover highlights on Intel Windows drivers and macOS.
 - Hardened 3D picking coordinate validation to avoid unsafe OpenGL reads near viewport edges and during zero-sized or out-of-range viewer states.
 - Improved Windows crash dumps so native access violations are captured from the original exception context before best-effort text stack reporting.
 

--- a/viewer3d/CMakeLists.txt
+++ b/viewer3d/CMakeLists.txt
@@ -23,6 +23,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/render/perastage_svg_symbol_builder.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/pick_mesh_validation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/opaque_truss_pass.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/render/opengl_state_guard.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/selection_overlay_pass.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/render_pipeline.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/viewer3d_render_style.cpp

--- a/viewer3d/picking/id_pick_pass.cpp
+++ b/viewer3d/picking/id_pick_pass.cpp
@@ -1,6 +1,7 @@
 #include "id_pick_pass.h"
 
 #include "picking_coordinate_utils.h"
+#include "render/opengl_state_guard.h"
 
 #include <GL/glew.h>
 #ifdef __APPLE__
@@ -110,6 +111,7 @@ void IdPickPass::EnsureFramebufferSize(int width, int height) {
 void IdPickPass::RebuildIfNeeded(
     int width, int height,
     const std::unordered_set<std::string> &hiddenLayers) {
+  viewer3d::render::OpenGLStateGuard stateGuard;
   EnsureFramebufferSize(width, height);
   if (m_fbo == 0 || !m_framebufferUsable || width <= 0 || height <= 0)
     return;
@@ -221,10 +223,21 @@ bool IdPickPass::ReadUuidAt(int mouseX, int mouseY, int width, int height,
     return false;
   }
 
+  viewer3d::render::OpenGLStateGuard stateGuard;
   unsigned char pixel[3] = {0, 0, 0};
+  viewer3d::render::ClearOpenGLErrors();
   glBindFramebuffer(GL_FRAMEBUFFER, m_fbo);
+  glReadBuffer(GL_COLOR_ATTACHMENT0);
   glReadPixels(framebufferX, framebufferY, 1, 1, GL_RGB, GL_UNSIGNED_BYTE, pixel);
-  glBindFramebuffer(GL_FRAMEBUFFER, 0);
+  const GLenum readError = viewer3d::render::DrainOpenGLErrors();
+  if (readError != GL_NO_ERROR) {
+    wxLogWarning(
+        "Picking: glReadPixels ID read failed error=0x%04x mouse=(%d,%d) framebuffer=(%d,%d) size=(%d,%d) vendor=%s renderer=%s.",
+        static_cast<unsigned int>(readError), mouseX, mouseY, framebufferX,
+        framebufferY, width, height, viewer3d::render::SafeGlString(GL_VENDOR),
+        viewer3d::render::SafeGlString(GL_RENDERER));
+    return false;
+  }
 
   const uint32_t pickId = (static_cast<uint32_t>(pixel[0]) << 16) |
                           (static_cast<uint32_t>(pixel[1]) << 8) |

--- a/viewer3d/picking/selectionsystem.cpp
+++ b/viewer3d/picking/selectionsystem.cpp
@@ -1,6 +1,7 @@
 #include "selectionsystem.h"
 
 #include "picking_coordinate_utils.h"
+#include "render/opengl_state_guard.h"
 
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
@@ -183,6 +184,22 @@ bool BuildMouseRay(int mouseX, int mouseY, int screenHeight,
 bool ReadWorldPointFromDepth(int mouseX, int mouseY, int screenHeight,
                              const ProjectionSnapshot &projection,
                              std::array<double, 3> &outWorldPoint) {
+  if (!viewer3d::render::HasCurrentOpenGLContext()) {
+    wxLogWarning("Picking: skipped due to invalid context before depth read.");
+    return false;
+  }
+
+  int currentViewport[4] = {0, 0, 0, 0};
+  glGetIntegerv(GL_VIEWPORT, currentViewport);
+  if (currentViewport[2] <= 0 || currentViewport[3] <= 0 ||
+      projection.viewport[2] <= 0 || projection.viewport[3] <= 0) {
+    wxLogWarning(
+        "Picking: skipped due to invalid viewport before depth read viewport=(%d,%d,%d,%d).",
+        currentViewport[0], currentViewport[1], currentViewport[2],
+        currentViewport[3]);
+    return false;
+  }
+
   int framebufferX = 0;
   int framebufferY = 0;
   if (!TryConvertMouseToFramebufferPoint(mouseX, mouseY, projection.viewport[2],
@@ -191,10 +208,42 @@ bool ReadWorldPointFromDepth(int mouseX, int mouseY, int screenHeight,
     return false;
   }
 
+  if (framebufferX < currentViewport[0] || framebufferY < currentViewport[1] ||
+      framebufferX >= currentViewport[0] + currentViewport[2] ||
+      framebufferY >= currentViewport[1] + currentViewport[3]) {
+    wxLogWarning(
+        "Picking: skipped due to out-of-viewport depth read mouse=(%d,%d) framebuffer=(%d,%d) viewport=(%d,%d,%d,%d).",
+        mouseX, mouseY, framebufferX, framebufferY, currentViewport[0],
+        currentViewport[1], currentViewport[2], currentViewport[3]);
+    return false;
+  }
+
+  GLint framebuffer = 0;
+  GLint readFramebuffer = 0;
+  GLint readBuffer = GL_BACK;
+  glGetIntegerv(GL_FRAMEBUFFER_BINDING, &framebuffer);
+  if (GLEW_VERSION_3_0 || GLEW_EXT_framebuffer_blit)
+    glGetIntegerv(GL_READ_FRAMEBUFFER_BINDING, &readFramebuffer);
+  else
+    readFramebuffer = framebuffer;
+  glGetIntegerv(GL_READ_BUFFER, &readBuffer);
+
+  viewer3d::render::ClearOpenGLErrors();
   float depth = 1.0f;
   glReadPixels(framebufferX, framebufferY, 1, 1, GL_DEPTH_COMPONENT, GL_FLOAT,
                &depth);
-  if (depth >= 1.0f)
+  const GLenum readError = viewer3d::render::DrainOpenGLErrors();
+  if (readError != GL_NO_ERROR) {
+    wxLogWarning(
+        "Picking: glReadPixels depth read failed error=0x%04x framebuffer=%d readFramebuffer=%d readBuffer=0x%04x viewport=(%d,%d,%d,%d) vendor=%s renderer=%s.",
+        static_cast<unsigned int>(readError), framebuffer, readFramebuffer,
+        static_cast<unsigned int>(readBuffer), currentViewport[0],
+        currentViewport[1], currentViewport[2], currentViewport[3],
+        viewer3d::render::SafeGlString(GL_VENDOR),
+        viewer3d::render::SafeGlString(GL_RENDERER));
+    return false;
+  }
+  if (depth < 0.0f || depth >= 1.0f || !std::isfinite(depth))
     return false;
 
   const double winX = static_cast<double>(framebufferX);

--- a/viewer3d/render/opengl_state_guard.cpp
+++ b/viewer3d/render/opengl_state_guard.cpp
@@ -1,0 +1,102 @@
+#include "opengl_state_guard.h"
+
+namespace viewer3d::render {
+
+// Captures OpenGL state that picking and highlight passes commonly modify.
+OpenGLStateGuard::OpenGLStateGuard() {
+  m_hasProgramBinding = GLEW_VERSION_2_0;
+  m_hasVertexArrayBinding = GLEW_VERSION_3_0 || GLEW_ARB_vertex_array_object;
+  m_hasReadFramebufferBinding = GLEW_VERSION_3_0 || GLEW_EXT_framebuffer_blit;
+  m_hasDrawFramebufferBinding = GLEW_VERSION_3_0 || GLEW_EXT_framebuffer_blit;
+
+  if (m_hasProgramBinding)
+    glGetIntegerv(GL_CURRENT_PROGRAM, &m_currentProgram);
+  if (m_hasVertexArrayBinding)
+    glGetIntegerv(GL_VERTEX_ARRAY_BINDING, &m_vertexArrayBinding);
+  glGetIntegerv(GL_ARRAY_BUFFER_BINDING, &m_arrayBufferBinding);
+  glGetIntegerv(GL_ELEMENT_ARRAY_BUFFER_BINDING, &m_elementArrayBufferBinding);
+  glGetIntegerv(GL_FRAMEBUFFER_BINDING, &m_framebufferBinding);
+  if (m_hasReadFramebufferBinding)
+    glGetIntegerv(GL_READ_FRAMEBUFFER_BINDING, &m_readFramebufferBinding);
+  if (m_hasDrawFramebufferBinding)
+    glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &m_drawFramebufferBinding);
+  glGetIntegerv(GL_READ_BUFFER, &m_readBuffer);
+  glGetIntegerv(GL_VIEWPORT, m_viewport);
+  m_depthTest = glIsEnabled(GL_DEPTH_TEST);
+  glGetIntegerv(GL_DEPTH_FUNC, &m_depthFunc);
+  glGetBooleanv(GL_DEPTH_WRITEMASK, &m_depthWriteMask);
+  m_cullFace = glIsEnabled(GL_CULL_FACE);
+  glGetIntegerv(GL_CULL_FACE_MODE, &m_cullFaceMode);
+  glGetIntegerv(GL_FRONT_FACE, &m_frontFace);
+  m_blend = glIsEnabled(GL_BLEND);
+  m_stencilTest = glIsEnabled(GL_STENCIL_TEST);
+  glGetBooleanv(GL_COLOR_WRITEMASK, m_colorWriteMask);
+  m_polygonOffsetFill = glIsEnabled(GL_POLYGON_OFFSET_FILL);
+  glGetIntegerv(GL_ACTIVE_TEXTURE, &m_activeTexture);
+  glGetIntegerv(GL_TEXTURE_BINDING_2D, &m_texture2dBinding);
+}
+
+// Restores OpenGL state captured before the guarded picking or highlight work.
+OpenGLStateGuard::~OpenGLStateGuard() {
+  if (m_hasProgramBinding)
+    glUseProgram(static_cast<GLuint>(m_currentProgram));
+  if (m_hasVertexArrayBinding)
+    glBindVertexArray(static_cast<GLuint>(m_vertexArrayBinding));
+  glBindBuffer(GL_ARRAY_BUFFER, static_cast<GLuint>(m_arrayBufferBinding));
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER,
+               static_cast<GLuint>(m_elementArrayBufferBinding));
+  if (m_hasReadFramebufferBinding || m_hasDrawFramebufferBinding) {
+    if (m_hasReadFramebufferBinding)
+      glBindFramebuffer(GL_READ_FRAMEBUFFER,
+                        static_cast<GLuint>(m_readFramebufferBinding));
+    if (m_hasDrawFramebufferBinding)
+      glBindFramebuffer(GL_DRAW_FRAMEBUFFER,
+                        static_cast<GLuint>(m_drawFramebufferBinding));
+  } else {
+    glBindFramebuffer(GL_FRAMEBUFFER,
+                      static_cast<GLuint>(m_framebufferBinding));
+  }
+  glReadBuffer(static_cast<GLenum>(m_readBuffer));
+  glViewport(m_viewport[0], m_viewport[1], m_viewport[2], m_viewport[3]);
+  m_depthTest ? glEnable(GL_DEPTH_TEST) : glDisable(GL_DEPTH_TEST);
+  glDepthFunc(static_cast<GLenum>(m_depthFunc));
+  glDepthMask(m_depthWriteMask);
+  m_cullFace ? glEnable(GL_CULL_FACE) : glDisable(GL_CULL_FACE);
+  glCullFace(static_cast<GLenum>(m_cullFaceMode));
+  glFrontFace(static_cast<GLenum>(m_frontFace));
+  m_blend ? glEnable(GL_BLEND) : glDisable(GL_BLEND);
+  m_stencilTest ? glEnable(GL_STENCIL_TEST) : glDisable(GL_STENCIL_TEST);
+  glColorMask(m_colorWriteMask[0], m_colorWriteMask[1], m_colorWriteMask[2],
+              m_colorWriteMask[3]);
+  m_polygonOffsetFill ? glEnable(GL_POLYGON_OFFSET_FILL)
+                      : glDisable(GL_POLYGON_OFFSET_FILL);
+  glActiveTexture(static_cast<GLenum>(m_activeTexture));
+  glBindTexture(GL_TEXTURE_2D, static_cast<GLuint>(m_texture2dBinding));
+}
+
+// Returns whether basic OpenGL queries can see a current context.
+bool HasCurrentOpenGLContext() { return glGetString(GL_VERSION) != nullptr; }
+
+// Returns an OpenGL string or a stable placeholder when no context reports it.
+const char *SafeGlString(GLenum name) {
+  const GLubyte *value = glGetString(name);
+  return value ? reinterpret_cast<const char *>(value) : "unknown";
+}
+
+// Clears queued OpenGL errors before an operation that needs clean diagnostics.
+void ClearOpenGLErrors() {
+  while (glGetError() != GL_NO_ERROR) {
+  }
+}
+
+// Drains OpenGL errors and returns the first error seen, if any.
+GLenum DrainOpenGLErrors() {
+  GLenum first = GL_NO_ERROR;
+  for (GLenum err = glGetError(); err != GL_NO_ERROR; err = glGetError()) {
+    if (first == GL_NO_ERROR)
+      first = err;
+  }
+  return first;
+}
+
+} // namespace viewer3d::render

--- a/viewer3d/render/opengl_state_guard.h
+++ b/viewer3d/render/opengl_state_guard.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <GL/glew.h>
+#ifdef __APPLE__
+#define GL_SILENCE_DEPRECATION
+#include <OpenGL/gl.h>
+#else
+#include <GL/gl.h>
+#endif
+
+namespace viewer3d::render {
+
+class OpenGLStateGuard {
+public:
+  OpenGLStateGuard();
+  ~OpenGLStateGuard();
+
+  OpenGLStateGuard(const OpenGLStateGuard &) = delete;
+  OpenGLStateGuard &operator=(const OpenGLStateGuard &) = delete;
+
+private:
+  GLint m_currentProgram = 0;
+  GLint m_vertexArrayBinding = 0;
+  GLint m_arrayBufferBinding = 0;
+  GLint m_elementArrayBufferBinding = 0;
+  GLint m_framebufferBinding = 0;
+  GLint m_readFramebufferBinding = 0;
+  GLint m_drawFramebufferBinding = 0;
+  GLint m_readBuffer = 0;
+  GLint m_viewport[4] = {0, 0, 0, 0};
+  GLboolean m_depthTest = GL_FALSE;
+  GLint m_depthFunc = GL_LESS;
+  GLboolean m_depthWriteMask = GL_TRUE;
+  GLboolean m_cullFace = GL_FALSE;
+  GLint m_cullFaceMode = GL_BACK;
+  GLint m_frontFace = GL_CCW;
+  GLboolean m_blend = GL_FALSE;
+  GLboolean m_stencilTest = GL_FALSE;
+  GLboolean m_colorWriteMask[4] = {GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE};
+  GLboolean m_polygonOffsetFill = GL_FALSE;
+  GLint m_activeTexture = GL_TEXTURE0;
+  GLint m_texture2dBinding = 0;
+  bool m_hasReadFramebufferBinding = false;
+  bool m_hasDrawFramebufferBinding = false;
+  bool m_hasVertexArrayBinding = false;
+  bool m_hasProgramBinding = false;
+};
+
+bool HasCurrentOpenGLContext();
+const char *SafeGlString(GLenum name);
+void ClearOpenGLErrors();
+GLenum DrainOpenGLErrors();
+
+} // namespace viewer3d::render

--- a/viewer3d/render/selection_overlay_pass.cpp
+++ b/viewer3d/render/selection_overlay_pass.cpp
@@ -69,10 +69,13 @@ bool ContainsUuid(const std::vector<std::string> &uuids,
 }
 
 // Returns whether the UUID belongs to any hover, group-hover, or selection overlay.
-bool IsUuidInSelectionOverlay(const Viewer3DController &controller,
-                              const std::string &uuid) {
-  return controller.IsUuidHighlighted(uuid) ||
-         controller.IsUuidGroupHighlighted(uuid) || controller.IsUuidSelected(uuid);
+bool IsUuidInSelectionOverlay(
+    const std::string &uuid, const std::string &highlightUuid,
+    const std::unordered_set<std::string> &groupHighlightUuids,
+    const std::unordered_set<std::string> &selectedUuids) {
+  return uuid == highlightUuid ||
+         groupHighlightUuids.find(uuid) != groupHighlightUuids.end() ||
+         selectedUuids.find(uuid) != selectedUuids.end();
 }
 
 void AppendUuidIfRenderable(
@@ -114,7 +117,9 @@ void SelectionOverlayPass::Render(Viewer3DController &controller,
       [&](const std::vector<std::string> &sourceUuids,
           std::vector<std::string> &targetUuids) {
         for (const auto &uuid : sourceUuids) {
-          if (IsUuidInSelectionOverlay(controller, uuid)) {
+          if (IsUuidInSelectionOverlay(uuid, controller.m_highlightUuid,
+                                       controller.m_groupHighlightUuids,
+                                       controller.m_selectedUuids)) {
             targetUuids.push_back(uuid);
           }
         }

--- a/viewer3d/render/selection_overlay_pass.cpp
+++ b/viewer3d/render/selection_overlay_pass.cpp
@@ -13,11 +13,13 @@
 #include <string_view>
 #include <unordered_map>
 #include <unordered_set>
+#include <wx/log.h>
 
 #include "configmanager.h"
 #include "opaque_fixture_pass.h"
 #include "opaque_object_pass.h"
 #include "opaque_truss_pass.h"
+#include "opengl_state_guard.h"
 #include "scenedatamanager.h"
 #include "viewer3dcontroller.h"
 
@@ -162,18 +164,24 @@ void SelectionOverlayPass::Render(Viewer3DController &controller,
     return std::array<float, 3>{1.0f, 1.0f, 1.0f};
   };
 
-  RenderFrameContext overlayContext = context;
-  overlayContext.skipCapture = true;
-  overlayContext.selectionOverlayPass = true;
-  GLint previousDepthFunc = GL_LESS;
-  glGetIntegerv(GL_DEPTH_FUNC, &previousDepthFunc);
-  glDepthFunc(GL_LEQUAL);
-  OpaqueObjectPass::Render(controller, overlayContext, overlaySet,
-                           getLayerColor, resolveSymbolView, getPickColor);
-  OpaqueTrussPass::Render(controller, overlayContext, overlaySet, getLayerColor,
-                          resolveSymbolView, getPickColor);
-  OpaqueFixturePass::Render(controller, overlayContext, overlaySet,
-                            getTypeColor, getLayerColor, resolveSymbolView,
-                            getPickColor);
-  glDepthFunc(static_cast<GLenum>(previousDepthFunc));
+  wxLogDebug("Highlight: begin");
+  {
+    viewer3d::render::OpenGLStateGuard stateGuard;
+
+    RenderFrameContext overlayContext = context;
+    overlayContext.skipCapture = true;
+    overlayContext.selectionOverlayPass = true;
+    GLint previousDepthFunc = GL_LESS;
+    glGetIntegerv(GL_DEPTH_FUNC, &previousDepthFunc);
+    glDepthFunc(GL_LEQUAL);
+    OpaqueObjectPass::Render(controller, overlayContext, overlaySet,
+                             getLayerColor, resolveSymbolView, getPickColor);
+    OpaqueTrussPass::Render(controller, overlayContext, overlaySet, getLayerColor,
+                            resolveSymbolView, getPickColor);
+    OpaqueFixturePass::Render(controller, overlayContext, overlaySet,
+                              getTypeColor, getLayerColor, resolveSymbolView,
+                              getPickColor);
+    glDepthFunc(static_cast<GLenum>(previousDepthFunc));
+  }
+  wxLogDebug("Highlight: restored OpenGL state");
 }

--- a/viewer3d/render/selection_overlay_pass.cpp
+++ b/viewer3d/render/selection_overlay_pass.cpp
@@ -71,10 +71,8 @@ bool ContainsUuid(const std::vector<std::string> &uuids,
 // Returns whether the UUID belongs to any hover, group-hover, or selection overlay.
 bool IsUuidInSelectionOverlay(const Viewer3DController &controller,
                               const std::string &uuid) {
-  return uuid == controller.m_highlightUuid ||
-         controller.m_groupHighlightUuids.find(uuid) !=
-             controller.m_groupHighlightUuids.end() ||
-         controller.m_selectedUuids.find(uuid) != controller.m_selectedUuids.end();
+  return controller.IsUuidHighlighted(uuid) ||
+         controller.IsUuidGroupHighlighted(uuid) || controller.IsUuidSelected(uuid);
 }
 
 void AppendUuidIfRenderable(

--- a/viewer3d/render/selection_overlay_pass.cpp
+++ b/viewer3d/render/selection_overlay_pass.cpp
@@ -68,6 +68,15 @@ bool ContainsUuid(const std::vector<std::string> &uuids,
   return std::find(uuids.begin(), uuids.end(), uuid) != uuids.end();
 }
 
+// Returns whether the UUID belongs to any hover, group-hover, or selection overlay.
+bool IsUuidInSelectionOverlay(const Viewer3DController &controller,
+                              const std::string &uuid) {
+  return uuid == controller.m_highlightUuid ||
+         controller.m_groupHighlightUuids.find(uuid) !=
+             controller.m_groupHighlightUuids.end() ||
+         controller.m_selectedUuids.find(uuid) != controller.m_selectedUuids.end();
+}
+
 void AppendUuidIfRenderable(
     const std::string &uuid,
     const std::unordered_map<std::string, Fixture> &fixtures,
@@ -107,11 +116,7 @@ void SelectionOverlayPass::Render(Viewer3DController &controller,
       [&](const std::vector<std::string> &sourceUuids,
           std::vector<std::string> &targetUuids) {
         for (const auto &uuid : sourceUuids) {
-          if (uuid == controller.m_highlightUuid ||
-              controller.m_groupHighlightUuids.find(uuid) !=
-                  controller.m_groupHighlightUuids.end() ||
-              controller.m_selectedUuids.find(uuid) !=
-                  controller.m_selectedUuids.end()) {
+          if (IsUuidInSelectionOverlay(controller, uuid)) {
             targetUuids.push_back(uuid);
           }
         }
@@ -164,7 +169,10 @@ void SelectionOverlayPass::Render(Viewer3DController &controller,
     return std::array<float, 3>{1.0f, 1.0f, 1.0f};
   };
 
-  wxLogDebug("Highlight: begin");
+  wxLogDebug("Highlight: begin hover=%d group=%llu selected=%llu",
+             controller.m_highlightUuid.empty() ? 0 : 1,
+             static_cast<unsigned long long>(controller.m_groupHighlightUuids.size()),
+             static_cast<unsigned long long>(controller.m_selectedUuids.size()));
   {
     viewer3d::render::OpenGLStateGuard stateGuard;
 
@@ -183,5 +191,6 @@ void SelectionOverlayPass::Render(Viewer3DController &controller,
                               getPickColor);
     glDepthFunc(static_cast<GLenum>(previousDepthFunc));
   }
-  wxLogDebug("Highlight: restored OpenGL state");
+  wxLogDebug(
+      "Highlight: restored OpenGL state for hover, group, and selected overlays");
 }


### PR DESCRIPTION
### Motivation
- Prevent native driver crashes and visual corruption traced to unsafe depth/id reads and leaked GL state during hover/picking/highlight (notably on Intel Windows drivers and macOS). 
- Ensure picking never runs when GL context, viewport, or framebuffer state is invalid and add diagnostics to make future crash reports actionable. 
- Restore critical GL state after temporary highlight/picking passes so normal rendering is not polluted by highlight work.

### Description
- Added `viewer3d::render::OpenGLStateGuard` (`viewer3d/render/opengl_state_guard.{h,cpp}`) that captures and restores shader/VAO/BUFFERS/framebuffer/read-buffer/viewport/depth/cull/front-face/blend/stencil/color-mask/polygon-offset/active-texture state. 
- Hardened `ReadWorldPointFromDepth` in `selectionsystem.cpp` to verify a current GL context, validate viewport and framebuffer coordinates (with clamping/out-of-range checks), clear/drain GL errors around `glReadPixels`, and reject invalid depth values instead of calling `glReadPixels` unsafely. 
- Wrapped ID-pick framebuffer rebuild/read and ID `glReadPixels` in `id_pick_pass.cpp` with the state guard and added GL-error diagnostics (including mouse/framebuffer coordinates and GL vendor/renderer strings) and safe `glReadBuffer` selection. 
- Wrapped highlight/overlay rendering in `selection_overlay_pass.cpp` inside the state guard and added concise begin/restore debug logs so highlight rendering cannot leak culling/front-face/depth/framebuffer state into the main pass. 
- Registered the new source in the explicit Viewer3D CMake lists and updated `docs/release-notes-draft.md` with the stability improvement note.

### Testing
- `tests/check_perastage_tree_modules.sh` ran and passed successfully. 
- `tests/check_no_configmanager_get_in_gui.sh` ran and passed successfully. 
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` could not complete in this environment because the system lacks the wxWidgets development libraries, so a full build was not executed here (CMake configure failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cdfe116c483249836b68c0b29de88)