### PR TITLE
Canonicalize Perastage truss GDTF exports

### DIFF
--- a/core/gdtfdictionary.cpp
+++ b/core/gdtfdictionary.cpp
@@ -320,19 +320,14 @@ bool TryReadGdtfIdentityFromDescription(const std::filesystem::path &sourcePath,
   return !manufacturerOut.empty() || !fixtureTypeOut.empty();
 }
 
-// Builds a canonical Perastage export filename using parsed GDTF identity
-// values.
-std::string
-BuildPerastageCanonicalGdtfFileName(const std::filesystem::path &sourcePath) {
-  std::string manufacturerName;
-  std::string fixtureTypeName;
-  TryReadGdtfIdentityFromDescription(sourcePath, manufacturerName,
-                                     fixtureTypeName);
-
+// Builds a canonical Perastage export filename from identity values.
+std::string BuildPerastageCanonicalGdtfFileNameFromIdentity(
+    std::string manufacturerName, std::string fixtureTypeName,
+    const std::string &fallbackStem) {
   if (manufacturerName.empty())
     manufacturerName = "Unknown";
   if (fixtureTypeName.empty())
-    fixtureTypeName = sourcePath.stem().string();
+    fixtureTypeName = fallbackStem;
 
   std::replace(manufacturerName.begin(), manufacturerName.end(), '@', '_');
   std::replace(manufacturerName.begin(), manufacturerName.end(), ' ', '_');
@@ -343,8 +338,19 @@ BuildPerastageCanonicalGdtfFileName(const std::filesystem::path &sourcePath) {
   if (manufacturerName.empty())
     manufacturerName = "Unknown";
   if (fixtureTypeName.empty())
-    fixtureTypeName = sourcePath.stem().string();
+    fixtureTypeName = "Fixture";
   return manufacturerName + "@" + fixtureTypeName + "@Perastage.gdtf";
+}
+
+// Builds a canonical Perastage export filename using parsed GDTF identity values.
+std::string
+BuildPerastageCanonicalGdtfFileName(const std::filesystem::path &sourcePath) {
+  std::string manufacturerName;
+  std::string fixtureTypeName;
+  TryReadGdtfIdentityFromDescription(sourcePath, manufacturerName,
+                                     fixtureTypeName);
+  return BuildPerastageCanonicalGdtfFileNameFromIdentity(
+      manufacturerName, fixtureTypeName, sourcePath.stem().string());
 }
 
 std::optional<std::string>
@@ -974,6 +980,14 @@ void UpdateDictionaryEntry(const std::string &type, const Entry &entry) {
 // Builds the canonical @Perastage derivative filename for a GDTF file.
 std::string BuildPerastageCanonicalGdtfFileName(const std::string &gdtfPath) {
   return BuildPerastageCanonicalGdtfFileName(PathUtils::PathFromUtf8(gdtfPath));
+}
+
+// Builds the canonical @Perastage derivative filename from explicit identity values.
+std::string BuildPerastageCanonicalGdtfFileName(
+    const std::string &manufacturer, const std::string &model,
+    const std::string &fallbackStem) {
+  return BuildPerastageCanonicalGdtfFileNameFromIdentity(
+      TrimAsciiWhitespace(manufacturer), TrimAsciiWhitespace(model), fallbackStem);
 }
 
 // Returns true when a GDTF path already has canonical Perastage derivative naming.

--- a/core/gdtfdictionary.h
+++ b/core/gdtfdictionary.h
@@ -69,6 +69,10 @@ namespace GdtfDictionary {
     void Update(const std::string& type, const std::string& gdtfPath, const std::string& mode = {}, const std::string& category = {});
     // Builds the stable @Perastage derivative filename for a GDTF path.
     std::string BuildPerastageCanonicalGdtfFileName(const std::string& gdtfPath);
+    // Builds the stable @Perastage derivative filename from explicit identity values.
+    std::string BuildPerastageCanonicalGdtfFileName(
+        const std::string& manufacturer, const std::string& model,
+        const std::string& fallbackStem = "");
     // Returns true when a GDTF filename already uses Perastage derivative naming.
     bool IsPerastageNamedGdtfFile(const std::string& gdtfPath);
     // Creates or overwrites the stable @Perastage derivative for a library fixture and updates the dictionary.

--- a/core/truss_gdtf_builder.cpp
+++ b/core/truss_gdtf_builder.cpp
@@ -16,8 +16,8 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "truss_gdtf_builder.h"
-#include "app_version.h"
 #include "filesystem_path_utils.h"
+#include "gdtf_mutation_audit.h"
 
 #include "json.hpp"
 #include "logger.h"
@@ -32,8 +32,6 @@
 #include <array>
 #include <cctype>
 #include <cstdint>
-#include <chrono>
-#include <ctime>
 #include <fstream>
 #include <iomanip>
 #include <memory>
@@ -79,21 +77,6 @@ std::string BuildDeterministicUuid(const std::string &seed) {
   return BytesToUuid(bytes);
 }
 
-// Builds the current UTC timestamp used by generated GDTF revisions.
-std::string BuildRevisionTimestampUtcNow() {
-  using Clock = std::chrono::system_clock;
-  const std::time_t nowTime = Clock::to_time_t(Clock::now());
-  std::tm utcTm{};
-#if defined(_WIN32)
-  gmtime_s(&utcTm, &nowTime);
-#else
-  gmtime_r(&nowTime, &utcTm);
-#endif
-  std::ostringstream stamp;
-  stamp << std::put_time(&utcTm, "%Y-%m-%dT%H:%M:%SZ");
-  return stamp.str();
-}
-
 struct TrussSourceData {
   std::string manufacturer;
   std::string model;
@@ -104,6 +87,7 @@ struct TrussSourceData {
   fs::path geometryPath;
   fs::path symbolPath;
   std::string typeKey;
+  std::string crossSection;
 };
 
 static std::string Trim(std::string value) {
@@ -272,6 +256,7 @@ static std::string BuildStableFixtureTypeId(const TrussSourceData &data) {
   seed << "perastage-truss-type:v2|" << data.typeKey << '|'
        << Slug(data.manufacturer, "manufacturer") << '|'
        << Slug(data.model, "model") << '|'
+       << Slug(data.crossSection, "cross_section") << '|'
        << Slug(data.geometryPath.generic_string(), "geometry") << '|'
        << Slug(data.symbolPath.generic_string(), "symbol") << '|'
        << std::fixed << std::setprecision(3) << data.lengthMm << '|'
@@ -298,9 +283,12 @@ static std::string BuildDescriptionXml(const TrussSourceData &data) {
 
   auto *fixtureType = doc.NewElement("FixtureType");
   const std::string fixtureName = data.model.empty() ? "Truss" : data.model;
+  const std::string manufacturer =
+      Trim(data.manufacturer).empty() ? "Unknown" : Trim(data.manufacturer);
   fixtureType->SetAttribute("Name", fixtureName.c_str());
   fixtureType->SetAttribute("ShortName", fixtureName.c_str());
-  fixtureType->SetAttribute("Manufacturer", data.manufacturer.c_str());
+  fixtureType->SetAttribute("LongName", fixtureName.c_str());
+  fixtureType->SetAttribute("Manufacturer", manufacturer.c_str());
   fixtureType->SetAttribute("FixtureTypeID", BuildStableFixtureTypeId(data).c_str());
   root->InsertEndChild(fixtureType);
 
@@ -315,13 +303,15 @@ static std::string BuildDescriptionXml(const TrussSourceData &data) {
   attributes->InsertEndChild(attributesNode);
   fixtureType->InsertEndChild(attributes);
 
-  auto *physical = doc.NewElement("PhysicalDescriptions");
-  auto *properties = doc.NewElement("Properties");
-  auto *weight = doc.NewElement("Weight");
-  weight->SetAttribute("Value", data.weightKg);
-  properties->InsertEndChild(weight);
-  physical->InsertEndChild(properties);
-  fixtureType->InsertEndChild(physical);
+  if (data.weightKg > 0.0f) {
+    auto *physical = doc.NewElement("PhysicalDescriptions");
+    auto *properties = doc.NewElement("Properties");
+    auto *weight = doc.NewElement("Weight");
+    weight->SetAttribute("Value", data.weightKg);
+    properties->InsertEndChild(weight);
+    physical->InsertEndChild(properties);
+    fixtureType->InsertEndChild(physical);
+  }
 
   auto *models = doc.NewElement("Models");
   auto *mainModel = doc.NewElement("Model");
@@ -335,10 +325,15 @@ static std::string BuildDescriptionXml(const TrussSourceData &data) {
   fixtureType->InsertEndChild(models);
 
   auto *geometries = doc.NewElement("Geometries");
-  auto *geometry = doc.NewElement("Geometry");
-  geometry->SetAttribute("Name", "Root");
-  geometry->SetAttribute("Model", "Main");
-  geometries->InsertEndChild(geometry);
+  auto *structure = doc.NewElement("Structure");
+  const std::string trussCrossSection =
+      Trim(data.crossSection).empty() ? "GenericTruss" : Trim(data.crossSection);
+  structure->SetAttribute("Name", "Root");
+  structure->SetAttribute("Model", "Main");
+  structure->SetAttribute("StructureType", "Detail");
+  structure->SetAttribute("CrossSectionType", "TrussFramework");
+  structure->SetAttribute("TrussCrossSection", trussCrossSection.c_str());
+  geometries->InsertEndChild(structure);
   fixtureType->InsertEndChild(geometries);
 
   auto *dmxModes = doc.NewElement("DMXModes");
@@ -354,21 +349,16 @@ static std::string BuildDescriptionXml(const TrussSourceData &data) {
   dmxModes->InsertEndChild(mode);
   fixtureType->InsertEndChild(dmxModes);
 
-  auto *revisions = doc.NewElement("Revisions");
-  auto *revision = doc.NewElement("Revision");
-  revision->SetAttribute("Date", BuildRevisionTimestampUtcNow().c_str());
-  revision->SetAttribute("UserID", 0);
-  const std::string modifiedBy = std::string("Perastage ") + app::kVersion;
-  revision->SetAttribute("ModifiedBy", modifiedBy.c_str());
-  revision->SetAttribute("Text", "Generated Perastage auxiliary truss fixture type for MVR export");
-  revisions->InsertEndChild(revision);
-  fixtureType->InsertEndChild(revisions);
+  GdtfMutationAudit::AppendRevision(
+      fixtureType, doc, "Generated canonical Perastage truss GDTF",
+      GdtfMutationAudit::BuildPerastageModifiedBy());
 
   tinyxml2::XMLPrinter printer;
   doc.Print(&printer);
   return printer.CStr();
 }
 
+// Builds a truss GDTF archive from normalized source data.
 static bool BuildFromSourceData(const TrussSourceData &data,
                                 const fs::path &outGdtfPath,
                                 std::string *outError) {
@@ -413,6 +403,7 @@ static bool BuildFromSourceData(const TrussSourceData &data,
 
 } // namespace
 
+// Converts a legacy .gtruss archive into a Perastage-authored GDTF archive.
 bool ConvertLegacyGtrussToGdtf(const fs::path &gtrussPath,
                                const fs::path &outGdtfPath,
                                std::string *outError) {
@@ -422,6 +413,7 @@ bool ConvertLegacyGtrussToGdtf(const fs::path &gtrussPath,
   return BuildFromSourceData(source, outGdtfPath, outError);
 }
 
+// Builds a Perastage-authored GDTF archive for one truss instance.
 bool BuildTrussGdtfFromInstance(const Truss &truss, const fs::path &outGdtfPath,
                                 std::string *outError) {
   TrussSourceData source;
@@ -432,6 +424,7 @@ bool BuildTrussGdtfFromInstance(const Truss &truss, const fs::path &outGdtfPath,
   source.heightMm = truss.heightMm;
   source.weightKg = truss.weightKg;
   source.typeKey = truss.perastageTypeKey;
+  source.crossSection = truss.crossSection;
 
   auto pickGeometry = [&](const std::string &path) {
     fs::path p = PathUtils::PathFromUtf8(path);

--- a/core/truss_gdtf_builder.cpp
+++ b/core/truss_gdtf_builder.cpp
@@ -101,6 +101,11 @@ static std::string Trim(std::string value) {
   return value;
 }
 
+// Converts Perastage truss dimensions from millimeters to GDTF meters.
+static float MillimetersToGdtfMeters(float millimeters) {
+  return millimeters / 1000.0f;
+}
+
 static std::string Slug(const std::string &input, const std::string &fallback) {
   std::string out;
   out.reserve(input.size());
@@ -316,9 +321,9 @@ static std::string BuildDescriptionXml(const TrussSourceData &data) {
   auto *models = doc.NewElement("Models");
   auto *mainModel = doc.NewElement("Model");
   mainModel->SetAttribute("Name", "Main");
-  mainModel->SetAttribute("Length", data.lengthMm / 1000.0f);
-  mainModel->SetAttribute("Width", data.widthMm / 1000.0f);
-  mainModel->SetAttribute("Height", data.heightMm / 1000.0f);
+  mainModel->SetAttribute("Length", MillimetersToGdtfMeters(data.lengthMm));
+  mainModel->SetAttribute("Width", MillimetersToGdtfMeters(data.widthMm));
+  mainModel->SetAttribute("Height", MillimetersToGdtfMeters(data.heightMm));
   mainModel->SetAttribute("PrimitiveType", "Base");
   mainModel->SetAttribute("File", "main");
   models->InsertEndChild(mainModel);

--- a/docs/gdtf_mutation_policy.md
+++ b/docs/gdtf_mutation_policy.md
@@ -20,6 +20,7 @@ Perastage currently mutates GDTF archives at the following integration points.
 | Viewer 3D API | `viewer3d/gdtfloader.cpp` | `SetGdtfProperties(...)` | Writes `PhysicalDescriptions/Properties` (`Weight`, `PowerConsumption`), appends a standard `Revision`, rewrites `.gdtf`. |
 | GUI symbol workflow | `gui/windows/symbol_fixture_applier.cpp` | `RewriteGdtf(...)` + `AppendMutationAuditMetadata(...)` (called by `ApplySymbolsToFixtureGdtf(...)`) | Writes/updates SVG symbol assets and model SVG offsets, appends a standard `Revision`, rewrites `.gdtf`. |
 | Project symbol cache manifest | `core/symbol_cache_manifest.cpp` | `SymbolCacheManifest::ValidateFixture(...)`, `MarkFixtureSymbolsValid(...)` | Stores project-level metadata in `.pstg` packages so startup can skip deep GDTF inspection only when the referenced GDTF hash and required view metadata still match. |
+| Truss GDTF generation | `core/truss_gdtf_builder.cpp` | `BuildTrussGdtfFromInstance(...)`, `ConvertLegacyGtrussToGdtf(...)` | Creates Perastage-owned truss GDTF archives with a standard `Structure` root geometry, deterministic `FixtureTypeID`, standard `Revision`, and no custom XML nodes. |
 | MVR export patching | `mvr/mvrexporter.cpp` | `CreatePatchedGdtf(...)` + export resource canonicalization | Creates temporary patched GDTF copies for export overrides (manufacturer/model/physical properties/color/dimensions), appends a standard `Revision` when patched, and canonicalizes every `.gdtf` before it is packaged. |
 | Shared audit helpers | `core/gdtf_mutation_audit.cpp` | `StampPerastageMutationMetadata(...)`, `AppendRevision(...)`, `ApplyPhysicalPropertiesWithAudit(...)` | Centralizes standard GDTF revision-appending semantics used by write flows. |
 
@@ -28,6 +29,7 @@ Perastage currently mutates GDTF archives at the following integration points.
 - `core/gdtf_mutation_audit.{h,cpp}` is the single owner of Perastage GDTF revision semantics.
 - `core/gdtf_canonicalizer.{h,cpp}` is the shared owner of export-time GDTF structural canonicalization and validation.
 - Write call sites in other modules must use this helper API instead of hand-rolling custom revision XML shapes.
+- Truss GDTF files generated, completed, normalized, or modified by Perastage are exported as derived Perastage-owned copies named `Manufacturer@Model@Perastage.gdtf`; external or library source GDTF files are read as inputs and are not overwritten.
 - Fixture SVG symbols remain stored inside their corresponding GDTF files; the `.pstg` symbol cache manifest stores metadata only and never stores SVG payloads.
 - Fixture display color is no longer persisted by mutating `description.xml` model `Color` values in place. The persisted source of truth for default color selection is the Perastage dictionary/project data layer, while `GetGdtfModelColor(...)` remains read-only for legacy fallback reads.
 

--- a/docs/gdtf_mutation_policy.md
+++ b/docs/gdtf_mutation_policy.md
@@ -30,6 +30,7 @@ Perastage currently mutates GDTF archives at the following integration points.
 - `core/gdtf_canonicalizer.{h,cpp}` is the shared owner of export-time GDTF structural canonicalization and validation.
 - Write call sites in other modules must use this helper API instead of hand-rolling custom revision XML shapes.
 - Truss GDTF files generated, completed, normalized, or modified by Perastage are exported as derived Perastage-owned copies named `Manufacturer@Model@Perastage.gdtf`; external or library source GDTF files are read as inputs and are not overwritten.
+- GDTF model dimensions are written in meters. Perastage truss dimensions are stored in millimeters, so truss GDTF generation converts length, width, and height from millimeters to meters at export time.
 - Fixture SVG symbols remain stored inside their corresponding GDTF files; the `.pstg` symbol cache manifest stores metadata only and never stores SVG payloads.
 - Fixture display color is no longer persisted by mutating `description.xml` model `Color` values in place. The persisted source of truth for default color selection is the Perastage dictionary/project data layer, while `GetGdtfModelColor(...)` remains read-only for legacy fallback reads.
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -11,7 +11,7 @@ Changes since **v1.4.0**.
 
 ## Improvements
 
-- Improved exported truss GDTF files so Perastage-generated or Perastage-normalized trusses use canonical `Manufacturer@Model@Perastage.gdtf` archive names, stricter GDTF truss structure metadata, and preserve edited truss values across save/reopen roundtrips, share edited type metadata across trusses from the same source, and show the active GDTF in the truss model-file column when available.
+- Improved exported truss GDTF files so Perastage-generated or Perastage-normalized trusses use canonical `Manufacturer@Model@Perastage.gdtf` archive names, stricter GDTF truss structure metadata, and preserve edited truss values across save/reopen roundtrips, share edited type metadata across trusses from the same source, and show the active GDTF in the truss model-file column when available, while keeping model-file replacements scoped to the selected trusses.
 - MVR-xchange now labels the default Perastage station with the local computer name, preferring the full host name when available, making it easier to identify in other applications.
 
 ## Fixes

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -11,7 +11,7 @@ Changes since **v1.4.0**.
 
 ## Improvements
 
-- Improved exported truss GDTF files so Perastage-generated or Perastage-normalized trusses use canonical `Manufacturer@Model@Perastage.gdtf` archive names, stricter GDTF truss structure metadata, and preserve edited truss values across save/reopen roundtrips.
+- Improved exported truss GDTF files so Perastage-generated or Perastage-normalized trusses use canonical `Manufacturer@Model@Perastage.gdtf` archive names, stricter GDTF truss structure metadata, and preserve edited truss values across save/reopen roundtrips, share edited type metadata across trusses from the same source, and show the active GDTF in the truss model-file column when available.
 - MVR-xchange now labels the default Perastage station with the local computer name, preferring the full host name when available, making it easier to identify in other applications.
 
 ## Fixes

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -11,7 +11,7 @@ Changes since **v1.4.0**.
 
 ## Improvements
 
-- Improved exported truss GDTF files so Perastage-generated or Perastage-normalized trusses use canonical `Manufacturer@Model@Perastage.gdtf` archive names and stricter GDTF truss structure metadata.
+- Improved exported truss GDTF files so Perastage-generated or Perastage-normalized trusses use canonical `Manufacturer@Model@Perastage.gdtf` archive names, stricter GDTF truss structure metadata, and preserve edited truss values across save/reopen roundtrips.
 - MVR-xchange now labels the default Perastage station with the local computer name, preferring the full host name when available, making it easier to identify in other applications.
 
 ## Fixes

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -11,6 +11,7 @@ Changes since **v1.4.0**.
 
 ## Improvements
 
+- Improved exported truss GDTF files so Perastage-generated or Perastage-normalized trusses use canonical `Manufacturer@Model@Perastage.gdtf` archive names and stricter GDTF truss structure metadata.
 - MVR-xchange now labels the default Perastage station with the local computer name, preferring the full host name when available, making it easier to identify in other applications.
 
 ## Fixes

--- a/gui/mainwindow_io.cpp
+++ b/gui/mainwindow_io.cpp
@@ -596,8 +596,10 @@ void MainWindow::OnExportMVR(wxCommandEvent &event) {
   }
 }
 
+// Exports a selected truss as a Perastage-owned canonical GDTF.
 void MainWindow::OnExportTruss(wxCommandEvent &WXUNUSED(event)) {
-  const auto &trusses = GetDefaultGuiConfigServices().LegacyConfigManager().GetScene().trusses;
+  auto &scene = GetDefaultGuiConfigServices().LegacyConfigManager().GetScene();
+  auto &trusses = scene.trusses;
   std::set<std::string> names;
   for (const auto &[uuid, t] : trusses)
     names.insert(t.name);
@@ -612,8 +614,9 @@ void MainWindow::OnExportTruss(wxCommandEvent &WXUNUSED(event)) {
     return;
 
   std::string sel = dlg.GetSelectedName();
-  const Truss *chosen = nullptr;
-  for (const auto &[uuid, t] : trusses) {
+  Truss *chosen = nullptr;
+  for (auto &entry : trusses) {
+    Truss &t = entry.second;
     if (t.name == sel) {
       chosen = &t;
       break;
@@ -622,10 +625,15 @@ void MainWindow::OnExportTruss(wxCommandEvent &WXUNUSED(event)) {
   if (!chosen)
     return;
 
+  const std::string canonicalFileName =
+      GdtfDictionary::BuildPerastageCanonicalGdtfFileName(
+          chosen->manufacturer,
+          chosen->model.empty() ? chosen->name : chosen->model,
+          chosen->name.empty() ? sel : chosen->name);
   wxString trussDir =
       wxString::FromUTF8(ProjectUtils::GetWritableLibraryPath("trusses"));
   wxFileDialog saveDlg(this, "Save Truss", trussDir,
-                       wxString::FromUTF8(sel) + ".gdtf",
+                       wxString::FromUTF8(canonicalFileName),
                        "GDTF files (*.gdtf)|*.gdtf",
                        wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
   if (saveDlg.ShowModal() != wxID_OK)
@@ -633,7 +641,6 @@ void MainWindow::OnExportTruss(wxCommandEvent &WXUNUSED(event)) {
 
   namespace fs = std::filesystem;
   std::string modelPath = chosen->symbolFile;
-  const auto &scene = GetDefaultGuiConfigServices().LegacyConfigManager().GetScene();
   if (fs::path(modelPath).is_relative() && !scene.basePath.empty())
     modelPath = (fs::path(scene.basePath) / modelPath).string();
   if (!fs::exists(modelPath)) {
@@ -644,12 +651,17 @@ void MainWindow::OnExportTruss(wxCommandEvent &WXUNUSED(event)) {
   Truss exportTruss = *chosen;
   exportTruss.symbolFile = modelPath;
   std::string error;
-  if (!BuildTrussGdtfFromInstance(
-          exportTruss, std::string(saveDlg.GetPath().mb_str()), &error)) {
+  const std::string exportedPath = std::string(saveDlg.GetPath().mb_str());
+  if (!BuildTrussGdtfFromInstance(exportTruss, exportedPath, &error)) {
     wxMessageBox(error.empty() ? "Failed to export truss GDTF." : error,
                  "Error", wxOK | wxICON_ERROR);
     return;
   }
+
+  chosen->gdtfSpec = exportedPath;
+  chosen->modelFile = exportedPath;
+  chosen->perastageAuxGdtfArchivePath = canonicalFileName;
+  chosen->gdtfMode = chosen->gdtfMode.empty() ? "Default" : chosen->gdtfMode;
 
   wxMessageBox("Truss exported successfully.", "Export Truss",
                wxOK | wxICON_INFORMATION);

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -569,35 +569,6 @@ void TrussTablePanel::OnContextMenu(wxDataViewEvent &event) {
                           ColumnIndex(TrussColumn::Weight));
                 }
             }
-            // Apply the model file to any other rows that share the original
-            // model name from the rider.  This lets multiple trusses with the
-            // same rider-specified model get updated in one action and ensures
-            // the dictionary entry uses that rider key.
-      for (unsigned int i = 0; i < table->GetItemCount(); ++i) {
-                wxVariant mv;
-        table->GetValue(mv, i, ColumnIndex(TrussColumn::Model));
-        if (mv.GetString() == wxString::FromUTF8(modelKey)) {
-                    SetModelPathsForRow(i, wxString::FromUTF8(archivePath),
-                                        wxString::FromUTF8(geomPath));
-          table->SetValue(wxVariant(fileName), i,
-                          ColumnIndex(TrussColumn::ModelFile));
-          if (parsedOk) {
-            table->SetValue(wxVariant(manuf), i,
-                            ColumnIndex(TrussColumn::Manufacturer));
-            table->SetValue(wxVariant(modelNameWx), i,
-                            ColumnIndex(TrussColumn::Model));
-            table->SetValue(wxVariant(lenStr), i,
-                            ColumnIndex(TrussColumn::Length));
-            table->SetValue(wxVariant(widStr), i,
-                            ColumnIndex(TrussColumn::Width));
-            table->SetValue(wxVariant(heiStr), i,
-                            ColumnIndex(TrussColumn::Height));
-            table->SetValue(wxVariant(weightStr), i,
-                            ColumnIndex(TrussColumn::Weight));
-                    }
-                    changed = true;
-                }
-            }
             if (!changed)
                 return;
             TrussDictionary::Update(modelKey, archivePath);

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -318,9 +318,11 @@ void TrussTablePanel::ReloadData()
         std::string displayPath;
         std::string symbolFullPath;
         const std::string &base = cfg.GetScene().basePath;
-        if (!truss.modelFile.empty()) {
-            fs::path p = base.empty() ? fs::path(truss.modelFile)
-                                     : fs::path(base) / truss.modelFile;
+        const std::string modelReference =
+            !truss.gdtfSpec.empty() ? truss.gdtfSpec : truss.modelFile;
+        if (!modelReference.empty()) {
+            fs::path p = base.empty() ? fs::path(modelReference)
+                                     : fs::path(base) / modelReference;
             displayPath = p.string();
         } else if (!truss.symbolFile.empty()) {
             fs::path p = base.empty() ? fs::path(truss.symbolFile)

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -1901,8 +1901,10 @@ static void AppendLayerAppearanceMetadata(tinyxml2::XMLDocument &doc,
 // Returns true when a truss carries Perastage-specific metadata for export.
 static bool HasTrussInfoMetadata(const Truss &truss) {
   return truss.hasManualLoadOverride || !truss.crossSection.empty() ||
-         !truss.modelFile.empty() ||
-         !truss.positionName.empty() ||
+         !truss.modelFile.empty() || !truss.positionName.empty() ||
+         !truss.manufacturer.empty() || !truss.model.empty() ||
+         truss.lengthMm > 0.0f || truss.widthMm > 0.0f ||
+         truss.heightMm > 0.0f || truss.weightKg > 0.0f ||
          truss.sourceRepresentation != Truss::GeometryRepresentation::Unknown ||
          !truss.perastageTypeKey.empty() ||
          !truss.perastageAuxGdtfArchivePath.empty();
@@ -1934,6 +1936,16 @@ static void AppendTrussInfoMetadata(tinyxml2::XMLDocument &doc,
     load->SetText(std::to_string(truss.manualLoadKg).c_str());
     info->InsertEndChild(load);
   }
+  addTxt("Manufacturer", truss.manufacturer);
+  addTxt("Model", truss.model);
+  if (truss.lengthMm > 0.0f)
+    addTxt("Length", std::to_string(truss.lengthMm));
+  if (truss.widthMm > 0.0f)
+    addTxt("Width", std::to_string(truss.widthMm));
+  if (truss.heightMm > 0.0f)
+    addTxt("Height", std::to_string(truss.heightMm));
+  if (truss.weightKg > 0.0f)
+    addTxt("Weight", std::to_string(truss.weightKg));
   addTxt("CrossSection", truss.crossSection);
   addTxt("ModelFile", SanitizeArchiveFileName(truss.modelFile, ""));
   addTxt("PositionName", truss.positionName);

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -782,25 +782,21 @@ static void AppendFixtureTypeMetadata(
   perastageData->InsertEndChild(map);
 }
 
-// Builds the preferred root-level GDTF archive filename for a truss.
+// Builds the canonical root-level Perastage GDTF archive filename for a truss.
 static std::string BuildTrussGdtfArchiveName(const Truss &truss) {
-  std::string baseName = TrimAscii(truss.model);
-  if (baseName.empty()) {
-    if (truss.lengthMm > 0.0f) {
-      const int lengthMeters =
-          static_cast<int>(std::lround(truss.lengthMm / 1000.0f));
-      if (lengthMeters > 0)
-        baseName = "truss " + std::to_string(lengthMeters) + "m";
-    }
+  std::string fallbackModel = TrimAscii(truss.model);
+  if (fallbackModel.empty() && truss.lengthMm > 0.0f) {
+    const int lengthMm = static_cast<int>(std::lround(truss.lengthMm));
+    if (lengthMm > 0)
+      fallbackModel = "Truss_" + std::to_string(lengthMm) + "mm";
   }
-  if (baseName.empty())
-    baseName = "truss";
+  if (fallbackModel.empty())
+    fallbackModel = "Truss";
 
-  fs::path candidate(baseName);
-  if (candidate.extension().empty())
-    baseName += ".gdtf";
-
-  return SanitizeArchiveFileName(baseName, "truss.gdtf");
+  return SanitizeArchiveFileName(
+      GdtfDictionary::BuildPerastageCanonicalGdtfFileName(
+          truss.manufacturer, truss.model, fallbackModel),
+      "Unknown@Truss@Perastage.gdtf");
 }
 
 // Builds the internal truss type key used for export-time resource reuse.
@@ -2521,8 +2517,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath,
 
   auto registerGdtfResource =
       [&](const std::string &objectUuid, const std::string &rawGdtfPath,
-                                  const std::string &preferredName,
-                                  bool allowReuseBySource = true) -> std::string {
+          const std::string &preferredName, bool allowReuseBySource = true,
+          bool usePreferredDerivativeName = false) -> std::string {
     if (rawGdtfPath.empty())
       return {};
 
@@ -2541,7 +2537,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath,
         resolvedGdtfPath.empty() ? rawGdtfPath : resolvedGdtfPath;
 
     std::string fileName = preferredName;
-    if (ToLowerAscii(PathUtils::PathFromUtf8(rawGdtfPath).extension().string()) ==
+    if (!usePreferredDerivativeName &&
+        ToLowerAscii(PathUtils::PathFromUtf8(rawGdtfPath).extension().string()) ==
             ".gdtf" &&
         !GdtfDictionary::IsPerastageNamedGdtfFile(rawGdtfPath)) {
       fileName =
@@ -3242,7 +3239,7 @@ bool MvrExporter::ExportToFile(const std::string &filePath,
 
       std::string trussPreferredName = BuildTrussGdtfArchiveName(t);
       trussGdtfArchivePath = registerGdtfResource(
-          exportedTrussUuid, trussSourceGdtf, trussPreferredName, true);
+          exportedTrussUuid, trussSourceGdtf, trussPreferredName, true, true);
       if (!trussGdtfArchivePath.empty())
         trussArchiveByTypeKey[trussTypeKey] = trussGdtfArchivePath;
     }

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -799,6 +799,46 @@ static std::string BuildTrussGdtfArchiveName(const Truss &truss) {
       "Unknown@Truss@Perastage.gdtf");
 }
 
+// Builds the stable source identity used to share edited truss type metadata.
+static std::string BuildTrussSourceMetadataKey(const Truss &truss) {
+  std::string key = TrimAscii(truss.gdtfSpec);
+  if (key.empty())
+    key = TrimAscii(truss.modelFile);
+  if (key.empty())
+    key = TrimAscii(truss.symbolFile);
+  return key;
+}
+
+// Copies edited type-level truss metadata when the source provides a value.
+static void MergeTrussTypeMetadata(Truss &target, const Truss &source) {
+  if (!source.manufacturer.empty())
+    target.manufacturer = source.manufacturer;
+  if (!source.model.empty())
+    target.model = source.model;
+  if (!source.crossSection.empty())
+    target.crossSection = source.crossSection;
+  if (source.lengthMm > 0.0f)
+    target.lengthMm = source.lengthMm;
+  if (source.widthMm > 0.0f)
+    target.widthMm = source.widthMm;
+  if (source.heightMm > 0.0f)
+    target.heightMm = source.heightMm;
+  if (source.weightKg > 0.0f)
+    target.weightKg = source.weightKg;
+}
+
+// Returns a truss copy with shared edited type metadata applied.
+static Truss BuildEffectiveTrussTypeMetadata(
+    const Truss &truss,
+    const std::unordered_map<std::string, Truss> &metadataBySourceKey) {
+  Truss effective = truss;
+  const std::string sourceKey = BuildTrussSourceMetadataKey(truss);
+  auto it = metadataBySourceKey.find(sourceKey);
+  if (it != metadataBySourceKey.end())
+    MergeTrussTypeMetadata(effective, it->second);
+  return effective;
+}
+
 // Builds the internal truss type key used for export-time resource reuse.
 static std::string BuildTrussTypeKey(const Truss &truss) {
   std::ostringstream key;
@@ -2965,6 +3005,14 @@ bool MvrExporter::ExportToFile(const std::string &filePath,
   tinyxml2::XMLElement *trussInfoMap = doc.NewElement("TrussInfoMap");
   tinyxml2::XMLElement *hoistInfoMap = doc.NewElement("HoistInfoMap");
   std::map<std::string, FixtureTypeInfoExport> fixtureTypeMetadata;
+  std::unordered_map<std::string, Truss> trussTypeMetadataBySourceKey;
+  for (const auto &[uuid, truss] : scene.trusses) {
+    (void)uuid;
+    const std::string sourceKey = BuildTrussSourceMetadataKey(truss);
+    if (sourceKey.empty())
+      continue;
+    MergeTrussTypeMetadata(trussTypeMetadataBySourceKey[sourceKey], truss);
+  }
 
   int exportedRealFixtureGdtfCount = 0;
   int exportedDummyFixtureGdtfCount = 0;
@@ -3190,6 +3238,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath,
   };
 
   auto exportTruss = [&](tinyxml2::XMLElement *parent, const Truss &t) {
+    const Truss effectiveTruss =
+        BuildEffectiveTrussTypeMetadata(t, trussTypeMetadataBySourceKey);
     tinyxml2::XMLElement *te = doc.NewElement("Truss");
     const auto exportUuidIt = trussExportUuids.find(t.uuid);
     const std::string exportedTrussUuid =
@@ -3222,7 +3272,7 @@ bool MvrExporter::ExportToFile(const std::string &filePath,
       fixtureNumericId = 1;
     std::string fixtureId = std::to_string(fixtureNumericId);
 
-    std::string trussTypeKey = BuildTrussTypeKey(t);
+    std::string trussTypeKey = BuildTrussTypeKey(effectiveTruss);
     std::string trussGdtfArchivePath;
     auto trussArchiveIt = trussArchiveByTypeKey.find(trussTypeKey);
     if (trussArchiveIt != trussArchiveByTypeKey.end()) {
@@ -3245,18 +3295,18 @@ bool MvrExporter::ExportToFile(const std::string &filePath,
             ("perastage-truss-export-" +
              (t.uuid.empty() ? std::string("truss") : t.uuid) + ".gdtf");
         std::string conversionError;
-        if (BuildTrussGdtfFromInstance(t, tempPath, &conversionError))
+        if (BuildTrussGdtfFromInstance(effectiveTruss, tempPath, &conversionError))
           trussSourceGdtf = tempPath.string();
       }
 
-      std::string trussPreferredName = BuildTrussGdtfArchiveName(t);
+      std::string trussPreferredName = BuildTrussGdtfArchiveName(effectiveTruss);
       trussGdtfArchivePath = registerGdtfResource(
           exportedTrussUuid, trussSourceGdtf, trussPreferredName, true, true);
       if (!trussGdtfArchivePath.empty())
         trussArchiveByTypeKey[trussTypeKey] = trussGdtfArchivePath;
     }
     const std::string exportTrussTypeKey =
-        BuildExportTrussTypeKey(t, trussGdtfArchivePath);
+        BuildExportTrussTypeKey(effectiveTruss, trussGdtfArchivePath);
     if (!trussTypeKey.empty()) {
       trussExportTypeKeyByTypeKey[trussTypeKey] = exportTrussTypeKey;
       trussInstanceToTypeKey[exportedTrussUuid] = exportTrussTypeKey;
@@ -3265,15 +3315,15 @@ bool MvrExporter::ExportToFile(const std::string &filePath,
     if (!trussGdtfArchivePath.empty()) {
       auto &ov = gdtfOverrides[trussGdtfArchivePath];
       ov.hasLengthMm = true;
-      ov.lengthMm = t.lengthMm;
+      ov.lengthMm = effectiveTruss.lengthMm;
       ov.hasWidthMm = true;
-      ov.widthMm = t.widthMm;
+      ov.widthMm = effectiveTruss.widthMm;
       ov.hasHeightMm = true;
-      ov.heightMm = t.heightMm;
+      ov.heightMm = effectiveTruss.heightMm;
       ov.hasWeightKg = true;
-      ov.weightKg = t.weightKg;
-      ov.manufacturer = t.manufacturer;
-      ov.model = t.model;
+      ov.weightKg = effectiveTruss.weightKg;
+      ov.manufacturer = effectiveTruss.manufacturer;
+      ov.model = effectiveTruss.model;
     }
 
     const bool writeWorldTransform = t.parentGroupUuid.empty();
@@ -3445,7 +3495,7 @@ bool MvrExporter::ExportToFile(const std::string &filePath,
     addInt("CustomId", t.customId);
     addInt("CustomIdType", t.customIdType);
 
-    AppendTrussInfoMetadata(doc, trussInfoMap, t, exportedTrussUuid,
+    AppendTrussInfoMetadata(doc, trussInfoMap, effectiveTruss, exportedTrussUuid,
                             exportTrussTypeKey, trussGdtfArchivePath);
 
     parent->InsertEndChild(te);

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -2586,50 +2586,49 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
         scene.fixtures[fixture.uuid] = fixture;
       };
 
-  // Applies Perastage TrussInfo metadata while preserving GDTF authority rules.
+  // Applies Perastage TrussInfo metadata as the effective edited truss state.
   auto applyTrussInfo = [&](tinyxml2::XMLElement *info, Truss &truss,
                               bool hasGdtfMetadataAuthority) {
     if (!info)
       return;
-    if (!hasGdtfMetadataAuthority) {
-      if (tinyxml2::XMLElement *m = info->FirstChildElement("Manufacturer"))
-        if (m->GetText())
-          truss.manufacturer = Trim(m->GetText());
-      if (tinyxml2::XMLElement *mo = info->FirstChildElement("Model"))
-        if (mo->GetText())
-          truss.model = Trim(mo->GetText());
-      if (tinyxml2::XMLElement *len = info->FirstChildElement("Length"))
-        if (len->GetText()) {
-          float parsed = 0.0f;
-          if (TryParseFloat(len->GetText(), parsed))
-            truss.lengthMm = parsed;
-        }
-      if (tinyxml2::XMLElement *wid = info->FirstChildElement("Width"))
-        if (wid->GetText()) {
-          float parsed = 0.0f;
-          if (TryParseFloat(wid->GetText(), parsed))
-            truss.widthMm = parsed;
-          else
-            truss.widthMm = 400.0f;
-        }
-      if (tinyxml2::XMLElement *hei = info->FirstChildElement("Height"))
-        if (hei->GetText()) {
-          float parsed = 0.0f;
-          if (TryParseFloat(hei->GetText(), parsed))
-            truss.heightMm = parsed;
-          else
-            truss.heightMm = 400.0f;
-        }
-      if (tinyxml2::XMLElement *wei = info->FirstChildElement("Weight"))
-        if (wei->GetText()) {
-          float parsed = 0.0f;
-          if (TryParseFloat(wei->GetText(), parsed))
-            truss.weightKg = parsed;
-        }
-      if (tinyxml2::XMLElement *cs = info->FirstChildElement("CrossSection"))
-        if (cs->GetText())
-          truss.crossSection = Trim(cs->GetText());
-    }
+    (void)hasGdtfMetadataAuthority;
+    if (tinyxml2::XMLElement *m = info->FirstChildElement("Manufacturer"))
+      if (m->GetText())
+        truss.manufacturer = Trim(m->GetText());
+    if (tinyxml2::XMLElement *mo = info->FirstChildElement("Model"))
+      if (mo->GetText())
+        truss.model = Trim(mo->GetText());
+    if (tinyxml2::XMLElement *len = info->FirstChildElement("Length"))
+      if (len->GetText()) {
+        float parsed = 0.0f;
+        if (TryParseFloat(len->GetText(), parsed))
+          truss.lengthMm = parsed;
+      }
+    if (tinyxml2::XMLElement *wid = info->FirstChildElement("Width"))
+      if (wid->GetText()) {
+        float parsed = 0.0f;
+        if (TryParseFloat(wid->GetText(), parsed))
+          truss.widthMm = parsed;
+        else
+          truss.widthMm = 400.0f;
+      }
+    if (tinyxml2::XMLElement *hei = info->FirstChildElement("Height"))
+      if (hei->GetText()) {
+        float parsed = 0.0f;
+        if (TryParseFloat(hei->GetText(), parsed))
+          truss.heightMm = parsed;
+        else
+          truss.heightMm = 400.0f;
+      }
+    if (tinyxml2::XMLElement *wei = info->FirstChildElement("Weight"))
+      if (wei->GetText()) {
+        float parsed = 0.0f;
+        if (TryParseFloat(wei->GetText(), parsed))
+          truss.weightKg = parsed;
+      }
+    if (tinyxml2::XMLElement *cs = info->FirstChildElement("CrossSection"))
+      if (cs->GetText())
+        truss.crossSection = Trim(cs->GetText());
     if (tinyxml2::XMLElement *load = info->FirstChildElement("Load"))
       if (load->GetText()) {
         float parsed = 0.0f;

--- a/tests/mvr_patched_gdtf_export_test.cpp
+++ b/tests/mvr_patched_gdtf_export_test.cpp
@@ -125,14 +125,15 @@ int main() {
   assert(exporter.ExportToFile(mvrPath.string()));
 
   const auto mvrEntries = ReadArchiveEntries(mvrPath);
-  std::string patchedGdtfBytes;
-  for (const auto &[entryName, content] : mvrEntries) {
-    if (entryName.size() >= 5 && entryName.substr(entryName.size() - 5) == ".gdtf") {
-      patchedGdtfBytes = content;
-      break;
-    }
-  }
-  assert(!patchedGdtfBytes.empty());
+  const std::string expectedGdtfName = "Perastage_QA@Truss_QA_Model@Perastage.gdtf";
+  auto patchedIt = mvrEntries.find(expectedGdtfName);
+  assert(patchedIt != mvrEntries.end());
+  const std::string patchedGdtfBytes = patchedIt->second;
+
+  auto gsdIt = mvrEntries.find("GeneralSceneDescription.xml");
+  assert(gsdIt != mvrEntries.end());
+  assert(gsdIt->second.find("<GDTFSpec>" + expectedGdtfName + "</GDTFSpec>") !=
+         std::string::npos);
 
   const fs::path extractedGdtfPath = tempDir / "patched_truss.gdtf";
   {

--- a/tests/mvr_truss_roundtrip_structure_test.cpp
+++ b/tests/mvr_truss_roundtrip_structure_test.cpp
@@ -67,6 +67,50 @@ static std::string ReadFixtureTypeIdFromGdtf(const fs::path &gdtfPath) {
   return id;
 }
 
+
+// Verifies generated truss GDTF archives use the canonical Structure root.
+static void AssertGeneratedTrussGdtfStructure(const fs::path &gdtfPath,
+                                             const std::string &crossSection) {
+  const auto entries = ReadArchiveTextEntries(gdtfPath);
+  auto it = entries.find("description.xml");
+  assert(it != entries.end());
+
+  tinyxml2::XMLDocument doc;
+  assert(doc.Parse(it->second.c_str()) == tinyxml2::XML_SUCCESS);
+  tinyxml2::XMLElement *root = doc.FirstChildElement("GDTF");
+  assert(root != nullptr);
+  assert(root->Attribute("DataVersion") != nullptr);
+  assert(std::string(root->Attribute("DataVersion")) == "1.2");
+
+  tinyxml2::XMLElement *fixtureType = root->FirstChildElement("FixtureType");
+  assert(fixtureType != nullptr);
+  assert(fixtureType->Attribute("FixtureTypeID") != nullptr);
+  assert(fixtureType->FirstChildElement("PerastageMutationAudit") == nullptr);
+
+  tinyxml2::XMLElement *geometries = fixtureType->FirstChildElement("Geometries");
+  assert(geometries != nullptr);
+  assert(geometries->FirstChildElement("Geometry") == nullptr);
+  tinyxml2::XMLElement *structure = geometries->FirstChildElement("Structure");
+  assert(structure != nullptr);
+  assert(std::string(structure->Attribute("Name")) == "Root");
+  assert(std::string(structure->Attribute("Model")) == "Main");
+  assert(std::string(structure->Attribute("StructureType")) == "Detail");
+  assert(std::string(structure->Attribute("CrossSectionType")) ==
+         "TrussFramework");
+  assert(std::string(structure->Attribute("TrussCrossSection")) == crossSection);
+  assert(fixtureType->FirstChildElement("Magnet") == nullptr);
+
+  tinyxml2::XMLElement *dmxModes = fixtureType->FirstChildElement("DMXModes");
+  assert(dmxModes != nullptr);
+  tinyxml2::XMLElement *mode = dmxModes->FirstChildElement("DMXMode");
+  assert(mode != nullptr);
+  assert(std::string(mode->Attribute("Name")) == "Default");
+  assert(std::string(mode->Attribute("Geometry")) == "Root");
+  tinyxml2::XMLElement *revisions = fixtureType->FirstChildElement("Revisions");
+  assert(revisions != nullptr);
+  assert(revisions->FirstChildElement("Revision") != nullptr);
+}
+
 // Returns the first Symbol UUID exported in GeneralSceneDescription.xml.
 static std::string ReadFirstSymbolUuid(const fs::path &mvrPath) {
   const auto entries = ReadArchiveTextEntries(mvrPath);
@@ -449,6 +493,7 @@ int main() {
   typeA.widthMm = 400.0f;
   typeA.heightMm = 400.0f;
   typeA.weightKg = 40.0f;
+  typeA.crossSection = "GenericTruss";
 
   Truss typeASame = typeA;
   Truss typeB = typeA;
@@ -461,6 +506,7 @@ int main() {
   assert(BuildTrussGdtfFromInstance(typeA, gdtfA1, &error));
   assert(BuildTrussGdtfFromInstance(typeASame, gdtfA2, &error));
   assert(BuildTrussGdtfFromInstance(typeB, gdtfB, &error));
+  AssertGeneratedTrussGdtfStructure(gdtfA1, "GenericTruss");
   assert(ReadFixtureTypeIdFromGdtf(gdtfA1) == ReadFixtureTypeIdFromGdtf(gdtfA2));
   assert(ReadFixtureTypeIdFromGdtf(gdtfA1) != ReadFixtureTypeIdFromGdtf(gdtfB));
 

--- a/tests/mvr_truss_roundtrip_structure_test.cpp
+++ b/tests/mvr_truss_roundtrip_structure_test.cpp
@@ -70,7 +70,10 @@ static std::string ReadFixtureTypeIdFromGdtf(const fs::path &gdtfPath) {
 
 // Verifies generated truss GDTF archives use the canonical Structure root.
 static void AssertGeneratedTrussGdtfStructure(const fs::path &gdtfPath,
-                                             const std::string &crossSection) {
+                                             const std::string &crossSection,
+                                             float expectedLengthMeters,
+                                             float expectedWidthMeters,
+                                             float expectedHeightMeters) {
   const auto entries = ReadArchiveTextEntries(gdtfPath);
   auto it = entries.find("description.xml");
   assert(it != entries.end());
@@ -86,6 +89,14 @@ static void AssertGeneratedTrussGdtfStructure(const fs::path &gdtfPath,
   assert(fixtureType != nullptr);
   assert(fixtureType->Attribute("FixtureTypeID") != nullptr);
   assert(fixtureType->FirstChildElement("PerastageMutationAudit") == nullptr);
+
+  tinyxml2::XMLElement *models = fixtureType->FirstChildElement("Models");
+  assert(models != nullptr);
+  tinyxml2::XMLElement *model = models->FirstChildElement("Model");
+  assert(model != nullptr);
+  assert(std::abs(model->FloatAttribute("Length") - expectedLengthMeters) < 0.001f);
+  assert(std::abs(model->FloatAttribute("Width") - expectedWidthMeters) < 0.001f);
+  assert(std::abs(model->FloatAttribute("Height") - expectedHeightMeters) < 0.001f);
 
   tinyxml2::XMLElement *geometries = fixtureType->FirstChildElement("Geometries");
   assert(geometries != nullptr);
@@ -506,7 +517,7 @@ int main() {
   assert(BuildTrussGdtfFromInstance(typeA, gdtfA1, &error));
   assert(BuildTrussGdtfFromInstance(typeASame, gdtfA2, &error));
   assert(BuildTrussGdtfFromInstance(typeB, gdtfB, &error));
-  AssertGeneratedTrussGdtfStructure(gdtfA1, "GenericTruss");
+  AssertGeneratedTrussGdtfStructure(gdtfA1, "GenericTruss", 3.0f, 0.4f, 0.4f);
   assert(ReadFixtureTypeIdFromGdtf(gdtfA1) == ReadFixtureTypeIdFromGdtf(gdtfA2));
   assert(ReadFixtureTypeIdFromGdtf(gdtfA1) != ReadFixtureTypeIdFromGdtf(gdtfB));
 

--- a/tests/mvr_truss_roundtrip_structure_test.cpp
+++ b/tests/mvr_truss_roundtrip_structure_test.cpp
@@ -323,10 +323,18 @@ int main() {
   tinyxml2::XMLElement *trussInfo = trussInfoMap->FirstChildElement("TrussInfo");
   assert(trussInfo != nullptr);
   assert(std::string(trussInfo->Attribute("uuid")) == truss.uuid);
-  assert(trussInfo->FirstChildElement("Manufacturer") == nullptr);
-  assert(trussInfo->FirstChildElement("Model") == nullptr);
-  assert(trussInfo->FirstChildElement("Length") == nullptr);
-  assert(trussInfo->FirstChildElement("Weight") == nullptr);
+  assert(std::string(trussInfo->FirstChildElement("Manufacturer")->GetText()) ==
+         truss.manufacturer);
+  assert(std::string(trussInfo->FirstChildElement("Model")->GetText()) ==
+         truss.model);
+  assert(std::abs(std::stof(trussInfo->FirstChildElement("Length")->GetText()) -
+                  truss.lengthMm) < 0.001f);
+  assert(std::abs(std::stof(trussInfo->FirstChildElement("Width")->GetText()) -
+                  truss.widthMm) < 0.001f);
+  assert(std::abs(std::stof(trussInfo->FirstChildElement("Height")->GetText()) -
+                  truss.heightMm) < 0.001f);
+  assert(std::abs(std::stof(trussInfo->FirstChildElement("Weight")->GetText()) -
+                  truss.weightKg) < 0.001f);
   assert(trussInfo->FirstChildElement("Load") == nullptr);
 
   scene.trusses.at(truss.uuid).manualLoadKg = 123.45f;
@@ -364,6 +372,11 @@ int main() {
   assert(!importedTruss.perastageAuxGdtfArchivePath.empty());
   assert(importedTruss.manufacturer == "Perastage");
   assert(importedTruss.model == "Tower 40");
+  assert(std::abs(importedTruss.lengthMm - truss.lengthMm) < 0.001f);
+  assert(std::abs(importedTruss.widthMm - truss.widthMm) < 0.001f);
+  assert(std::abs(importedTruss.heightMm - truss.heightMm) < 0.001f);
+  assert(std::abs(importedTruss.weightKg - truss.weightKg) < 0.001f);
+  assert(importedTruss.crossSection == truss.crossSection);
 
   cfg.Reset();
   assert(importer.ImportFromFile(manualLoadMvrPath.string(), false, false));


### PR DESCRIPTION
### Motivation
- Ensure truss `.gdtf` archives generated/modified by Perastage follow the official GDTF structure for trusses and carry a canonical Perastage-owned identity instead of ad-hoc truss-only names. 
- Exported MVRs must reference Perastage-derived truss GDTF copies (not overwrite original source/library files) with a stable `Manufacturer@Model@Perastage.gdtf` filename and valid `GDTFMode`. 
- Keep export-time mutation metadata consistent with the shared audit/canonicalizer policy and avoid non-standard XML nodes (no `PerastageMutationAudit`, no `Magnet` nodes). 

### Description
- `core/truss_gdtf_builder.cpp`: produce stricter GDTF `description.xml` for generated trusses by writing a `Geometries/Structure` root with attributes `StructureType="Detail"`, `CrossSectionType="TrussFramework"`, and `TrussCrossSection` (use truss.crossSection or fallback to `GenericTruss`), convert dimensions from mm→m in `Models/Model`, include optional positive `PhysicalDescriptions/Properties/Weight`, include deterministic `FixtureTypeID` (now includes `crossSection` in seed), and stamp revisions via `GdtfMutationAudit::AppendRevision(...)` instead of hand-rolled revision XML. Also added concise one-line comments above modified/new functions and preserved support for legacy `.gtruss` conversion.  
- `core/gdtfdictionary.{h,cpp}`: added a helper to build canonical Perastage derivative filenames from explicit identity values (`BuildPerastageCanonicalGdtfFileName(manufacturer, model, fallbackStem)` / `BuildPerastageCanonicalGdtfFileNameFromIdentity`) and reused the canonical `Manufacturer@Model@Perastage.gdtf` policy for truss exports. 
- `mvr/mvrexporter.cpp`: changed truss archive naming to use the canonical Perastage filename via `GdtfDictionary::BuildPerastageCanonicalGdtfFileName(...)` in `BuildTrussGdtfArchiveName(...)`, and adapted `registerGdtfResource` to accept a flag that preserves the preferred derivative name when registering Perastage-generated truss GDTFs so the MVR archive entry and `GeneralSceneDescription.xml` reference the derived `@Perastage.gdtf`. 
- Tests and docs: updated/added tests to assert generated truss GDTF structure and MVR references: `tests/mvr_truss_roundtrip_structure_test.cpp` now verifies `Geometries/Structure` attributes, absence of fallback `Geometry` and `Magnet` nodes, presence of `Revisions`, and deterministic `FixtureTypeID`; `tests/mvr_patched_gdtf_export_test.cpp` asserts the exported MVR contains the expected `Manufacturer@Model@Perastage.gdtf` entry and that `GeneralSceneDescription.xml` contains the correct `<GDTFSpec>` reference. Updated `docs/gdtf_mutation_policy.md` and `docs/release-notes-draft.md` to reflect the change. 

### Testing
- Ran repository mandatory checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both succeeded. 
- Ran `git diff --check` (no whitespace/errors). 
- Attempted `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug` to build tests, but configuration failed in this environment due to missing `wxWidgets` development files so the full unit test binaries could not be built here (blocking verification of compiled tests). 
- Note: updated/added unit tests (`mvr_truss_roundtrip_structure_test`, `mvr_patched_gdtf_export_test`) were modified in this PR and should be built+run in CI or a dev environment with `wxWidgets` to validate runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4507d6dbe88324bd4f5ceff465f365)