### PR TITLE
Add visible diagnostics for Layout preview texture and rasterization failures

### DIFF
--- a/docs/layout_2d_view_rasterization.md
+++ b/docs/layout_2d_view_rasterization.md
@@ -6,4 +6,10 @@ PDF export remains separate from this preview texture flow. Exported PDFs must c
 
 The current `Layout2DViewRasterizer` service wraps the existing `Viewer2DOffscreenRenderer` and `Viewer2DPanel` path. It preserves the command-buffer cache reuse path, persistent RGBA cache reuse, and the fallback `Viewer2DPanel::RenderToRGBA` behavior that the layout preview already used.
 
+## Interactive preview diagnostics
+
+When an embedded 2D view cannot be rasterized or uploaded as a preview texture, the interactive Layout preview now shows a subtle non-printing placeholder inside that view frame. The placeholder says that the 2D view render is unavailable and points maintainers to the diagnostics log.
+
+This placeholder is only part of the editor preview. It does not change successful preview rendering, persistent RGBA cache reuse, command-buffer cache reuse, `Viewer2DPanel::RenderToRGBA`, print preview, or exported PDF output. PDF export remains independent from preview texture failures and must not include the placeholder text.
+
 Future work may optimize how layout previews are captured or cached, but this layer intentionally does not replace the rendering backend. Do not reintroduce Cairo or add a new Skia, Qt, NanoVG, EGL pbuffer, or FBO-based backend as part of this rasterization boundary.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -126,3 +126,4 @@ If you encounter any problems installing or running Perastage, please open an is
 - Centralized wxGLCanvas attribute selection, OpenGL context binding diagnostics, and GLEW initialization ownership across shared viewer components for the 3D, 2D, Layout, and Fixture Preview panels.
 - Encapsulated Layout 2D view preview rasterization behind a focused service while preserving the existing Viewer2D-based rendering path and PDF export separation.
 - Added visible, non-printing diagnostics for failed Layout 2D preview textures while keeping PDF export behavior unchanged.
+- Fixed Windows build compatibility for Layout 2D preview diagnostics.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -125,3 +125,4 @@ If you encounter any problems installing or running Perastage, please open an is
 ## Internal changes
 - Centralized wxGLCanvas attribute selection, OpenGL context binding diagnostics, and GLEW initialization ownership across shared viewer components for the 3D, 2D, Layout, and Fixture Preview panels.
 - Encapsulated Layout 2D view preview rasterization behind a focused service while preserving the existing Viewer2D-based rendering path and PDF export separation.
+- Added visible, non-printing diagnostics for failed Layout 2D preview textures while keeping PDF export behavior unchanged.

--- a/gui/layout_2d_view_rasterizer.cpp
+++ b/gui/layout_2d_view_rasterizer.cpp
@@ -95,14 +95,20 @@ Layout2DViewRasterResult Layout2DViewRasterizer::Rasterize(
     const Layout2DViewRasterCacheInput &cacheInput) const {
   Layout2DViewRasterResult result;
   if (!request.view) {
+    result.failureReason =
+        Layout2DViewRasterFailureReason::MissingViewDefinition;
     result.diagnosticMessage = "missing 2D view definition";
     return result;
   }
   if (request.renderSize.GetWidth() <= 0 || request.renderSize.GetHeight() <= 0) {
+    result.failureReason = Layout2DViewRasterFailureReason::InvalidFrameSize;
     result.diagnosticMessage = "invalid frame size";
     return result;
   }
   if (!cacheInput.hasCapture || !cacheInput.hasRenderState) {
+    result.failureReason = !cacheInput.hasCapture
+                               ? Layout2DViewRasterFailureReason::MissingCaptureData
+                               : Layout2DViewRasterFailureReason::MissingRenderState;
     result.diagnosticMessage = "missing capture data or render state";
     return result;
   }
@@ -120,9 +126,13 @@ Layout2DViewRasterResult Layout2DViewRasterizer::Rasterize(
   if (cacheInput.restoredFromPersistentCache) {
     if (!cacheInput.buffer || !cacheInput.viewState) {
       result.rejectedRestoredPersistentCache = true;
+      result.failureReason =
+          Layout2DViewRasterFailureReason::MissingCaptureData;
       result.diagnosticMessage = "missing command-buffer cache data";
     } else if (cacheInput.buffer->commands.empty()) {
       result.rejectedRestoredPersistentCache = true;
+      result.failureReason =
+          Layout2DViewRasterFailureReason::EmptyCommandBuffer;
       result.diagnosticMessage = "empty command buffer";
     } else if (gui::layoutcache::RenderCommandBufferCacheToRgba(
                    request.renderSize, *cacheInput.buffer, *cacheInput.viewState,
@@ -133,19 +143,25 @@ Layout2DViewRasterResult Layout2DViewRasterizer::Rasterize(
       return result;
     } else {
       result.rejectedRestoredPersistentCache = true;
+      result.failureReason =
+          Layout2DViewRasterFailureReason::CommandBufferRasterizationFailed;
       result.diagnosticMessage = "RenderCommandBufferCacheToRgba failed";
     }
   }
 
   if (!capturePanel_) {
+    result.failureReason = Layout2DViewRasterFailureReason::MissingCapturePanel;
     result.diagnosticMessage = "missing capture panel";
     return result;
   }
   if (!offscreenRenderer_) {
+    result.failureReason =
+        Layout2DViewRasterFailureReason::MissingOffscreenRenderer;
     result.diagnosticMessage = "missing offscreen renderer";
     return result;
   }
   if (!cacheInput.renderState) {
+    result.failureReason = Layout2DViewRasterFailureReason::MissingRenderState;
     result.diagnosticMessage = "missing render state";
     return result;
   }
@@ -178,10 +194,13 @@ Layout2DViewRasterResult Layout2DViewRasterizer::Rasterize(
 
   if (!capturePanel_->RenderToRGBA(result.rgbaPixels, result.width,
                                    result.height, request.renderSize)) {
+    result.failureReason = Layout2DViewRasterFailureReason::RenderToRgbaFailed;
     result.diagnosticMessage = "Viewer2DPanel::RenderToRGBA failed";
     return result;
   }
   if (result.width <= 0 || result.height <= 0 || result.rgbaPixels.empty()) {
+    result.failureReason =
+        Layout2DViewRasterFailureReason::InvalidRgbaDimensions;
     result.diagnosticMessage = "invalid RGBA dimensions";
     return result;
   }

--- a/gui/layout_2d_view_rasterizer.h
+++ b/gui/layout_2d_view_rasterizer.h
@@ -38,6 +38,21 @@ struct Layout2DViewDefinition;
 
 namespace gui::layoutraster {
 
+enum class Layout2DViewRasterFailureReason {
+  None,
+  MissingViewDefinition,
+  InvalidFrameSize,
+  MissingCaptureData,
+  MissingCapturePanel,
+  MissingOffscreenRenderer,
+  MissingRenderState,
+  EmptyCommandBuffer,
+  CommandBufferRasterizationFailed,
+  RenderToRgbaFailed,
+  InvalidRgbaDimensions,
+  TextureUploadFailed
+};
+
 struct Layout2DViewRasterRequest {
   const layouts::Layout2DViewDefinition *view = nullptr;
   wxSize renderSize{0, 0};
@@ -68,6 +83,8 @@ struct Layout2DViewRasterResult {
   int width = 0;
   int height = 0;
   std::vector<unsigned char> rgbaPixels;
+  Layout2DViewRasterFailureReason failureReason =
+      Layout2DViewRasterFailureReason::None;
   std::string diagnosticMessage;
 };
 

--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -2258,6 +2258,16 @@ bool LayoutViewerPanel::RebuildCachedTexture() {
         ClearCachedTexture(cache);
         cache.textureSize = wxSize(0, 0);
         cache.renderZoom = 0.0;
+        cache.hasLastRenderFailure = true;
+        cache.lastRenderFailureReason =
+            !cache.hasCapture
+                ? gui::layoutraster::Layout2DViewRasterFailureReason::
+                      MissingCaptureData
+                : gui::layoutraster::Layout2DViewRasterFailureReason::
+                      MissingRenderState;
+        cache.lastRenderFailureMessage =
+            !GetFrameRect(view.frame, frameRect) ? "invalid frame size"
+                                                : "missing capture data or render state";
         continue;
       }
   
@@ -2266,6 +2276,10 @@ bool LayoutViewerPanel::RebuildCachedTexture() {
         ClearCachedTexture(cache);
         cache.textureSize = wxSize(0, 0);
         cache.renderZoom = 0.0;
+        cache.hasLastRenderFailure = true;
+        cache.lastRenderFailureReason =
+            gui::layoutraster::Layout2DViewRasterFailureReason::InvalidFrameSize;
+        cache.lastRenderFailureMessage = "invalid frame size";
         continue;
       }
   
@@ -2308,9 +2322,19 @@ bool LayoutViewerPanel::RebuildCachedTexture() {
       if (rasterResult.rejectedRestoredPersistentCache)
         cache.restoredFromPersistentCache = false;
       if (!rasterResult.success) {
-        wxLogTrace("layoutviewer_raster",
-                   "Rasterizing 2D view id=%d failed: %s", view.id,
-                   wxString::FromUTF8(rasterResult.diagnosticMessage).c_str());
+        cache.hasLastRenderFailure = true;
+        cache.lastRenderFailureReason = rasterResult.failureReason;
+        cache.lastRenderFailureMessage = rasterResult.diagnosticMessage;
+        if (cache.lastLoggedFailureContentHash != viewContentHash ||
+            cache.lastLoggedFailureMessage != rasterResult.diagnosticMessage) {
+          wxLogTrace("layoutviewer_raster",
+                     "Rasterizing 2D view id=%d failed size=%dx%d zoom=%.3f hash=%zu: %s",
+                     view.id, renderSize.GetWidth(), renderSize.GetHeight(),
+                     renderZoom, viewContentHash,
+                     wxString::FromUTF8(rasterResult.diagnosticMessage).c_str());
+          cache.lastLoggedFailureContentHash = viewContentHash;
+          cache.lastLoggedFailureMessage = rasterResult.diagnosticMessage;
+        }
         ClearCachedTexture(cache);
         cache.textureSize = wxSize(0, 0);
         cache.renderZoom = 0.0;
@@ -2337,6 +2361,15 @@ bool LayoutViewerPanel::RebuildCachedTexture() {
                                            cache.pboBytes);
       if (!UploadRgbaToTexture(cache.texture, width, height, pixels.data(),
                                cache.textureSize, true)) {
+        cache.hasLastRenderFailure = true;
+        cache.lastRenderFailureReason =
+            gui::layoutraster::Layout2DViewRasterFailureReason::
+                TextureUploadFailed;
+        cache.lastRenderFailureMessage = "GPU texture upload failed";
+        wxLogTrace("layoutviewer_raster",
+                   "Uploading 2D view texture id=%d failed size=%dx%d zoom=%.3f hash=%zu: %s",
+                   view.id, width, height, renderZoom, viewContentHash,
+                   cache.lastRenderFailureMessage.c_str());
         ClearCachedTexture(cache);
         cache.textureSize = wxSize(0, 0);
         cache.renderZoom = 0.0;
@@ -2349,6 +2382,10 @@ bool LayoutViewerPanel::RebuildCachedTexture() {
       cache.textureSize = wxSize(width, height);
       cache.renderZoom = renderZoom;
       cache.contentHash = viewContentHash;
+      cache.hasLastRenderFailure = false;
+      cache.lastRenderFailureReason =
+          gui::layoutraster::Layout2DViewRasterFailureReason::None;
+      cache.lastRenderFailureMessage.clear();
       cache.persistentRgba = pixels;
       cache.persistentRgbaSize = cache.textureSize;
       cache.persistentRgbaRenderZoom = renderZoom;

--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <string>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -28,6 +29,7 @@
 #include "LayoutCollection.h"
 #include "configservices.h"
 #include "canvas2d.h"
+#include "layout_2d_view_rasterizer.h"
 #include "symbolcache.h"
 #include "viewer2dpanel.h"
 #include "viewer2dstate.h"
@@ -93,6 +95,12 @@ private:
     wxSize persistentRgbaSize{0, 0};
     double persistentRgbaRenderZoom = 0.0;
     size_t persistentRgbaContentHash = 0;
+    bool hasLastRenderFailure = false;
+    std::string lastRenderFailureMessage;
+    gui::layoutraster::Layout2DViewRasterFailureReason lastRenderFailureReason =
+        gui::layoutraster::Layout2DViewRasterFailureReason::None;
+    size_t lastLoggedFailureContentHash = 0;
+    std::string lastLoggedFailureMessage;
   };
 
   struct LegendCache {

--- a/gui/layoutviewerpanel_view.cpp
+++ b/gui/layoutviewerpanel_view.cpp
@@ -40,6 +40,10 @@
 #  include <GL/glu.h>
 #endif
 
+#ifndef GL_CLAMP_TO_EDGE
+#define GL_CLAMP_TO_EDGE 0x812F
+#endif
+
 #include "configmanager.h"
 #include "guiconfigservices.h"
 #include "LayoutManager.h"

--- a/gui/layoutviewerpanel_view.cpp
+++ b/gui/layoutviewerpanel_view.cpp
@@ -19,6 +19,11 @@
 
 #include <algorithm>
 #include <memory>
+#include <vector>
+
+#include <wx/bitmap.h>
+#include <wx/dcmemory.h>
+#include <wx/image.h>
 
 // Include GLEW or other OpenGL loader first if present
 #ifdef _WIN32
@@ -41,6 +46,155 @@
 #include "viewer2doffscreenrenderer.h"
 #include "viewer2dstate.h"
 
+namespace {
+
+constexpr const char *kLayout2DViewFailurePlaceholderText =
+    "2D view render unavailable";
+constexpr const char *kLayout2DViewFailurePlaceholderHint =
+    "See diagnostics log";
+
+// Draws one subtle filled rectangle for a failed interactive preview item.
+void DrawFailurePlaceholderBackground(const wxRect &frameRect) {
+  glColor4ub(238, 240, 242, 255);
+  glBegin(GL_QUADS);
+  glVertex2f(static_cast<float>(frameRect.GetLeft()),
+             static_cast<float>(frameRect.GetTop()));
+  glVertex2f(static_cast<float>(frameRect.GetRight()),
+             static_cast<float>(frameRect.GetTop()));
+  glVertex2f(static_cast<float>(frameRect.GetRight()),
+             static_cast<float>(frameRect.GetBottom()));
+  glVertex2f(static_cast<float>(frameRect.GetLeft()),
+             static_cast<float>(frameRect.GetBottom()));
+  glEnd();
+
+  glColor4ub(185, 190, 196, 255);
+  glLineWidth(1.0f);
+  glBegin(GL_LINE_LOOP);
+  glVertex2f(static_cast<float>(frameRect.GetLeft()),
+             static_cast<float>(frameRect.GetTop()));
+  glVertex2f(static_cast<float>(frameRect.GetRight()),
+             static_cast<float>(frameRect.GetTop()));
+  glVertex2f(static_cast<float>(frameRect.GetRight()),
+             static_cast<float>(frameRect.GetBottom()));
+  glVertex2f(static_cast<float>(frameRect.GetLeft()),
+             static_cast<float>(frameRect.GetBottom()));
+  glEnd();
+}
+
+// Builds an RGBA texture containing the preview failure message.
+unsigned int CreateFailurePlaceholderTextTexture(const wxRect &frameRect,
+                                                 wxSize &textureSize) {
+  const bool showHint = frameRect.GetWidth() >= 180 && frameRect.GetHeight() >= 70;
+  wxFont titleFont = wxFontInfo(10).Bold();
+  wxFont hintFont = wxFontInfo(9);
+  int titleWidth = 0;
+  int titleHeight = 0;
+  int hintWidth = 0;
+  int hintHeight = 0;
+  {
+    wxMemoryDC measureDc;
+    measureDc.SetFont(titleFont);
+    measureDc.GetTextExtent(kLayout2DViewFailurePlaceholderText, &titleWidth,
+                            &titleHeight);
+    if (showHint) {
+      measureDc.SetFont(hintFont);
+      measureDc.GetTextExtent(kLayout2DViewFailurePlaceholderHint, &hintWidth,
+                              &hintHeight);
+    }
+  }
+  const int padding = 8;
+  const int bmpWidth =
+      std::max(titleWidth, showHint ? hintWidth : 0) + padding * 2;
+  const int bmpHeight =
+      titleHeight + (showHint ? hintHeight + 4 : 0) + padding * 2;
+  if (bmpWidth <= 0 || bmpHeight <= 0)
+    return 0;
+
+  wxBitmap bitmap(bmpWidth, bmpHeight, 32);
+  {
+    wxMemoryDC dc(bitmap);
+    dc.SetBackground(wxBrush(wxColour(238, 240, 242)));
+    dc.Clear();
+    dc.SetFont(titleFont);
+    dc.SetTextForeground(wxColour(88, 94, 102));
+    dc.DrawText(kLayout2DViewFailurePlaceholderText, padding, padding);
+    if (showHint) {
+      dc.SetFont(hintFont);
+      dc.SetTextForeground(wxColour(112, 118, 126));
+      dc.DrawText(kLayout2DViewFailurePlaceholderHint, padding,
+                  padding + titleHeight + 4);
+    }
+    dc.SelectObject(wxNullBitmap);
+  }
+
+  wxImage image = bitmap.ConvertToImage();
+  if (!image.IsOk() || !image.GetData())
+    return 0;
+  std::vector<unsigned char> pixels(static_cast<size_t>(bmpWidth) * bmpHeight *
+                                    4);
+  const unsigned char *rgb = image.GetData();
+  for (int i = 0; i < bmpWidth * bmpHeight; ++i) {
+    pixels[static_cast<size_t>(i) * 4] = rgb[i * 3];
+    pixels[static_cast<size_t>(i) * 4 + 1] = rgb[i * 3 + 1];
+    pixels[static_cast<size_t>(i) * 4 + 2] = rgb[i * 3 + 2];
+    pixels[static_cast<size_t>(i) * 4 + 3] = 255;
+  }
+
+  unsigned int texture = 0;
+  glGenTextures(1, &texture);
+  glBindTexture(GL_TEXTURE_2D, texture);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+  glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, bmpWidth, bmpHeight, 0, GL_RGBA,
+               GL_UNSIGNED_BYTE, pixels.data());
+  textureSize = wxSize(bmpWidth, bmpHeight);
+  return texture;
+}
+
+// Draws the preview-only failure placeholder text inside the layout view frame.
+void DrawFailurePlaceholderText(const wxRect &frameRect) {
+  wxSize textureSize;
+  const unsigned int texture =
+      CreateFailurePlaceholderTextTexture(frameRect, textureSize);
+  if (texture == 0)
+    return;
+
+  const int left = frameRect.GetLeft() +
+                   (frameRect.GetWidth() - textureSize.GetWidth()) / 2;
+  const int top = frameRect.GetTop() +
+                  (frameRect.GetHeight() - textureSize.GetHeight()) / 2;
+  const int right = left + textureSize.GetWidth();
+  const int bottom = top + textureSize.GetHeight();
+  glEnable(GL_TEXTURE_2D);
+  glBindTexture(GL_TEXTURE_2D, texture);
+  glColor4ub(255, 255, 255, 255);
+  glBegin(GL_QUADS);
+  glTexCoord2f(0.0f, 1.0f);
+  glVertex2f(static_cast<float>(left), static_cast<float>(top));
+  glTexCoord2f(1.0f, 1.0f);
+  glVertex2f(static_cast<float>(right), static_cast<float>(top));
+  glTexCoord2f(1.0f, 0.0f);
+  glVertex2f(static_cast<float>(right), static_cast<float>(bottom));
+  glTexCoord2f(0.0f, 0.0f);
+  glVertex2f(static_cast<float>(left), static_cast<float>(bottom));
+  glEnd();
+  glDisable(GL_TEXTURE_2D);
+  glDeleteTextures(1, &texture);
+}
+
+// Draws the non-printing placeholder for a failed Layout 2D preview item.
+void DrawFailurePlaceholder(const wxRect &frameRect) {
+  DrawFailurePlaceholderBackground(frameRect);
+  if (frameRect.GetWidth() >= 120 && frameRect.GetHeight() >= 36)
+    DrawFailurePlaceholderText(frameRect);
+}
+
+} // namespace
+
+// Returns the currently editable Layout 2D view.
 layouts::Layout2DViewDefinition *LayoutViewerPanel::GetEditableView() {
   if (currentLayout.view2dViews.empty())
     return nullptr;
@@ -56,6 +210,7 @@ layouts::Layout2DViewDefinition *LayoutViewerPanel::GetEditableView() {
   return &currentLayout.view2dViews.front();
 }
 
+// Returns the currently editable Layout 2D view without mutating state.
 const layouts::Layout2DViewDefinition *LayoutViewerPanel::GetEditableView()
     const {
   if (currentLayout.view2dViews.empty())
@@ -102,12 +257,14 @@ void LayoutViewerPanel::RefreshEditedViewById(int viewId) {
   Refresh();
 }
 
+// Emits a request to edit the selected Layout 2D view.
 void LayoutViewerPanel::OnEditView(wxCommandEvent &) {
   if (selectedElementType != SelectedElementType::View2D)
     return;
   EmitEditViewRequest();
 }
 
+// Deletes the selected Layout 2D view from the current layout.
 void LayoutViewerPanel::OnDeleteView(wxCommandEvent &) {
   if (selectedElementType != SelectedElementType::View2D)
     return;
@@ -159,6 +316,7 @@ void LayoutViewerPanel::OnDeleteView(wxCommandEvent &) {
   Refresh();
 }
 
+// Toggles the visible frame for the selected Layout 2D view.
 void LayoutViewerPanel::OnToggleViewFrame(wxCommandEvent &) {
   if (selectedElementType != SelectedElementType::View2D)
     return;
@@ -176,6 +334,7 @@ void LayoutViewerPanel::OnToggleViewFrame(wxCommandEvent &) {
   Refresh();
 }
 
+// Updates the selected Layout 2D view frame and invalidates cached rendering.
 void LayoutViewerPanel::UpdateFrame(const layouts::Layout2DViewFrame &frame,
                                     bool updatePosition) {
   layouts::Layout2DViewDefinition *view = GetEditableView();
@@ -217,6 +376,7 @@ void LayoutViewerPanel::UpdateFrame(const layouts::Layout2DViewFrame &frame,
   Refresh();
 }
 
+// Draws one interactive Layout 2D view preview element.
 void LayoutViewerPanel::DrawViewElement(
     const layouts::Layout2DViewDefinition &view, Viewer2DPanel *capturePanel,
     Viewer2DOffscreenRenderer *offscreenRenderer, int activeViewId) {
@@ -319,6 +479,8 @@ void LayoutViewerPanel::DrawViewElement(
                static_cast<float>(frameRect.GetBottom()));
     glEnd();
     glDisable(GL_TEXTURE_2D);
+  } else if (cache.hasLastRenderFailure) {
+    DrawFailurePlaceholder(frameRect);
   } else {
     glColor4ub(240, 240, 240, 255);
     glBegin(GL_QUADS);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,6 +34,8 @@ if(BASH_EXECUTABLE)
              COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_opengl_lifecycle_centralized.sh)
     add_test(NAME Layout2DRasterizationBoundary
              COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_layout_2d_rasterization_boundary.sh)
+    add_test(NAME LayoutPreviewFailureDiagnostics
+             COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_layout_preview_failure_diagnostics.sh)
     add_test(NAME LibraryUserDataPolicy
              COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_library_user_data_policy.sh)
     add_test(NAME DictionaryPathsPolicy

--- a/tests/check_layout_preview_failure_diagnostics.sh
+++ b/tests/check_layout_preview_failure_diagnostics.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+rasterizer_header="$repo_root/gui/layout_2d_view_rasterizer.h"
+rasterizer_source="$repo_root/gui/layout_2d_view_rasterizer.cpp"
+panel_header="$repo_root/gui/layoutviewerpanel.h"
+preview_source="$repo_root/gui/layoutviewerpanel_view.cpp"
+pdf_sources=("$repo_root/viewer2d/pdf" "$repo_root/gui/mainwindow_print.cpp")
+placeholder="2D view render unavailable"
+
+for file in "$rasterizer_header" "$rasterizer_source" "$panel_header" "$preview_source"; do
+  if [[ ! -f "$file" ]]; then
+    echo "Required Layout preview diagnostics file is missing: ${file#$repo_root/}" >&2
+    exit 1
+  fi
+done
+
+for token in \
+  "Layout2DViewRasterFailureReason" \
+  "diagnosticMessage" \
+  "MissingCaptureData" \
+  "CommandBufferRasterizationFailed" \
+  "RenderToRgbaFailed"; do
+  if ! rg -n "$token" "$rasterizer_header" "$rasterizer_source" >/dev/null; then
+    echo "Raster failure diagnostic token is missing: $token" >&2
+    exit 1
+  fi
+done
+
+for token in \
+  "hasLastRenderFailure" \
+  "lastRenderFailureMessage" \
+  "lastRenderFailureReason"; do
+  if ! rg -n "$token" "$panel_header" "$repo_root/gui/layoutviewerpanel.cpp" >/dev/null; then
+    echo "Layout view cache failure state is missing: $token" >&2
+    exit 1
+  fi
+done
+
+if ! rg -n "$placeholder" "$preview_source" >/dev/null; then
+  echo "Interactive Layout preview placeholder text is not owned by preview rendering." >&2
+  exit 1
+fi
+
+for source in "${pdf_sources[@]}"; do
+  if rg -n "$placeholder" "$source" >/dev/null; then
+    echo "PDF/export path must not reference the preview failure placeholder: ${source#$repo_root/}" >&2
+    exit 1
+  fi
+done


### PR DESCRIPTION
### Motivation

- Improve developer and user visibility when an embedded Layout 2D view fails to rasterize or upload as an interactive preview texture while preserving all existing PDF/export and printing behaviour.
- Surface a subtle, non-printing placeholder in the interactive Layout preview instead of a silent blank area and provide structured diagnostics for easier triage.

### Description

- Add a structured failure reason enum `Layout2DViewRasterFailureReason` and propagate it on `Layout2DViewRasterResult` while preserving the existing `diagnosticMessage` string in `gui/layout_2d_view_rasterizer.{h,cpp}`.
- Store per-view last-failure state on `LayoutViewerPanel::ViewCache` (`hasLastRenderFailure`, `lastRenderFailureMessage`, `lastRenderFailureReason`) and clear it after a successful texture upload in `gui/layoutviewerpanel.{h,cpp}`.
- Improve logging with view id, render size, zoom, content hash, and diagnostic text and add simple per-view throttling to avoid repeated spam via `wxLogTrace` in `gui/layoutviewerpanel.cpp`.
- Add an interactive-only, subtle fallback placeholder (background + optional small text texture) drawn by preview rendering when a view has no valid texture and a stored failure exists in `gui/layoutviewerpanel_view.cpp`, keeping successful rendering unchanged.
- Add a lightweight guard test `tests/check_layout_preview_failure_diagnostics.sh` and register it in `tests/CMakeLists.txt` to ensure the rasterizer/cache boundary diagnostics exist and that the placeholder text is not referenced by PDF/export code.
- Update documentation in `docs/layout_2d_view_rasterization.md` and `docs/release-notes-draft.md` to explain the non-printing interactive placeholder and confirm PDF/export independence.

### Testing

- Ran the existing boundary and GUI checks: `tests/check_layout_2d_rasterization_boundary.sh`, `tests/check_perastage_tree_modules.sh`, and `tests/check_no_configmanager_get_in_gui.sh`, and they completed successfully.
- Ran the new guard `tests/check_layout_preview_failure_diagnostics.sh` and it passed, including the assertion that the placeholder text is not referenced by PDF/export sources.
- Verified `git diff --check` reports no whitespace or trailing-errors.
- Attempted full CMake builds `cmake -S . -B build-debug -DCMAKE_BUILD_TYPE=Debug && cmake --build build-debug -j2` and `cmake -S . -B build-release -DCMAKE_BUILD_TYPE=Release`, but both configure steps are blocked in this environment due to missing `wxWidgets` packages (so full binary build could not be completed here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ad53a45988324b03d36626f0753f8)