### PR TITLE
Repair duplicate FixtureIDNumeric during MVR export and log as non-blocking warning

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -17,6 +17,7 @@ Changes since **v1.4.0**.
 
 ## Fixes
 
+- Fixed MVR export so duplicate fixture numeric IDs are repaired with the next available number, logged as non-blocking warnings, and no longer prevent saving the MVR file.
 - Fixed first-attempt truss weight edits by propagating shared truss type weights before scene synchronization and hoist-load recalculation.
 - Fixed the Trusses table so hoist-load recalculation prompts only appear when an edit can change a position rigging total, such as weight or hang-position changes, instead of dimension-only edits like width or height.
 - Fixed MVR merge imports so incoming fixture, truss, hoist, scene-object, and symbol resources are copied into a valid merge resource root before references are applied, including when merging into an empty or unsaved scene.

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -2785,7 +2785,7 @@ bool MvrExporter::ExportToFile(const std::string &filePath,
 
     auto logFixtureIdRepair = [&](const Fixture &fixture, int originalId,
                                   int repairedId) {
-      std::string fixtureName = TrimAscii(fixture.name);
+      std::string fixtureName = TrimAscii(fixture.instanceName);
       if (fixtureName.empty())
         fixtureName = fixture.uuid.empty() ? "unnamed fixture" : fixture.uuid;
       const std::string message =

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -2753,33 +2753,9 @@ bool MvrExporter::ExportToFile(const std::string &filePath,
 
   auto assignIds = [&]() {
     int nextNumericId = 1;
+    std::unordered_set<int> reservedFixtureIds;
+    std::unordered_set<int> assignedFixtureIds;
     std::unordered_set<int> usedIds;
-
-    auto reserveId = [&](int candidate) {
-      if (candidate > 0)
-        return usedIds.insert(candidate).second;
-      return false;
-    };
-    for (const auto &[uid, f] : scene.fixtures) {
-      reserveId(ResolveFixtureExportId(f).numeric);
-    }
-
-    auto allocId = [&]() {
-      while (usedIds.contains(nextNumericId))
-        ++nextNumericId;
-      usedIds.insert(nextNumericId);
-      return nextNumericId++;
-    };
-
-    std::unordered_map<std::string, std::pair<std::string, int>> result;
-    for (const auto &[uid, f] : scene.fixtures) {
-      FixtureExportId fixtureId = ResolveFixtureExportId(f);
-      if (fixtureId.numeric <= 0) {
-        fixtureId.numeric = allocId();
-        fixtureId.text = std::to_string(fixtureId.numeric);
-      }
-      result[uid] = {fixtureId.text, fixtureId.numeric};
-    }
 
     auto sortedKeys = [](const auto &map) {
       std::vector<std::string> keys;
@@ -2791,6 +2767,54 @@ bool MvrExporter::ExportToFile(const std::string &filePath,
       std::sort(keys.begin(), keys.end());
       return keys;
     };
+
+    for (const std::string &uid : sortedKeys(scene.fixtures)) {
+      const Fixture &fixture = scene.fixtures.at(uid);
+      const int candidate = ResolveFixtureExportId(fixture).numeric;
+      if (candidate > 0)
+        reservedFixtureIds.insert(candidate);
+    }
+    usedIds = reservedFixtureIds;
+
+    auto allocId = [&]() {
+      while (usedIds.contains(nextNumericId))
+        ++nextNumericId;
+      usedIds.insert(nextNumericId);
+      return nextNumericId++;
+    };
+
+    auto logFixtureIdRepair = [&](const Fixture &fixture, int originalId,
+                                  int repairedId) {
+      std::string fixtureName = TrimAscii(fixture.name);
+      if (fixtureName.empty())
+        fixtureName = fixture.uuid.empty() ? "unnamed fixture" : fixture.uuid;
+      const std::string message =
+          "MVR export reassigned duplicate FixtureIDNumeric " +
+          std::to_string(originalId) + " for fixture '" + fixtureName +
+          "' to the next available value " + std::to_string(repairedId) + ".";
+      m_exportWarnings.push_back(message);
+      Logger::Instance().Log(Logger::Level::Warn, message);
+    };
+
+    std::unordered_map<std::string, std::pair<std::string, int>> result;
+    for (const std::string &uid : sortedKeys(scene.fixtures)) {
+      const Fixture &f = scene.fixtures.at(uid);
+      FixtureExportId fixtureId = ResolveFixtureExportId(f);
+      if (fixtureId.numeric > 0) {
+        if (!assignedFixtureIds.insert(fixtureId.numeric).second) {
+          const int originalId = fixtureId.numeric;
+          fixtureId.numeric = allocId();
+          fixtureId.text = std::to_string(fixtureId.numeric);
+          logFixtureIdRepair(f, originalId, fixtureId.numeric);
+        }
+      } else {
+        fixtureId.numeric = allocId();
+        fixtureId.text = std::to_string(fixtureId.numeric);
+      }
+      if (fixtureId.text.empty())
+        fixtureId.text = std::to_string(fixtureId.numeric);
+      result[uid] = {fixtureId.text, fixtureId.numeric};
+    }
 
     for (const std::string &uid : sortedKeys(scene.trusses)) {
       const Truss &t = scene.trusses.at(uid);
@@ -2813,7 +2837,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath,
     for (const std::string &uid : sortedKeys(scene.sceneObjects)) {
       const SceneObject &obj = scene.sceneObjects.at(uid);
       int numeric = 0;
-      if (obj.fixtureIdNumeric > 0 && reserveId(obj.fixtureIdNumeric))
+      if (obj.fixtureIdNumeric > 0 &&
+          usedIds.insert(obj.fixtureIdNumeric).second)
         numeric = obj.fixtureIdNumeric;
       else
         numeric = allocId();
@@ -3073,9 +3098,10 @@ bool MvrExporter::ExportToFile(const std::string &filePath,
       }
     };
     auto idIt = assignedIds.find(f.uuid);
-    FixtureExportId fixtureExportId = ResolveFixtureExportId(f);
-    if (fixtureExportId.numeric <= 0 && idIt != assignedIds.end())
-      fixtureExportId = {idIt->second.first, idIt->second.second};
+    FixtureExportId fixtureExportId =
+        idIt != assignedIds.end()
+            ? FixtureExportId{idIt->second.first, idIt->second.second}
+            : ResolveFixtureExportId(f);
     if (fixtureExportId.numeric <= 0) {
       fixtureExportId.numeric = 1;
       fixtureExportId.text = "1";


### PR DESCRIPTION
### Motivation
- Duplicate `FixtureIDNumeric` values during MVR export currently trigger blocking validation failures that prevent saving; the exporter should instead repair conflicts, log them, and allow the export to proceed.

### Description
- Modified `mvr/mvrexporter.cpp` exporter ID assignment so existing fixture numeric IDs are reserved, duplicate fixture numerics are detected and reassigned to the next available number, and the repaired value is used when writing `FixtureID` / `FixtureIDNumeric` elements.
- Added non-blocking diagnostics by appending a human-readable message to `m_exportWarnings` and logging a `Logger::Level::Warn` entry when a fixture numeric is repaired.
- Unified the used-ID pool so trusses, supports, and scene objects are allocated from the same `usedIds` set after fixture repairs to preserve global numeric uniqueness.
- Updated `docs/release-notes-draft.md` with a short entry describing the export fix.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed (OK). 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed (OK). 
- Ran `git diff --check` and found no issues (OK). 
- Attempted a local CMake configure with `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug`, which was blocked by the environment due to missing `wxWidgets` (configuration not completed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46f6621c608324820d700d6373fb7b)