### PR TITLE
Add mdns vcpkg port to installer CI dependency lists

### DIFF
--- a/.github/workflows/arch-package.yml
+++ b/.github/workflows/arch-package.yml
@@ -116,6 +116,7 @@ jobs:
             podofo:x64-linux \
             meshoptimizer:x64-linux \
             backward-cpp:x64-linux \
+            mdns:x64-linux \
             --x-install-root="$VCPKG_INSTALLED" \
             --x-packages-root="$VCPKG_PACKAGES" \
             --downloads-root="$VCPKG_DOWNLOADS"

--- a/.github/workflows/linux-installer.yml
+++ b/.github/workflows/linux-installer.yml
@@ -120,6 +120,7 @@ jobs:
             podofo:x64-linux \
             meshoptimizer:x64-linux \
             backward-cpp:x64-linux \
+            mdns:x64-linux \
             --x-install-root="$VCPKG_INSTALLED" \
             --x-packages-root="$VCPKG_PACKAGES" \
             --downloads-root="$VCPKG_DOWNLOADS"

--- a/.github/workflows/macos-15-manual-installer.yml
+++ b/.github/workflows/macos-15-manual-installer.yml
@@ -150,6 +150,7 @@ jobs:
             podofo:$VCPKG_TRIPLET \
             meshoptimizer:$VCPKG_TRIPLET \
             backward-cpp:$VCPKG_TRIPLET \
+            mdns:$VCPKG_TRIPLET \
             --x-install-root="$VCPKG_INSTALLED" \
             --x-packages-root="$VCPKG_PACKAGES" \
             --downloads-root="$VCPKG_DOWNLOADS"

--- a/.github/workflows/macos-installer.yml
+++ b/.github/workflows/macos-installer.yml
@@ -150,6 +150,7 @@ jobs:
             podofo:$VCPKG_TRIPLET \
             meshoptimizer:$VCPKG_TRIPLET \
             backward-cpp:$VCPKG_TRIPLET \
+            mdns:$VCPKG_TRIPLET \
             --x-install-root="$VCPKG_INSTALLED" \
             --x-packages-root="$VCPKG_PACKAGES" \
             --downloads-root="$VCPKG_DOWNLOADS"

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -90,6 +90,7 @@ jobs:
             podofo:x64-windows `
             meshoptimizer:x64-windows `
             backward-cpp:x64-windows `
+            mdns:x64-windows `
             --x-install-root="$env:VCPKG_INSTALLED" `
             --x-packages-root="$env:VCPKG_PACKAGES" `
             --downloads-root="$env:VCPKG_DOWNLOADS"

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -33,6 +33,7 @@ Changes since **v1.4.0**.
 
 ## Build, packaging and CI
 
+- Added the mdns vcpkg port to installer CI dependency setup so MVR-xchange mDNS-enabled builds can configure reliably on all packaged platforms.
 - Improved the MVR-xchange TCP publisher with safer dialog shutdown, specification-aligned JSON responses, commit broadcasting, and the vcpkg mdns discovery backend, explicit mDNS interface selection, and detailed TCP/protocol diagnostics, remote station tracking, and the active mDNS group discovery, group-qualified service instance names, canonical UUID reuse, non-blocking diagnostics, and outgoing join-flow pieces needed to distinguish incoming and outgoing MVR-xchange handshakes without repeated modal message boxes, and visible advertised IP/port status in the dialog.
 
 ## Documentation


### PR DESCRIPTION
### Motivation
- MVR-xchange now depends on the vcpkg `mdns` port when `PERASTAGE_ENABLE_MVR_XCHANGE_MDNS` is enabled, and CI configure fails on platforms where `mdns` was not installed by the workflow.
- Installer workflows must install the `mdns` port so `find_package(mdns CONFIG REQUIRED)` succeeds during CMake configure on all packaged platforms.

### Description
- Added `mdns:x64-windows` to the vcpkg package list in `.github/workflows/windows-installer.yml` to ensure the mdns port is available on Windows.
- Added `mdns:x64-linux` to the vcpkg package list in `.github/workflows/linux-installer.yml` and `.github/workflows/arch-package.yml` to ensure the mdns port is available on Linux workflows.
- Added `mdns:$VCPKG_TRIPLET` to the vcpkg package lists in `.github/workflows/macos-installer.yml` and `.github/workflows/macos-15-manual-installer.yml` to ensure the mdns port is available on macOS workflows.
- Updated `docs/release-notes-draft.md` with a short release-note entry documenting the CI dependency fix for mDNS-enabled MVR-xchange builds.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it returned OK.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it returned OK.
- Verified the new `mdns:` triplets are present with `rg -n 'mdns:' .github/workflows docs/release-notes-draft.md` and found entries in the modified workflows.
- Parsed workflow YAML files with Ruby (`YAML.load_file`) to validate workflow syntax and `git diff --check` to validate no trailing whitespace issues, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f7c3b96e88324969a45374685abd9)