### PR TITLE
Fix truss hoist recalculation prompts

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -17,6 +17,7 @@ Changes since **v1.4.0**.
 
 ## Fixes
 
+- Fixed the Trusses table so hoist-load recalculation prompts only appear when an edit can change a position rigging total, such as weight or hang-position changes, instead of dimension-only edits like width or height.
 - Fixed MVR merge imports so incoming fixture, truss, hoist, scene-object, and symbol resources are copied into a valid merge resource root before references are applied, including when merging into an empty or unsaved scene.
 - Fixed the MVR-xchange log text styling so transfer messages use the same readable Console colors and monospaced font.
 - Fixed MVR-xchange remote imports so merging keeps the current project name, while opening a requested MVR as a new project uses the advertised MVR file name.

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -1062,11 +1062,12 @@ void TrussTablePanel::UpdateSceneData(bool logChanges)
                                            0.001);
         const bool weightChanged =
             !Units::NearlyEqualWeightKilograms(old.weightKg, next.weightKg, 0.001);
+        const bool hangPositionChanged = old.positionName != next.positionName;
 
     if (trussChanged) {
             pushUndoIfNeeded();
             anyChanged = true;
-            if (weightChanged) {
+            if (weightChanged || hangPositionChanged) {
                 changedWeightPositions.insert(NormalizePositionName(old.positionName));
                 changedWeightPositions.insert(NormalizePositionName(next.positionName));
             }
@@ -1108,16 +1109,20 @@ void TrussTablePanel::UpdateSceneData(bool logChanges)
         const float heiMm = dit->second.hei;
         const float weightKg = dit->second.weight;
 
+        const bool synchronizedWeightChanged =
+            !Units::NearlyEqualWeightKilograms(it->second.weightKg, weightKg, 0.001);
         if (it->second.lengthMm != lenMm || it->second.widthMm != widMm ||
-        it->second.heightMm != heiMm || it->second.weightKg != weightKg) {
+        it->second.heightMm != heiMm || synchronizedWeightChanged) {
             pushUndoIfNeeded();
             anyChanged = true;
             it->second.lengthMm = lenMm;
             it->second.widthMm = widMm;
             it->second.heightMm = heiMm;
             it->second.weightKg = weightKg;
+            if (synchronizedWeightChanged) {
       changedWeightPositions.insert(
           NormalizePositionName(it->second.positionName));
+            }
 
             wxString lenStr = wxString::Format("%.2f", lenMm / 1000.0f);
             wxString widStr =


### PR DESCRIPTION
### Motivation
- The Trusses table could show the hoist-load recalculation prompt when editing fields that do not affect a position rigging total (for example width/height), causing unnecessary modal dialogs.
- The prompt should only appear when an edit can change the rigging total for a hang position, e.g. when truss weight changes, when a truss is moved to a different hang position, or when synchronized updates actually change weight.

### Description
- Update `TrussTablePanel::UpdateSceneData` to detect hang-position changes and only mark positions for hoist recalculation when the truss weight or the hang position changed (`gui/trusstablepanel.cpp`).
- Prevent synchronized dimension-only updates from marking positions for recalculation by only inserting a position into `changedWeightPositions` when the synchronized weight actually changes (`gui/trusstablepanel.cpp`).
- Add a short release-note entry describing the user-facing fix in `docs/release-notes-draft.md`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both reported `OK`.
- Ran `git diff --check` to ensure no whitespace or diff issues, which passed.
- Changes committed and prepared for PR; unit/integration tests in CI are expected to run as usual.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45fe101e888324bc45786a91758075)