### PR TITLE
Extract Layout 2D view capture service

### DIFF
--- a/docs/layout_2d_view_rasterization.md
+++ b/docs/layout_2d_view_rasterization.md
@@ -6,6 +6,16 @@ PDF export remains separate from this preview texture flow. Exported PDFs must c
 
 The current `Layout2DViewRasterizer` service wraps the existing `Viewer2DOffscreenRenderer` and `Viewer2DPanel` path. It preserves the command-buffer cache reuse path, persistent RGBA cache reuse, and the fallback `Viewer2DPanel::RenderToRGBA` behavior that the layout preview already used.
 
+## Interactive preview responsibility boundaries
+
+The interactive Layout 2D preview path is split across focused responsibilities:
+
+- `Layout2DViewCaptureService` schedules and applies command-buffer captures for embedded Layout 2D views. It decides when a capture is stale, applies the Layout 2D view definition to the capture panel, invokes the existing `Viewer2DPanel::CaptureFrameNow` path, and updates capture metadata through the owning panel.
+- `Layout2DViewRasterizer` converts cached or captured preview data into RGBA pixels. It remains responsible for command-buffer rasterization, persistent RGBA reuse, and the existing `Viewer2DPanel::RenderToRGBA` fallback.
+- `LayoutViewerPanel` owns the Layout view cache, OpenGL texture IDs and upload lifecycle, frame drawing, selection handles, persistent preview state, and interactive failure placeholders.
+
+PDF export, print preview, and printing remain separate from the interactive preview texture path. They must not depend on preview OpenGL textures, transient preview capture state, or the non-printing interactive failure placeholder.
+
 ## Interactive preview diagnostics
 
 When an embedded 2D view cannot be rasterized or uploaded as a preview texture, the interactive Layout preview now shows a subtle non-printing placeholder inside that view frame. The placeholder says that the 2D view render is unavailable and points maintainers to the diagnostics log.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -124,6 +124,6 @@ If you encounter any problems installing or running Perastage, please open an is
 
 ## Internal changes
 - Centralized wxGLCanvas attribute selection, OpenGL context binding diagnostics, and GLEW initialization ownership across shared viewer components for the 3D, 2D, Layout, and Fixture Preview panels.
-- Encapsulated Layout 2D view preview rasterization behind a focused service while preserving the existing Viewer2D-based rendering path and PDF export separation.
+- Encapsulated Layout 2D view preview capture and rasterization behind focused services while preserving the existing Viewer2D-based rendering path and PDF export separation.
 - Added visible, non-printing diagnostics for failed Layout 2D preview textures while keeping PDF export behavior unchanged.
 - Fixed Windows build compatibility for Layout 2D preview diagnostics.

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -50,6 +50,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/layouttextdialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/layouttextutils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/layoutviewerpanel.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/layout_2d_view_capture_service.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/layout_2d_view_rasterizer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/layout_view_cache_archive.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/layoutviewerpanel_render_invalidation.cpp

--- a/gui/layout_2d_view_capture_service.cpp
+++ b/gui/layout_2d_view_capture_service.cpp
@@ -1,0 +1,131 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "layout_2d_view_capture_service.h"
+
+#include <memory>
+#include <utility>
+
+#include <wx/log.h>
+
+#include "configmanager.h"
+#include "guiconfigservices.h"
+#include "viewer2doffscreenrenderer.h"
+#include "viewer2dpanel.h"
+
+namespace gui::layoutcapture {
+namespace {
+
+// Returns whether the cached command buffer must be refreshed for this view.
+bool NeedsCapture(const Layout2DViewCaptureRequest &request) {
+  return !request.cacheHasCapture || !request.cacheHasRenderState ||
+         request.cacheCaptureVersion != request.viewRenderVersion ||
+         !request.cacheHasCaptureContentHash ||
+         request.cacheCaptureContentHash != request.contentHash;
+}
+
+} // namespace
+
+// Schedules a capture for one embedded Layout 2D view when required.
+Layout2DViewCaptureScheduleResult ScheduleLayout2DViewCaptureIfNeeded(
+    const Layout2DViewCaptureRequest &request,
+    const Layout2DViewCaptureCallbacks &callbacks) {
+  Layout2DViewCaptureScheduleResult result;
+  result.captureNeeded = NeedsCapture(request);
+  if (!result.captureNeeded)
+    return result;
+
+  if (!request.view || request.panelIsDestroying) {
+    wxLogTrace("layout2d.capture",
+               "Skipping Layout 2D capture because the view is unavailable.");
+    return result;
+  }
+  if (!request.capturePanel) {
+    wxLogTrace("layout2d.capture",
+               "Skipping Layout 2D capture for view %d because capture panel "
+               "is unavailable.",
+               request.view->id);
+    return result;
+  }
+  if (request.panelCaptureInProgress || request.cacheCaptureInProgress)
+    return result;
+  if (!callbacks.setPanelCaptureInProgress ||
+      !callbacks.setCacheCaptureInProgress || !callbacks.storeRenderState ||
+      !callbacks.completeCapture) {
+    wxLogTrace("layout2d.capture",
+               "Skipping Layout 2D capture for view %d because callbacks are "
+               "incomplete.",
+               request.view->id);
+    return result;
+  }
+
+  const int fallbackViewportWidth = request.view->camera.viewportWidth > 0
+                                        ? request.view->camera.viewportWidth
+                                        : request.view->frame.width;
+  const int fallbackViewportHeight = request.view->camera.viewportHeight > 0
+                                         ? request.view->camera.viewportHeight
+                                         : request.view->frame.height;
+  if (fallbackViewportWidth <= 0 || fallbackViewportHeight <= 0) {
+    wxLogTrace("layout2d.capture",
+               "Skipping Layout 2D capture for view %d because the viewport is "
+               "invalid.",
+               request.view->id);
+    return result;
+  }
+
+  callbacks.setPanelCaptureInProgress(true);
+  callbacks.setCacheCaptureInProgress(true);
+
+  ConfigManager &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
+  viewer2d::Viewer2DState layoutState =
+      viewer2d::FromLayoutDefinition(*request.view);
+  layoutState.renderOptions.darkMode = false;
+  callbacks.storeRenderState(layoutState);
+
+  if (request.offscreenRenderer) {
+    request.offscreenRenderer->SetViewportSize(
+        wxSize(fallbackViewportWidth, fallbackViewportHeight));
+    request.offscreenRenderer->PrepareForCapture();
+  } else {
+    wxLogTrace("layout2d.capture",
+               "Scheduling Layout 2D capture for view %d without offscreen "
+               "renderer preparation.",
+               request.view->id);
+  }
+
+  auto stateGuard = std::make_shared<viewer2d::ScopedViewer2DState>(
+      request.capturePanel, nullptr, cfg, layoutState, nullptr, nullptr, false);
+  Viewer2DPanel *capturePanel = request.capturePanel;
+  const size_t captureContentHash = request.contentHash;
+  const int captureVersion = request.viewRenderVersion;
+  capturePanel->CaptureFrameNow(
+      [callbacks, stateGuard, capturePanel, fallbackViewportWidth,
+       fallbackViewportHeight, captureContentHash,
+       captureVersion](CommandBuffer buffer, Viewer2DViewState state) {
+        std::shared_ptr<const SymbolDefinitionSnapshot> symbols;
+        if (capturePanel)
+          symbols = capturePanel->GetBottomSymbolCacheSnapshot();
+        callbacks.completeCapture(std::move(buffer), state, std::move(symbols),
+                                  fallbackViewportWidth, fallbackViewportHeight,
+                                  captureContentHash, captureVersion);
+      },
+      true, true);
+  result.captureScheduled = true;
+  return result;
+}
+
+} // namespace gui::layoutcapture

--- a/gui/layout_2d_view_capture_service.h
+++ b/gui/layout_2d_view_capture_service.h
@@ -1,0 +1,69 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <cstddef>
+#include <functional>
+#include <memory>
+
+#include "LayoutCollection.h"
+#include "canvas2d.h"
+#include "symbolcache.h"
+#include "viewer2dpanel.h"
+#include "viewer2dstate.h"
+
+class Viewer2DOffscreenRenderer;
+
+namespace gui::layoutcapture {
+
+struct Layout2DViewCaptureRequest {
+  const layouts::Layout2DViewDefinition *view = nullptr;
+  Viewer2DPanel *capturePanel = nullptr;
+  Viewer2DOffscreenRenderer *offscreenRenderer = nullptr;
+  int viewRenderVersion = 0;
+  size_t contentHash = 0;
+  bool panelCaptureInProgress = false;
+  bool cacheCaptureInProgress = false;
+  bool cacheHasCapture = false;
+  bool cacheHasRenderState = false;
+  bool cacheHasCaptureContentHash = false;
+  size_t cacheCaptureContentHash = 0;
+  int cacheCaptureVersion = -1;
+  bool panelIsDestroying = false;
+};
+
+struct Layout2DViewCaptureCallbacks {
+  std::function<void(bool)> setPanelCaptureInProgress;
+  std::function<void(bool)> setCacheCaptureInProgress;
+  std::function<void(const viewer2d::Viewer2DState &)> storeRenderState;
+  std::function<void(CommandBuffer, Viewer2DViewState,
+                     std::shared_ptr<const SymbolDefinitionSnapshot>, int, int,
+                     size_t, int)>
+      completeCapture;
+};
+
+struct Layout2DViewCaptureScheduleResult {
+  bool captureNeeded = false;
+  bool captureScheduled = false;
+};
+
+Layout2DViewCaptureScheduleResult ScheduleLayout2DViewCaptureIfNeeded(
+    const Layout2DViewCaptureRequest &request,
+    const Layout2DViewCaptureCallbacks &callbacks);
+
+} // namespace gui::layoutcapture

--- a/gui/layoutviewerpanel_view.cpp
+++ b/gui/layoutviewerpanel_view.cpp
@@ -33,22 +33,21 @@
 #endif
 
 #ifdef __APPLE__
-#  include <OpenGL/gl.h>
-#  include <OpenGL/glu.h>
+#include <OpenGL/gl.h>
+#include <OpenGL/glu.h>
 #else
-#  include <GL/gl.h>
-#  include <GL/glu.h>
+#include <GL/gl.h>
+#include <GL/glu.h>
 #endif
 
 #ifndef GL_CLAMP_TO_EDGE
 #define GL_CLAMP_TO_EDGE 0x812F
 #endif
 
+#include "LayoutManager.h"
 #include "configmanager.h"
 #include "guiconfigservices.h"
-#include "LayoutManager.h"
-#include "viewer2doffscreenrenderer.h"
-#include "viewer2dstate.h"
+#include "layout_2d_view_capture_service.h"
 
 namespace {
 
@@ -88,7 +87,8 @@ void DrawFailurePlaceholderBackground(const wxRect &frameRect) {
 // Builds an RGBA texture containing the preview failure message.
 unsigned int CreateFailurePlaceholderTextTexture(const wxRect &frameRect,
                                                  wxSize &textureSize) {
-  const bool showHint = frameRect.GetWidth() >= 180 && frameRect.GetHeight() >= 70;
+  const bool showHint =
+      frameRect.GetWidth() >= 180 && frameRect.GetHeight() >= 70;
   wxFont titleFont = wxFontInfo(10).Bold();
   wxFont hintFont = wxFontInfo(9);
   int titleWidth = 0;
@@ -166,8 +166,8 @@ void DrawFailurePlaceholderText(const wxRect &frameRect) {
   if (texture == 0)
     return;
 
-  const int left = frameRect.GetLeft() +
-                   (frameRect.GetWidth() - textureSize.GetWidth()) / 2;
+  const int left =
+      frameRect.GetLeft() + (frameRect.GetWidth() - textureSize.GetWidth()) / 2;
   const int top = frameRect.GetTop() +
                   (frameRect.GetHeight() - textureSize.GetHeight()) / 2;
   const int right = left + textureSize.GetWidth();
@@ -215,8 +215,8 @@ layouts::Layout2DViewDefinition *LayoutViewerPanel::GetEditableView() {
 }
 
 // Returns the currently editable Layout 2D view without mutating state.
-const layouts::Layout2DViewDefinition *LayoutViewerPanel::GetEditableView()
-    const {
+const layouts::Layout2DViewDefinition *
+LayoutViewerPanel::GetEditableView() const {
   if (currentLayout.view2dViews.empty())
     return nullptr;
   if (selectedElementType == SelectedElementType::View2D &&
@@ -231,7 +231,8 @@ const layouts::Layout2DViewDefinition *LayoutViewerPanel::GetEditableView()
   return nullptr;
 }
 
-// Marks one 2D view cache dirty and schedules a rebuild only for the updated view element.
+// Marks one 2D view cache dirty and schedules a rebuild only for the updated
+// view element.
 void LayoutViewerPanel::RefreshEditedViewById(int viewId) {
   if (viewId <= 0)
     return;
@@ -280,7 +281,7 @@ void LayoutViewerPanel::OnDeleteView(wxCommandEvent &) {
     auto &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
     cfg.PushUndoState("delete layout 2d view");
     if (layouts::LayoutManager::Get().RemoveLayout2DView(currentLayout.name,
-                                                        viewId)) {
+                                                         viewId)) {
       auto &views = currentLayout.view2dViews;
       views.erase(std::remove_if(views.begin(), views.end(),
                                  [viewId](const auto &entry) {
@@ -331,8 +332,7 @@ void LayoutViewerPanel::OnToggleViewFrame(wxCommandEvent &) {
   if (!currentLayout.name.empty()) {
     auto &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
     cfg.PushUndoState("toggle layout 2d view border");
-    layouts::LayoutManager::Get().UpdateLayout2DView(currentLayout.name,
-                                                     *view);
+    layouts::LayoutManager::Get().UpdateLayout2DView(currentLayout.name, *view);
   }
   RequestRenderRebuild();
   Refresh();
@@ -370,8 +370,7 @@ void LayoutViewerPanel::UpdateFrame(const layouts::Layout2DViewFrame &frame,
     return;
   }
   if (!currentLayout.name.empty()) {
-    layouts::LayoutManager::Get().UpdateLayout2DView(currentLayout.name,
-                                                     *view);
+    layouts::LayoutManager::Get().UpdateLayout2DView(currentLayout.name, *view);
   }
   InvalidateRenderIfFrameChanged(false);
   if (NeedsRenderRebuild()) {
@@ -386,71 +385,50 @@ void LayoutViewerPanel::DrawViewElement(
     Viewer2DOffscreenRenderer *offscreenRenderer, int activeViewId) {
   ViewCache &cache = GetViewCache(view.id);
   const size_t viewContentHash = HashViewContent(view);
-  const bool needsCapture =
-      !cache.hasCapture || !cache.hasRenderState ||
-      cache.captureVersion != viewRenderVersion ||
-      !cache.hasCaptureContentHash || cache.captureContentHash != viewContentHash;
-  if (!captureInProgress && !cache.captureInProgress && needsCapture &&
-      capturePanel) {
-    captureInProgress = true;
-    cache.captureInProgress = true;
-    const int viewId = view.id;
-    const size_t captureContentHash = viewContentHash;
-    const int fallbackViewportWidth = view.camera.viewportWidth > 0
-                                          ? view.camera.viewportWidth
-                                          : view.frame.width;
-    const int fallbackViewportHeight = view.camera.viewportHeight > 0
-                                           ? view.camera.viewportHeight
-                                           : view.frame.height;
-    ConfigManager &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
-    viewer2d::Viewer2DState layoutState =
-        viewer2d::FromLayoutDefinition(view);
-    layoutState.renderOptions.darkMode = false;
-    cache.renderState = layoutState;
-    cache.hasRenderState = true;
-    if (offscreenRenderer && fallbackViewportWidth > 0 &&
-        fallbackViewportHeight > 0) {
-      offscreenRenderer->SetViewportSize(
-          wxSize(fallbackViewportWidth, fallbackViewportHeight));
-      offscreenRenderer->PrepareForCapture();
-    }
-    auto stateGuard = std::make_shared<viewer2d::ScopedViewer2DState>(
-        capturePanel, nullptr, cfg, layoutState, nullptr, nullptr, false);
-    capturePanel->CaptureFrameNow(
-        [this, viewId, stateGuard, fallbackViewportWidth, fallbackViewportHeight,
-         capturePanel, captureContentHash](CommandBuffer buffer,
-                                           Viewer2DViewState state) {
-          ViewCache &cache = GetViewCache(viewId);
-          cache.buffer = std::move(buffer);
-          cache.viewState = state;
-          if (cache.viewState.viewportWidth <= 0 &&
-              fallbackViewportWidth > 0) {
-            cache.viewState.viewportWidth = fallbackViewportWidth;
-          }
-          if (cache.viewState.viewportHeight <= 0 &&
-              fallbackViewportHeight > 0) {
-            cache.viewState.viewportHeight = fallbackViewportHeight;
-          }
-          cache.symbols.reset();
-          if (capturePanel) {
-            cache.symbols = capturePanel->GetBottomSymbolCacheSnapshot();
-          }
-          cache.hasCapture = !cache.buffer.commands.empty();
-          cache.captureContentHash = captureContentHash;
-          cache.hasCaptureContentHash = true;
-          cache.captureVersion = viewRenderVersion;
-          cache.restoredFromPersistentCache = false;
-          cache.captureInProgress = false;
-          captureInProgress = false;
-          cache.renderDirty = true;
-          renderDirty = true;
-          cache.textureSize = wxSize(0, 0);
-          cache.renderZoom = 0.0;
-          RequestRenderRebuild();
-          Refresh();
-        },
-        true, true);
-  }
+  gui::layoutcapture::ScheduleLayout2DViewCaptureIfNeeded(
+      gui::layoutcapture::Layout2DViewCaptureRequest{
+          &view, capturePanel, offscreenRenderer, viewRenderVersion,
+          viewContentHash, captureInProgress, cache.captureInProgress,
+          cache.hasCapture, cache.hasRenderState, cache.hasCaptureContentHash,
+          cache.captureContentHash, cache.captureVersion, false},
+      gui::layoutcapture::Layout2DViewCaptureCallbacks{
+          [this](bool inProgress) { captureInProgress = inProgress; },
+          [&cache](bool inProgress) { cache.captureInProgress = inProgress; },
+          [&cache](const viewer2d::Viewer2DState &renderState) {
+            cache.renderState = renderState;
+            cache.hasRenderState = true;
+          },
+          [this, viewId = view.id](
+              CommandBuffer buffer, Viewer2DViewState state,
+              std::shared_ptr<const SymbolDefinitionSnapshot> symbols,
+              int fallbackViewportWidth, int fallbackViewportHeight,
+              size_t captureContentHash, int captureVersion) {
+            ViewCache &cache = GetViewCache(viewId);
+            cache.buffer = std::move(buffer);
+            cache.viewState = state;
+            if (cache.viewState.viewportWidth <= 0 &&
+                fallbackViewportWidth > 0) {
+              cache.viewState.viewportWidth = fallbackViewportWidth;
+            }
+            if (cache.viewState.viewportHeight <= 0 &&
+                fallbackViewportHeight > 0) {
+              cache.viewState.viewportHeight = fallbackViewportHeight;
+            }
+            cache.symbols = std::move(symbols);
+            cache.hasCapture = !cache.buffer.commands.empty();
+            cache.captureContentHash = captureContentHash;
+            cache.hasCaptureContentHash = true;
+            cache.captureVersion = captureVersion;
+            cache.restoredFromPersistentCache = false;
+            cache.captureInProgress = false;
+            captureInProgress = false;
+            cache.renderDirty = true;
+            renderDirty = true;
+            cache.textureSize = wxSize(0, 0);
+            cache.renderZoom = 0.0;
+            RequestRenderRebuild();
+            Refresh();
+          }});
 
   wxRect frameRect;
   if (!GetFrameRect(view.frame, frameRect))
@@ -476,8 +454,7 @@ void LayoutViewerPanel::DrawViewElement(
     glVertex2f(static_cast<float>(frameRight),
                static_cast<float>(frameRect.GetTop()));
     glTexCoord2f(1.0f, 0.0f);
-    glVertex2f(static_cast<float>(frameRight),
-               static_cast<float>(frameBottom));
+    glVertex2f(static_cast<float>(frameRight), static_cast<float>(frameBottom));
     glTexCoord2f(0.0f, 0.0f);
     glVertex2f(static_cast<float>(frameRect.GetLeft()),
                static_cast<float>(frameRect.GetBottom()));
@@ -492,8 +469,7 @@ void LayoutViewerPanel::DrawViewElement(
                static_cast<float>(frameRect.GetTop()));
     glVertex2f(static_cast<float>(frameRect.GetRight()),
                static_cast<float>(frameRect.GetTop()));
-    glVertex2f(static_cast<float>(frameRight),
-               static_cast<float>(frameBottom));
+    glVertex2f(static_cast<float>(frameRight), static_cast<float>(frameBottom));
     glVertex2f(static_cast<float>(frameRect.GetLeft()),
                static_cast<float>(frameRect.GetBottom()));
     glEnd();
@@ -512,8 +488,7 @@ void LayoutViewerPanel::DrawViewElement(
                static_cast<float>(frameRect.GetTop()));
     glVertex2f(static_cast<float>(frameRight),
                static_cast<float>(frameRect.GetTop()));
-    glVertex2f(static_cast<float>(frameRight),
-               static_cast<float>(frameBottom));
+    glVertex2f(static_cast<float>(frameRight), static_cast<float>(frameBottom));
     glVertex2f(static_cast<float>(frameRect.GetLeft()),
                static_cast<float>(frameRect.GetBottom()));
     glEnd();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,6 +34,8 @@ if(BASH_EXECUTABLE)
              COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_opengl_lifecycle_centralized.sh)
     add_test(NAME Layout2DRasterizationBoundary
              COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_layout_2d_rasterization_boundary.sh)
+    add_test(NAME Layout2DViewCaptureBoundary
+             COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_layout_2d_view_capture_boundary.sh)
     add_test(NAME LayoutPreviewFailureDiagnostics
              COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_layout_preview_failure_diagnostics.sh)
     add_test(NAME LibraryUserDataPolicy

--- a/tests/check_layout_2d_view_capture_boundary.sh
+++ b/tests/check_layout_2d_view_capture_boundary.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+panel_file="$repo_root/gui/layoutviewerpanel_view.cpp"
+service_file="$repo_root/gui/layout_2d_view_capture_service.cpp"
+
+if [[ ! -f "$service_file" ]]; then
+  echo "Missing Layout 2D view capture service: gui/layout_2d_view_capture_service.cpp" >&2
+  exit 1
+fi
+
+for token in "CaptureFrameNow" "ScopedViewer2DState" "FromLayoutDefinition"; do
+  if rg -n "$token" "$panel_file" >/dev/null; then
+    echo "LayoutViewerPanel view drawing should not own 2D capture token: $token" >&2
+    exit 1
+  fi
+  if ! rg -n "$token" "$service_file" >/dev/null; then
+    echo "Layout 2D view capture service is expected to own token: $token" >&2
+    exit 1
+  fi
+done
+
+if rg -n "GetBottomSymbolCacheSnapshot" "$panel_file" | rg -v "completeCapture|capturePanel" >/dev/null; then
+  echo "LayoutViewerPanel should only update captured symbol snapshots from the capture completion callback" >&2
+  exit 1
+fi


### PR DESCRIPTION
### Motivation
- Reduce responsibility and size of `LayoutViewerPanel` by extracting the Layout 2D view capture orchestration into a focused service while preserving existing rendering behavior and cache ownership.
- Keep `LayoutViewerPanel` as the single owner of view caches, OpenGL texture ids, PBO state, persistent RGBA cache and failure diagnostics per architecture rules.

### Description
- Added a capture service with `gui/layout_2d_view_capture_service.h` and `gui/layout_2d_view_capture_service.cpp` exposing `ScheduleLayout2DViewCaptureIfNeeded` and small `Request`/`Callbacks`/`Result` structs to encapsulate stale-capture detection, `viewer2d::FromLayoutDefinition`, `viewer2d::ScopedViewer2DState`, and `Viewer2DPanel::CaptureFrameNow` orchestration.
- Updated `LayoutViewerPanel::DrawViewElement(...)` in `gui/layoutviewerpanel_view.cpp` to delegate capture scheduling to the new service and to keep only the final cache/texture mutation and drawing flow, preserving the original capture completion behavior that moves `CommandBuffer` into the view cache, stores `Viewer2DViewState`, fills fallback viewport sizes, updates symbol snapshots, and flags cache/panel state (e.g. `hasCapture`, `captureContentHash`, `captureVersion`, `renderDirty`).
- Kept rasterization responsibility unchanged: `Layout2DViewRasterizer` remains the rasterizer and `Viewer2DPanel::RenderToRGBA` fallback is untouched, and no PDF/print export code was changed.
- Registered the new source in `gui/CMakeLists.txt`, added an architecture guard test `tests/check_layout_2d_view_capture_boundary.sh` and registered it in `tests/CMakeLists.txt`, and documented the responsibility split in `docs/layout_2d_view_rasterization.md` and updated `docs/release-notes-draft.md`.

### Testing
- Ran the new architectural guard: `bash tests/check_layout_2d_view_capture_boundary.sh` and it passed.
- Ran existing boundary and diagnostics checks: `bash tests/check_layout_2d_rasterization_boundary.sh`, `bash tests/check_layout_preview_failure_diagnostics.sh`, `bash tests/check_opengl_lifecycle_centralized.sh`, `bash tests/check_perastage_tree_modules.sh`, and `bash tests/check_no_configmanager_get_in_gui.sh`; all passed.
- Performed basic static checks: `bash -n tests/check_layout_2d_view_capture_boundary.sh` and `git diff --check`; they passed with no issues.
- Attempted full CMake configure with `cmake -S . -B /tmp/perastage-codex-build -DPERASTAGE_BUILD_TESTS=ON` but configuration failed in this environment due to missing `wxWidgets` development files (`wxWidgets_LIBRARIES` and `wxWidgets_INCLUDE_DIRS`), so a complete build/test run was not performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4adbbb6af88324b707b694c10301d7)