### PR TITLE
Harden MVR-xchange protocol handling

### DIFF
--- a/docs/mvr_xchange.md
+++ b/docs/mvr_xchange.md
@@ -16,13 +16,13 @@ MVR-xchange lets compatible applications discover each other on a local network 
 - Active mDNS discovery of stations in the selected group and outgoing `MVR_JOIN` attempts to resolved stations.
 - Outgoing `MVR_JOIN` message construction and short-lived TCP client support for station handshakes and commit announcements.
 - Canonical lowercase UUID handling for local and remote MVR-xchange `StationUUID` and `FileUUID` values using Perastage's shared UUID utilities.
-- Requests for a known `FileUUID` return the matching MVR binary packet. Requests with an empty `FileUUID` or `latest` return the latest published revision when one exists.
+- Requests for a known `FileUUID` return the matching non-empty MVR binary packet. Requests with an empty `FileUUID` use the specification-defined latest-revision behavior and return the latest published revision when one exists.
 
 ## Discovery requirements
 
 Perastage uses the vcpkg `mdns` port for MVR-xchange discovery. The CMake option `PERASTAGE_ENABLE_MVR_XCHANGE_MDNS` defaults to `ON`; when it is enabled, CMake requires the `mdns` package and links the `mdns::mdns` target. If the option is turned `OFF`, Perastage builds a disabled backend that reports a clear runtime error instead of pretending discovery is active.
 
-The dialog log reports the service type, group service name, station name, station UUID, advertised TCP port, backend name (`mdns`), host name, and local address diagnostics. These diagnostics are written to the dialog log and application log without blocking modal message boxes. Use this information to compare Perastage's advertised interface with the interface selected in the receiving application.
+The dialog log reports the service type, group service name, station name, station UUID, advertised TCP port, backend name (`mdns`), host name, selected interface, advertised address, discovered stations, resolved endpoints, failed resolutions, and transfer byte counts. These diagnostics are written to the dialog log and application log without blocking modal message boxes. Use this information to compare Perastage's advertised interface with the interface selected in the receiving application.
 
 ## Build dependency
 
@@ -60,9 +60,28 @@ The current MVR-xchange specification says TCP Mode uses mDNS discovery, the `_m
 The dialog shows remote station counts and a simple station list for discovered, incoming joined, and outgoing joined stations. These counts help distinguish a raw TCP connection from a completed MVR-xchange handshake. Use **Discover Now** to run an immediate discovery pass instead of waiting for the periodic discovery loop.
 
 
+## Compliance and hardening notes
+
+Perastage implements the official TCP Mode exchange path conservatively:
+
+- Supported official flows: mDNS/DNS-SD service advertisement, same-group discovery, `MVR_JOIN`, `MVR_JOIN_RET`, `MVR_LEAVE`, `MVR_COMMIT`, `MVR_COMMIT_RET`, `MVR_REQUEST`, and `MVR_REQUEST_RET` error responses.
+- Supported packet payloads: JSON UTF-8 packets for protocol messages and MVR file packets for successful file requests. Multi-packet payload reassembly is not currently implemented; Perastage emits single-packet JSON and MVR file payloads.
+- Message parsing rejects malformed JSON, missing required identity fields, invalid UUIDs in required UUID fields, and unsupported message types without crashing the service. Unsupported official session migration messages are not acted on by the TCP publisher.
+- Published revisions are kept in a bounded in-memory history. Each revision records the canonical `FileUUID`, local `StationUUID`, file name, comment, creation timestamp, file size, and MVR payload.
+- Perastage only serves already-published in-memory MVR payloads. It does not export a new MVR from a network worker, and it refuses empty payloads. Manual publishing validates that the exported archive contains `GeneralSceneDescription.xml` before the revision is announced.
+- Unknown `FileUUID` requests receive a standard `MVR_REQUEST_RET` error. Empty `FileUUID` requests use the specification-defined latest-file behavior and return an error when no revision is available.
+
+The following items are intentionally outside this implementation:
+
+- WebSocket Mode and DNS-routable session hosting.
+- `MVR_NEW_SESSION_HOST` based migration or mode switching.
+- Proprietary Peraviz Live Link, incremental synchronization, private messages, automatic Peraviz launch, or automatic scene-change publishing.
+
+If a specification detail is ambiguous in the local copy of the MVR documentation, Perastage keeps the behavior conservative and documents the assumption here instead of adding private behavior to the official MVR-xchange layer.
+
 ## UUID policy
 
-MVR-xchange station and file identifiers use Perastage's shared `core/uuidutils.h` helpers. Locally generated `StationUUID` and `FileUUID` values are canonical lowercase UUID strings in `8-4-4-4-12` form. UUIDs read from settings, JSON messages, and mDNS TXT records are canonicalized before storage and comparison so uppercase remote station UUIDs still deduplicate correctly.
+MVR-xchange station and file identifiers use Perastage's shared `core/uuidutils.h` helpers. Locally generated `StationUUID` and `FileUUID` values are canonical lowercase UUID strings in `8-4-4-4-12` form. UUIDs read from settings, JSON messages, and mDNS TXT records are canonicalized before storage and comparison so uppercase or dashless remote station UUIDs still deduplicate correctly. Invalid UUIDs are rejected for protocol fields where the official message requires a UUID, including `StationUUID` in join/leave messages and `FileUUID`/`StationUUID` in commit messages.
 
 ## Network interface and port debugging
 
@@ -85,7 +104,7 @@ After Start, check the log for `MVR-xchange selected interface`, `MVR-xchange ad
 - **Service is not visible:** Check that the dialog reports the `mdns` backend, matching group name, matching selected interface, and no disabled-backend error. Also check for `MVR-xchange discovered station` logs; if grandMA3 shows only its own service, active discovery did not resolve Perastage or the selected group/interface does not match.
 - **Wrong interface:** Make sure grandMA3 is watching the same Ethernet/Wi-Fi or loopback interface selected in Perastage, and that the logged advertised A record matches that interface.
 - **Loopback vs LAN:** A loopback advertisement is not visible to another computer. Use loopback only for same-machine tests and a real LAN interface for cross-device testing.
-- **No published files:** Start the service and click **Publish Current MVR** before requesting a file. Empty `FileUUID` requests return the latest published revision when one exists; if no revision exists, Perastage returns an error instead of exporting from the network thread.
+- **No published files:** Start the service and click **Publish Current MVR** before requesting a file. Empty `FileUUID` requests return the latest published revision when one exists; if no revision exists, Perastage returns an error instead of exporting from the network thread. Literal placeholder values such as `latest` are not treated as a standard FileUUID request.
 - **Incoming join but no visible station:** Check whether the log also shows an outgoing `MVR_JOIN`, a `MVR_JOIN_RET OK=true`, different station UUIDs, the same group name, and a matching interface. If only an incoming `MVR_JOIN` is visible, Perastage can answer the client but may not yet have a resolved endpoint for the reverse join.
 
 ## Settings

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -26,6 +26,7 @@ Changes since **v1.4.0**.
 
 ## Stability and diagnostics
 
+- Hardened MVR-xchange TCP Mode protocol handling with stricter UUID validation, safer malformed-message responses, bounded latest-revision requests, non-empty payload checks, archive sanity checks, clearer transfer diagnostics, and additional deterministic protocol tests.
 - Disabled optional depth-read picking by default and skipped it on Windows Intel OpenGL drivers to avoid unsafe depth-buffer reads during normal selection.
 - Hardened 3D hover picking plus hover, group, and selected highlight rendering to avoid unsafe OpenGL pixel reads and restore critical render state after overlay highlights on Intel Windows drivers and macOS.
 - Hardened 3D picking coordinate validation to avoid unsafe OpenGL reads near viewport edges and during zero-sized or out-of-range viewer states.
@@ -38,6 +39,7 @@ Changes since **v1.4.0**.
 
 ## Documentation
 
+- Updated the MVR-xchange documentation with a compliance summary, supported official flows, conservative latest-request behavior, and explicit out-of-scope notes for WebSocket Mode and private live synchronization.
 ## Compatibility notes
 
 ## Downloads and installation

--- a/mvr/xchange/mvr_xchange_message.cpp
+++ b/mvr/xchange/mvr_xchange_message.cpp
@@ -36,6 +36,8 @@ MvrXchangeCommit CommitFromJson(const nlohmann::json &json) {
   commit.stationUuid = CanonicalizeUuid(JsonStringValue(json, "StationUUID"));
   commit.fileName = JsonStringValue(json, "FileName");
   commit.comment = JsonStringValue(json, "Comment");
+  const auto fileSize = json.find("FileSize");
+  if (fileSize != json.end() && fileSize->is_number_unsigned()) commit.payload.resize(fileSize->get<std::size_t>());
   return commit;
 }
 
@@ -69,9 +71,14 @@ std::optional<Message> ParseMessage(const std::string &jsonText) {
   msg.type = JsonStringValue(json, "Type");
   if (msg.type.empty()) msg.type = JsonStringValue(json, "MessageType");
   if (msg.type.empty()) return std::nullopt;
+  const auto fileUuidIt = json.find("FileUUID");
+  msg.fileUuidSpecified = fileUuidIt != json.end() && !JsonStringValue(json, "FileUUID").empty();
   msg.fileUuid = CanonicalizeUuid(JsonStringValue(json, "FileUUID"));
-  msg.stationUuid = CanonicalizeUuid(JsonStringValue(json, "StationUUID"));
-  if (msg.stationUuid.empty()) msg.stationUuid = CanonicalizeUuid(JsonStringValue(json, "FromStationUUID"));
+  const auto stationUuid = JsonStringValue(json, "StationUUID");
+  const auto fromStationUuid = JsonStringValue(json, "FromStationUUID");
+  msg.stationUuidSpecified = !stationUuid.empty() || !fromStationUuid.empty();
+  msg.stationUuid = CanonicalizeUuid(stationUuid);
+  if (msg.stationUuid.empty()) msg.stationUuid = CanonicalizeUuid(fromStationUuid);
   msg.stationName = JsonStringValue(json, "StationName");
   msg.groupName = JsonStringValue(json, "GroupName");
   msg.provider = JsonStringValue(json, "Provider");
@@ -86,6 +93,35 @@ std::optional<Message> ParseMessage(const std::string &jsonText) {
     if (msg.commits.empty()) AppendCommitsFromJsonArray(*filesIt, msg.commits);
   }
   return msg;
+}
+
+// Validates required fields for official MVR-xchange message types handled by Perastage.
+std::string ValidateMessage(const Message &message) {
+  if (message.type == "MVR_JOIN" || message.type == "MVR_JOIN_RET") {
+    if (message.stationUuid.empty()) return message.type + " is missing a valid StationUUID.";
+    if (message.stationName.empty()) return message.type + " is missing StationName.";
+    if (message.provider.empty()) return message.type + " is missing Provider.";
+    for (const auto &commit : message.commits) {
+      if (commit.fileUuid.empty()) return message.type + " contains a commit with an invalid FileUUID.";
+      if (commit.stationUuid.empty()) return message.type + " contains a commit with an invalid StationUUID.";
+    }
+    return {};
+  }
+  if (message.type == "MVR_LEAVE") {
+    if (message.stationUuid.empty()) return "MVR_LEAVE is missing a valid StationUUID.";
+    return {};
+  }
+  if (message.type == "MVR_COMMIT") {
+    if (message.fileUuid.empty()) return "MVR_COMMIT is missing a valid FileUUID.";
+    if (message.stationUuid.empty()) return "MVR_COMMIT is missing a valid StationUUID.";
+    return {};
+  }
+  if (message.type == "MVR_REQUEST") {
+    if (message.fileUuidSpecified && message.fileUuid.empty()) return "MVR_REQUEST contains an invalid FileUUID.";
+    return {};
+  }
+  if (message.type == "MVR_REQUEST_RET" || message.type == "MVR_COMMIT_RET" || message.type == "MVR_LEAVE_RET") return {};
+  return "Unsupported MVR-xchange message type.";
 }
 
 // Builds a JOIN-style message with local station identity and commit metadata.

--- a/mvr/xchange/mvr_xchange_message.h
+++ b/mvr/xchange/mvr_xchange_message.h
@@ -18,11 +18,14 @@ struct Message {
   int verMajor = 0;
   int verMinor = 0;
   bool ok = false;
+  bool fileUuidSpecified = false;
+  bool stationUuidSpecified = false;
   std::size_t filesCount = 0;
   std::vector<MvrXchangeCommit> commits;
 };
 
 std::optional<Message> ParseMessage(const std::string &json);
+std::string ValidateMessage(const Message &message);
 std::string BuildJoin(const std::string &stationUuid, const std::string &stationName, const std::vector<MvrXchangeCommit> &commits);
 std::string BuildJoinRet(const std::string &stationUuid, const std::string &stationName, const std::vector<MvrXchangeCommit> &commits);
 std::string BuildLeaveRet();

--- a/mvr/xchange/mvr_xchange_service.cpp
+++ b/mvr/xchange/mvr_xchange_service.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <chrono>
 #include <iomanip>
+#include <iterator>
 #include <sstream>
 
 namespace {
@@ -21,6 +22,12 @@ std::string CurrentUtcTimestamp() {
   std::ostringstream out;
   out << std::put_time(&tm, "%Y-%m-%dT%H:%M:%SZ");
   return out.str();
+}
+
+// Checks that an exported MVR archive has the required scene description entry.
+bool ContainsGeneralSceneDescription(const std::vector<uint8_t> &bytes) {
+  static constexpr char kEntryName[] = "GeneralSceneDescription.xml";
+  return std::search(bytes.begin(), bytes.end(), std::begin(kEntryName), std::end(kEntryName) - 1) != bytes.end();
 }
 }
 
@@ -83,6 +90,10 @@ bool MvrXchangeService::PublishCurrentScene(const std::string &comment) {
     Log("MVR-xchange publish failed because the current scene could not be exported.");
     return false;
   }
+  if (!ContainsGeneralSceneDescription(bytes)) {
+    Log("MVR-xchange publish failed because the exported MVR archive does not contain GeneralSceneDescription.xml.");
+    return false;
+  }
   MvrXchangeCommit commit;
   commit.fileUuid = GenerateMvrXchangeUuid();
   commit.stationUuid = CanonicalizeUuid(settings_.stationUuid);
@@ -96,6 +107,7 @@ bool MvrXchangeService::PublishCurrentScene(const std::string &comment) {
   }
   tcpServer_.BroadcastCommit(commit);
   SendCommitToJoinedStations(commit);
+  Log("MVR-xchange published revision FileUUID=" + commit.fileUuid + ", bytes=" + std::to_string(commit.FileSize()) + ", created=" + commit.timestampUtc + ".");
   return true;
 }
 
@@ -122,7 +134,7 @@ void MvrXchangeService::SetLogCallback(LogCallback callback) { logCallback_ = st
 // Resolves a request by FileUUID, treating an empty FileUUID as the latest commit.
 std::optional<MvrXchangeCommit> MvrXchangeService::ResolveRequest(const std::string &fileUuid) const {
   std::lock_guard lock(mutex_);
-  if (fileUuid.empty() || fileUuid == "latest" || fileUuid == "LATEST") return commits_.Latest();
+  if (fileUuid.empty()) return commits_.Latest();
   return commits_.FindByFileUuid(fileUuid);
 }
 

--- a/mvr/xchange/mvr_xchange_tcp_server.cpp
+++ b/mvr/xchange/mvr_xchange_tcp_server.cpp
@@ -10,6 +10,7 @@
 #include <arpa/inet.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
+#include <sys/time.h>
 #include <unistd.h>
 #endif
 
@@ -38,6 +39,21 @@ std::string FormatEndpoint(const sockaddr_in &addr) {
   char host[INET_ADDRSTRLEN]{};
   inet_ntop(AF_INET, &addr.sin_addr, host, sizeof(host));
   return std::string(host) + ":" + std::to_string(ntohs(addr.sin_port));
+}
+
+// Applies bounded send and receive timeouts to an accepted client socket.
+void ApplySocketTimeouts(int fd) {
+#ifdef _WIN32
+  DWORD timeout = 5000;
+  setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, reinterpret_cast<const char *>(&timeout), sizeof(timeout));
+  setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, reinterpret_cast<const char *>(&timeout), sizeof(timeout));
+#else
+  timeval timeout{};
+  timeout.tv_sec = 5;
+  timeout.tv_usec = 0;
+  setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
+  setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout));
+#endif
 }
 }
 
@@ -138,6 +154,7 @@ void MvrXchangeTcpServer::Run() {
     socklen_t len = sizeof(client);
     int fd = static_cast<int>(accept(listenFd_, reinterpret_cast<sockaddr *>(&client), &len));
     if (fd < 0) continue;
+    ApplySocketTimeouts(fd);
     if (logCallback_) logCallback_("MVR-xchange TCP client connected from " + FormatEndpoint(client) + ".");
     std::lock_guard lock(clientThreadsMutex_);
     clientThreads_.emplace_back(&MvrXchangeTcpServer::HandleClient, this, fd);
@@ -165,6 +182,13 @@ void MvrXchangeTcpServer::HandleClient(int clientFd) {
       auto msg = mvr::xchange::ParseMessage(line);
       if (!msg) { if (logCallback_) logCallback_("MVR-xchange received malformed JSON from " + endpoint + "."); SendJson(clientFd, mvr::xchange::BuildRequestError("Malformed JSON message.")); continue; }
       if (logCallback_) logCallback_("MVR-xchange received message " + msg->type + " from " + endpoint + ".");
+      const std::string validationError = mvr::xchange::ValidateMessage(*msg);
+      if (!validationError.empty()) {
+        if (logCallback_) logCallback_("MVR-xchange rejected " + msg->type + " from " + endpoint + ": " + validationError);
+        if (msg->type == "MVR_COMMIT") SendJson(clientFd, mvr::xchange::BuildCommitRet(false, validationError));
+        else SendJson(clientFd, mvr::xchange::BuildRequestError(validationError));
+        continue;
+      }
       if (msg->type == "MVR_JOIN") {
         if (logCallback_) logCallback_("MVR-xchange received MVR_JOIN from " + endpoint + ":\n  provider=" + msg->provider + "\n  station=" + msg->stationName + "\n  uuid=" + msg->stationUuid + "\n  version=" + std::to_string(msg->verMajor) + "." + std::to_string(msg->verMinor) + "\n  commits=" + std::to_string(msg->commits.size()) + "\n  files=" + std::to_string(msg->filesCount));
         MvrXchangeRemoteStation station;
@@ -186,8 +210,8 @@ void MvrXchangeTcpServer::HandleClient(int clientFd) {
       else if (msg->type == "MVR_COMMIT") { SendJson(clientFd, mvr::xchange::BuildCommitRet(true)); if (logCallback_) logCallback_("MVR-xchange sent MVR_COMMIT_RET to " + endpoint + "."); }
       else if (msg->type == "MVR_REQUEST") {
         auto commit = resolver_ ? resolver_(msg->fileUuid) : std::nullopt;
-        if (!commit) { SendJson(clientFd, mvr::xchange::BuildRequestError("The MVR is not available on this client")); if (logCallback_) logCallback_("MVR-xchange sent MVR_REQUEST_RET error to " + endpoint + "."); }
-        else { const auto payloadPacket = mvr::xchange::EncodePacket(mvr::xchange::PacketType::MvrFile, commit->payload); SendPacket(clientFd, payloadPacket); if (logCallback_) logCallback_("MVR-xchange sent MVR binary payload to " + endpoint + ", bytes=" + std::to_string(commit->payload.size()) + "."); }
+        if (!commit || commit->payload.empty()) { SendJson(clientFd, mvr::xchange::BuildRequestError("The MVR is not available on this client")); if (logCallback_) logCallback_("MVR-xchange sent MVR_REQUEST_RET error to " + endpoint + " for FileUUID=" + msg->fileUuid + "."); }
+        else { const auto payloadPacket = mvr::xchange::EncodePacket(mvr::xchange::PacketType::MvrFile, commit->payload); SendPacket(clientFd, payloadPacket); if (logCallback_) logCallback_("MVR-xchange sent MVR binary payload to " + endpoint + ", FileUUID=" + commit->fileUuid + ", bytes=" + std::to_string(commit->payload.size()) + "."); }
       } else { SendJson(clientFd, mvr::xchange::BuildRequestError("Unsupported MVR-xchange message.")); if (logCallback_) logCallback_("MVR-xchange received unsupported message " + msg->type + " from " + endpoint + "."); }
     }
   }

--- a/tests/mvr_xchange_protocol_test.cpp
+++ b/tests/mvr_xchange_protocol_test.cpp
@@ -45,7 +45,9 @@ static void TestMessages() {
   assert(msg);
   assert(msg->type == "MVR_REQUEST");
   assert(msg->fileUuid == "abcdefab-cdef-abcd-efab-cdefabcdefab");
+  assert(mvr::xchange::ValidateMessage(*msg).empty());
   assert(!mvr::xchange::ParseMessage("not json"));
+  assert(!mvr::xchange::ParseMessage("[]"));
 
   MvrXchangeCommit commit{"ABCDEFAB-CDEF-ABCD-EFAB-CDEFABCDEFAB", "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE", "scene.mvr", "Manual", {}, {1, 2, 3}};
   const auto commitJson = nlohmann::json::parse(mvr::xchange::BuildCommit(commit));
@@ -56,6 +58,12 @@ static void TestMessages() {
   assert(commitJson["FileUUID"] == "abcdefab-cdef-abcd-efab-cdefabcdefab");
   assert(commitJson["StationUUID"] == "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
   assert(commitJson["ForStationsUUID"].is_array());
+  auto parsedCommit = mvr::xchange::ParseMessage(commitJson.dump());
+  assert(parsedCommit);
+  assert(parsedCommit->type == "MVR_COMMIT");
+  assert(parsedCommit->fileUuid == "abcdefab-cdef-abcd-efab-cdefabcdefab");
+  assert(parsedCommit->stationUuid == "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+  assert(mvr::xchange::ValidateMessage(*parsedCommit).empty());
 
   const auto outgoingJoinJson = nlohmann::json::parse(mvr::xchange::BuildJoin("AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE", "Perastage", {commit}));
   assert(outgoingJoinJson["Type"] == "MVR_JOIN");
@@ -74,6 +82,8 @@ static void TestMessages() {
   assert(parsedJoin->verMajor == 1);
   assert(parsedJoin->verMinor == 6);
   assert(parsedJoin->commits.size() == 1);
+  assert(parsedJoin->commits[0].FileSize() == 3);
+  assert(mvr::xchange::ValidateMessage(*parsedJoin).empty());
 
   const auto joinJson = nlohmann::json::parse(mvr::xchange::BuildJoinRet("AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE", "Perastage", {commit}));
   assert(joinJson["Type"] == "MVR_JOIN_RET");
@@ -87,11 +97,35 @@ static void TestMessages() {
   assert(parsedJoinRet->type == "MVR_JOIN_RET");
   assert(parsedJoinRet->ok);
   assert(parsedJoinRet->commits.size() == 1);
+  assert(mvr::xchange::ValidateMessage(*parsedJoinRet).empty());
 
   const auto errorJson = nlohmann::json::parse(mvr::xchange::BuildRequestError("The MVR is not available on this client"));
   assert(errorJson["Type"] == "MVR_REQUEST_RET");
   assert(errorJson["OK"] == false);
   assert(errorJson["Message"] == "The MVR is not available on this client");
+}
+
+// Verifies malformed official messages are parsed safely and rejected with clear errors.
+static void TestMalformedMessages() {
+  auto invalidJoinUuid = mvr::xchange::ParseMessage("{\"Type\":\"MVR_JOIN\",\"Provider\":\"Other\",\"StationName\":\"Desk\",\"StationUUID\":\"not-a-uuid\"}");
+  assert(invalidJoinUuid);
+  assert(!mvr::xchange::ValidateMessage(*invalidJoinUuid).empty());
+
+  auto missingProvider = mvr::xchange::ParseMessage("{\"Type\":\"MVR_JOIN\",\"StationName\":\"Desk\",\"StationUUID\":\"BBBBBBBB-CCCC-DDDD-EEEE-FFFFFFFFFFFF\"}");
+  assert(missingProvider);
+  assert(mvr::xchange::ValidateMessage(*missingProvider) == "MVR_JOIN is missing Provider.");
+
+  auto invalidCommitUuid = mvr::xchange::ParseMessage("{\"Type\":\"MVR_COMMIT\",\"FileUUID\":\"bad\",\"StationUUID\":\"BBBBBBBB-CCCC-DDDD-EEEE-FFFFFFFFFFFF\"}");
+  assert(invalidCommitUuid);
+  assert(mvr::xchange::ValidateMessage(*invalidCommitUuid) == "MVR_COMMIT is missing a valid FileUUID.");
+
+  auto invalidRequestUuid = mvr::xchange::ParseMessage("{\"Type\":\"MVR_REQUEST\",\"FileUUID\":\"latest\"}");
+  assert(invalidRequestUuid);
+  assert(mvr::xchange::ValidateMessage(*invalidRequestUuid) == "MVR_REQUEST contains an invalid FileUUID.");
+
+  auto unknown = mvr::xchange::ParseMessage("{\"Type\":\"PRIVATE_SYNC\",\"StationUUID\":\"BBBBBBBB-CCCC-DDDD-EEEE-FFFFFFFFFFFF\"}");
+  assert(unknown);
+  assert(mvr::xchange::ValidateMessage(*unknown) == "Unsupported MVR-xchange message type.");
 }
 
 // Verifies MVR-xchange DNS-SD naming helpers.
@@ -105,6 +139,8 @@ static void TestCanonicalUuidUse() {
   const auto generated = GenerateUuid();
   assert(CanonicalizeUuid(generated) == generated);
   assert(CanonicalizeUuid("ABCDEFABCDEFABCDEFABCDEFABCDEFAB") == "abcdefab-cdef-abcd-efab-cdefabcdefab");
+  assert(CanonicalizeUuid("ABCDEFAB-CDEF-ABCD-EFAB-CDEFABCDEFAB") == "abcdefab-cdef-abcd-efab-cdefabcdefab");
+  assert(CanonicalizeUuid("not-a-uuid").empty());
 }
 
 // Verifies remote station registry self-filtering, deduplication, and join states.
@@ -156,6 +192,7 @@ int main() {
   TestCommitStore();
   TestPackets();
   TestMessages();
+  TestMalformedMessages();
   TestDnsNames();
   TestCanonicalUuidUse();
   TestStationRegistry();


### PR DESCRIPTION
### Motivation
- Make Perastage's MVR-xchange TCP Mode implementation stricter and more robust against malformed/ambiguous protocol inputs while preserving existing successful flows for grandMA3 and Peraviz. 
- Improve diagnostics, avoid unsafe blocking or export work on network threads, and keep published MVR transfers safe and auditable.

### Description
- Added explicit JSON parsing/validation with `ParseMessage` + `ValidateMessage` and two presence flags (`fileUuidSpecified`, `stationUuidSpecified`) so required UUID/identity fields are checked and invalid UUIDs are rejected for protocol fields that must be UUIDs (`mvr/xchange/mvr_xchange_message.{h,cpp}`).
- Preserved commit `FileSize` metadata when parsing `MVR_COMMIT` entries and reject commits/requests with invalid or empty `FileUUID` values, and reject unsupported message types with clear validation messages (`mvr/xchange/mvr_xchange_message.cpp`).
- Applied bounded send/receive timeouts to accepted TCP client sockets and added validation/error responses for malformed or unsupported JSON messages; prevented sending empty MVR payloads and enhanced transfer logs to include `FileUUID` and byte counts (`mvr/xchange/mvr_xchange_tcp_server.cpp`).
- Added a publish-time archive sanity check to ensure exported MVR archives contain `GeneralSceneDescription.xml`, logged published revision metadata (`FileUUID`, size, timestamp), and made latest-request handling conservative (empty `FileUUID` returns latest, literal `latest` treated as non-UUID) (`mvr/xchange/mvr_xchange_service.cpp`).
- Expanded deterministic protocol tests with malformed-message, invalid-UUID, commit parsing, and validation checks; and updated `docs/mvr_xchange.md` and `docs/release-notes-draft.md` with a compliance/hardening summary and explicit out-of-scope notes for WebSocket Mode and private live sync.

### Testing
- Ran the focused protocol unit test binary built with `g++` which executed `tests/mvr_xchange_protocol_test` and passed (covers packet framing, JSON parsing, commit store, DNS name helpers, UUID canonicalization, station registry, and the added malformed-message tests). 
- Compiled `mvr_xchange` TCP server/service translation units (`mvr_xchange_tcp_server.cpp`, `mvr_xchange_service.cpp`) as object files to smoke-check integration and those compilations succeeded. 
- Ran repository checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh` which returned OK. 
- Full CMake configuration/build was not completed in this container because `wxWidgets` is not available here, so full product-level CMake build was not exercised; local partial builds and unit tests above were used instead.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fea5d9c708324ae193388c7dedee8)