### PR TITLE
Add MVR-xchange remote import requests (MVR_REQUEST) and dialog action

### DIFF
--- a/docs/mvr_exporter.md
+++ b/docs/mvr_exporter.md
@@ -31,4 +31,4 @@ MVR `Symbol` nodes represent geometry instances defined by a referenced `Symdef`
 
 Perastage can now request an advertised MVR revision from a compatible MVR-xchange TCP Mode station. The request uses the standard `MVR_REQUEST` message with the selected `FileUUID`, expects the peer to return an MVR file packet, writes the payload to a temporary `.mvr` file, and then runs the same MVR import policy used by **File > Import MVR...**.
 
-The dialog currently requests the latest advertised remote revision from the discovered station list. Publishing still uses `MVR_COMMIT` announcements, while requesting/importing keeps the MVR payload unchanged and relies on the existing importer for project integration.
+The dialog lists advertised remote revisions from the discovered station list so the user can choose the exact MVR file to request. Publishing still uses `MVR_COMMIT` announcements, while requesting/importing keeps the MVR payload unchanged and relies on the existing importer for project integration. After a payload is received, Perastage shows the normal import choice so users can open it as a new project or merge it into the current project.

--- a/docs/mvr_exporter.md
+++ b/docs/mvr_exporter.md
@@ -25,3 +25,10 @@ Support is a standard MVR scene node and is preserved as `<Support>` during impo
 ## Symbol/Symdef UUID handling
 
 MVR `Symbol` nodes represent geometry instances defined by a referenced `Symdef`. MVR 1.6 requires every exported `Symbol` to carry both a canonical `uuid` attribute for the symbol instance and a non-empty `symdef` reference. Perastage preserves an imported Symbol UUID when it is valid and belongs to preserved Symbol/Symdef geometry; if the original Symbol UUID is missing, invalid, or collides with another exported Symbol, Perastage derives a deterministic replacement from the container type, container UUID, Symdef UUID, Symbol matrix, and stable index context so repeated exports of the same scene remain logically stable.
+
+
+## MVR-xchange request/import behavior
+
+Perastage can now request an advertised MVR revision from a compatible MVR-xchange TCP Mode station. The request uses the standard `MVR_REQUEST` message with the selected `FileUUID`, expects the peer to return an MVR file packet, writes the payload to a temporary `.mvr` file, and then runs the same MVR import policy used by **File > Import MVR...**.
+
+The dialog currently requests the latest advertised remote revision from the discovered station list. Publishing still uses `MVR_COMMIT` announcements, while requesting/importing keeps the MVR payload unchanged and relies on the existing importer for project integration.

--- a/docs/mvr_exporter.md
+++ b/docs/mvr_exporter.md
@@ -32,3 +32,5 @@ MVR `Symbol` nodes represent geometry instances defined by a referenced `Symdef`
 Perastage can now request an advertised MVR revision from a compatible MVR-xchange TCP Mode station. The request uses the standard `MVR_REQUEST` message with the selected `FileUUID`, expects the peer to return an MVR file packet, writes the payload to a temporary `.mvr` file, and then runs the same MVR import policy used by **File > Import MVR...**.
 
 The dialog lists advertised remote revisions from the discovered station list so the user can choose the exact MVR file to request. Publishing still uses `MVR_COMMIT` announcements, while requesting/importing keeps the MVR payload unchanged and relies on the existing importer for project integration. After a payload is received, Perastage shows the normal import choice so users can open it as a new project or merge it into the current project.
+
+Perastage binds the mDNS responder to the interface selected for the advertised MVR-xchange address. When multiple adapters exist on the same computer, select the same network interface in Perastage and the peer application so service discovery and TCP file exchange use the same local link.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -6,7 +6,7 @@ Changes since **v1.4.0**.
 
 ## New features
 
-- Added MVR-xchange remote file requests with a selectable advertised-MVR list, Console-styled transfer log, and the standard import choice to open as a new project or merge into the current project.
+- Added MVR-xchange remote file requests with a larger selectable advertised-MVR list, Console-styled transfer log, corrected station-name alignment, and the standard import choice to open as a new project or merge into the current project.
 - Added the first MVR-xchange TCP Mode publisher so Perastage can manually publish the current scene as an MVR revision for compatible clients.
 
 ## Improvements

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -15,6 +15,7 @@ Changes since **v1.4.0**.
 
 ## Fixes
 
+- Fixed the MVR-xchange log text styling so transfer messages use the same readable Console colors and monospaced font.
 - Fixed MVR-xchange mDNS advertisement so the service responder binds to the selected advertised interface, improving visibility in peer service lists when multiple local interfaces are available.
 - Improved MVR-xchange compatibility with clients such as grandMA3 by keeping joined TCP Mode peer connections available for immediate publish broadcasts, using a grandMA3 endpoint fallback when discovery only reports an incoming join, refreshing discovery before manual publishes, and sending each join refresh and commit announcement over the same TCP connection before waiting for acknowledgements.
 - Fixed MVR-xchange station naming so generated default names use the full Windows DNS computer name without slow reverse lookups, repair older truncated defaults, and no longer open with the station-name field selected or horizontally scrolled.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -6,6 +6,7 @@ Changes since **v1.4.0**.
 
 ## New features
 
+- Added MVR-xchange remote file requests so Perastage can obtain advertised MVR revisions from compatible TCP Mode stations and import them into the current project.
 - Added the first MVR-xchange TCP Mode publisher so Perastage can manually publish the current scene as an MVR revision for compatible clients.
 
 ## Improvements

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -15,6 +15,7 @@ Changes since **v1.4.0**.
 
 ## Fixes
 
+- Fixed MVR-xchange mDNS advertisement so the service responder binds to the selected advertised interface, improving visibility in peer service lists when multiple local interfaces are available.
 - Improved MVR-xchange compatibility with clients such as grandMA3 by keeping joined TCP Mode peer connections available for immediate publish broadcasts, using a grandMA3 endpoint fallback when discovery only reports an incoming join, refreshing discovery before manual publishes, and sending each join refresh and commit announcement over the same TCP connection before waiting for acknowledgements.
 - Fixed MVR-xchange station naming so generated default names use the full Windows DNS computer name without slow reverse lookups, repair older truncated defaults, and no longer open with the station-name field selected or horizontally scrolled.
 - Simplified MVR-xchange file names so manual publishes use a readable project-name-and-timestamp pattern instead of exposing the internal file UUID.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -6,7 +6,7 @@ Changes since **v1.4.0**.
 
 ## New features
 
-- Added MVR-xchange remote file requests so Perastage can obtain advertised MVR revisions from compatible TCP Mode stations and import them into the current project.
+- Added MVR-xchange remote file requests with a selectable advertised-MVR list, Console-styled transfer log, and the standard import choice to open as a new project or merge into the current project.
 - Added the first MVR-xchange TCP Mode publisher so Perastage can manually publish the current scene as an MVR revision for compatible clients.
 
 ## Improvements

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -72,6 +72,7 @@ public:
   void EnqueueExternalOpenPath(const std::string &path);
   void CancelStartupProjectLoadForExternalOpenPath(const std::string &path);
   bool OpenPathFromCommandLine(const std::string &path);
+  bool ImportMvrWithUserChoice(const std::string &path);
   void ResetProject(bool applyLayoutDefaultsForNewProject = false); // Clear current project
   bool IsStartupProjectLoadPending() const { return startupProjectLoadPending; }
   bool IsStartupInitializationPending() const { return startupSplashInitializationPending; }

--- a/gui/mainwindow/controllers/mainwindow_io_controller.cpp
+++ b/gui/mainwindow/controllers/mainwindow_io_controller.cpp
@@ -395,6 +395,23 @@ void MainWindowIoController::OnImportMVR(wxCommandEvent &) {
   }
 }
 
+
+// Imports an MVR file after asking whether to open or merge it.
+bool MainWindowIoController::ImportMvrWithUserChoice(const std::string &pathUtf8) {
+  if (!ownerRef_)
+    return false;
+
+  switch (ShowMvrImportChoiceDialog(ownerRef_)) {
+  case MvrImportChoice::OpenAsNewProject:
+    return ImportMvrWithOfficialPolicy(pathUtf8);
+  case MvrImportChoice::MergeIntoCurrentProject:
+    return MergeMvrFromPath(pathUtf8);
+  case MvrImportChoice::Cancel:
+    return false;
+  }
+  return false;
+}
+
 // Merges an MVR file into the current scene.
 bool MainWindowIoController::MergeMvrFromPath(const std::string &pathUtf8) {
   constexpr const char *kLayoutsConfigKey = "layouts_collection";

--- a/gui/mainwindow/controllers/mainwindow_io_controller.h
+++ b/gui/mainwindow/controllers/mainwindow_io_controller.h
@@ -10,6 +10,7 @@ public:
   explicit MainWindowIoController(MainWindow &owner);
   void OnImportMVR(wxCommandEvent &event);
   bool OpenPathFromCommandLine(const std::string &pathUtf8);
+  bool ImportMvrWithUserChoice(const std::string &pathUtf8);
   bool MergeMvrFromPath(const std::string &pathUtf8);
 
 private:

--- a/gui/mainwindow_io.cpp
+++ b/gui/mainwindow_io.cpp
@@ -249,6 +249,13 @@ bool MainWindow::OpenPathFromCommandLine(const std::string &path) {
   return ioController->OpenPathFromCommandLine(path);
 }
 
+// Imports an MVR file through the normal user choice dialog.
+bool MainWindow::ImportMvrWithUserChoice(const std::string &path) {
+  if (!CanProcessExternalOpenPath())
+    return false;
+  return ioController->ImportMvrWithUserChoice(path);
+}
+
 // Queues an external open path and processes it immediately only when startup is fully ready.
 void MainWindow::EnqueueExternalOpenPath(const std::string &path) {
   QueueDeferredStartupOpenPath(path);

--- a/gui/mvrxchange/mvr_xchange_dialog.cpp
+++ b/gui/mvrxchange/mvr_xchange_dialog.cpp
@@ -4,6 +4,8 @@
 #include <wx/sizer.h>
 #include <wx/stattext.h>
 #include <wx/thread.h>
+#include <wx/filename.h>
+#include <fstream>
 
 // Creates the MVR-xchange publisher dialog and loads persisted settings.
 MvrXchangeDialog::MvrXchangeDialog(wxWindow *parent)
@@ -65,8 +67,9 @@ void MvrXchangeDialog::BuildLayout() {
   startButton_ = new wxButton(this, wxID_ANY, "Start");
   stopButton_ = new wxButton(this, wxID_ANY, "Stop");
   publishButton_ = new wxButton(this, wxID_ANY, "Publish Current MVR");
+  requestButton_ = new wxButton(this, wxID_ANY, "Request Latest Remote MVR");
   discoverButton_ = new wxButton(this, wxID_ANY, "Discover Now");
-  buttons->Add(startButton_, 0, wxRIGHT, 8); buttons->Add(stopButton_, 0, wxRIGHT, 8); buttons->Add(discoverButton_, 0, wxRIGHT, 8); buttons->Add(publishButton_, 0, wxRIGHT, 8); buttons->AddStretchSpacer(); buttons->Add(new wxButton(this, wxID_CLOSE, "Close"));
+  buttons->Add(startButton_, 0, wxRIGHT, 8); buttons->Add(stopButton_, 0, wxRIGHT, 8); buttons->Add(discoverButton_, 0, wxRIGHT, 8); buttons->Add(publishButton_, 0, wxRIGHT, 8); buttons->Add(requestButton_, 0, wxRIGHT, 8); buttons->AddStretchSpacer(); buttons->Add(new wxButton(this, wxID_CLOSE, "Close"));
   root->Add(buttons, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 12);
   logCtrl_ = new wxTextCtrl(this, wxID_ANY, {}, wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE | wxTE_READONLY);
   root->Add(logCtrl_, 1, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 12);
@@ -74,6 +77,7 @@ void MvrXchangeDialog::BuildLayout() {
   startButton_->Bind(wxEVT_BUTTON, &MvrXchangeDialog::OnStart, this);
   stopButton_->Bind(wxEVT_BUTTON, &MvrXchangeDialog::OnStop, this);
   publishButton_->Bind(wxEVT_BUTTON, &MvrXchangeDialog::OnPublish, this);
+  requestButton_->Bind(wxEVT_BUTTON, &MvrXchangeDialog::OnRequest, this);
   discoverButton_->Bind(wxEVT_BUTTON, &MvrXchangeDialog::OnDiscover, this);
   Bind(wxEVT_BUTTON, [this](wxCommandEvent &) { Close(); }, wxID_CLOSE);
   startButton_->SetFocus();
@@ -88,6 +92,7 @@ void MvrXchangeDialog::RefreshState() {
   startButton_->Enable(!running);
   stopButton_->Enable(running);
   publishButton_->Enable(running);
+  requestButton_->Enable(running);
   discoverButton_->Enable(running);
   if (remoteStationsText_) {
     std::size_t discovered = 0;
@@ -142,5 +147,37 @@ void MvrXchangeDialog::OnPublish(wxCommandEvent &) {
   std::string projectName;
   if (auto *mainWindow = dynamic_cast<MainWindow *>(GetParent())) projectName = mainWindow->GetCurrentProjectDisplayName().ToStdString();
   if (!service_->PublishCurrentScene("Manual publish from Perastage", projectName)) AppendLog("Publish failed.");
+  RefreshState();
+}
+
+// Requests the newest advertised remote MVR payload and imports it into the project.
+void MvrXchangeDialog::OnRequest(wxCommandEvent &) {
+  service_->DiscoverNow();
+  const auto stations = service_->GetKnownStations();
+  for (const auto &station : stations) {
+    if (station.commits.empty()) continue;
+    const auto &metadata = station.commits.back();
+    auto commit = service_->RequestRemoteCommit(station.stationUuid, metadata.fileUuid);
+    if (!commit || commit->payload.empty()) {
+      AppendLog(wxString("MVR-xchange request failed for FileUUID=") + wxString::FromUTF8(metadata.fileUuid) + ".");
+      continue;
+    }
+    wxFileName tempFile(wxFileName::CreateTempFileName("perastage_mvr_xchange_"));
+    tempFile.SetExt("mvr");
+    std::ofstream out(tempFile.GetFullPath().ToStdString(), std::ios::binary);
+    out.write(reinterpret_cast<const char *>(commit->payload.data()), static_cast<std::streamsize>(commit->payload.size()));
+    out.close();
+    if (!out) {
+      AppendLog("MVR-xchange could not write the requested MVR payload to a temporary file.");
+      return;
+    }
+    if (auto *mainWindow = dynamic_cast<MainWindow *>(GetParent())) {
+      AppendLog(wxString("Importing requested MVR-xchange file ") + wxString::FromUTF8(metadata.fileUuid) + ".");
+      mainWindow->OpenPathFromCommandLine(tempFile.GetFullPath().ToStdString());
+    }
+    RefreshState();
+    return;
+  }
+  AppendLog("No remote MVR-xchange files are currently advertised. Click Discover Now and try again.");
   RefreshState();
 }

--- a/gui/mvrxchange/mvr_xchange_dialog.cpp
+++ b/gui/mvrxchange/mvr_xchange_dialog.cpp
@@ -1,15 +1,47 @@
 #include "mvr_xchange_dialog.h"
 #include "../mainwindow.h"
 #include <wx/app.h>
-#include <wx/sizer.h>
-#include <wx/stattext.h>
-#include <wx/thread.h>
+#include <wx/filefn.h>
 #include <wx/filename.h>
+#include <wx/sizer.h>
+#include <wx/statbox.h>
+#include <wx/stattext.h>
+#include <wx/settings.h>
+#include <wx/thread.h>
 #include <fstream>
 
-// Creates the MVR-xchange publisher dialog and loads persisted settings.
+namespace {
+
+// Formats bytes for the MVR file list.
+wxString FormatFileSize(std::size_t bytes) {
+  if (bytes >= 1024u * 1024u)
+    return wxString::Format("%.1f MB", static_cast<double>(bytes) / (1024.0 * 1024.0));
+  if (bytes >= 1024u)
+    return wxString::Format("%.1f KB", static_cast<double>(bytes) / 1024.0);
+  return wxString::Format("%zu B", bytes);
+}
+
+// Returns the most useful display name for a remote station.
+std::string StationDisplayName(const MvrXchangeRemoteStation &station) {
+  if (!station.stationName.empty()) return station.stationName;
+  if (!station.serviceInstanceName.empty()) return station.serviceInstanceName;
+  if (!station.ipAddress.empty()) return station.ipAddress + ":" + std::to_string(station.port);
+  return "Unknown station";
+}
+
+// Returns the most useful display name for an advertised MVR file.
+std::string CommitDisplayName(const MvrXchangeCommit &commit) {
+  if (!commit.fileName.empty()) return commit.fileName;
+  if (!commit.comment.empty()) return commit.comment;
+  return commit.fileUuid;
+}
+
+} // namespace
+
+// Creates the MVR-xchange dialog and loads persisted settings.
 MvrXchangeDialog::MvrXchangeDialog(wxWindow *parent)
-    : wxDialog(parent, wxID_ANY, "MVR-xchange", wxDefaultPosition, wxSize(560, 420)),
+    : wxDialog(parent, wxID_ANY, "MVR-xchange", wxDefaultPosition,
+               wxSize(920, 680), wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER),
       settings_(LoadMvrXchangeSettings()), service_(std::make_unique<MvrXchangeService>()) {
   std::weak_ptr<bool> weakLifetime = lifetimeToken_;
   service_->SetLogCallback([this, weakLifetime](const std::string &message) {
@@ -34,18 +66,34 @@ MvrXchangeDialog::~MvrXchangeDialog() {
   logCtrl_ = nullptr;
 }
 
-// Builds the dialog controls for service status, settings, and manual publishing.
+// Builds the dialog controls for service status, settings, file requests, and logging.
 void MvrXchangeDialog::BuildLayout() {
+  SetMinSize(wxSize(840, 620));
+  SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW));
+
   auto *root = new wxBoxSizer(wxVERTICAL);
+  auto *title = new wxStaticText(this, wxID_ANY, "MVR-xchange");
+  wxFont titleFont = title->GetFont();
+  titleFont.SetPointSize(titleFont.GetPointSize() + 4);
+  titleFont.SetWeight(wxFONTWEIGHT_BOLD);
+  title->SetFont(titleFont);
+  auto *subtitle = new wxStaticText(
+      this, wxID_ANY,
+      "Publish the current scene or request advertised MVR revisions from compatible TCP Mode stations.");
+  subtitle->SetForegroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT));
+  root->Add(title, 0, wxLEFT | wxRIGHT | wxTOP, 14);
+  root->Add(subtitle, 0, wxLEFT | wxRIGHT | wxBOTTOM, 14);
+
+  auto *settingsBox = new wxStaticBoxSizer(wxVERTICAL, this, "Station settings");
   auto *grid = new wxFlexGridSizer(2, 8, 8);
   grid->AddGrowableCol(1, 1);
-  statusText_ = new wxStaticText(this, wxID_ANY, "Stopped");
-  stationNameCtrl_ = new wxTextCtrl(this, wxID_ANY, wxString::FromUTF8(settings_.stationName));
+  statusText_ = new wxStaticText(settingsBox->GetStaticBox(), wxID_ANY, "Stopped");
+  stationNameCtrl_ = new wxTextCtrl(settingsBox->GetStaticBox(), wxID_ANY, wxString::FromUTF8(settings_.stationName));
   stationNameCtrl_->SetSelection(0, 0);
-  groupNameCtrl_ = new wxTextCtrl(this, wxID_ANY, wxString::FromUTF8(settings_.groupName));
-  stationUuidCtrl_ = new wxTextCtrl(this, wxID_ANY, wxString::FromUTF8(settings_.stationUuid), wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
-  portCtrl_ = new wxTextCtrl(this, wxID_ANY, settings_.port > 0 ? wxString::Format("%d", settings_.port) : wxString("Auto"));
-  interfaceChoice_ = new wxChoice(this, wxID_ANY);
+  groupNameCtrl_ = new wxTextCtrl(settingsBox->GetStaticBox(), wxID_ANY, wxString::FromUTF8(settings_.groupName));
+  stationUuidCtrl_ = new wxTextCtrl(settingsBox->GetStaticBox(), wxID_ANY, wxString::FromUTF8(settings_.stationUuid), wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
+  portCtrl_ = new wxTextCtrl(settingsBox->GetStaticBox(), wxID_ANY, settings_.port > 0 ? wxString::Format("%d", settings_.port) : wxString("Auto"));
+  interfaceChoice_ = new wxChoice(settingsBox->GetStaticBox(), wxID_ANY);
   interfaceChoice_->Append("Auto / All suitable interfaces");
   interfaces_ = ListMvrXchangeNetworkInterfaces();
   int selectedInterfaceIndex = 0;
@@ -54,36 +102,62 @@ void MvrXchangeDialog::BuildLayout() {
     if (!settings_.selectedInterfaceId.empty() && (settings_.selectedInterfaceId == interfaces_[i].id || settings_.selectedInterfaceId == interfaces_[i].ipv4Address)) selectedInterfaceIndex = static_cast<int>(i + 1);
   }
   interfaceChoice_->SetSelection(selectedInterfaceIndex);
-  grid->Add(new wxStaticText(this, wxID_ANY, "Status:"), 0, wxALIGN_CENTER_VERTICAL); grid->Add(statusText_, 1, wxEXPAND);
-  grid->Add(new wxStaticText(this, wxID_ANY, "Station name:"), 0, wxALIGN_CENTER_VERTICAL); grid->Add(stationNameCtrl_, 1, wxEXPAND);
-  grid->Add(new wxStaticText(this, wxID_ANY, "Group name:"), 0, wxALIGN_CENTER_VERTICAL); grid->Add(groupNameCtrl_, 1, wxEXPAND);
-  grid->Add(new wxStaticText(this, wxID_ANY, "Station UUID:"), 0, wxALIGN_CENTER_VERTICAL); grid->Add(stationUuidCtrl_, 1, wxEXPAND);
-  grid->Add(new wxStaticText(this, wxID_ANY, "Network interface:"), 0, wxALIGN_CENTER_VERTICAL); grid->Add(interfaceChoice_, 1, wxEXPAND);
-  grid->Add(new wxStaticText(this, wxID_ANY, "TCP port:"), 0, wxALIGN_CENTER_VERTICAL); grid->Add(portCtrl_, 1, wxEXPAND);
-  remoteStationsText_ = new wxTextCtrl(this, wxID_ANY, "0 discovered, 0 incoming joined, 0 outgoing joined", wxDefaultPosition, wxSize(-1, 70), wxTE_MULTILINE | wxTE_READONLY);
-  grid->Add(new wxStaticText(this, wxID_ANY, "Remote stations:"), 0, wxALIGN_CENTER_VERTICAL); grid->Add(remoteStationsText_, 1, wxEXPAND);
-  root->Add(grid, 0, wxEXPAND | wxALL, 12);
+  grid->Add(new wxStaticText(settingsBox->GetStaticBox(), wxID_ANY, "Status:"), 0, wxALIGN_CENTER_VERTICAL); grid->Add(statusText_, 1, wxEXPAND);
+  grid->Add(new wxStaticText(settingsBox->GetStaticBox(), wxID_ANY, "Station name:"), 0, wxALIGN_CENTER_VERTICAL); grid->Add(stationNameCtrl_, 1, wxEXPAND);
+  grid->Add(new wxStaticText(settingsBox->GetStaticBox(), wxID_ANY, "Group name:"), 0, wxALIGN_CENTER_VERTICAL); grid->Add(groupNameCtrl_, 1, wxEXPAND);
+  grid->Add(new wxStaticText(settingsBox->GetStaticBox(), wxID_ANY, "Station UUID:"), 0, wxALIGN_CENTER_VERTICAL); grid->Add(stationUuidCtrl_, 1, wxEXPAND);
+  grid->Add(new wxStaticText(settingsBox->GetStaticBox(), wxID_ANY, "Network interface:"), 0, wxALIGN_CENTER_VERTICAL); grid->Add(interfaceChoice_, 1, wxEXPAND);
+  grid->Add(new wxStaticText(settingsBox->GetStaticBox(), wxID_ANY, "TCP port:"), 0, wxALIGN_CENTER_VERTICAL); grid->Add(portCtrl_, 1, wxEXPAND);
+  settingsBox->Add(grid, 0, wxEXPAND | wxALL, 10);
+  root->Add(settingsBox, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 14);
+
+  auto *remoteBox = new wxStaticBoxSizer(wxVERTICAL, this, "Remote MVR files");
+  remoteStationsText_ = new wxStaticText(remoteBox->GetStaticBox(), wxID_ANY, "0 discovered, 0 incoming joined, 0 outgoing joined");
+  remoteStationsText_->SetForegroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT));
+  remoteBox->Add(remoteStationsText_, 0, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, 10);
+  availableFilesList_ = new wxDataViewListCtrl(remoteBox->GetStaticBox(), wxID_ANY, wxDefaultPosition, wxSize(-1, 180), wxDV_ROW_LINES | wxDV_SINGLE);
+  const int flags = wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE;
+  availableFilesList_->AppendTextColumn("Station", wxDATAVIEW_CELL_INERT, 170, wxALIGN_LEFT, flags);
+  availableFilesList_->AppendTextColumn("MVR file", wxDATAVIEW_CELL_INERT, 230, wxALIGN_LEFT, flags);
+  availableFilesList_->AppendTextColumn("Size", wxDATAVIEW_CELL_INERT, 90, wxALIGN_LEFT, flags);
+  availableFilesList_->AppendTextColumn("File UUID", wxDATAVIEW_CELL_INERT, 250, wxALIGN_LEFT, flags);
+  availableFilesList_->AppendTextColumn("Comment", wxDATAVIEW_CELL_INERT, 220, wxALIGN_LEFT, flags);
+  remoteBox->Add(availableFilesList_, 1, wxEXPAND | wxALL, 10);
+  root->Add(remoteBox, 1, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 14);
+
+  auto *logBox = new wxStaticBoxSizer(wxVERTICAL, this, "Log");
+  logCtrl_ = new wxTextCtrl(logBox->GetStaticBox(), wxID_ANY, {}, wxDefaultPosition, wxSize(-1, 130), wxTE_MULTILINE | wxTE_READONLY | wxTE_RICH2);
+  ApplyConsoleLogStyle();
+  logBox->Add(logCtrl_, 1, wxEXPAND | wxALL, 10);
+  root->Add(logBox, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 14);
+
   auto *buttons = new wxBoxSizer(wxHORIZONTAL);
   startButton_ = new wxButton(this, wxID_ANY, "Start");
   stopButton_ = new wxButton(this, wxID_ANY, "Stop");
-  publishButton_ = new wxButton(this, wxID_ANY, "Publish Current MVR");
-  requestButton_ = new wxButton(this, wxID_ANY, "Request Latest Remote MVR");
   discoverButton_ = new wxButton(this, wxID_ANY, "Discover Now");
-  buttons->Add(startButton_, 0, wxRIGHT, 8); buttons->Add(stopButton_, 0, wxRIGHT, 8); buttons->Add(discoverButton_, 0, wxRIGHT, 8); buttons->Add(publishButton_, 0, wxRIGHT, 8); buttons->Add(requestButton_, 0, wxRIGHT, 8); buttons->AddStretchSpacer(); buttons->Add(new wxButton(this, wxID_CLOSE, "Close"));
-  root->Add(buttons, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 12);
-  logCtrl_ = new wxTextCtrl(this, wxID_ANY, {}, wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE | wxTE_READONLY);
-  root->Add(logCtrl_, 1, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 12);
+  publishButton_ = new wxButton(this, wxID_ANY, "Publish Current MVR");
+  requestButton_ = new wxButton(this, wxID_ANY, "Request Selected MVR");
+  buttons->Add(startButton_, 0, wxRIGHT, 8);
+  buttons->Add(stopButton_, 0, wxRIGHT, 8);
+  buttons->Add(discoverButton_, 0, wxRIGHT, 8);
+  buttons->AddStretchSpacer();
+  buttons->Add(publishButton_, 0, wxRIGHT, 8);
+  buttons->Add(requestButton_, 0, wxRIGHT, 8);
+  buttons->Add(new wxButton(this, wxID_CLOSE, "Close"), 0);
+  root->Add(buttons, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 14);
+
   SetSizer(root);
   startButton_->Bind(wxEVT_BUTTON, &MvrXchangeDialog::OnStart, this);
   stopButton_->Bind(wxEVT_BUTTON, &MvrXchangeDialog::OnStop, this);
   publishButton_->Bind(wxEVT_BUTTON, &MvrXchangeDialog::OnPublish, this);
   requestButton_->Bind(wxEVT_BUTTON, &MvrXchangeDialog::OnRequest, this);
   discoverButton_->Bind(wxEVT_BUTTON, &MvrXchangeDialog::OnDiscover, this);
+  availableFilesList_->Bind(wxEVT_DATAVIEW_ITEM_ACTIVATED, &MvrXchangeDialog::OnAvailableFileActivated, this);
   Bind(wxEVT_BUTTON, [this](wxCommandEvent &) { Close(); }, wxID_CLOSE);
   startButton_->SetFocus();
 }
 
-// Refreshes status labels and button enablement from the service state.
+// Refreshes status labels, remote file rows, and button enablement from the service state.
 void MvrXchangeDialog::RefreshState() {
   if (shuttingDown_ || IsBeingDeleted() || !statusText_) return;
   const bool running = service_->IsRunning();
@@ -92,29 +166,60 @@ void MvrXchangeDialog::RefreshState() {
   startButton_->Enable(!running);
   stopButton_->Enable(running);
   publishButton_->Enable(running);
-  requestButton_->Enable(running);
   discoverButton_->Enable(running);
-  if (remoteStationsText_) {
-    std::size_t discovered = 0;
-    std::size_t incoming = 0;
-    std::size_t outgoing = 0;
-    wxString summary;
-    const auto stations = service_->GetKnownStations();
-    for (const auto &station : stations) {
-      if (station.discovered) ++discovered;
-      if (station.incomingJoined) ++incoming;
-      if (station.outgoingJoined) ++outgoing;
-    }
-    summary << wxString::Format("%zu discovered, %zu incoming joined, %zu outgoing joined", discovered, incoming, outgoing);
-    for (const auto &station : stations) {
-      summary << "\n" << wxString::FromUTF8(station.stationName.empty() ? station.serviceInstanceName : station.stationName)
-              << " | " << wxString::FromUTF8(station.ipAddress) << ":" << station.port
-              << (station.discovered ? " | discovered" : "")
-              << (station.incomingJoined ? " | incoming joined" : "")
-              << (station.outgoingJoined ? " | outgoing joined" : "");
-    }
-    remoteStationsText_->SetValue(summary);
+  const auto stations = service_->GetKnownStations();
+  RefreshAvailableFiles(stations);
+  requestButton_->Enable(running && SelectedAvailableFile().has_value());
+  std::size_t discovered = 0;
+  std::size_t incoming = 0;
+  std::size_t outgoing = 0;
+  for (const auto &station : stations) {
+    if (station.discovered) ++discovered;
+    if (station.incomingJoined) ++incoming;
+    if (station.outgoingJoined) ++outgoing;
   }
+  if (remoteStationsText_) {
+    remoteStationsText_->SetLabel(wxString::Format("%zu discovered, %zu incoming joined, %zu outgoing joined", discovered, incoming, outgoing));
+  }
+}
+
+// Rebuilds the remote MVR file list from advertised station commit metadata.
+void MvrXchangeDialog::RefreshAvailableFiles(const std::vector<MvrXchangeRemoteStation> &stations) {
+  if (!availableFilesList_) return;
+  const int selectedRow = availableFilesList_->GetSelectedRow();
+  availableFiles_.clear();
+  availableFilesList_->DeleteAllItems();
+  for (const auto &station : stations) {
+    for (const auto &commit : station.commits) {
+      AvailableMvrFile file;
+      file.stationUuid = station.stationUuid;
+      file.stationName = StationDisplayName(station);
+      file.fileUuid = commit.fileUuid;
+      file.fileName = CommitDisplayName(commit);
+      file.comment = commit.comment;
+      file.fileSize = commit.FileSize();
+      availableFiles_.push_back(file);
+      wxVector<wxVariant> row;
+      row.push_back(wxVariant(wxString::FromUTF8(file.stationName)));
+      row.push_back(wxVariant(wxString::FromUTF8(file.fileName)));
+      row.push_back(wxVariant(FormatFileSize(file.fileSize)));
+      row.push_back(wxVariant(wxString::FromUTF8(file.fileUuid)));
+      row.push_back(wxVariant(wxString::FromUTF8(file.comment)));
+      availableFilesList_->AppendItem(row);
+    }
+  }
+  if (!availableFiles_.empty()) {
+    const unsigned rowToSelect = selectedRow >= 0 && static_cast<std::size_t>(selectedRow) < availableFiles_.size() ? static_cast<unsigned>(selectedRow) : 0;
+    availableFilesList_->SelectRow(rowToSelect);
+  }
+}
+
+// Applies the same font and color style used by the Console panel output.
+void MvrXchangeDialog::ApplyConsoleLogStyle() {
+  if (!logCtrl_) return;
+  logCtrl_->SetBackgroundColour(*wxBLACK);
+  logCtrl_->SetForegroundColour(wxColour(0, 255, 0));
+  logCtrl_->SetFont(wxFont(10, wxFONTFAMILY_TELETYPE, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL));
 }
 
 // Appends a status line to the dialog log area.
@@ -150,34 +255,53 @@ void MvrXchangeDialog::OnPublish(wxCommandEvent &) {
   RefreshState();
 }
 
-// Requests the newest advertised remote MVR payload and imports it into the project.
+// Requests the selected advertised remote MVR payload and imports it into the project.
 void MvrXchangeDialog::OnRequest(wxCommandEvent &) {
-  service_->DiscoverNow();
-  const auto stations = service_->GetKnownStations();
-  for (const auto &station : stations) {
-    if (station.commits.empty()) continue;
-    const auto &metadata = station.commits.back();
-    auto commit = service_->RequestRemoteCommit(station.stationUuid, metadata.fileUuid);
-    if (!commit || commit->payload.empty()) {
-      AppendLog(wxString("MVR-xchange request failed for FileUUID=") + wxString::FromUTF8(metadata.fileUuid) + ".");
-      continue;
-    }
-    wxFileName tempFile(wxFileName::CreateTempFileName("perastage_mvr_xchange_"));
-    tempFile.SetExt("mvr");
-    std::ofstream out(tempFile.GetFullPath().ToStdString(), std::ios::binary);
-    out.write(reinterpret_cast<const char *>(commit->payload.data()), static_cast<std::streamsize>(commit->payload.size()));
-    out.close();
-    if (!out) {
-      AppendLog("MVR-xchange could not write the requested MVR payload to a temporary file.");
-      return;
-    }
-    if (auto *mainWindow = dynamic_cast<MainWindow *>(GetParent())) {
-      AppendLog(wxString("Importing requested MVR-xchange file ") + wxString::FromUTF8(metadata.fileUuid) + ".");
-      mainWindow->OpenPathFromCommandLine(tempFile.GetFullPath().ToStdString());
-    }
+  const auto selectedFile = SelectedAvailableFile();
+  if (!selectedFile) {
+    AppendLog("Select an advertised remote MVR file before requesting it.");
+    return;
+  }
+  auto commit = service_->RequestRemoteCommit(selectedFile->stationUuid, selectedFile->fileUuid);
+  if (!commit || commit->payload.empty()) {
+    AppendLog(wxString("MVR-xchange request failed for FileUUID=") + wxString::FromUTF8(selectedFile->fileUuid) + ".");
     RefreshState();
     return;
   }
-  AppendLog("No remote MVR-xchange files are currently advertised. Click Discover Now and try again.");
+  ImportRequestedCommit(*selectedFile, *commit);
   RefreshState();
+}
+
+// Requests the activated remote MVR row.
+void MvrXchangeDialog::OnAvailableFileActivated(wxDataViewEvent &) {
+  wxCommandEvent event;
+  OnRequest(event);
+}
+
+// Returns metadata for the currently selected advertised MVR file.
+std::optional<MvrXchangeDialog::AvailableMvrFile> MvrXchangeDialog::SelectedAvailableFile() const {
+  if (!availableFilesList_) return std::nullopt;
+  const int row = availableFilesList_->GetSelectedRow();
+  if (row < 0 || static_cast<std::size_t>(row) >= availableFiles_.size()) return std::nullopt;
+  return availableFiles_[static_cast<std::size_t>(row)];
+}
+
+// Writes a requested MVR payload to a temporary file and runs the normal import choice flow.
+bool MvrXchangeDialog::ImportRequestedCommit(const AvailableMvrFile &file, const MvrXchangeCommit &commit) {
+  wxFileName tempFile(wxFileName::CreateTempFileName("perastage_mvr_xchange_"));
+  const wxString originalPath = tempFile.GetFullPath();
+  if (!originalPath.empty()) wxRemoveFile(originalPath);
+  tempFile.SetExt("mvr");
+  std::ofstream out(tempFile.GetFullPath().ToStdString(), std::ios::binary);
+  out.write(reinterpret_cast<const char *>(commit.payload.data()), static_cast<std::streamsize>(commit.payload.size()));
+  out.close();
+  if (!out) {
+    AppendLog("MVR-xchange could not write the requested MVR payload to a temporary file.");
+    return false;
+  }
+  if (auto *mainWindow = dynamic_cast<MainWindow *>(GetParent())) {
+    AppendLog(wxString("Importing requested MVR-xchange file ") + wxString::FromUTF8(file.fileUuid) + ".");
+    return mainWindow->ImportMvrWithUserChoice(tempFile.GetFullPath().ToStdString());
+  }
+  return false;
 }

--- a/gui/mvrxchange/mvr_xchange_dialog.cpp
+++ b/gui/mvrxchange/mvr_xchange_dialog.cpp
@@ -224,14 +224,18 @@ void MvrXchangeDialog::RefreshAvailableFiles(const std::vector<MvrXchangeRemoteS
 // Applies the same font and color style used by the Console panel output.
 void MvrXchangeDialog::ApplyConsoleLogStyle() {
   if (!logCtrl_) return;
+  const wxFont consoleFont(10, wxFONTFAMILY_TELETYPE, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL);
+  const wxColour consoleText(0, 255, 0);
   logCtrl_->SetBackgroundColour(*wxBLACK);
-  logCtrl_->SetForegroundColour(wxColour(0, 255, 0));
-  logCtrl_->SetFont(wxFont(10, wxFONTFAMILY_TELETYPE, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL));
+  logCtrl_->SetForegroundColour(consoleText);
+  logCtrl_->SetFont(consoleFont);
+  logCtrl_->SetDefaultStyle(wxTextAttr(consoleText, *wxBLACK, consoleFont));
 }
 
 // Appends a status line to the dialog log area.
 void MvrXchangeDialog::AppendLog(const wxString &message) {
   if (shuttingDown_ || IsBeingDeleted() || !logCtrl_) return;
+  ApplyConsoleLogStyle();
   logCtrl_->AppendText(message + "\n");
 }
 

--- a/gui/mvrxchange/mvr_xchange_dialog.cpp
+++ b/gui/mvrxchange/mvr_xchange_dialog.cpp
@@ -41,7 +41,7 @@ std::string CommitDisplayName(const MvrXchangeCommit &commit) {
 // Creates the MVR-xchange dialog and loads persisted settings.
 MvrXchangeDialog::MvrXchangeDialog(wxWindow *parent)
     : wxDialog(parent, wxID_ANY, "MVR-xchange", wxDefaultPosition,
-               wxSize(920, 680), wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER),
+               wxSize(1150, 850), wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER),
       settings_(LoadMvrXchangeSettings()), service_(std::make_unique<MvrXchangeService>()) {
   std::weak_ptr<bool> weakLifetime = lifetimeToken_;
   service_->SetLogCallback([this, weakLifetime](const std::string &message) {
@@ -68,7 +68,7 @@ MvrXchangeDialog::~MvrXchangeDialog() {
 
 // Builds the dialog controls for service status, settings, file requests, and logging.
 void MvrXchangeDialog::BuildLayout() {
-  SetMinSize(wxSize(840, 620));
+  SetMinSize(wxSize(1050, 775));
   SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW));
 
   auto *root = new wxBoxSizer(wxVERTICAL);
@@ -90,6 +90,8 @@ void MvrXchangeDialog::BuildLayout() {
   statusText_ = new wxStaticText(settingsBox->GetStaticBox(), wxID_ANY, "Stopped");
   stationNameCtrl_ = new wxTextCtrl(settingsBox->GetStaticBox(), wxID_ANY, wxString::FromUTF8(settings_.stationName));
   stationNameCtrl_->SetSelection(0, 0);
+  stationNameCtrl_->SetInsertionPoint(0);
+  stationNameCtrl_->ShowPosition(0);
   groupNameCtrl_ = new wxTextCtrl(settingsBox->GetStaticBox(), wxID_ANY, wxString::FromUTF8(settings_.groupName));
   stationUuidCtrl_ = new wxTextCtrl(settingsBox->GetStaticBox(), wxID_ANY, wxString::FromUTF8(settings_.stationUuid), wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
   portCtrl_ = new wxTextCtrl(settingsBox->GetStaticBox(), wxID_ANY, settings_.port > 0 ? wxString::Format("%d", settings_.port) : wxString("Auto"));
@@ -115,7 +117,7 @@ void MvrXchangeDialog::BuildLayout() {
   remoteStationsText_ = new wxStaticText(remoteBox->GetStaticBox(), wxID_ANY, "0 discovered, 0 incoming joined, 0 outgoing joined");
   remoteStationsText_->SetForegroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT));
   remoteBox->Add(remoteStationsText_, 0, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, 10);
-  availableFilesList_ = new wxDataViewListCtrl(remoteBox->GetStaticBox(), wxID_ANY, wxDefaultPosition, wxSize(-1, 180), wxDV_ROW_LINES | wxDV_SINGLE);
+  availableFilesList_ = new wxDataViewListCtrl(remoteBox->GetStaticBox(), wxID_ANY, wxDefaultPosition, wxSize(-1, 225), wxDV_ROW_LINES | wxDV_SINGLE);
   const int flags = wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE;
   availableFilesList_->AppendTextColumn("Station", wxDATAVIEW_CELL_INERT, 170, wxALIGN_LEFT, flags);
   availableFilesList_->AppendTextColumn("MVR file", wxDATAVIEW_CELL_INERT, 230, wxALIGN_LEFT, flags);
@@ -126,7 +128,7 @@ void MvrXchangeDialog::BuildLayout() {
   root->Add(remoteBox, 1, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 14);
 
   auto *logBox = new wxStaticBoxSizer(wxVERTICAL, this, "Log");
-  logCtrl_ = new wxTextCtrl(logBox->GetStaticBox(), wxID_ANY, {}, wxDefaultPosition, wxSize(-1, 130), wxTE_MULTILINE | wxTE_READONLY | wxTE_RICH2);
+  logCtrl_ = new wxTextCtrl(logBox->GetStaticBox(), wxID_ANY, {}, wxDefaultPosition, wxSize(-1, 160), wxTE_MULTILINE | wxTE_READONLY | wxTE_RICH2);
   ApplyConsoleLogStyle();
   logBox->Add(logCtrl_, 1, wxEXPAND | wxALL, 10);
   root->Add(logBox, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 14);
@@ -155,6 +157,11 @@ void MvrXchangeDialog::BuildLayout() {
   availableFilesList_->Bind(wxEVT_DATAVIEW_ITEM_ACTIVATED, &MvrXchangeDialog::OnAvailableFileActivated, this);
   Bind(wxEVT_BUTTON, [this](wxCommandEvent &) { Close(); }, wxID_CLOSE);
   startButton_->SetFocus();
+  wxTheApp->CallAfter([this] {
+    if (shuttingDown_ || IsBeingDeleted() || !stationNameCtrl_) return;
+    stationNameCtrl_->SetInsertionPoint(0);
+    stationNameCtrl_->ShowPosition(0);
+  });
 }
 
 // Refreshes status labels, remote file rows, and button enablement from the service state.

--- a/gui/mvrxchange/mvr_xchange_dialog.h
+++ b/gui/mvrxchange/mvr_xchange_dialog.h
@@ -23,6 +23,7 @@ private:
   void OnStop(wxCommandEvent &event);
   void OnPublish(wxCommandEvent &event);
   void OnDiscover(wxCommandEvent &event);
+  void OnRequest(wxCommandEvent &event);
 
   MvrXchangeSettings settings_;
   std::unique_ptr<MvrXchangeService> service_;
@@ -40,5 +41,6 @@ private:
   wxButton *startButton_ = nullptr;
   wxButton *stopButton_ = nullptr;
   wxButton *publishButton_ = nullptr;
+  wxButton *requestButton_ = nullptr;
   wxButton *discoverButton_ = nullptr;
 };

--- a/gui/mvrxchange/mvr_xchange_dialog.h
+++ b/gui/mvrxchange/mvr_xchange_dialog.h
@@ -2,9 +2,11 @@
 #include "xchange/mvr_xchange_service.h"
 #include "xchange/mvr_xchange_network_interfaces.h"
 #include <memory>
+#include <optional>
 #include <atomic>
 #include <wx/button.h>
 #include <wx/choice.h>
+#include <wx/dataview.h>
 #include <wx/dialog.h>
 #include <wx/event.h>
 #include <wx/stattext.h>
@@ -16,27 +18,43 @@ public:
   ~MvrXchangeDialog() override;
 
 private:
+  struct AvailableMvrFile {
+    std::string stationUuid;
+    std::string stationName;
+    std::string fileUuid;
+    std::string fileName;
+    std::string comment;
+    std::size_t fileSize = 0;
+  };
+
   void BuildLayout();
   void RefreshState();
+  void RefreshAvailableFiles(const std::vector<MvrXchangeRemoteStation> &stations);
+  void ApplyConsoleLogStyle();
   void AppendLog(const wxString &message);
   void OnStart(wxCommandEvent &event);
   void OnStop(wxCommandEvent &event);
   void OnPublish(wxCommandEvent &event);
   void OnDiscover(wxCommandEvent &event);
   void OnRequest(wxCommandEvent &event);
+  void OnAvailableFileActivated(wxDataViewEvent &event);
+  std::optional<AvailableMvrFile> SelectedAvailableFile() const;
+  bool ImportRequestedCommit(const AvailableMvrFile &file, const MvrXchangeCommit &commit);
 
   MvrXchangeSettings settings_;
   std::unique_ptr<MvrXchangeService> service_;
   std::shared_ptr<bool> lifetimeToken_ = std::make_shared<bool>(true);
   std::atomic<bool> shuttingDown_{false};
   wxStaticText *statusText_ = nullptr;
-  wxTextCtrl *remoteStationsText_ = nullptr;
+  wxStaticText *remoteStationsText_ = nullptr;
+  wxDataViewListCtrl *availableFilesList_ = nullptr;
   wxTextCtrl *stationNameCtrl_ = nullptr;
   wxTextCtrl *groupNameCtrl_ = nullptr;
   wxTextCtrl *stationUuidCtrl_ = nullptr;
   wxTextCtrl *portCtrl_ = nullptr;
   wxChoice *interfaceChoice_ = nullptr;
   std::vector<MvrXchangeNetworkInterface> interfaces_;
+  std::vector<AvailableMvrFile> availableFiles_;
   wxTextCtrl *logCtrl_ = nullptr;
   wxButton *startButton_ = nullptr;
   wxButton *stopButton_ = nullptr;

--- a/mvr/xchange/mvr_xchange_mdns_service.cpp
+++ b/mvr/xchange/mvr_xchange_mdns_service.cpp
@@ -278,16 +278,14 @@ void MvrXchangeMdnsService::Run() {
 #endif
 }
 
-// Opens the IPv4 mDNS socket on all available interfaces.
+// Opens the IPv4 mDNS socket on the interface selected for advertisement.
 bool MvrXchangeMdnsService::OpenSocket() {
 #ifdef PERASTAGE_MVR_XCHANGE_ENABLE_MDNS
-  sockaddr_in address{};
-  address.sin_family = AF_INET;
-  address.sin_addr.s_addr = INADDR_ANY;
+  sockaddr_in address = Ipv4AddressFromString(advertisedIpAddress_);
   address.sin_port = htons(MDNS_PORT);
   socket_ = mdns_socket_open_ipv4(&address);
   if (socket_ < 0) {
-    lastError_ = "The vcpkg mdns backend could not open UDP port 5353 for _mvrxchange._tcp.local.";
+    lastError_ = "The vcpkg mdns backend could not open UDP port 5353 for _mvrxchange._tcp.local on " + advertisedIpAddress_ + ".";
     return false;
   }
   return true;

--- a/mvr/xchange/mvr_xchange_message.cpp
+++ b/mvr/xchange/mvr_xchange_message.cpp
@@ -166,6 +166,11 @@ std::string BuildCommitRet(bool ok, const std::string &message) {
   return nlohmann::json{{"Type", "MVR_COMMIT_RET"}, {"OK", ok}, {"Message", message}}.dump();
 }
 
+// Builds the official MVR_REQUEST message for one advertised file.
+std::string BuildRequest(const std::string &fileUuid, const std::string &fromStationUuid) {
+  return nlohmann::json{{"Type", "MVR_REQUEST"}, {"FileUUID", CanonicalizeUuid(fileUuid)}, {"FromStationUUID", CanonicalizeUuid(fromStationUuid)}}.dump();
+}
+
 // Builds the official MVR_REQUEST_RET error response.
 std::string BuildRequestError(const std::string &message) {
   return nlohmann::json{{"Type", "MVR_REQUEST_RET"}, {"OK", false}, {"Message", message}}.dump();

--- a/mvr/xchange/mvr_xchange_message.h
+++ b/mvr/xchange/mvr_xchange_message.h
@@ -31,6 +31,7 @@ std::string BuildJoinRet(const std::string &stationUuid, const std::string &stat
 std::string BuildLeaveRet();
 std::string BuildCommit(const MvrXchangeCommit &commit);
 std::string BuildCommitRet(bool ok, const std::string &message = {});
+std::string BuildRequest(const std::string &fileUuid, const std::string &fromStationUuid = {});
 std::string BuildRequestError(const std::string &message);
 
 }

--- a/mvr/xchange/mvr_xchange_service.cpp
+++ b/mvr/xchange/mvr_xchange_service.cpp
@@ -165,6 +165,27 @@ void MvrXchangeService::DiscoverNow() {
   if (IsRunning()) DiscoverStationsOnce();
 }
 
+
+// Requests an advertised remote MVR commit payload by station and FileUUID.
+std::optional<MvrXchangeCommit> MvrXchangeService::RequestRemoteCommit(const std::string &stationUuid, const std::string &fileUuid) {
+  const std::string canonicalStationUuid = CanonicalizeUuid(stationUuid);
+  const std::string canonicalFileUuid = CanonicalizeUuid(fileUuid);
+  const auto stations = GetKnownStations();
+  auto stationIt = std::find_if(stations.begin(), stations.end(), [&](const MvrXchangeRemoteStation &station) {
+    return !canonicalStationUuid.empty() && station.stationUuid == canonicalStationUuid;
+  });
+  if (stationIt == stations.end()) {
+    Log("MVR-xchange request failed because the remote station is no longer known.");
+    return std::nullopt;
+  }
+  const auto endpoint = ResolveOutgoingEndpoint(*stationIt);
+  if (endpoint.ipAddress.empty() || endpoint.port <= 0) {
+    Log("MVR-xchange request failed because the remote station has no reachable endpoint.");
+    return std::nullopt;
+  }
+  return tcpClient_.RequestCommit(endpoint, canonicalFileUuid, [this](const std::string &msg) { Log(msg); });
+}
+
 // Installs a log callback for GUI-safe status forwarding.
 void MvrXchangeService::SetLogCallback(LogCallback callback) { logCallback_ = std::move(callback); }
 

--- a/mvr/xchange/mvr_xchange_service.h
+++ b/mvr/xchange/mvr_xchange_service.h
@@ -25,6 +25,7 @@ public:
   std::vector<MvrXchangeCommit> GetLocalCommits() const;
   std::vector<MvrXchangeRemoteStation> GetKnownStations() const;
   void DiscoverNow();
+  std::optional<MvrXchangeCommit> RequestRemoteCommit(const std::string &stationUuid, const std::string &fileUuid);
   void SetLogCallback(LogCallback callback);
 
 private:

--- a/mvr/xchange/mvr_xchange_tcp_client.cpp
+++ b/mvr/xchange/mvr_xchange_tcp_client.cpp
@@ -1,6 +1,7 @@
 #include "mvr_xchange_tcp_client.h"
 #include "mvr_xchange_message.h"
 #include "mvr_xchange_packet.h"
+#include "../../core/uuidutils.h"
 #include <cstring>
 #ifdef _WIN32
 #include <winsock2.h>
@@ -161,6 +162,40 @@ bool MvrXchangeTcpClient::SendJoinThenCommit(const MvrXchangeRemoteStation &stat
   const bool ok = commitMessage && commitMessage->type == "MVR_COMMIT_RET" && commitMessage->ok;
   if (logCallback) logCallback(ok ? "MVR-xchange sent MVR_JOIN and MVR_COMMIT to " + StationDisplayName(station) + " and received MVR_COMMIT_RET." : "MVR-xchange MVR_COMMIT was not acknowledged by " + StationDisplayName(station) + ".");
   return ok;
+}
+
+// Requests one advertised MVR file from a remote MVR-xchange station.
+std::optional<MvrXchangeCommit> MvrXchangeTcpClient::RequestCommit(const MvrXchangeRemoteStation &station, const std::string &fileUuid, LogCallback logCallback) {
+  int fd = -1;
+  if (!Connect(station, fd, logCallback)) return std::nullopt;
+  const bool sent = SendJson(fd, mvr::xchange::BuildRequest(fileUuid, station.stationUuid));
+  std::vector<uint8_t> buffer;
+  char chunk[4096];
+  while (sent) {
+    const int n = static_cast<int>(recv(fd, chunk, sizeof(chunk), 0));
+    if (n <= 0) break;
+    buffer.insert(buffer.end(), chunk, chunk + n);
+    if (auto packet = mvr::xchange::TryDecodePacket(buffer)) {
+      CloseSocketFd(fd);
+      if (packet->type == mvr::xchange::PacketType::MvrFile) {
+        MvrXchangeCommit commit;
+        commit.fileUuid = CanonicalizeUuid(fileUuid);
+        commit.stationUuid = CanonicalizeUuid(station.stationUuid);
+        commit.payload = std::move(packet->payload);
+        if (logCallback) logCallback("MVR-xchange received requested MVR payload from " + StationDisplayName(station) + ", bytes=" + std::to_string(commit.payload.size()) + ".");
+        return commit;
+      }
+      if (packet->type == mvr::xchange::PacketType::Json && logCallback) {
+        const std::string response(packet->payload.begin(), packet->payload.end());
+        auto message = mvr::xchange::ParseMessage(response);
+        logCallback("MVR-xchange request was rejected by " + StationDisplayName(station) + (message && !message->text.empty() ? ": " + message->text : "."));
+      }
+      return std::nullopt;
+    }
+  }
+  CloseSocketFd(fd);
+  if (logCallback) logCallback("MVR-xchange request failed while receiving from " + StationDisplayName(station) + ".");
+  return std::nullopt;
 }
 
 // Opens a short-lived TCP connection to a discovered MVR-xchange station.

--- a/mvr/xchange/mvr_xchange_tcp_client.h
+++ b/mvr/xchange/mvr_xchange_tcp_client.h
@@ -3,6 +3,7 @@
 #include "mvr_xchange_remote_station.h"
 #include "mvr_xchange_settings.h"
 #include <functional>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -13,6 +14,7 @@ public:
   bool SendJoin(const MvrXchangeRemoteStation &station, const MvrXchangeSettings &settings, const std::vector<MvrXchangeCommit> &localCommits, MvrXchangeRemoteStation &joinedStation, LogCallback logCallback);
   bool SendCommit(const MvrXchangeRemoteStation &station, const MvrXchangeCommit &commit, LogCallback logCallback);
   bool SendJoinThenCommit(const MvrXchangeRemoteStation &station, const MvrXchangeSettings &settings, const std::vector<MvrXchangeCommit> &localCommits, const MvrXchangeCommit &commit, MvrXchangeRemoteStation &joinedStation, LogCallback logCallback);
+  std::optional<MvrXchangeCommit> RequestCommit(const MvrXchangeRemoteStation &station, const std::string &fileUuid, LogCallback logCallback);
 
 private:
   bool Connect(const MvrXchangeRemoteStation &station, int &fd, LogCallback logCallback);


### PR DESCRIPTION
### Motivation

- Add missing MVR-xchange import flow so Perastage can request advertised MVR revisions from remote TCP Mode stations and import them into the project following the official MVR-xchange spec. 
- Provide parity with existing export/publish behavior and reuse the existing MVR importer for payload integration.

### Description

- Added `MVR_REQUEST` JSON builder and parsing support in `mvr/xchange/mvr_xchange_message.{h,cpp}` to construct requests with `FileUUID` and optional `FromStationUUID` fields. 
- Implemented `MvrXchangeTcpClient::RequestCommit(...)` in `mvr/xchange/mvr_xchange_tcp_client.cpp` to open a short-lived TCP connection, send `MVR_REQUEST`, decode framed packets, accept `MvrFile` binary payloads, and report JSON rejections. 
- Exposed `MvrXchangeService::RequestRemoteCommit(...)` in `mvr/xchange/mvr_xchange_service.{h,cpp}` to resolve known stations, validate endpoints, and delegate retrieval to the TCP client. 
- Added a GUI action `Request Latest Remote MVR` in `gui/mvrxchange/mvr_xchange_dialog.{h,cpp}` that triggers discovery, requests the latest advertised commit, writes the received payload to a temporary `.mvr` file, and opens it via the existing import/open path so the normal MVR import policy is applied. 
- Updated documentation: `docs/mvr_exporter.md` (describes request/import behavior) and `docs/release-notes-draft.md` (New features entry). 
- Kept code modular and aligned with existing MVR-xchange responsibilities (message construction, TCP framing, server/client, GUI glue). One-line English comments were added above newly introduced function definitions where applicable.

### Testing

- Ran module and GUI policy checks: `tests/check_perastage_tree_modules.sh` — OK. 
- Ran GUI ConfigManager usage check: `tests/check_no_configmanager_get_in_gui.sh` — OK. 
- Ran static syntax check by compiling relevant translation units: `g++ -std=c++17 -Ithird_party -Imvr -Imvr/xchange -Icore -fsyntax-only mvr/xchange/mvr_xchange_message.cpp mvr/xchange/mvr_xchange_tcp_client.cpp mvr/xchange/mvr_xchange_service.cpp` — OK (no syntax errors). 
- Ran `git diff --check` to ensure whitespace/format sanity — OK. 
- Attempted full CMake build: `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug && cmake --build build -j2` — Not completed in this environment due to missing wxWidgets development libraries (`Could NOT find wxWidgets`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43cf4d0b6483248a138ced9deb6311)