### PR TITLE
Fix MVR-xchange requested project naming

### DIFF
--- a/docs/mvr_xchange.md
+++ b/docs/mvr_xchange.md
@@ -17,6 +17,7 @@ MVR-xchange lets compatible applications discover each other on a local network 
 - Outgoing `MVR_JOIN` message construction and short-lived TCP client support for station handshakes and commit announcements.
 - Canonical lowercase UUID handling for local and remote MVR-xchange `StationUUID` and `FileUUID` values using Perastage's shared UUID utilities.
 - Requests for a known `FileUUID` return the matching non-empty MVR binary packet. Requests with an empty `FileUUID` use the specification-defined latest-revision behavior and return the latest published revision when one exists.
+- Requested remote MVR payloads keep the advertised MVR file name when opened as a new project, while merge imports preserve the current project name.
 
 ## Discovery requirements
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -16,6 +16,7 @@ Changes since **v1.4.0**.
 ## Fixes
 
 - Fixed the MVR-xchange log text styling so transfer messages use the same readable Console colors and monospaced font.
+- Fixed MVR-xchange remote imports so merging keeps the current project name, while opening a requested MVR as a new project uses the advertised MVR file name.
 - Fixed MVR-xchange mDNS advertisement so the service responder binds to the selected advertised interface, improving visibility in peer service lists when multiple local interfaces are available.
 - Improved MVR-xchange compatibility with clients such as grandMA3 by keeping joined TCP Mode peer connections available for immediate publish broadcasts, using a grandMA3 endpoint fallback when discovery only reports an incoming join, refreshing discovery before manual publishes, and sending each join refresh and commit announcement over the same TCP connection before waiting for acknowledgements.
 - Fixed MVR-xchange station naming so generated default names use the full Windows DNS computer name without slow reverse lookups, repair older truncated defaults, and no longer open with the station-name field selected or horizontally scrolled.

--- a/gui/mvrxchange/mvr_xchange_dialog.cpp
+++ b/gui/mvrxchange/mvr_xchange_dialog.cpp
@@ -36,6 +36,40 @@ std::string CommitDisplayName(const MvrXchangeCommit &commit) {
   return commit.fileUuid;
 }
 
+// Returns a filesystem-safe MVR filename from advertised commit metadata.
+wxString RequestedMvrFileName(const std::string &fileName, const std::string &fileUuid) {
+  wxString name = wxString::FromUTF8(fileName.empty() ? fileUuid : fileName);
+  name.Trim(true).Trim(false);
+  if (name.empty())
+    name = "requested-mvr";
+
+  for (wxString::iterator it = name.begin(); it != name.end(); ++it) {
+    if (*it == '/' || *it == '\\' || *it == ':' || *it == '*' ||
+        *it == '?' || *it == '"' || *it == '<' || *it == '>' ||
+        *it == '|') {
+      *it = '_';
+    }
+  }
+
+  wxFileName filename(name);
+  if (filename.GetExt().IsEmpty())
+    filename.SetExt("mvr");
+  return filename.GetFullName();
+}
+
+// Creates a unique temporary path that preserves the advertised MVR filename.
+wxString CreateRequestedMvrTempPath(const std::string &fileName, const std::string &fileUuid) {
+  wxFileName tempDir(wxFileName::CreateTempFileName("perastage_mvr_xchange_"));
+  const wxString tempPath = tempDir.GetFullPath();
+  if (!tempPath.empty())
+    wxRemoveFile(tempPath);
+  if (!wxFileName::Mkdir(tempPath, wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL))
+    return {};
+
+  wxFileName requestedFile(tempPath, RequestedMvrFileName(fileName, fileUuid));
+  return requestedFile.GetFullPath();
+}
+
 } // namespace
 
 // Creates the MVR-xchange dialog and loads persisted settings.
@@ -299,11 +333,13 @@ std::optional<MvrXchangeDialog::AvailableMvrFile> MvrXchangeDialog::SelectedAvai
 
 // Writes a requested MVR payload to a temporary file and runs the normal import choice flow.
 bool MvrXchangeDialog::ImportRequestedCommit(const AvailableMvrFile &file, const MvrXchangeCommit &commit) {
-  wxFileName tempFile(wxFileName::CreateTempFileName("perastage_mvr_xchange_"));
-  const wxString originalPath = tempFile.GetFullPath();
-  if (!originalPath.empty()) wxRemoveFile(originalPath);
-  tempFile.SetExt("mvr");
-  std::ofstream out(tempFile.GetFullPath().ToStdString(), std::ios::binary);
+  const wxString tempPath = CreateRequestedMvrTempPath(file.fileName, file.fileUuid);
+  if (tempPath.empty()) {
+    AppendLog("MVR-xchange could not create a temporary folder for the requested MVR payload.");
+    return false;
+  }
+
+  std::ofstream out(tempPath.ToStdString(), std::ios::binary);
   out.write(reinterpret_cast<const char *>(commit.payload.data()), static_cast<std::streamsize>(commit.payload.size()));
   out.close();
   if (!out) {
@@ -312,7 +348,7 @@ bool MvrXchangeDialog::ImportRequestedCommit(const AvailableMvrFile &file, const
   }
   if (auto *mainWindow = dynamic_cast<MainWindow *>(GetParent())) {
     AppendLog(wxString("Importing requested MVR-xchange file ") + wxString::FromUTF8(file.fileUuid) + ".");
-    return mainWindow->ImportMvrWithUserChoice(tempFile.GetFullPath().ToStdString());
+    return mainWindow->ImportMvrWithUserChoice(tempPath.ToStdString());
   }
   return false;
 }


### PR DESCRIPTION
### Motivation
- Ensure MVR-xchange imports apply the intended project naming policy: when the user chooses to merge, preserve the current project name; when opening a requested MVR as a new project, use the advertised MVR file name.

### Description
- Add `RequestedMvrFileName` to sanitize an advertised commit name and ensure a safe `.mvr` filename is derived for the requested payload.
- Add `CreateRequestedMvrTempPath` to create a unique temporary folder and place the sanitized advertised filename inside it.
- Update `MvrXchangeDialog::ImportRequestedCommit` to write the requested MVR payload into the named temporary path and pass that path to `ImportMvrWithUserChoice`, preserving the advertised filename for "Open as new project" while keeping merge behavior unchanged.
- Update `docs/mvr_xchange.md` and `docs/release-notes-draft.md` to document the naming behavior change.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded.
- Ran `git diff --check` (style/sanity check) and it passed.
- Attempted a local `cmake -S . -B /tmp/perastage-build -DPERASTAGE_ENABLE_MVR_XCHANGE_MDNS=OFF` to smoke-build, but configuration failed due to missing system `wxWidgets` development libraries in the environment (not a regression in the changes above).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a44c0c0d6288324a3ad027f1016b568)