### PR TITLE
Refine 3D picking depth confirmation policy

### DIFF
--- a/core/configmanager.cpp
+++ b/core/configmanager.cpp
@@ -230,7 +230,7 @@ ConfigManager::ConfigManager() {
   RegisterVariable("viewer3d_fast_interaction_mode", "float", 1.0f, 0.0f,
                    1.0f);
   RegisterVariable("viewer3d_pick_use_id_buffer", "float", 1.0f, 0.0f, 1.0f);
-  RegisterVariable("viewer3d_pick_confirm_depth_ambiguous", "float", 1.0f,
+  RegisterVariable("viewer3d_pick_confirm_depth_ambiguous", "float", 0.0f,
                    0.0f, 1.0f);
   RegisterVariable("viewer3d_ambient_occlusion", "float", 1.0f, 0.0f,
                    1.0f);

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -14,7 +14,7 @@ Changes since **v1.4.0**.
 - Hardened 3D ID-buffer picking setup so incomplete OpenGL framebuffers fall back to ray-based selection.
 - Simplified 3D hover and selection highlighting so highlighted objects are drawn in the normal scene pass instead of a separate overlay pass or cached framebuffer refresh.
 - Fixed 3D mesh GPU draw paths so VAO element-buffer bindings are preserved during highlight, wireframe, and shaded rendering.
-- Changed 3D hover picking to avoid the offscreen ID-buffer render path, reducing hover-related OpenGL side effects on macOS and Intel drivers.
+- Changed 3D hover and click picking to trust valid ID-buffer hits first while keeping depth/ray confirmation as an opt-in diagnostic fallback.
 - Reset transient OpenGL state at the start of each 3D frame to prevent stale hover-highlight state from affecting subsequent macOS renders.
 - Windows crash reports now include a matching `.dmp` minidump file for post-crash analysis with release `.pdb` symbols.
 - Improved Windows diagnostic OS version reporting so modern Windows versions are identified more accurately.
@@ -23,6 +23,7 @@ Changes since **v1.4.0**.
 
 ## Stability and diagnostics
 
+- Disabled optional depth-read picking by default and skipped it on Windows Intel OpenGL drivers to avoid unsafe depth-buffer reads during normal selection.
 - Hardened 3D hover picking plus hover, group, and selected highlight rendering to avoid unsafe OpenGL pixel reads and restore critical render state after overlay highlights on Intel Windows drivers and macOS.
 - Hardened 3D picking coordinate validation to avoid unsafe OpenGL reads near viewport edges and during zero-sized or out-of-range viewer states.
 - Improved Windows crash dumps so native access violations are captured from the original exception context before best-effort text stack reporting.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -14,7 +14,7 @@ Changes since **v1.4.0**.
 - Hardened 3D ID-buffer picking setup so incomplete OpenGL framebuffers fall back to ray-based selection.
 - Simplified 3D hover and selection highlighting so highlighted objects are drawn in the normal scene pass instead of a separate overlay pass or cached framebuffer refresh.
 - Fixed 3D mesh GPU draw paths so VAO element-buffer bindings are preserved during highlight, wireframe, and shaded rendering.
-- Changed 3D hover and click picking to trust valid ID-buffer hits first, treat confirmed empty ID pixels as no hit, and keep depth/ray confirmation as an opt-in diagnostic fallback.
+- Changed 3D hover and click picking to trust valid ID-buffer hits first, treat confirmed empty ID pixels as no hit, support two-sided ID picking for inverted faces, and keep depth/ray confirmation as an opt-in diagnostic fallback.
 - Prevented recoverable 3D picking fallback conditions during mouse movement from showing blocking warning dialogs.
 - Reset transient OpenGL state at the start of each 3D frame to prevent stale hover-highlight state from affecting subsequent macOS renders.
 - Windows crash reports now include a matching `.dmp` minidump file for post-crash analysis with release `.pdb` symbols.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -14,7 +14,7 @@ Changes since **v1.4.0**.
 - Hardened 3D ID-buffer picking setup so incomplete OpenGL framebuffers fall back to ray-based selection.
 - Simplified 3D hover and selection highlighting so highlighted objects are drawn in the normal scene pass instead of a separate overlay pass or cached framebuffer refresh.
 - Fixed 3D mesh GPU draw paths so VAO element-buffer bindings are preserved during highlight, wireframe, and shaded rendering.
-- Changed 3D hover and click picking to trust valid ID-buffer hits first while keeping depth/ray confirmation as an opt-in diagnostic fallback.
+- Changed 3D hover and click picking to trust valid ID-buffer hits first, treat confirmed empty ID pixels as no hit, and keep depth/ray confirmation as an opt-in diagnostic fallback.
 - Prevented recoverable 3D picking fallback conditions during mouse movement from showing blocking warning dialogs.
 - Reset transient OpenGL state at the start of each 3D frame to prevent stale hover-highlight state from affecting subsequent macOS renders.
 - Windows crash reports now include a matching `.dmp` minidump file for post-crash analysis with release `.pdb` symbols.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -15,6 +15,7 @@ Changes since **v1.4.0**.
 - Simplified 3D hover and selection highlighting so highlighted objects are drawn in the normal scene pass instead of a separate overlay pass or cached framebuffer refresh.
 - Fixed 3D mesh GPU draw paths so VAO element-buffer bindings are preserved during highlight, wireframe, and shaded rendering.
 - Changed 3D hover and click picking to trust valid ID-buffer hits first while keeping depth/ray confirmation as an opt-in diagnostic fallback.
+- Prevented benign out-of-range 3D ID-picking checks during mouse movement from showing blocking warning dialogs.
 - Reset transient OpenGL state at the start of each 3D frame to prevent stale hover-highlight state from affecting subsequent macOS renders.
 - Windows crash reports now include a matching `.dmp` minidump file for post-crash analysis with release `.pdb` symbols.
 - Improved Windows diagnostic OS version reporting so modern Windows versions are identified more accurately.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -15,7 +15,7 @@ Changes since **v1.4.0**.
 - Simplified 3D hover and selection highlighting so highlighted objects are drawn in the normal scene pass instead of a separate overlay pass or cached framebuffer refresh.
 - Fixed 3D mesh GPU draw paths so VAO element-buffer bindings are preserved during highlight, wireframe, and shaded rendering.
 - Changed 3D hover and click picking to trust valid ID-buffer hits first while keeping depth/ray confirmation as an opt-in diagnostic fallback.
-- Prevented benign out-of-range 3D ID-picking checks during mouse movement from showing blocking warning dialogs.
+- Prevented recoverable 3D picking fallback conditions during mouse movement from showing blocking warning dialogs.
 - Reset transient OpenGL state at the start of each 3D frame to prevent stale hover-highlight state from affecting subsequent macOS renders.
 - Windows crash reports now include a matching `.dmp` minidump file for post-crash analysis with release `.pdb` symbols.
 - Improved Windows diagnostic OS version reporting so modern Windows versions are identified more accurately.

--- a/viewer3d/interfaces/iselectioncontext.h
+++ b/viewer3d/interfaces/iselectioncontext.h
@@ -16,6 +16,8 @@ public:
   using VisibleSet = Viewer3DVisibleSet;
   using ViewFrustumSnapshot = Viewer3DViewFrustumSnapshot;
 
+  enum class PickReadResult { Unavailable, Miss, Hit };
+
   virtual ~ISelectionContext() = default;
 
   virtual void ApplyHighlightUuid(const std::string &uuid) = 0;
@@ -46,6 +48,10 @@ public:
   virtual ICanvas2D *GetCaptureCanvas() const = 0;
   virtual void RecordText(float x, float y, const std::string &text,
                           const CanvasTextStyle &style) const = 0;
+  virtual PickReadResult ReadPickUuidAtDetailed(
+      int mouseX, int mouseY, int width, int height,
+      const std::unordered_set<std::string> &hiddenLayers,
+      std::string &outUuid) = 0;
   virtual bool ReadPickUuidAt(int mouseX, int mouseY, int width, int height,
                               const std::unordered_set<std::string> &hiddenLayers,
                               std::string &outUuid) = 0;

--- a/viewer3d/picking/id_pick_pass.cpp
+++ b/viewer3d/picking/id_pick_pass.cpp
@@ -143,6 +143,7 @@ void IdPickPass::RebuildIfNeeded(
   glViewport(0, 0, width, height);
   glDisable(GL_BLEND);
   glEnable(GL_DEPTH_TEST);
+  glDisable(GL_CULL_FACE);
   glDisable(GL_LIGHTING);
   glDisable(GL_TEXTURE_2D);
   glClearColor(0.0f, 0.0f, 0.0f, 0.0f);

--- a/viewer3d/picking/id_pick_pass.cpp
+++ b/viewer3d/picking/id_pick_pass.cpp
@@ -203,6 +203,7 @@ void IdPickPass::RebuildIfNeeded(
   m_dirty = false;
 }
 
+// Reads the UUID encoded in the ID-picking framebuffer at the requested pixel.
 bool IdPickPass::ReadUuidAt(int mouseX, int mouseY, int width, int height,
                             const std::unordered_set<std::string> &hiddenLayers,
                             std::string &outUuid) {
@@ -215,11 +216,12 @@ bool IdPickPass::ReadUuidAt(int mouseX, int mouseY, int width, int height,
   if (!TryConvertMouseToFramebufferPoint(mouseX, mouseY, width, height,
                                          framebufferX, framebufferY)) {
     if (!m_loggedInvalidReadCoordinates) {
-      wxLogWarning(
+      wxLogDebug(
           "Viewer3D ID picking skipped an out-of-range read at mouse=(%d,%d), framebuffer=(%d,%d).",
           mouseX, mouseY, width, height);
       m_loggedInvalidReadCoordinates = true;
     }
+    outUuid.clear();
     return false;
   }
 

--- a/viewer3d/picking/id_pick_pass.cpp
+++ b/viewer3d/picking/id_pick_pass.cpp
@@ -93,7 +93,7 @@ void IdPickPass::EnsureFramebufferSize(int width, int height) {
   const GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
   if (status != GL_FRAMEBUFFER_COMPLETE) {
     if (!m_loggedFramebufferFailure) {
-      wxLogWarning(
+      wxLogDebug(
           "Viewer3D ID picking framebuffer is incomplete (status=0x%04x). Falling back to ray picking for this session.",
           static_cast<unsigned int>(status));
       m_loggedFramebufferFailure = true;
@@ -233,7 +233,7 @@ bool IdPickPass::ReadUuidAt(int mouseX, int mouseY, int width, int height,
   glReadPixels(framebufferX, framebufferY, 1, 1, GL_RGB, GL_UNSIGNED_BYTE, pixel);
   const GLenum readError = viewer3d::render::DrainOpenGLErrors();
   if (readError != GL_NO_ERROR) {
-    wxLogWarning(
+    wxLogDebug(
         "Picking: glReadPixels ID read failed error=0x%04x mouse=(%d,%d) framebuffer=(%d,%d) size=(%d,%d) vendor=%s renderer=%s.",
         static_cast<unsigned int>(readError), mouseX, mouseY, framebufferX,
         framebufferY, width, height, viewer3d::render::SafeGlString(GL_VENDOR),

--- a/viewer3d/picking/id_pick_pass.cpp
+++ b/viewer3d/picking/id_pick_pass.cpp
@@ -204,12 +204,13 @@ void IdPickPass::RebuildIfNeeded(
 }
 
 // Reads the UUID encoded in the ID-picking framebuffer at the requested pixel.
-bool IdPickPass::ReadUuidAt(int mouseX, int mouseY, int width, int height,
-                            const std::unordered_set<std::string> &hiddenLayers,
-                            std::string &outUuid) {
+IdPickPass::ReadResult IdPickPass::ReadUuidAtDetailed(
+    int mouseX, int mouseY, int width, int height,
+    const std::unordered_set<std::string> &hiddenLayers, std::string &outUuid) {
+  outUuid.clear();
   RebuildIfNeeded(width, height, hiddenLayers);
   if (m_fbo == 0 || !m_framebufferUsable)
-    return false;
+    return ReadResult::Unavailable;
 
   int framebufferX = 0;
   int framebufferY = 0;
@@ -221,8 +222,7 @@ bool IdPickPass::ReadUuidAt(int mouseX, int mouseY, int width, int height,
           mouseX, mouseY, width, height);
       m_loggedInvalidReadCoordinates = true;
     }
-    outUuid.clear();
-    return false;
+    return ReadResult::Miss;
   }
 
   viewer3d::render::OpenGLStateGuard stateGuard;
@@ -238,19 +238,27 @@ bool IdPickPass::ReadUuidAt(int mouseX, int mouseY, int width, int height,
         static_cast<unsigned int>(readError), mouseX, mouseY, framebufferX,
         framebufferY, width, height, viewer3d::render::SafeGlString(GL_VENDOR),
         viewer3d::render::SafeGlString(GL_RENDERER));
-    return false;
+    return ReadResult::Unavailable;
   }
 
   const uint32_t pickId = (static_cast<uint32_t>(pixel[0]) << 16) |
                           (static_cast<uint32_t>(pixel[1]) << 8) |
                           static_cast<uint32_t>(pixel[2]);
   if (pickId == 0)
-    return false;
+    return ReadResult::Miss;
 
   auto it = m_pickIdToUuid.find(pickId);
   if (it == m_pickIdToUuid.end())
-    return false;
+    return ReadResult::Miss;
 
   outUuid = it->second;
-  return true;
+  return ReadResult::Hit;
+}
+
+// Reads whether the ID-picking framebuffer contains a UUID at the requested pixel.
+bool IdPickPass::ReadUuidAt(int mouseX, int mouseY, int width, int height,
+                            const std::unordered_set<std::string> &hiddenLayers,
+                            std::string &outUuid) {
+  return ReadUuidAtDetailed(mouseX, mouseY, width, height, hiddenLayers,
+                            outUuid) == ReadResult::Hit;
 }

--- a/viewer3d/picking/id_pick_pass.h
+++ b/viewer3d/picking/id_pick_pass.h
@@ -15,6 +15,11 @@ public:
   explicit IdPickPass(Viewer3DController &controller);
   ~IdPickPass();
 
+  enum class ReadResult { Unavailable, Miss, Hit };
+
+  ReadResult ReadUuidAtDetailed(
+      int mouseX, int mouseY, int width, int height,
+      const std::unordered_set<std::string> &hiddenLayers, std::string &outUuid);
   bool ReadUuidAt(int mouseX, int mouseY, int width, int height,
                   const std::unordered_set<std::string> &hiddenLayers,
                   std::string &outUuid);

--- a/viewer3d/picking/selectionsystem.cpp
+++ b/viewer3d/picking/selectionsystem.cpp
@@ -585,8 +585,10 @@ bool SelectionSystem::GetHoverUuidAt(int mouseX, int mouseY, int width,
 
   if (useIdBuffer) {
     std::string pickedUuid;
-    if (m_controller.ReadPickUuidAt(mouseX, mouseY, width, height, hiddenLayers,
-                                    pickedUuid) &&
+    const ISelectionContext::PickReadResult pickResult =
+        m_controller.ReadPickUuidAtDetailed(mouseX, mouseY, width, height,
+                                            hiddenLayers, pickedUuid);
+    if (pickResult == ISelectionContext::PickReadResult::Hit &&
         IsUuidValidForTarget(pickedUuid, target, hiddenLayers, m_controller,
                              nullptr)) {
       metrics.usedIdPath = true;
@@ -596,6 +598,10 @@ bool SelectionSystem::GetHoverUuidAt(int mouseX, int mouseY, int width,
       LogQueryMetrics("hover_uuid(id)", metrics, m_queryTelemetry,
                       ++m_queryCounter);
       return true;
+    }
+    if (pickResult != ISelectionContext::PickReadResult::Unavailable) {
+      outUuid.clear();
+      return false;
     }
   }
 
@@ -711,8 +717,10 @@ bool SelectionSystem::GetFixtureLabelAt(int mouseX, int mouseY, int width,
 
   if (useIdBuffer) {
     std::string pickedUuid;
-    if (m_controller.ReadPickUuidAt(mouseX, mouseY, width, height, hiddenLayers,
-                                    pickedUuid)) {
+    const ISelectionContext::PickReadResult pickResult =
+        m_controller.ReadPickUuidAtDetailed(mouseX, mouseY, width, height,
+                                            hiddenLayers, pickedUuid);
+    if (pickResult == ISelectionContext::PickReadResult::Hit) {
       const auto &fixtures = SceneDataManager::Instance().GetFixtures();
       auto fixtureIt = fixtures.find(pickedUuid);
       if (fixtureIt != fixtures.end()) {
@@ -747,6 +755,11 @@ bool SelectionSystem::GetFixtureLabelAt(int mouseX, int mouseY, int width,
           }
         }
       }
+    }
+    if (!found && pickResult != ISelectionContext::PickReadResult::Unavailable) {
+      if (outUuid)
+        outUuid->clear();
+      return false;
     }
     if (found) {
       m_queryTelemetry.totalQueries++;
@@ -925,8 +938,10 @@ bool SelectionSystem::GetTrussLabelAt(int mouseX, int mouseY, int width,
   std::string bestUuid;
   if (useIdBuffer) {
     std::string pickedUuid;
-    if (m_controller.ReadPickUuidAt(mouseX, mouseY, width, height, hiddenLayers,
-                                    pickedUuid)) {
+    const ISelectionContext::PickReadResult pickResult =
+        m_controller.ReadPickUuidAtDetailed(mouseX, mouseY, width, height,
+                                            hiddenLayers, pickedUuid);
+    if (pickResult == ISelectionContext::PickReadResult::Hit) {
       const auto &trusses = SceneDataManager::Instance().GetTrusses();
       auto trussIt = trusses.find(pickedUuid);
       if (trussIt != trusses.end()) {
@@ -944,6 +959,11 @@ bool SelectionSystem::GetTrussLabelAt(int mouseX, int mouseY, int width,
           }
         }
       }
+    }
+    if (!found && pickResult != ISelectionContext::PickReadResult::Unavailable) {
+      if (outUuid)
+        outUuid->clear();
+      return false;
     }
     if (found) {
       m_queryTelemetry.totalQueries++;
@@ -1100,8 +1120,10 @@ bool SelectionSystem::GetSceneObjectLabelAt(int mouseX, int mouseY, int width,
   std::string bestUuid;
   if (useIdBuffer) {
     std::string pickedUuid;
-    if (m_controller.ReadPickUuidAt(mouseX, mouseY, width, height, hiddenLayers,
-                                    pickedUuid)) {
+    const ISelectionContext::PickReadResult pickResult =
+        m_controller.ReadPickUuidAtDetailed(mouseX, mouseY, width, height,
+                                            hiddenLayers, pickedUuid);
+    if (pickResult == ISelectionContext::PickReadResult::Hit) {
       const auto &sceneObjects = SceneDataManager::Instance().GetSceneObjects();
       auto objectIt = sceneObjects.find(pickedUuid);
       if (objectIt != sceneObjects.end()) {
@@ -1118,6 +1140,11 @@ bool SelectionSystem::GetSceneObjectLabelAt(int mouseX, int mouseY, int width,
           }
         }
       }
+    }
+    if (!found && pickResult != ISelectionContext::PickReadResult::Unavailable) {
+      if (outUuid)
+        outUuid->clear();
+      return false;
     }
     if (found) {
       m_queryTelemetry.totalQueries++;

--- a/viewer3d/picking/selectionsystem.cpp
+++ b/viewer3d/picking/selectionsystem.cpp
@@ -25,9 +25,11 @@
 #include "units/units.h"
 #include <algorithm>
 #include <array>
+#include <cctype>
 #include <cfloat>
 #include <cmath>
 #include <cstring>
+#include <string>
 #include <unordered_set>
 #include <wx/log.h>
 
@@ -74,6 +76,70 @@ bool IsAmbiguousDepthConfirmEnabled(const ConfigManager &cfg) {
   return cfg.GetFloat("viewer3d_pick_confirm_depth_ambiguous") >= 0.5f;
 }
 
+// Returns whether a GL renderer string appears to be an Intel Windows driver.
+bool IsWindowsIntelRenderer() {
+#ifdef _WIN32
+  const char *vendor = viewer3d::render::SafeGlString(GL_VENDOR);
+  const char *renderer = viewer3d::render::SafeGlString(GL_RENDERER);
+  const std::string vendorText = vendor ? vendor : "";
+  const std::string rendererText = renderer ? renderer : "";
+  auto containsIntel = [](std::string text) {
+    std::transform(text.begin(), text.end(), text.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    return text.find("intel") != std::string::npos;
+  };
+  return containsIntel(vendorText) || containsIntel(rendererText);
+#else
+  return false;
+#endif
+}
+
+// Stores the session-level depth-read picking disable state.
+bool &DepthReadPickingDisabledForSession() {
+  static bool disabledForSession = false;
+  return disabledForSession;
+}
+
+// Returns whether depth-buffer picking may use glReadPixels for this session.
+bool IsDepthReadPickingAllowed(const ConfigManager &cfg, const char **outReason) {
+  if (!IsAmbiguousDepthConfirmEnabled(cfg)) {
+    if (outReason)
+      *outReason = "viewer3d_pick_confirm_depth_ambiguous is disabled";
+    return false;
+  }
+  if (DepthReadPickingDisabledForSession()) {
+    if (outReason)
+      *outReason = "depth-read picking was disabled after an earlier GL error";
+    return false;
+  }
+  if (IsWindowsIntelRenderer()) {
+    if (outReason)
+      *outReason = "depth-read picking is disabled on Windows Intel OpenGL drivers";
+    return false;
+  }
+  if (outReason)
+    *outReason = "enabled";
+  return true;
+}
+
+// Disables depth-buffer picking for the remainder of the session.
+void DisableDepthReadPickingForSession() {
+  DepthReadPickingDisabledForSession() = true;
+}
+
+// Returns whether this query should perform optional depth confirmation.
+bool ShouldConfirmDepthForQuery(bool confirmDepth, const ConfigManager &cfg) {
+  if (!confirmDepth)
+    return false;
+  const char *reason = nullptr;
+  const bool allowed = IsDepthReadPickingAllowed(cfg, &reason);
+  if (!allowed)
+    wxLogDebug("Picking: skipped depth confirmation because %s.",
+               reason ? reason : "depth-read picking is not allowed");
+  return allowed;
+}
+
+// Captures the current OpenGL projection matrices and viewport.
 ProjectionSnapshot CaptureProjectionSnapshot() {
   ProjectionSnapshot snapshot;
   glGetDoublev(GL_MODELVIEW_MATRIX, snapshot.model);
@@ -227,6 +293,30 @@ bool ReadWorldPointFromDepth(int mouseX, int mouseY, int screenHeight,
   else
     readFramebuffer = framebuffer;
   glGetIntegerv(GL_READ_BUFFER, &readBuffer);
+  if (readFramebuffer == 0) {
+    wxLogWarning(
+        "Picking: skipped depth read because no controlled read framebuffer is bound.");
+    return false;
+  }
+  if (readBuffer == GL_NONE) {
+    wxLogWarning(
+        "Picking: skipped depth read because the active read buffer is GL_NONE framebuffer=%d readFramebuffer=%d.",
+        framebuffer, readFramebuffer);
+    return false;
+  }
+
+  if (GLEW_VERSION_3_0 || GLEW_EXT_framebuffer_object ||
+      GLEW_ARB_framebuffer_object) {
+    const GLenum framebufferStatus = glCheckFramebufferStatus(GL_READ_FRAMEBUFFER);
+    if (framebufferStatus != GL_FRAMEBUFFER_COMPLETE) {
+      wxLogWarning(
+          "Picking: skipped depth read because read framebuffer is incomplete status=0x%04x framebuffer=%d readFramebuffer=%d.",
+          static_cast<unsigned int>(framebufferStatus), framebuffer,
+          readFramebuffer);
+      DisableDepthReadPickingForSession();
+      return false;
+    }
+  }
 
   viewer3d::render::ClearOpenGLErrors();
   float depth = 1.0f;
@@ -235,12 +325,13 @@ bool ReadWorldPointFromDepth(int mouseX, int mouseY, int screenHeight,
   const GLenum readError = viewer3d::render::DrainOpenGLErrors();
   if (readError != GL_NO_ERROR) {
     wxLogWarning(
-        "Picking: glReadPixels depth read failed error=0x%04x framebuffer=%d readFramebuffer=%d readBuffer=0x%04x viewport=(%d,%d,%d,%d) vendor=%s renderer=%s.",
+        "Picking: glReadPixels depth read failed error=0x%04x framebuffer=%d readFramebuffer=%d readBuffer=0x%04x viewport=(%d,%d,%d,%d) vendor=%s renderer=%s. Depth-read picking is disabled for this session.",
         static_cast<unsigned int>(readError), framebuffer, readFramebuffer,
         static_cast<unsigned int>(readBuffer), currentViewport[0],
         currentViewport[1], currentViewport[2], currentViewport[3],
         viewer3d::render::SafeGlString(GL_VENDOR),
         viewer3d::render::SafeGlString(GL_RENDERER));
+    DisableDepthReadPickingForSession();
     return false;
   }
   if (depth < 0.0f || depth >= 1.0f || !std::isfinite(depth))
@@ -483,9 +574,7 @@ bool SelectionSystem::GetHoverUuidAt(int mouseX, int mouseY, int width,
   if (m_controller.IsCameraMoving() && IsFastInteractionModeEnabled(cfg))
     return false;
 
-  const bool cameraMoving = m_controller.IsCameraMoving();
-  // Hover picking avoids the offscreen ID render path to keep hover side-effect free.
-  const bool useIdBuffer = false;
+  const bool useIdBuffer = IsIdBufferPickingEnabled(cfg);
   const auto hiddenLayers = SnapshotHiddenLayers(cfg);
   QueryMetrics metrics;
   std::string bestUuid;
@@ -497,14 +586,12 @@ bool SelectionSystem::GetHoverUuidAt(int mouseX, int mouseY, int width,
         IsUuidValidForTarget(pickedUuid, target, hiddenLayers, m_controller,
                              nullptr)) {
       metrics.usedIdPath = true;
-      if (cameraMoving || !IsAmbiguousDepthConfirmEnabled(cfg) || !confirmDepth) {
-        outUuid = pickedUuid;
-        metrics.total = std::chrono::duration_cast<std::chrono::microseconds>(
-            std::chrono::steady_clock::now() - queryStart);
-        LogQueryMetrics("hover_uuid(id)", metrics, m_queryTelemetry,
-                        ++m_queryCounter);
-        return true;
-      }
+      outUuid = pickedUuid;
+      metrics.total = std::chrono::duration_cast<std::chrono::microseconds>(
+          std::chrono::steady_clock::now() - queryStart);
+      LogQueryMetrics("hover_uuid(id)", metrics, m_queryTelemetry,
+                      ++m_queryCounter);
+      return true;
     }
   }
 
@@ -531,7 +618,8 @@ bool SelectionSystem::GetHoverUuidAt(int mouseX, int mouseY, int width,
   const auto depthReadStart = std::chrono::steady_clock::now();
   bool hasDepthWorldPoint = false;
   std::array<double, 3> depthWorldPoint{};
-  const bool shouldReadDepth = confirmDepth &&
+  const bool allowDepthConfirmation = ShouldConfirmDepthForQuery(confirmDepth, cfg);
+  const bool shouldReadDepth = allowDepthConfirmation &&
                                (projectionChanged || m_queryCache.depthMouseX != mouseX ||
                                 m_queryCache.depthMouseY != mouseY ||
                                 m_queryCache.depthHeight != height);
@@ -543,7 +631,7 @@ bool SelectionSystem::GetHoverUuidAt(int mouseX, int mouseY, int width,
     m_queryCache.depthMouseY = mouseY;
     m_queryCache.depthHeight = height;
   }
-  if (confirmDepth) {
+  if (allowDepthConfirmation) {
     hasDepthWorldPoint = m_queryCache.hasDepthWorldPoint;
     depthWorldPoint = m_queryCache.depthWorldPoint;
   }
@@ -611,7 +699,6 @@ bool SelectionSystem::GetFixtureLabelAt(int mouseX, int mouseY, int width,
   ConfigManager &cfg = ConfigManager::Get();
   if (m_controller.IsCameraMoving() && IsFastInteractionModeEnabled(cfg))
     return false;
-  const bool cameraMoving = m_controller.IsCameraMoving();
   const bool useIdBuffer = IsIdBufferPickingEnabled(cfg);
   const auto hiddenLayers = SnapshotHiddenLayers(cfg);
   QueryMetrics metrics;
@@ -653,10 +740,6 @@ bool SelectionSystem::GetFixtureLabelAt(int mouseX, int mouseY, int width,
               *outUuid = pickedUuid;
             found = true;
             metrics.usedIdPath = true;
-            if (!cameraMoving && IsAmbiguousDepthConfirmEnabled(cfg) &&
-                confirmDepth) {
-              found = false;
-            }
           }
         }
       }
@@ -698,7 +781,8 @@ bool SelectionSystem::GetFixtureLabelAt(int mouseX, int mouseY, int width,
   const auto depthReadStart = std::chrono::steady_clock::now();
   bool hasDepthWorldPoint = false;
   std::array<double, 3> depthWorldPoint{};
-  const bool shouldReadDepth = confirmDepth &&
+  const bool allowDepthConfirmation = ShouldConfirmDepthForQuery(confirmDepth, cfg);
+  const bool shouldReadDepth = allowDepthConfirmation &&
                                (projectionChanged || m_queryCache.depthMouseX != mouseX ||
                                 m_queryCache.depthMouseY != mouseY ||
                                 m_queryCache.depthHeight != height);
@@ -710,7 +794,7 @@ bool SelectionSystem::GetFixtureLabelAt(int mouseX, int mouseY, int width,
     m_queryCache.depthMouseY = mouseY;
     m_queryCache.depthHeight = height;
   }
-  if (confirmDepth) {
+  if (allowDepthConfirmation) {
     hasDepthWorldPoint = m_queryCache.hasDepthWorldPoint;
     depthWorldPoint = m_queryCache.depthWorldPoint;
   }
@@ -830,7 +914,6 @@ bool SelectionSystem::GetTrussLabelAt(int mouseX, int mouseY, int width,
   ConfigManager &cfg = ConfigManager::Get();
   if (m_controller.IsCameraMoving() && IsFastInteractionModeEnabled(cfg))
     return false;
-  const bool cameraMoving = m_controller.IsCameraMoving();
   const bool useIdBuffer = IsIdBufferPickingEnabled(cfg);
   const auto hiddenLayers = SnapshotHiddenLayers(cfg);
   QueryMetrics metrics;
@@ -854,10 +937,6 @@ bool SelectionSystem::GetTrussLabelAt(int mouseX, int mouseY, int width,
               *outUuid = pickedUuid;
             found = true;
             metrics.usedIdPath = true;
-            if (!cameraMoving && IsAmbiguousDepthConfirmEnabled(cfg) &&
-                confirmDepth) {
-              found = false;
-            }
           }
         }
       }
@@ -898,7 +977,8 @@ bool SelectionSystem::GetTrussLabelAt(int mouseX, int mouseY, int width,
   const auto depthReadStart = std::chrono::steady_clock::now();
   bool hasDepthWorldPoint = false;
   std::array<double, 3> depthWorldPoint{};
-  const bool shouldReadDepth = confirmDepth &&
+  const bool allowDepthConfirmation = ShouldConfirmDepthForQuery(confirmDepth, cfg);
+  const bool shouldReadDepth = allowDepthConfirmation &&
                                (projectionChanged || m_queryCache.depthMouseX != mouseX ||
                                 m_queryCache.depthMouseY != mouseY ||
                                 m_queryCache.depthHeight != height);
@@ -910,7 +990,7 @@ bool SelectionSystem::GetTrussLabelAt(int mouseX, int mouseY, int width,
     m_queryCache.depthMouseY = mouseY;
     m_queryCache.depthHeight = height;
   }
-  if (confirmDepth) {
+  if (allowDepthConfirmation) {
     hasDepthWorldPoint = m_queryCache.hasDepthWorldPoint;
     depthWorldPoint = m_queryCache.depthWorldPoint;
   }
@@ -1009,7 +1089,6 @@ bool SelectionSystem::GetSceneObjectLabelAt(int mouseX, int mouseY, int width,
   ConfigManager &cfg = ConfigManager::Get();
   if (m_controller.IsCameraMoving() && IsFastInteractionModeEnabled(cfg))
     return false;
-  const bool cameraMoving = m_controller.IsCameraMoving();
   const bool useIdBuffer = IsIdBufferPickingEnabled(cfg);
   const auto hiddenLayers = SnapshotHiddenLayers(cfg);
   QueryMetrics metrics;
@@ -1032,10 +1111,6 @@ bool SelectionSystem::GetSceneObjectLabelAt(int mouseX, int mouseY, int width,
               *outUuid = pickedUuid;
             found = true;
             metrics.usedIdPath = true;
-            if (!cameraMoving && IsAmbiguousDepthConfirmEnabled(cfg) &&
-                confirmDepth) {
-              found = false;
-            }
           }
         }
       }
@@ -1076,7 +1151,8 @@ bool SelectionSystem::GetSceneObjectLabelAt(int mouseX, int mouseY, int width,
   const auto depthReadStart = std::chrono::steady_clock::now();
   bool hasDepthWorldPoint = false;
   std::array<double, 3> depthWorldPoint{};
-  const bool shouldReadDepth = confirmDepth &&
+  const bool allowDepthConfirmation = ShouldConfirmDepthForQuery(confirmDepth, cfg);
+  const bool shouldReadDepth = allowDepthConfirmation &&
                                (projectionChanged || m_queryCache.depthMouseX != mouseX ||
                                 m_queryCache.depthMouseY != mouseY ||
                                 m_queryCache.depthHeight != height);
@@ -1088,7 +1164,7 @@ bool SelectionSystem::GetSceneObjectLabelAt(int mouseX, int mouseY, int width,
     m_queryCache.depthMouseY = mouseY;
     m_queryCache.depthHeight = height;
   }
-  if (confirmDepth) {
+  if (allowDepthConfirmation) {
     hasDepthWorldPoint = m_queryCache.hasDepthWorldPoint;
     depthWorldPoint = m_queryCache.depthWorldPoint;
   }

--- a/viewer3d/picking/selectionsystem.cpp
+++ b/viewer3d/picking/selectionsystem.cpp
@@ -251,7 +251,8 @@ bool ReadWorldPointFromDepth(int mouseX, int mouseY, int screenHeight,
                              const ProjectionSnapshot &projection,
                              std::array<double, 3> &outWorldPoint) {
   if (!viewer3d::render::HasCurrentOpenGLContext()) {
-    wxLogWarning("Picking: skipped due to invalid context before depth read.");
+    wxLogDebug("Picking: skipped due to invalid context before depth read.");
+    DisableDepthReadPickingForSession();
     return false;
   }
 
@@ -259,10 +260,11 @@ bool ReadWorldPointFromDepth(int mouseX, int mouseY, int screenHeight,
   glGetIntegerv(GL_VIEWPORT, currentViewport);
   if (currentViewport[2] <= 0 || currentViewport[3] <= 0 ||
       projection.viewport[2] <= 0 || projection.viewport[3] <= 0) {
-    wxLogWarning(
+    wxLogDebug(
         "Picking: skipped due to invalid viewport before depth read viewport=(%d,%d,%d,%d).",
         currentViewport[0], currentViewport[1], currentViewport[2],
         currentViewport[3]);
+    DisableDepthReadPickingForSession();
     return false;
   }
 
@@ -277,7 +279,7 @@ bool ReadWorldPointFromDepth(int mouseX, int mouseY, int screenHeight,
   if (framebufferX < currentViewport[0] || framebufferY < currentViewport[1] ||
       framebufferX >= currentViewport[0] + currentViewport[2] ||
       framebufferY >= currentViewport[1] + currentViewport[3]) {
-    wxLogWarning(
+    wxLogDebug(
         "Picking: skipped due to out-of-viewport depth read mouse=(%d,%d) framebuffer=(%d,%d) viewport=(%d,%d,%d,%d).",
         mouseX, mouseY, framebufferX, framebufferY, currentViewport[0],
         currentViewport[1], currentViewport[2], currentViewport[3]);
@@ -294,14 +296,16 @@ bool ReadWorldPointFromDepth(int mouseX, int mouseY, int screenHeight,
     readFramebuffer = framebuffer;
   glGetIntegerv(GL_READ_BUFFER, &readBuffer);
   if (readFramebuffer == 0) {
-    wxLogWarning(
+    wxLogDebug(
         "Picking: skipped depth read because no controlled read framebuffer is bound.");
+    DisableDepthReadPickingForSession();
     return false;
   }
   if (readBuffer == GL_NONE) {
-    wxLogWarning(
+    wxLogDebug(
         "Picking: skipped depth read because the active read buffer is GL_NONE framebuffer=%d readFramebuffer=%d.",
         framebuffer, readFramebuffer);
+    DisableDepthReadPickingForSession();
     return false;
   }
 
@@ -309,7 +313,7 @@ bool ReadWorldPointFromDepth(int mouseX, int mouseY, int screenHeight,
       GLEW_ARB_framebuffer_object) {
     const GLenum framebufferStatus = glCheckFramebufferStatus(GL_READ_FRAMEBUFFER);
     if (framebufferStatus != GL_FRAMEBUFFER_COMPLETE) {
-      wxLogWarning(
+      wxLogDebug(
           "Picking: skipped depth read because read framebuffer is incomplete status=0x%04x framebuffer=%d readFramebuffer=%d.",
           static_cast<unsigned int>(framebufferStatus), framebuffer,
           readFramebuffer);
@@ -324,7 +328,7 @@ bool ReadWorldPointFromDepth(int mouseX, int mouseY, int screenHeight,
                &depth);
   const GLenum readError = viewer3d::render::DrainOpenGLErrors();
   if (readError != GL_NO_ERROR) {
-    wxLogWarning(
+    wxLogDebug(
         "Picking: glReadPixels depth read failed error=0x%04x framebuffer=%d readFramebuffer=%d readBuffer=0x%04x viewport=(%d,%d,%d,%d) vendor=%s renderer=%s. Depth-read picking is disabled for this session.",
         static_cast<unsigned int>(readError), framebuffer, readFramebuffer,
         static_cast<unsigned int>(readBuffer), currentViewport[0],

--- a/viewer3d/render/scenerenderer.cpp
+++ b/viewer3d/render/scenerenderer.cpp
@@ -107,7 +107,7 @@ void RestoreMeshVaoElementBindingAndUnbind(const Mesh &mesh,
 
 // Logs VAO and EBO state for macOS highlight diagnostics.
 void LogMeshVaoDiagnostic(const Mesh &mesh, const char *label) {
-#ifdef __APPLE__
+#if defined(__APPLE__) && !defined(NDEBUG)
   GLint currentVao = 0;
   GLint currentEbo = 0;
   glGetIntegerv(GL_VERTEX_ARRAY_BINDING, &currentVao);

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -618,14 +618,35 @@ void Viewer3DController::RecordText(float x, float y, const std::string &text,
   m_impl->captureCanvas->DrawText(x, y, text, style);
 }
 
+// Reads and classifies the ID-buffer pick result at the requested pixel.
+ISelectionContext::PickReadResult Viewer3DController::ReadPickUuidAtDetailed(
+    int mouseX, int mouseY, int width, int height,
+    const std::unordered_set<std::string> &hiddenLayers, std::string &outUuid) {
+  if (!m_impl->idPickPass) {
+    outUuid.clear();
+    return ISelectionContext::PickReadResult::Unavailable;
+  }
+
+  switch (m_impl->idPickPass->ReadUuidAtDetailed(mouseX, mouseY, width, height,
+                                                 hiddenLayers, outUuid)) {
+  case IdPickPass::ReadResult::Hit:
+    return ISelectionContext::PickReadResult::Hit;
+  case IdPickPass::ReadResult::Miss:
+    return ISelectionContext::PickReadResult::Miss;
+  case IdPickPass::ReadResult::Unavailable:
+    return ISelectionContext::PickReadResult::Unavailable;
+  }
+
+  outUuid.clear();
+  return ISelectionContext::PickReadResult::Unavailable;
+}
+
 // Reads and returns pick UUID At.
 bool Viewer3DController::ReadPickUuidAt(
     int mouseX, int mouseY, int width, int height,
     const std::unordered_set<std::string> &hiddenLayers, std::string &outUuid) {
-  if (!m_impl->idPickPass)
-    return false;
-  return m_impl->idPickPass->ReadUuidAt(mouseX, mouseY, width, height,
-                                        hiddenLayers, outUuid);
+  return ReadPickUuidAtDetailed(mouseX, mouseY, width, height, hiddenLayers,
+                                outUuid) == ISelectionContext::PickReadResult::Hit;
 }
 
 // Handles d Controller.

--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -256,6 +256,10 @@ private:
                      const CanvasFill *fill) const override;
   void RecordText(float x, float y, const std::string &text,
                   const CanvasTextStyle &style) const override;
+  PickReadResult ReadPickUuidAtDetailed(
+      int mouseX, int mouseY, int width, int height,
+      const std::unordered_set<std::string> &hiddenLayers,
+      std::string &outUuid) override;
   bool ReadPickUuidAt(int mouseX, int mouseY, int width, int height,
                       const std::unordered_set<std::string> &hiddenLayers,
                       std::string &outUuid) override;


### PR DESCRIPTION
### Motivation
- Prevent unsafe GL depth reads during normal hover/click selection by trusting valid ID-buffer hits first and using depth/ray/AABB only as a fallback or diagnostic opt-in.
- Avoid recurring Windows Intel/OpenGL crash paths caused by `glReadPixels(GL_DEPTH_COMPONENT)` during normal interactions and make depth-read confirmation safer and auditable.
- Keep the VAO/EBO invariant fixes intact and remove noisy macOS VAO diagnostics from release builds.

### Description
- Trust ID-buffer hits for normal hover, label, and click UUID picking when `viewer3d_pick_use_id_buffer` is enabled, returning the picked UUID immediately instead of forcing depth confirmation. (`viewer3d/picking/selectionsystem.cpp`)
- Make depth confirmation opt-in by default by changing `viewer3d_pick_confirm_depth_ambiguous` default to `0.0` and gate runtime depth reads behind a new policy function that disables depth-read picking on Windows Intel renderers or after a GL/read-framebuffer failure. (`core/configmanager.cpp`, `viewer3d/picking/selectionsystem.cpp`)
- Add session-level disable state and helpers: `IsWindowsIntelRenderer()`, `DepthReadPickingDisabledForSession()`, `IsDepthReadPickingAllowed(...)`, `DisableDepthReadPickingForSession()`, and `ShouldConfirmDepthForQuery(...)` to centralize capability checks and logging. (`viewer3d/picking/selectionsystem.cpp`)
- Harden depth-read pre-checks before calling `glReadPixels`: require a controlled/read framebuffer, reject `GL_NONE` read buffer, validate `glCheckFramebufferStatus(GL_READ_FRAMEBUFFER)` completeness, validate and drain GL errors, and permanently disable depth-read picking for the session after an error; log clear reasons when skipping. (`viewer3d/picking/selectionsystem.cpp`)
- Preserve ID-buffer behavior for fixture/truss/object label queries so valid ID hits are not forced into fallback when confirmation is toggled. (`viewer3d/picking/selectionsystem.cpp`)
- Guard macOS VAO diagnostic logging so it's compiled only in debug builds (`#if defined(__APPLE__) && !defined(NDEBUG)`), leaving the VAO/EBO invariant fixes unchanged. (`viewer3d/render/scenerenderer.cpp`)
- Update release notes to document the new picking policy and depth-read safety behavior. (`docs/release-notes-draft.md`)

### Testing
- `tests/check_perastage_tree_modules.sh` — passed.
- `tests/check_no_configmanager_get_in_gui.sh` — passed.
- `git diff --check` — passed (no whitespace/overlap warnings).
- Attempted full CMake build (`cmake -S . -B build && cmake --build build --target Perastage`) could not be executed in this environment because `wxWidgets` was not available, so a local build/test is recommended on a dev machine with dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d4c9ee088832492d731326649d3d2)