### PR TITLE
Fix MVR merge resource resolution and SymDef remapping

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -15,6 +15,7 @@ Changes since **v1.4.0**.
 
 ## Fixes
 
+- Fixed MVR merge imports so incoming fixture, truss, hoist, scene-object, and symbol resources are copied from the selected MVR package into the current scene before references are applied, preventing merged models from resolving against the already-open MVR.
 - Fixed the MVR-xchange log text styling so transfer messages use the same readable Console colors and monospaced font.
 - Fixed MVR-xchange remote imports so merging keeps the current project name, while opening a requested MVR as a new project uses the advertised MVR file name.
 - Fixed MVR-xchange mDNS advertisement so the service responder binds to the selected advertised interface, improving visibility in peer service lists when multiple local interfaces are available.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -15,7 +15,7 @@ Changes since **v1.4.0**.
 
 ## Fixes
 
-- Fixed MVR merge imports so incoming fixture, truss, hoist, scene-object, and symbol resources are copied from the selected MVR package into the current scene before references are applied, preventing merged models from resolving against the already-open MVR.
+- Fixed MVR merge imports so incoming fixture, truss, hoist, scene-object, and symbol resources are copied into a valid merge resource root before references are applied, including when merging into an empty or unsaved scene.
 - Fixed the MVR-xchange log text styling so transfer messages use the same readable Console colors and monospaced font.
 - Fixed MVR-xchange remote imports so merging keeps the current project name, while opening a requested MVR as a new project uses the advertised MVR file name.
 - Fixed MVR-xchange mDNS advertisement so the service responder binds to the selected advertised interface, improving visibility in peer service lists when multiple local interfaces are available.

--- a/gui/mainwindow/controllers/mainwindow_io_controller.cpp
+++ b/gui/mainwindow/controllers/mainwindow_io_controller.cpp
@@ -490,8 +490,10 @@ bool MainWindowIoController::MergeMvrFromPath(const std::string &pathUtf8) {
   MvrImportResult importResult;
   MvrImporter mergeImporter;
   owner->LockViewportInteraction();
+  MvrImportOptions importOptions;
+  importOptions.sourceKind = MvrImportSourceKind::MergeImport;
   const bool imported = mergeImporter.ImportFromFile(
-      pathUtf8, importResult, MvrImportMode::ParseOnly, true, true);
+      pathUtf8, importResult, MvrImportMode::ParseOnly, importOptions);
   owner->UnlockViewportInteraction();
 
   if (!imported) {

--- a/mvr/mvr_merge_applier.cpp
+++ b/mvr/mvr_merge_applier.cpp
@@ -164,11 +164,17 @@ void RemapImportedReferences(MvrScene &scene,
         RemapImportedUuidReference(support.motorFixtureUuid, analysis);
     support.parentGroupUuid =
         RemapImportedUuidReference(support.parentGroupUuid, analysis);
+    for (auto &geometry : support.geometries)
+      geometry.sourceSymdefUuid =
+          RemapImportedUuidReference(geometry.sourceSymdefUuid, analysis);
   }
 
   for (auto &[uuid, object] : scene.sceneObjects) {
     object.parentGroupUuid =
         RemapImportedUuidReference(object.parentGroupUuid, analysis);
+    for (auto &geometry : object.geometries)
+      geometry.sourceSymdefUuid =
+          RemapImportedUuidReference(geometry.sourceSymdefUuid, analysis);
   }
 
   for (auto &[uuid, group] : scene.groupObjects) {

--- a/mvr/mvr_merge_applier.cpp
+++ b/mvr/mvr_merge_applier.cpp
@@ -20,7 +20,11 @@
 #include "mvr_merge_resource_rewriter.h"
 
 #include <algorithm>
+#include <chrono>
 #include <cctype>
+#include <filesystem>
+#include <string>
+#include <system_error>
 #include <utility>
 
 namespace mvr {
@@ -42,6 +46,37 @@ std::string ToLowerAscii(std::string value) {
       value.begin(), value.end(), value.begin(),
       [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
   return value;
+}
+
+// Creates a temporary resource root for merges into unsaved scenes.
+std::string CreateTemporaryMergeResourceBasePath() {
+  namespace fs = std::filesystem;
+  std::error_code tempEc;
+  const fs::path tempBase = fs::temp_directory_path(tempEc);
+  if (tempEc)
+    return {};
+
+  for (int attempt = 0; attempt < 32; ++attempt) {
+    const fs::path fullPath =
+        tempBase / ("ps_mvr_merge_" +
+                    std::to_string(
+                        std::chrono::steady_clock::now()
+                            .time_since_epoch()
+                            .count()) +
+                    "_" + std::to_string(attempt));
+    std::error_code ec;
+    if (fs::create_directory(fullPath, ec) && !ec)
+      return fullPath.string();
+  }
+  return {};
+}
+
+// Ensures imported resources have a target base path before merge rewriting.
+void EnsureMergeResourceBasePath(MvrScene &target, const MvrScene &imported) {
+  if (!target.basePath.empty() || imported.basePath.empty())
+    return;
+
+  target.basePath = CreateTemporaryMergeResourceBasePath();
 }
 
 // Normalizes fixture type names for merge decision lookup.
@@ -212,6 +247,7 @@ MvrSceneMergeResult ApplyImportedSceneMerge(MvrScene &target,
   }
   result.fixtureUuidRemap = analysis.fixtureUuidRemap;
 
+  EnsureMergeResourceBasePath(target, imported);
   MvrScene importedCopy = imported;
   RewriteImportedSceneResourceReferences(target, importedCopy);
   ApplyFixtureTypeDecisions(importedCopy, analysis);

--- a/mvr/mvr_merge_resource_rewriter.cpp
+++ b/mvr/mvr_merge_resource_rewriter.cpp
@@ -185,6 +185,16 @@ void RewriteImportedSceneResourceReferences(const MvrScene &target,
                              rewrittenByOriginal);
   }
 
+  for (auto &[uuid, support] : imported.supports) {
+    RewriteResourceReference(target, imported, support.gdtfSpec,
+                             rewrittenByOriginal);
+    RewriteResourceReference(target, imported, support.modelFile,
+                             rewrittenByOriginal);
+    for (auto &geometry : support.geometries)
+      RewriteResourceReference(target, imported, geometry.modelFile,
+                               rewrittenByOriginal);
+  }
+
   for (auto &[uuid, object] : imported.sceneObjects) {
     RewriteResourceReference(target, imported, object.modelFile,
                              rewrittenByOriginal);

--- a/tests/mvr_merge_analyzer_applier_test.cpp
+++ b/tests/mvr_merge_analyzer_applier_test.cpp
@@ -327,6 +327,7 @@ static void VerifyImportedResourcesAreRewrittenIntoTargetBasePath() {
   const std::filesystem::path importedBase = tempDir / "incoming_mvr";
 
   WriteGdtfFile(targetBase / "shared" / "fixture.gdtf", "current fixture");
+  WriteGdtfFile(targetBase / "symbols" / "symdef.3ds", "current symdef");
   WriteGdtfFile(importedBase / "shared" / "fixture.gdtf", "incoming fixture");
   WriteGdtfFile(importedBase / "truss" / "type.gdtf", "incoming truss gdtf");
   WriteGdtfFile(importedBase / "truss" / "symbol.3ds", "incoming symbol");
@@ -335,6 +336,12 @@ static void VerifyImportedResourcesAreRewrittenIntoTargetBasePath() {
   WriteGdtfFile(importedBase / "truss" / "aux.gdtf", "incoming truss aux");
   WriteGdtfFile(importedBase / "objects" / "object.3ds", "incoming object");
   WriteGdtfFile(importedBase / "objects" / "geometry.3ds", "incoming geometry");
+  WriteGdtfFile(importedBase / "supports" / "hoist.gdtf",
+                "incoming hoist gdtf");
+  WriteGdtfFile(importedBase / "supports" / "hoist.3ds",
+                "incoming hoist model");
+  WriteGdtfFile(importedBase / "supports" / "hoist_child.3ds",
+                "incoming hoist child");
   WriteGdtfFile(importedBase / "symbols" / "symdef.3ds", "incoming symdef");
   WriteGdtfFile(importedBase / "symbols" / "symdef_child.3ds",
                 "incoming symdef child");
@@ -343,6 +350,7 @@ static void VerifyImportedResourcesAreRewrittenIntoTargetBasePath() {
   target.basePath = targetBase.string();
   target.fixtures["current-fixture"] = MakeTypedFixture(
       "current-fixture", "Current", "shared/fixture.gdtf", "Mode A");
+  target.symdefFiles["incoming-symdef"] = "symbols/symdef.3ds";
 
   MvrScene imported;
   imported.basePath = importedBase.string();
@@ -362,7 +370,17 @@ static void VerifyImportedResourcesAreRewrittenIntoTargetBasePath() {
   object.modelFile = "objects/object.3ds";
   object.geometries.push_back(
       GeometryInstance{"objects/geometry.3ds", Matrix{}});
+  object.geometries.front().sourceSymdefUuid = "incoming-symdef";
   imported.sceneObjects[object.uuid] = object;
+
+  Support support;
+  support.uuid = "incoming-support";
+  support.gdtfSpec = "supports/hoist.gdtf";
+  support.modelFile = "supports/hoist.3ds";
+  support.geometries.push_back(
+      GeometryInstance{"supports/hoist_child.3ds", Matrix{}});
+  support.geometries.front().sourceSymdefUuid = "incoming-symdef";
+  imported.supports[support.uuid] = support;
 
   imported.symdefFiles["incoming-symdef"] = "symbols/symdef.3ds";
   imported.symdefGeometries["incoming-symdef"] = {
@@ -387,11 +405,20 @@ static void VerifyImportedResourcesAreRewrittenIntoTargetBasePath() {
   assert(ResourceExists(targetBase, mergedTruss.modelFile));
   assert(ResourceExists(targetBase, mergedTruss.perastageAuxGdtfArchivePath));
 
+  const Support &mergedSupport = target.supports.at("incoming-support");
+  assert(ResourceExists(targetBase, mergedSupport.gdtfSpec));
+  assert(ResourceExists(targetBase, mergedSupport.modelFile));
+  assert(
+      ResourceExists(targetBase, mergedSupport.geometries.front().modelFile));
+
   const SceneObject &mergedObject = target.sceneObjects.at("incoming-object");
   assert(ResourceExists(targetBase, mergedObject.modelFile));
   assert(ResourceExists(targetBase, mergedObject.geometries.front().modelFile));
   const std::string mergedSymdefUuid =
       mvr::RemapImportedUuidReference("incoming-symdef", analysis);
+  assert(mergedSupport.geometries.front().sourceSymdefUuid == mergedSymdefUuid);
+  assert(mergedObject.geometries.front().sourceSymdefUuid == mergedSymdefUuid);
+  assert(mergedSymdefUuid != "incoming-symdef");
   assert(ResourceExists(targetBase, target.symdefFiles.at(mergedSymdefUuid)));
   assert(ResourceExists(
       targetBase, target.symdefGeometries.at(mergedSymdefUuid).front().file));
@@ -405,6 +432,9 @@ static void VerifyImportedResourcesAreRewrittenIntoTargetBasePath() {
   assert(ResourceExists(reloadedBase, mergedTruss.symbolFile));
   assert(
       ResourceExists(reloadedBase, mergedObject.geometries.front().modelFile));
+  assert(ResourceExists(reloadedBase, mergedSupport.gdtfSpec));
+  assert(
+      ResourceExists(reloadedBase, mergedSupport.geometries.front().modelFile));
 }
 
 // Verifies duplicate patch addresses are warnings and do not block apply.

--- a/tests/mvr_merge_analyzer_applier_test.cpp
+++ b/tests/mvr_merge_analyzer_applier_test.cpp
@@ -437,6 +437,43 @@ static void VerifyImportedResourcesAreRewrittenIntoTargetBasePath() {
       ResourceExists(reloadedBase, mergedSupport.geometries.front().modelFile));
 }
 
+// Verifies merge imports into unsaved scenes create a resource base for models.
+static void VerifyMergeIntoEmptyBasePathCreatesResourceRoot() {
+  const std::filesystem::path tempDir = std::filesystem::temp_directory_path() /
+                                        "perastage_mvr_merge_empty_base_test";
+  std::filesystem::remove_all(tempDir);
+  const std::filesystem::path importedBase = tempDir / "incoming_mvr";
+
+  WriteGdtfFile(importedBase / "fixture.gdtf", "incoming fixture");
+  WriteGdtfFile(importedBase / "models" / "object.3ds", "incoming object");
+
+  MvrScene target;
+  MvrScene imported;
+  imported.basePath = importedBase.string();
+  imported.fixtures["incoming-fixture"] = MakeTypedFixture(
+      "incoming-fixture", "Incoming", "fixture.gdtf", "Mode A");
+  SceneObject object;
+  object.uuid = "incoming-object";
+  object.modelFile = "models/object.3ds";
+  object.geometries.push_back(
+      GeometryInstance{"models/object.3ds", Matrix{}});
+  imported.sceneObjects[object.uuid] = object;
+
+  const mvr::MvrMergeAnalysis analysis =
+      mvr::AnalyzeImportedSceneMerge(target, imported);
+  const mvr::MvrSceneMergeResult result =
+      mvr::ApplyImportedSceneMerge(target, imported, analysis);
+
+  assert(result.fixturesAdded == 1);
+  assert(!target.basePath.empty());
+  const std::filesystem::path targetBase = target.basePath;
+  assert(ResourceExists(targetBase,
+                        target.fixtures.at("incoming-fixture").gdtfSpec));
+  assert(ResourceExists(
+      targetBase,
+      target.sceneObjects.at("incoming-object").geometries.front().modelFile));
+}
+
 // Verifies duplicate patch addresses are warnings and do not block apply.
 static void VerifyDuplicatePatchAddressWarningDoesNotBlockMerge() {
   MvrScene target;
@@ -538,6 +575,7 @@ int main() {
   VerifySameLayerNameWithDifferentUuidRenamesIncomingLayer();
   VerifySymdefUuidCollisionWithDifferentGeometryFilesRemapsSymbol();
   VerifyImportedResourcesAreRewrittenIntoTargetBasePath();
+  VerifyMergeIntoEmptyBasePathCreatesResourceRoot();
   VerifyDuplicatePatchAddressWarningDoesNotBlockMerge();
   VerifyCancelBeforeApplyLeavesTargetUnchanged();
   VerifyFailureDuringApplyLeavesTargetUnchanged();


### PR DESCRIPTION
### Motivation
- Merging an MVR into an already-open project sometimes left incoming 3D models unresolved because resource copy/remap happened after references were applied or importer was not marked as a merge import.
- Support/hoist geometry and per-geometry SymDef UUID references were not fully handled during merge, which could leave stale UUIDs pointing at the current project instead of the incoming package.

### Description
- Mark UI merge imports with `MvrImportOptions::sourceKind = MvrImportSourceKind::MergeImport` so importer behavior and diagnostics use the merge pipeline (`gui/mainwindow/controllers/mainwindow_io_controller.cpp`).
- Copy incoming support/hoist resources into the target project during merge resource rewriting so `gdtfSpec`, `modelFile`, and support geometry files are rewritten before references are applied (`mvr/mvr_merge_resource_rewriter.cpp`).
- Remap geometry-level `sourceSymdefUuid` on merged `Support` and `SceneObject` geometries during merge apply so SymDef UUID collisions are resolved and no stale references remain (`mvr/mvr_merge_applier.cpp`).
- Extend the merge analyzer/applier unit test to include supports/hoists and SymDef-based geometry so the resource-copying and remapping behavior is validated (`tests/mvr_merge_analyzer_applier_test.cpp`).
- Update `docs/release-notes-draft.md` with a brief user-facing fix entry describing the merge resource-resolution fix.

### Testing
- Built and ran the focused merge analyzer/applier test: `g++ -std=c++20 -Icore -Imodels -Imvr -Ithird_party tests/mvr_merge_analyzer_applier_test.cpp mvr/mvr_merge_analyzer.cpp mvr/mvr_merge_applier.cpp mvr/mvr_merge_resource_rewriter.cpp mvr/mvrscenemerger.cpp core/uuidutils.cpp models/mvrscene.cpp -o /tmp/mvr_merge_analyzer_applier_test && /tmp/mvr_merge_analyzer_applier_test`, which completed successfully.
- Ran repository checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both of which returned `OK`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a44c633bc1c832485e68b6dc51fc931)