### PR TITLE
Classify Viewer2D state ownership

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -56,7 +56,9 @@ Changes since **v1.4.0**.
 
 ## Documentation
 
+- Added Viewer2D state ownership documentation to clarify runtime-only, user preference/config, and project/Layout definition boundaries before future offscreen rendering refactors.
 - Updated the MVR-xchange documentation with a compliance summary, supported official flows, conservative latest-request behavior, and explicit out-of-scope notes for WebSocket Mode and private live synchronization.
+
 ## Compatibility notes
 
 ## Downloads and installation

--- a/docs/viewer2d_state_ownership.md
+++ b/docs/viewer2d_state_ownership.md
@@ -1,0 +1,39 @@
+# Viewer2D state ownership
+
+Viewer2D state is intentionally classified before deeper Layout/offscreen refactors. This document keeps runtime interaction state, user preference/config state, and project/Layout definition state separate so temporary Layout preview rendering does not accidentally become persistent application or project state.
+
+## Ownership categories
+
+| Category | Owner | Examples | Persistence rule |
+| --- | --- | --- | --- |
+| Runtime-only state | Active Viewer2D panels, render panels, and temporary capture guards | Current interactive panel offsets, zoom, viewport size, view while the user is navigating, temporary capture state, dragging, hover, measurement, selection overlays, repaint throttling, capture-in-progress flags, render overrides, and offscreen capture-panel setup | Must not be persisted just because a Layout preview needs a temporary render. Temporary preview capture must restore the previous state through `viewer2d::ScopedViewer2DState` or an equivalent scoped mechanism. |
+| User preference/config state | `ConfigManager` and intentional editor preference actions | Default 2D render mode, dark mode, grid visibility, grid style, grid color, grid draw order, ruler visibility and colors, label visibility, label font sizes, label offsets, top-fixtures inversion, hidden layers, hidden fixture types, and the persisted editor camera when the user intentionally changes the editor view | May survive application sessions only when changed through normal editor preference or view flows. Layout preview capture/rasterization must not call `SaveUserConfig` or introduce new config persistence. |
+| Project/Layout definition state | `layouts::Layout2DViewDefinition` stored in the project/Layout model | Embedded Layout 2D view frame, camera, render options, layers, drawFrame, zIndex, and id | Belongs to the project/Layout model. Runtime navigation and temporary capture state must not mutate or save project/Layout definitions unless the user is editing the Layout definition itself. |
+
+## Current Viewer2D state bridge
+
+`viewer2d::Viewer2DState` is a bridge structure used by both editor state capture and Layout 2D view rendering. It currently contains:
+
+- `layouts::Layout2DViewCameraState` for camera/view values.
+- `layouts::Layout2DViewRenderOptions` for render preferences and embedded view render options.
+- `layouts::Layout2DViewLayers` for hidden layers and hidden fixture types.
+
+`viewer2d::CaptureState(...)` currently reads camera values from a `Viewer2DPanel` when one is available, and reads render options, labels, grid, ruler, and layer visibility from `ConfigManager`. `viewer2d::ApplyState(...)` currently writes many of those values back into `ConfigManager` because the editor still uses shared config-backed Viewer2D state. This behavior is documented here as existing behavior, not as a target architecture.
+
+The lightweight ownership map in `viewer2d/viewer2dstate.h` and `viewer2d/viewer2dstate.cpp` identifies known Viewer2D config keys as user preference/config state. Future refactors should use that map as a checklist when moving runtime-only state away from shared configuration.
+
+## Layout preview capture and rasterization rules
+
+Interactive Layout preview 2D views may temporarily apply a `layouts::Layout2DViewDefinition` to the capture panel so the existing Viewer2D render path can produce command buffers or RGBA pixels. That temporary application is runtime-only capture state.
+
+Layout preview capture/rasterization code must:
+
+- Use `viewer2d::ScopedViewer2DState` or an equivalent scoped restore mechanism when applying temporary 2D view state.
+- Pass `persistCameraToConfig = false` or an equivalent non-persistent mode for temporary preview captures.
+- Avoid direct `SaveUserConfig`, project save, or Layout definition save calls.
+- Leave `LayoutViewerPanel` as the owner of interactive preview caches, OpenGL texture ids, PBO state, persistent RGBA cache, failure diagnostics, frame drawing, selection handles, and preview placeholders.
+- Keep PDF/export/print separate from the interactive preview texture path and preview placeholder/failure diagnostic state.
+
+## Future FBO/offscreen cleanup note
+
+The current `Viewer2DOffscreenRenderer` still uses a hidden/off-screen wx window and `Viewer2DPanel` for capture. Replacing or reducing that dependency with a more explicit framebuffer/render-target capture path is a separate future task. The FBO/offscreen cleanup should not be mixed with Viewer2D state ownership changes; state boundaries should be clarified first, then the rendering target can be refactored with less risk.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,6 +36,8 @@ if(BASH_EXECUTABLE)
              COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_layout_2d_rasterization_boundary.sh)
     add_test(NAME Layout2DViewCaptureBoundary
              COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_layout_2d_view_capture_boundary.sh)
+    add_test(NAME Viewer2DStateOwnershipBoundary
+             COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_viewer2d_state_ownership_boundary.sh)
     add_test(NAME LayoutPreviewFailureDiagnostics
              COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_layout_preview_failure_diagnostics.sh)
     add_test(NAME LibraryUserDataPolicy

--- a/tests/check_viewer2d_state_ownership_boundary.sh
+++ b/tests/check_viewer2d_state_ownership_boundary.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+doc_file="$repo_root/docs/viewer2d_state_ownership.md"
+state_header="$repo_root/viewer2d/viewer2dstate.h"
+state_source="$repo_root/viewer2d/viewer2dstate.cpp"
+capture_file="$repo_root/gui/layout_2d_view_capture_service.cpp"
+rasterizer_file="$repo_root/gui/layout_2d_view_rasterizer.cpp"
+pdf_dir="$repo_root/viewer2d/pdf"
+
+if [[ ! -f "$doc_file" ]]; then
+  echo "Missing Viewer2D state ownership documentation: docs/viewer2d_state_ownership.md" >&2
+  exit 1
+fi
+
+for phrase in "Runtime-only state" "User preference/config state" "Project/Layout definition state" "FBO/offscreen cleanup"; do
+  if ! rg -n "$phrase" "$doc_file" >/dev/null; then
+    echo "Viewer2D state ownership documentation must mention: $phrase" >&2
+    exit 1
+  fi
+done
+
+for token in "Viewer2DStateOwnership" "RuntimeOnly" "UserPreferenceConfig" "ProjectLayoutDefinition" "IsViewer2DUserPreferenceConfigKey"; do
+  if ! rg -n "$token" "$state_header" "$state_source" >/dev/null; then
+    echo "Viewer2D state ownership map is missing token: $token" >&2
+    exit 1
+  fi
+done
+
+for file in "$capture_file" "$rasterizer_file"; do
+  if [[ ! -f "$file" ]]; then
+    echo "Missing Layout preview state boundary file: ${file#$repo_root/}" >&2
+    exit 1
+  fi
+  if ! rg -n "ScopedViewer2DState" "$file" >/dev/null; then
+    echo "Layout preview capture/rasterization must use scoped temporary Viewer2D state: ${file#$repo_root/}" >&2
+    exit 1
+  fi
+  if ! rg -n "ScopedViewer2DState\([^;]*false|false\)" "$file" >/dev/null; then
+    echo "Layout preview temporary state must avoid persisting camera config: ${file#$repo_root/}" >&2
+    exit 1
+  fi
+  if rg -n "SaveUserConfig|SaveProject|SaveAsProject|WriteProject|SerializeProject|SaveLayout" "$file" >/dev/null; then
+    echo "Layout preview capture/rasterization must not save user config or project data: ${file#$repo_root/}" >&2
+    exit 1
+  fi
+done
+
+if rg -n "preview placeholder|placeholder text|failure diagnostic|diagnosticMessage|Layout2DViewRasterFailure|persistent RGBA|OpenGL texture|PBO" "$pdf_dir" >/dev/null; then
+  echo "PDF/export/print code must not depend on interactive Layout preview placeholder or texture failure state" >&2
+  exit 1
+fi

--- a/viewer2d/viewer2dstate.cpp
+++ b/viewer2d/viewer2dstate.cpp
@@ -23,6 +23,7 @@
 
 #include <algorithm>
 #include <array>
+#include <string_view>
 #include <unordered_set>
 #include <utility>
 
@@ -49,8 +50,71 @@ const std::array<const char *, 3> kRulerColorGKeys = {
     "ruler_axis_x_color_g", "ruler_axis_y_color_g", "ruler_axis_z_color_g"};
 const std::array<const char *, 3> kRulerColorBKeys = {
     "ruler_axis_x_color_b", "ruler_axis_y_color_b", "ruler_axis_z_color_b"};
+
+const std::array<Viewer2DStateConfigKeyOwnership, 41>
+    kViewer2DStateConfigKeyOwnership = {{
+        {"view2d_offset_x", Viewer2DStateOwnership::UserPreferenceConfig},
+        {"view2d_offset_y", Viewer2DStateOwnership::UserPreferenceConfig},
+        {"view2d_zoom", Viewer2DStateOwnership::UserPreferenceConfig},
+        {"view2d_view", Viewer2DStateOwnership::UserPreferenceConfig},
+        {"view2d_render_mode", Viewer2DStateOwnership::UserPreferenceConfig},
+        {"view2d_dark_mode", Viewer2DStateOwnership::UserPreferenceConfig},
+        {"view2d_top_fixtures_inverted",
+         Viewer2DStateOwnership::UserPreferenceConfig},
+        {"grid_show", Viewer2DStateOwnership::UserPreferenceConfig},
+        {"grid_style", Viewer2DStateOwnership::UserPreferenceConfig},
+        {"grid_color_r", Viewer2DStateOwnership::UserPreferenceConfig},
+        {"grid_color_g", Viewer2DStateOwnership::UserPreferenceConfig},
+        {"grid_color_b", Viewer2DStateOwnership::UserPreferenceConfig},
+        {"grid_draw_above", Viewer2DStateOwnership::UserPreferenceConfig},
+        {"ruler_show", Viewer2DStateOwnership::UserPreferenceConfig},
+        {"ruler_axis_x_color_r", Viewer2DStateOwnership::UserPreferenceConfig},
+        {"ruler_axis_y_color_r", Viewer2DStateOwnership::UserPreferenceConfig},
+        {"ruler_axis_z_color_r", Viewer2DStateOwnership::UserPreferenceConfig},
+        {"ruler_axis_x_color_g", Viewer2DStateOwnership::UserPreferenceConfig},
+        {"ruler_axis_y_color_g", Viewer2DStateOwnership::UserPreferenceConfig},
+        {"ruler_axis_z_color_g", Viewer2DStateOwnership::UserPreferenceConfig},
+        {"ruler_axis_x_color_b", Viewer2DStateOwnership::UserPreferenceConfig},
+        {"ruler_axis_y_color_b", Viewer2DStateOwnership::UserPreferenceConfig},
+        {"ruler_axis_z_color_b", Viewer2DStateOwnership::UserPreferenceConfig},
+        {"label_show_name_top", Viewer2DStateOwnership::UserPreferenceConfig},
+        {"label_show_name_front", Viewer2DStateOwnership::UserPreferenceConfig},
+        {"label_show_name_side", Viewer2DStateOwnership::UserPreferenceConfig},
+        {"label_show_id_top", Viewer2DStateOwnership::UserPreferenceConfig},
+        {"label_show_id_front", Viewer2DStateOwnership::UserPreferenceConfig},
+        {"label_show_id_side", Viewer2DStateOwnership::UserPreferenceConfig},
+        {"label_show_dmx_top", Viewer2DStateOwnership::UserPreferenceConfig},
+        {"label_show_dmx_front", Viewer2DStateOwnership::UserPreferenceConfig},
+        {"label_show_dmx_side", Viewer2DStateOwnership::UserPreferenceConfig},
+        {"label_offset_distance_top",
+         Viewer2DStateOwnership::UserPreferenceConfig},
+        {"label_offset_distance_front",
+         Viewer2DStateOwnership::UserPreferenceConfig},
+        {"label_offset_distance_side",
+         Viewer2DStateOwnership::UserPreferenceConfig},
+        {"label_offset_angle_top", Viewer2DStateOwnership::UserPreferenceConfig},
+        {"label_offset_angle_front",
+         Viewer2DStateOwnership::UserPreferenceConfig},
+        {"label_offset_angle_side",
+         Viewer2DStateOwnership::UserPreferenceConfig},
+        {"label_font_size_name", Viewer2DStateOwnership::UserPreferenceConfig},
+        {"label_font_size_id", Viewer2DStateOwnership::UserPreferenceConfig},
+        {"label_font_size_dmx", Viewer2DStateOwnership::UserPreferenceConfig},
+    }};
 } // namespace
 
+// Returns whether the key is known Viewer2D user preference/config state.
+bool IsViewer2DUserPreferenceConfigKey(std::string_view key) {
+  return std::any_of(kViewer2DStateConfigKeyOwnership.begin(),
+                     kViewer2DStateConfigKeyOwnership.end(),
+                     [key](const Viewer2DStateConfigKeyOwnership &entry) {
+                       return entry.key == key &&
+                              entry.ownership ==
+                                  Viewer2DStateOwnership::UserPreferenceConfig;
+                     });
+}
+
+// Captures the current Viewer2D camera, render options, and layer visibility.
 Viewer2DState CaptureState(const Viewer2DPanel *panel,
                            const ConfigManager &cfg) {
   Viewer2DState state;
@@ -120,6 +184,7 @@ Viewer2DState CaptureState(const Viewer2DPanel *panel,
   return state;
 }
 
+// Applies a captured Viewer2D state to config and optionally refreshes panels.
 void ApplyState(Viewer2DPanel *panel, Viewer2DRenderPanel *renderPanel,
                 ConfigManager &cfg, const Viewer2DState &state,
                 bool persistCameraToConfig, bool updatePanels) {
@@ -194,6 +259,7 @@ void ApplyState(Viewer2DPanel *panel, Viewer2DRenderPanel *renderPanel,
     renderPanel->ApplyConfig();
 }
 
+// Applies a temporary Viewer2D state and saves the previous state for restore.
 ScopedViewer2DState::ScopedViewer2DState(Viewer2DPanel *applyPanel,
                                          Viewer2DRenderPanel *applyRenderPanel,
                                          ConfigManager &cfg,
@@ -211,12 +277,15 @@ ScopedViewer2DState::ScopedViewer2DState(Viewer2DPanel *applyPanel,
              persistCameraToConfig_, true);
 }
 
+// Restores the previously captured state when the guard leaves scope.
 ScopedViewer2DState::~ScopedViewer2DState() { Restore(); }
 
+// Moves ownership of an active scoped Viewer2D state guard.
 ScopedViewer2DState::ScopedViewer2DState(ScopedViewer2DState &&other) noexcept {
   *this = std::move(other);
 }
 
+// Transfers restore responsibility from another scoped Viewer2D state guard.
 ScopedViewer2DState &
 ScopedViewer2DState::operator=(ScopedViewer2DState &&other) noexcept {
   if (this == &other)
@@ -241,6 +310,7 @@ ScopedViewer2DState::operator=(ScopedViewer2DState &&other) noexcept {
   return *this;
 }
 
+// Restores the previous Viewer2D state if this guard is still active.
 void ScopedViewer2DState::Restore() {
   if (!cfg_ || restored_)
     return;
@@ -256,6 +326,7 @@ void ScopedViewer2DState::Restore() {
   restored_ = true;
 }
 
+// Converts a Layout 2D view definition into a Viewer2D state snapshot.
 Viewer2DState FromLayoutDefinition(const layouts::Layout2DViewDefinition &view) {
   Viewer2DState state;
   state.camera = view.camera;
@@ -264,6 +335,7 @@ Viewer2DState FromLayoutDefinition(const layouts::Layout2DViewDefinition &view) 
   return state;
 }
 
+// Fills editor-only render options that are not embedded in older definitions.
 void ApplyEditorRenderOptions(Viewer2DState &state, const ConfigManager &cfg) {
   if (!state.renderOptions.forceBottomViewForTopFixtures.has_value()) {
     state.renderOptions.forceBottomViewForTopFixtures =
@@ -271,6 +343,7 @@ void ApplyEditorRenderOptions(Viewer2DState &state, const ConfigManager &cfg) {
   }
 }
 
+// Converts a Viewer2D state snapshot into a Layout 2D view definition.
 layouts::Layout2DViewDefinition ToLayoutDefinition(
     const Viewer2DState &state, const layouts::Layout2DViewFrame &frame) {
   layouts::Layout2DViewDefinition view;
@@ -287,6 +360,7 @@ layouts::Layout2DViewDefinition ToLayoutDefinition(
   return view;
 }
 
+// Captures the current Viewer2D state as a Layout 2D view definition.
 layouts::Layout2DViewDefinition CaptureLayoutDefinition(
     const Viewer2DPanel *panel, const ConfigManager &cfg,
     const layouts::Layout2DViewFrame &frame) {

--- a/viewer2d/viewer2dstate.h
+++ b/viewer2d/viewer2dstate.h
@@ -19,6 +19,8 @@
 
 #include "LayoutCollection.h"
 
+#include <string_view>
+
 #include <wx/weakref.h>
 
 class ConfigManager;
@@ -27,11 +29,24 @@ class Viewer2DRenderPanel;
 
 namespace viewer2d {
 
+enum class Viewer2DStateOwnership {
+  RuntimeOnly,
+  UserPreferenceConfig,
+  ProjectLayoutDefinition
+};
+
+struct Viewer2DStateConfigKeyOwnership {
+  std::string_view key;
+  Viewer2DStateOwnership ownership;
+};
+
 struct Viewer2DState {
   layouts::Layout2DViewCameraState camera;
   layouts::Layout2DViewRenderOptions renderOptions;
   layouts::Layout2DViewLayers layers;
 };
+
+bool IsViewer2DUserPreferenceConfigKey(std::string_view key);
 
 Viewer2DState CaptureState(const Viewer2DPanel *panel,
                            const ConfigManager &cfg);


### PR DESCRIPTION
### Motivation
- Clarify and guard which Viewer2D fields are runtime-only, user preference/config, or project/Layout definition state before any offscreen/FBO refactor to avoid accidental persistence from temporary preview captures.
- Provide lightweight, maintainable in-code ownership metadata and automated checks so future refactors can move state safely without behavioral regressions.

### Description
- Add `docs/viewer2d_state_ownership.md` that classifies Viewer2D state into Runtime-only, User preference/config, and Project/Layout definition categories and documents rules for Layout preview capture/rasterization and a short FBO/offscreen cleanup note. 
- Introduce `Viewer2DStateOwnership`, `Viewer2DStateConfigKeyOwnership`, a constexpr key map, and `IsViewer2DUserPreferenceConfigKey(...)` helper in `viewer2d/viewer2dstate.{h,cpp}` to record known config-backed Viewer2D preference keys without changing runtime behavior. 
- Keep existing `CaptureState`, `ApplyState`, `ScopedViewer2DState`, and layout-definition conversion paths unchanged while adding concise English one-line comments above modified function definitions. 
- Add `tests/check_viewer2d_state_ownership_boundary.sh` and register it in `tests/CMakeLists.txt` to assert documentation presence, the ownership tokens and helper symbols, that capture/raster paths use `ScopedViewer2DState` with non-persistent capture, and that preview code does not save user/project data or leak preview-failure state into PDF/export. 
- Update `docs/release-notes-draft.md` with an internal note about the new Viewer2D state ownership documentation.

### Testing
- Ran `tests/check_viewer2d_state_ownership_boundary.sh` locally and it passed. 
- Ran existing guard scripts `tests/check_perastage_tree_modules.sh`, `tests/check_no_configmanager_get_in_gui.sh`, `tests/check_opengl_lifecycle_centralized.sh`, `tests/check_layout_2d_rasterization_boundary.sh`, `tests/check_layout_preview_failure_diagnostics.sh`, and `tests/check_layout_2d_view_capture_boundary.sh` together with the new guard and they completed successfully in this environment. 
- Ran `git diff --check` and `bash -n tests/check_viewer2d_state_ownership_boundary.sh` static checks which succeeded. 
- Attempted `cmake -S tests -B /tmp/perastage-tests-configure` but configuration failed in this environment because wxWidgets development files were not available (`wxWidgets_LIBRARIES` and `wxWidgets_INCLUDE_DIRS` missing), so a full CMake build/test run could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b7d6a6bcc8324b318d9b89db102f5)