### PR TITLE
Fix Layers visibility double-click rename

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -17,6 +17,7 @@ Changes since **v1.4.0**.
 
 ## Fixes
 
+- Fixed Layers visibility checkbox double-clicks so they only toggle visibility and no longer open the layer rename dialog.
 - Fixed MVR export so duplicate fixture numeric IDs are repaired with the next available number, logged as non-blocking warnings, and no longer prevent saving the MVR file.
 - Fixed first-attempt truss weight edits by propagating shared truss type weights before scene synchronization and hoist-load recalculation.
 - Fixed the Trusses table so hoist-load recalculation prompts only appear when an edit can change a position rigging total, such as weight or hang-position changes, instead of dimension-only edits like width or height.

--- a/gui/layerpanel.cpp
+++ b/gui/layerpanel.cpp
@@ -40,6 +40,7 @@ constexpr int ColumnIndex(LayerColumn column) {
     return TableColumnIndices::ToIndex(column);
 }
 
+// Refreshes open viewer panels after layer visibility or color changes.
 void RefreshVisibleViewers() {
     std::function<void(wxWindow*)> visit;
     visit = [&](wxWindow* window) {
@@ -72,6 +73,7 @@ void RefreshVisibleViewers() {
 }
 } // namespace
 
+// Builds the layer list panel and wires layer management events.
 LayerPanel::LayerPanel(wxWindow* parent, bool showButtons, ConfigManager* config)
     : wxPanel(parent, wxID_ANY), configManager(config ? config : &GetDefaultGuiConfigServices().LegacyConfigManager())
 {
@@ -151,10 +153,13 @@ LayerPanel::LayerPanel(wxWindow* parent, bool showButtons, ConfigManager* config
     ReloadLayers();
 }
 
+// Returns the globally registered layer panel instance.
 LayerPanel *LayerPanel::Instance() { return s_instance; }
 
+// Stores the globally registered layer panel instance.
 void LayerPanel::SetInstance(LayerPanel *p) { s_instance = p; }
 
+// Rebuilds the visible layer rows from the current scene and visibility state.
 void LayerPanel::ReloadLayers() {
   if (!list)
     return;
@@ -223,6 +228,7 @@ void LayerPanel::ReloadLayers() {
     }
 }
 
+// Applies visibility checkbox changes to the hidden-layer set.
 void LayerPanel::OnCheck(wxDataViewEvent &evt) {
     int idx = static_cast<int>(list->ItemToRow(evt.GetItem()));
   if (idx == wxNOT_FOUND || idx < 0 ||
@@ -242,6 +248,7 @@ void LayerPanel::OnCheck(wxDataViewEvent &evt) {
     RefreshVisibleViewers();
 }
 
+// Updates the current layer when the selected row changes.
 void LayerPanel::OnSelect(wxDataViewEvent &evt) {
     unsigned int idx = list->ItemToRow(evt.GetItem());
     if (idx == wxNOT_FOUND)
@@ -250,6 +257,7 @@ void LayerPanel::OnSelect(wxDataViewEvent &evt) {
     (*configManager).SetCurrentLayer(wname.ToStdString());
 }
 
+// Opens the layer color picker for the context-menu row.
 void LayerPanel::OnContext(wxDataViewEvent &evt) {
     unsigned int idx = list->ItemToRow(evt.GetItem());
     if (idx == wxNOT_FOUND)
@@ -287,6 +295,7 @@ void LayerPanel::OnContext(wxDataViewEvent &evt) {
     }
 }
 
+// Adds a new named layer to the scene.
 void LayerPanel::OnAddLayer(wxCommandEvent &) {
     wxTextEntryDialog dlg(this, "Enter new layer name:", "Add Layer");
     if (dlg.ShowModal() != wxID_OK)
@@ -314,6 +323,7 @@ void LayerPanel::OnAddLayer(wxCommandEvent &) {
     ReloadLayers();
 }
 
+// Deletes the selected non-default layer and any contained elements when confirmed.
 void LayerPanel::OnDeleteLayer(wxCommandEvent&)
 {
     if (!list)
@@ -444,9 +454,14 @@ void LayerPanel::OnDeleteLayer(wxCommandEvent&)
     }
 }
 
+// Renames the activated layer when the layer-name column is activated.
 void LayerPanel::OnRenameLayer(wxDataViewEvent &evt) {
     if (!list)
         return;
+    if (evt.GetColumn() != ColumnIndex(LayerColumn::Layer)) {
+        evt.Skip();
+        return;
+    }
     unsigned int idx = list->ItemToRow(evt.GetItem());
     if (idx == wxNOT_FOUND)
         return;


### PR DESCRIPTION
### Motivation
- Double-clicking the visibility checkbox in the Layers panel incorrectly opened the rename dialog because activation handling did not distinguish the checkbox column from the layer-name column.

### Description
- Restrict rename activation in `gui/layerpanel.cpp` so `OnRenameLayer` only opens the rename dialog when the activated column equals the layer-name column (`ColumnIndex(LayerColumn::Layer)`).
- Add concise one-line English comments above several C++ function definitions in `gui/layerpanel.cpp` to satisfy code-style requirements and improve clarity.
- Add a release-note entry to `docs/release-notes-draft.md` documenting the Layers visibility checkbox double-click fix.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.
- Ran `git diff --check` to validate whitespace/patch issues and it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46fc0488c88324ab4ba47ea6d62bac)