### PR TITLE
Unify Viewer2D RenderToRGBA to use real FBO capture target

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -17,6 +17,7 @@ Changes since **v1.4.0**.
 
 ## Fixes
 
+- Fixed Layout View so opening another project cannot briefly reuse the previous project's cached layout preview before the new layout rebuilds.
 - Fixed table selection highlights so sorting fixtures, trusses, hoists, or scene objects keeps the same UUID-backed elements selected, and fixture multi-selection actions preserve the original selection order after sorting.
 - Fixed Layers visibility checkbox double-clicks so they only toggle visibility and no longer open the layer rename dialog.
 - Fixed MVR export so duplicate fixture numeric IDs are repaired with the next available number, logged as non-blocking warnings, and no longer prevent saving the MVR file.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -127,7 +127,7 @@ If you encounter any problems installing or running Perastage, please open an is
 
 ## Internal changes
 
-- Unified Viewer2D RGBA capture around a real framebuffer target on all platforms while keeping the existing hidden-host offscreen preview architecture and a conservative back-buffer fallback.
+- Unified and hardened Viewer2D RGBA capture around a real framebuffer target on all platforms while keeping the existing hidden-host offscreen preview architecture and a conservative back-buffer fallback.
 - Centralized wxGLCanvas attribute selection, OpenGL context binding diagnostics, and GLEW initialization ownership across shared viewer components for the 3D, 2D, Layout, and Fixture Preview panels.
 - Encapsulated Layout 2D view preview capture and rasterization behind focused services while preserving the existing Viewer2D-based rendering path and PDF export separation.
 - Added visible, non-printing diagnostics for failed Layout 2D preview textures while keeping PDF export behavior unchanged.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -125,6 +125,8 @@ sudo pacman -U Perastage-1.4.0-arch-x86_64.pkg.tar.zst
 If you encounter any problems installing or running Perastage, please open an issue on GitHub or contact the developer. Including a diagnostic report (available from the Help menu) makes it much easier to investigate problems.
 
 ## Internal changes
+
+- Unified Viewer2D RGBA capture around a real framebuffer target on all platforms while keeping the existing hidden-host offscreen preview architecture and a conservative back-buffer fallback.
 - Centralized wxGLCanvas attribute selection, OpenGL context binding diagnostics, and GLEW initialization ownership across shared viewer components for the 3D, 2D, Layout, and Fixture Preview panels.
 - Encapsulated Layout 2D view preview capture and rasterization behind focused services while preserving the existing Viewer2D-based rendering path and PDF export separation.
 - Added visible, non-printing diagnostics for failed Layout 2D preview textures while keeping PDF export behavior unchanged.

--- a/docs/viewer2d_render_to_rgba_fbo.md
+++ b/docs/viewer2d_render_to_rgba_fbo.md
@@ -1,0 +1,27 @@
+# Viewer2D RenderToRGBA framebuffer capture
+
+`Viewer2DPanel::RenderToRGBA(...)` captures the interactive Viewer2D scene into an RGBA pixel buffer for Layout preview rasterization and related capture services. The capture path now prefers a real OpenGL framebuffer object on every platform, including Windows.
+
+## Current capture model
+
+- `Viewer2DPanel::RenderToRGBA(...)` resolves the requested framebuffer size, enables the existing offscreen-render flag temporarily, renders into a dedicated framebuffer capture target, and reads pixels from `GL_COLOR_ATTACHMENT0`.
+- The framebuffer capture target owns only OpenGL objects: a framebuffer, a color texture attachment, and a depth/stencil renderbuffer. It does not create or own an OpenGL context.
+- The capture path preserves temporary Viewer2D state by restoring the offscreen-render flag, the capture framebuffer size override, framebuffer binding, viewport, scissor state, read buffer, and pixel pack alignment after capture.
+- If framebuffer creation or completeness checks fail on a driver, `RenderToRGBA(...)` logs the diagnostic and uses the legacy `GL_BACK` read path as a conservative fallback.
+
+## Architecture boundaries
+
+This phase intentionally keeps the existing higher-level offscreen preview architecture intact:
+
+- `Viewer2DOffscreenRenderer` still owns the hidden/off-screen wx host used for Viewer2D-based capture.
+- Layout preview ownership remains in `LayoutViewerPanel`, including OpenGL preview textures, PBO upload state, persistent RGBA cache, failure diagnostics, frame drawing, selection handles, and preview placeholders.
+- PDF, export, and print rendering remain separate from the interactive Layout preview texture and failure-diagnostic path.
+- Layout preview capture continues to use the scoped temporary Viewer2D state rules documented in `docs/viewer2d_state_ownership.md`.
+
+## Temporary fallback
+
+The `GL_BACK` path is a temporary fallback for conservative compatibility while the shared framebuffer capture path is tested across drivers and platforms. It is isolated in a named fallback helper so a future phase can remove it without changing the default capture flow.
+
+## Future phase
+
+A later phase may reduce the dependency on `Viewer2DOffscreenRenderer` and the hidden wx host. That work is out of scope for this framebuffer unification step and should be planned separately from Layout preview scheduling, command-buffer capture, PDF/export/print, and preview texture ownership.

--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -521,11 +521,37 @@ LayoutViewerPanel::~LayoutViewerPanel() {
   delete glContext_;
 }
 
+// Clears project-scoped Layout preview render caches before applying a new project.
+void LayoutViewerPanel::ResetPreviewCachesForProjectLoad() {
+  ClearCachedTexture();
+  pendingPersistentViewCacheJson_.clear();
+  pendingPersistentViewCacheRasters_.clear();
+
+  captureInProgress = false;
+  renderDirty = true;
+  renderPending = false;
+  isLoading = false;
+  loadingRequested = false;
+  loadingTimer_.Stop();
+  renderDelayTimer_.Stop();
+  legendDataDirty_ = true;
+  legendItems_.clear();
+  legendDataHash = 0;
+  hasSceneContentHash = false;
+  lastSceneContentHash = 0;
+  pendingFrameCommit_ = false;
+  deferredResizeFrame_.reset();
+  layoutVersion++;
+  viewRenderVersion++;
+  InvalidateSelectionIndexCache();
+}
+
 // Applies a layout snapshot, preserving selection and scheduling texture rebuilds when renderable data changes.
 void LayoutViewerPanel::SetLayoutDefinition(
     const layouts::LayoutDefinition &layout) {
   if (IsSameRenderableLayout(currentLayout, layout)) {
-    currentLayout.name = layout.name;
+    currentLayout = layout;
+    InvalidateSelectionIndexCache();
     legendDataDirty_ = true;
     RefreshLegendData();
     HydratePendingPersistentViewCache();

--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -46,6 +46,7 @@ public:
   ~LayoutViewerPanel();
 
   void SetLayoutDefinition(const layouts::LayoutDefinition &layout);
+  void ResetPreviewCachesForProjectLoad();
   layouts::Layout2DViewDefinition *GetEditableView();
   const layouts::Layout2DViewDefinition *GetEditableView() const;
   bool DeleteSelectedElement();

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -868,8 +868,10 @@ bool MainWindow::LoadProjectFromPath(const std::string &path,
     return false;
   }
   loadProfiler.EndPhase();
-  if (layoutViewerPanel)
+  if (layoutViewerPanel) {
+    layoutViewerPanel->ResetPreviewCachesForProjectLoad();
     layoutViewerPanel->LoadPersistentViewCacheFromProject(path);
+  }
   viewer2d::ReconcileFixtureLabelOverridesWithScene(
       GetDefaultGuiConfigServices().LegacyConfigManager());
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,6 +42,8 @@ if(BASH_EXECUTABLE)
              COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_viewer2d_render_to_rgba_fbo_boundary.sh)
     add_test(NAME LayoutPreviewFailureDiagnostics
              COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_layout_preview_failure_diagnostics.sh)
+    add_test(NAME LayoutProjectLoadCacheReset
+             COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_layout_project_load_cache_reset.sh)
     add_test(NAME LibraryUserDataPolicy
              COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_library_user_data_policy.sh)
     add_test(NAME DictionaryPathsPolicy

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,6 +38,8 @@ if(BASH_EXECUTABLE)
              COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_layout_2d_view_capture_boundary.sh)
     add_test(NAME Viewer2DStateOwnershipBoundary
              COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_viewer2d_state_ownership_boundary.sh)
+    add_test(NAME Viewer2DRenderToRGBAFboBoundary
+             COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_viewer2d_render_to_rgba_fbo_boundary.sh)
     add_test(NAME LayoutPreviewFailureDiagnostics
              COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_layout_preview_failure_diagnostics.sh)
     add_test(NAME LibraryUserDataPolicy

--- a/tests/check_layout_project_load_cache_reset.sh
+++ b/tests/check_layout_project_load_cache_reset.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+panel_cpp="$repo_root/gui/layoutviewerpanel.cpp"
+panel_h="$repo_root/gui/layoutviewerpanel.h"
+mainwindow_cpp="$repo_root/gui/mainwindow.cpp"
+
+for required in "$panel_cpp" "$panel_h" "$mainwindow_cpp"; do
+  if [[ ! -f "$required" ]]; then
+    echo "Missing required Layout project-load cache reset file: ${required#$repo_root/}" >&2
+    exit 1
+  fi
+done
+
+if ! rg -n "ResetPreviewCachesForProjectLoad" "$panel_h" "$panel_cpp" >/dev/null; then
+  echo "LayoutViewerPanel must expose and implement ResetPreviewCachesForProjectLoad" >&2
+  exit 1
+fi
+
+helper_body="$(python3 - "$panel_cpp" <<'PY'
+import re
+import sys
+text = open(sys.argv[1], encoding='utf-8').read()
+match = re.search(r'void LayoutViewerPanel::ResetPreviewCachesForProjectLoad\(\) \{[\s\S]*?\n\}\n\n// Applies a layout snapshot', text)
+if not match:
+    sys.exit(1)
+print(match.group(0))
+PY
+)"
+
+for token in \
+  "ClearCachedTexture" \
+  "pendingPersistentViewCacheJson_.clear" \
+  "pendingPersistentViewCacheRasters_.clear" \
+  "captureInProgress = false" \
+  "renderDirty = true" \
+  "renderPending = false" \
+  "isLoading = false" \
+  "loadingRequested = false" \
+  "legendDataDirty_ = true" \
+  "legendItems_.clear" \
+  "legendDataHash = 0" \
+  "hasSceneContentHash = false" \
+  "lastSceneContentHash = 0" \
+  "viewRenderVersion++" \
+  "InvalidateSelectionIndexCache"; do
+  if [[ "$helper_body" != *"$token"* ]]; then
+    echo "ResetPreviewCachesForProjectLoad is missing expected reset token: $token" >&2
+    exit 1
+  fi
+done
+
+load_body="$(python3 - "$mainwindow_cpp" <<'PY'
+import re
+import sys
+text = open(sys.argv[1], encoding='utf-8').read()
+match = re.search(r'bool MainWindow::LoadProjectFromPath\([\s\S]*?ApplySavedLayout\(\);', text)
+if not match:
+    sys.exit(1)
+print(match.group(0))
+PY
+)"
+
+reset_index=$(awk -v body="$load_body" 'BEGIN { print index(body, "ResetPreviewCachesForProjectLoad") }')
+load_cache_index=$(awk -v body="$load_body" 'BEGIN { print index(body, "LoadPersistentViewCacheFromProject") }')
+apply_index=$(awk -v body="$load_body" 'BEGIN { print index(body, "ApplySavedLayout") }')
+
+if (( reset_index <= 0 )); then
+  echo "Project load must reset Layout preview caches before applying the saved layout" >&2
+  exit 1
+fi
+if (( load_cache_index <= 0 || reset_index >= load_cache_index )); then
+  echo "Project load must reset stale Layout preview caches before loading the new project's persistent cache" >&2
+  exit 1
+fi
+if (( apply_index <= 0 || reset_index >= apply_index )); then
+  echo "Project load must reset Layout preview caches before ApplySavedLayout" >&2
+  exit 1
+fi

--- a/tests/check_viewer2d_render_to_rgba_fbo_boundary.sh
+++ b/tests/check_viewer2d_render_to_rgba_fbo_boundary.sh
@@ -53,6 +53,46 @@ if [[ "$render_body" == *"GL_BACK"* ]]; then
   exit 1
 fi
 
+render_internal_body="$(python3 - "$panel_cpp" <<'PY'
+import re
+import sys
+text = open(sys.argv[1], encoding='utf-8').read()
+match = re.search(r'void Viewer2DPanel::RenderInternal\(bool swapBuffers\) \{[\s\S]*?const RenderSize viewportSize', text)
+if not match:
+    sys.exit(1)
+print(match.group(0))
+PY
+)"
+
+if [[ "$render_internal_body" != *"if (m_captureFramebufferSizeOverride)"* ||
+      "$render_internal_body" != *"glDisable(GL_SCISSOR_TEST)"* ||
+      "$render_internal_body" != *"glViewport(0, 0, w, h)"* ]]; then
+  echo "RenderInternal must use the active capture framebuffer by disabling scissor and setting the viewport" >&2
+  exit 1
+fi
+
+capture_branch="$(python3 - "$panel_cpp" <<'PY'
+import re
+import sys
+text = open(sys.argv[1], encoding='utf-8').read()
+match = re.search(r'if \(m_captureFramebufferSizeOverride\) \{[\s\S]*?\n  \} else \{', text)
+if not match:
+    sys.exit(1)
+print(match.group(0))
+PY
+)"
+
+if [[ "$capture_branch" == *"ApplyKnownBaseOnscreenState"* ||
+      "$capture_branch" == *"glBindFramebuffer(GL_FRAMEBUFFER, 0"* ]]; then
+  echo "RenderInternal must not bind framebuffer 0 while a capture framebuffer override is active" >&2
+  exit 1
+fi
+
+if [[ "$render_internal_body" != *"ApplyKnownBaseOnscreenState"* ]]; then
+  echo "RenderInternal must keep the normal onscreen ApplyKnownBaseOnscreenState path" >&2
+  exit 1
+fi
+
 if ! rg -n "RenderToRGBABackBufferFallback" "$panel_cpp" "$panel_h" >/dev/null; then
   echo "GL_BACK fallback must be isolated in a clearly named RenderToRGBABackBufferFallback helper" >&2
   exit 1

--- a/tests/check_viewer2d_render_to_rgba_fbo_boundary.sh
+++ b/tests/check_viewer2d_render_to_rgba_fbo_boundary.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+panel_cpp="$repo_root/viewer2d/viewer2dpanel.cpp"
+panel_h="$repo_root/viewer2d/viewer2dpanel.h"
+helper_h="$repo_root/viewer_common/gl_framebuffer_capture_target.h"
+helper_cpp="$repo_root/viewer_common/gl_framebuffer_capture_target.cpp"
+cmake_file="$repo_root/viewer_common/CMakeLists.txt"
+
+for required in "$panel_cpp" "$panel_h" "$helper_h" "$helper_cpp"; do
+  if [[ ! -f "$required" ]]; then
+    echo "Missing required Viewer2D RenderToRGBA FBO file: ${required#$repo_root/}" >&2
+    exit 1
+  fi
+done
+
+for token in "FramebufferCaptureTarget" "GL_COLOR_ATTACHMENT0" "BindForReading"; do
+  if ! rg -n "$token" "$helper_h" "$helper_cpp" >/dev/null; then
+    echo "Framebuffer capture helper is missing expected token: $token" >&2
+    exit 1
+  fi
+done
+
+if ! rg -n "gl_framebuffer_capture_target\.cpp" "$cmake_file" >/dev/null; then
+  echo "Framebuffer capture helper source is not registered explicitly in viewer_common/CMakeLists.txt" >&2
+  exit 1
+fi
+
+render_body="$(python3 - "$panel_cpp" <<'PY'
+import re
+import sys
+text = open(sys.argv[1], encoding='utf-8').read()
+match = re.search(r'bool Viewer2DPanel::RenderToRGBA\([\s\S]*?\n}\n\n// Captures RGBA pixels from the legacy back buffer path', text)
+if not match:
+    sys.exit(1)
+print(match.group(0))
+PY
+)"
+
+if [[ "$render_body" != *"FramebufferCaptureTarget"* ]]; then
+  echo "Viewer2DPanel::RenderToRGBA must use the dedicated framebuffer capture helper" >&2
+  exit 1
+fi
+
+if [[ "$render_body" != *"BindForReading"* ]] || ! rg -n "GL_COLOR_ATTACHMENT0" "$helper_h" "$helper_cpp" >/dev/null; then
+  echo "Viewer2DPanel::RenderToRGBA must read from GL_COLOR_ATTACHMENT0 through the FBO path" >&2
+  exit 1
+fi
+
+if [[ "$render_body" == *"GL_BACK"* ]]; then
+  echo "Viewer2DPanel::RenderToRGBA must not mix GL_BACK into the main FBO path" >&2
+  exit 1
+fi
+
+if ! rg -n "RenderToRGBABackBufferFallback" "$panel_cpp" "$panel_h" >/dev/null; then
+  echo "GL_BACK fallback must be isolated in a clearly named RenderToRGBABackBufferFallback helper" >&2
+  exit 1
+fi
+
+fallback_body="$(python3 - "$panel_cpp" <<'PY'
+import re
+import sys
+text = open(sys.argv[1], encoding='utf-8').read()
+match = re.search(r'bool Viewer2DPanel::RenderToRGBABackBufferFallback\([\s\S]*?\n}\n\nvoid Viewer2DPanel::OnPaint', text)
+if not match:
+    sys.exit(1)
+print(match.group(0))
+PY
+)"
+
+if [[ "$fallback_body" != *"GL_BACK"* || "$fallback_body" != *"fallback"* ]]; then
+  echo "Back-buffer read behavior must be limited to a logged fallback helper" >&2
+  exit 1
+fi
+
+if ! rg -n "Viewer2DOffscreenRenderer|viewer2doffscreenrenderer" "$repo_root/viewer2d" >/dev/null; then
+  echo "Viewer2DOffscreenRenderer must not be removed" >&2
+  exit 1
+fi
+
+if rg -n "Layout.*(texture|PBO|failure diagnostic)|preview.*(texture|PBO|failure diagnostic)" \
+    "$repo_root/viewer2d/pdf" "$repo_root/viewer2d/viewer2dpdfexporter.cpp" >/dev/null; then
+  echo "PDF/export/print code must not depend on Layout preview texture, PBO, or failure diagnostics" >&2
+  exit 1
+fi
+
+if rg -n "\b(Cairo|cairo|Skia|skia|Qt|qt|EGL|egl|pbuffer|Pbuffer)\b" \
+    "$repo_root/CMakeLists.txt" "$repo_root/viewer2d" "$repo_root/viewer_common" \
+    --glob '!tests/check_viewer2d_render_to_rgba_fbo_boundary.sh' >/dev/null; then
+  echo "RenderToRGBA FBO work must not introduce a new rendering backend dependency" >&2
+  exit 1
+fi

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -1024,16 +1024,12 @@ void Viewer2DPanel::RenderInternal(bool swapBuffers) {
   if (!resolvedSize.IsValid())
     return;
 
-#if defined(__WXGTK__) || defined(__WXOSX__)
   if (m_captureFramebufferSizeOverride) {
     glDisable(GL_SCISSOR_TEST);
     glViewport(0, 0, w, h);
   } else {
     glstate::ApplyKnownBaseOnscreenState(w, h);
   }
-#else
-  glstate::ApplyKnownBaseOnscreenState(w, h);
-#endif
   const RenderSize viewportSize{w, h, "RenderInternal(active-framebuffer-px)"};
 
   glMatrixMode(GL_PROJECTION);

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -1389,8 +1389,8 @@ bool Viewer2DPanel::RenderToRGBA(std::vector<unsigned char> &pixels, int &width,
     return false;
 
   glcapture::FramebufferCaptureTarget target;
-  glstate::ScopedFramebufferViewportScissorState framebufferStateGuard;
   ScopedReadBufferPackAlignmentState readStateGuard;
+  glstate::ScopedFramebufferViewportScissorState framebufferStateGuard;
   if (!target.Initialize(w, h) || !target.IsComplete()) {
     wxLogWarning(wxString::Format(
         "Viewer2D RenderToRGBA FBO capture unavailable; using "

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -66,6 +66,7 @@
 #include "gl_state_guard.h"
 #include "units/units.h"
 #include "../viewer_common/gl_canvas_config.h"
+#include "../viewer_common/gl_framebuffer_capture_target.h"
 #include "../viewer_common/measure_overlay_style.h"
 #include "ui_render_size.h"
 #include <wx/app.h>
@@ -89,6 +90,30 @@ static constexpr float PIXELS_PER_METER = 25.0f;
 namespace {
 constexpr size_t kMaxCapturePixels = 8192u * 8192u;
 constexpr size_t kMaxCaptureBytes = 64u * 1024u * 1024u;
+
+class ScopedReadBufferPackAlignmentState {
+public:
+  // Captures read-buffer and pack-alignment state before a pixel read.
+  ScopedReadBufferPackAlignmentState() {
+    glGetIntegerv(GL_READ_BUFFER, &readBuffer_);
+    glGetIntegerv(GL_PACK_ALIGNMENT, &packAlignment_);
+  }
+
+  ScopedReadBufferPackAlignmentState(
+      const ScopedReadBufferPackAlignmentState &) = delete;
+  ScopedReadBufferPackAlignmentState &
+  operator=(const ScopedReadBufferPackAlignmentState &) = delete;
+
+  // Restores read-buffer and pack-alignment state after a pixel read.
+  ~ScopedReadBufferPackAlignmentState() {
+    glReadBuffer(static_cast<GLenum>(readBuffer_));
+    glPixelStorei(GL_PACK_ALIGNMENT, packAlignment_);
+  }
+
+private:
+  GLint readBuffer_ = GL_BACK;
+  GLint packAlignment_ = 4;
+};
 
 wxRect BuildSelectionRectDirtyRegion(const wxPoint &a, const wxPoint &b) {
   const int x = std::min(a.x, b.x);
@@ -1350,68 +1375,71 @@ bool Viewer2DPanel::RenderToRGBA(std::vector<unsigned char> &pixels, int &width,
   width = w;
   height = h;
 
-  bool previousForce = m_forceOffscreenRender;
+  struct ForceOffscreenGuard {
+    Viewer2DPanel &panel;
+    bool previous;
+
+    // Restores the panel offscreen-render flag after capture.
+    ~ForceOffscreenGuard() { panel.m_forceOffscreenRender = previous; }
+  } forceGuard{*this, m_forceOffscreenRender};
   m_forceOffscreenRender = true;
+
   InitGL();
-  if (!m_glInitialized) {
-    m_forceOffscreenRender = previousForce;
+  if (!m_glInitialized)
     return false;
-  }
-  glstate::ScopedFramebufferViewportScissorState stateGuard;
-#if defined(__WXGTK__) || defined(__WXOSX__)
-  GLuint fbo = 0;
-  GLuint colorTexture = 0;
-  GLuint depthStencilRbo = 0;
-  glGenFramebuffers(1, &fbo);
-  glBindFramebuffer(GL_FRAMEBUFFER, fbo);
 
-  glGenTextures(1, &colorTexture);
-  glBindTexture(GL_TEXTURE_2D, colorTexture);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, w, h, 0, GL_RGBA, GL_UNSIGNED_BYTE,
-               nullptr);
-  glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
-                         colorTexture, 0);
-
-  glGenRenderbuffers(1, &depthStencilRbo);
-  glBindRenderbuffer(GL_RENDERBUFFER, depthStencilRbo);
-  glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, w, h);
-  glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT,
-                            GL_RENDERBUFFER, depthStencilRbo);
-
-  if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
-    glDeleteRenderbuffers(1, &depthStencilRbo);
-    glDeleteTextures(1, &colorTexture);
-    glDeleteFramebuffers(1, &fbo);
-    m_forceOffscreenRender = previousForce;
-    return false;
+  glcapture::FramebufferCaptureTarget target;
+  glstate::ScopedFramebufferViewportScissorState framebufferStateGuard;
+  ScopedReadBufferPackAlignmentState readStateGuard;
+  if (!target.Initialize(w, h) || !target.IsComplete()) {
+    wxLogWarning(wxString::Format(
+        "Viewer2D RenderToRGBA FBO capture unavailable; using "
+        "back-buffer fallback. %s",
+        wxString::FromUTF8(target.Diagnostic())));
+    return RenderToRGBABackBufferFallback(pixels, w, h);
   }
 
-  m_captureFramebufferSizeOverride = wxSize(w, h);
-  RenderInternal(false);
-  m_captureFramebufferSizeOverride.reset();
+  target.BindForRendering();
+  {
+    struct CaptureSizeOverrideGuard {
+      Viewer2DPanel &panel;
 
-  glReadBuffer(GL_COLOR_ATTACHMENT0);
+      // Clears the temporary capture framebuffer size override after capture.
+      ~CaptureSizeOverrideGuard() {
+        panel.m_captureFramebufferSizeOverride.reset();
+      }
+    } captureSizeGuard{*this};
+
+    m_captureFramebufferSizeOverride = wxSize(w, h);
+    RenderInternal(false);
+  }
+
+  target.BindForReading();
   glPixelStorei(GL_PACK_ALIGNMENT, 1);
   glReadPixels(0, 0, w, h, GL_RGBA, GL_UNSIGNED_BYTE, pixels.data());
 
-  glDeleteRenderbuffers(1, &depthStencilRbo);
-  glDeleteTextures(1, &colorTexture);
-  glDeleteFramebuffers(1, &fbo);
-#else
-  m_captureFramebufferSizeOverride = wxSize(w, h);
+  return true;
+}
+
+// Captures RGBA pixels from the legacy back buffer path when FBO capture fails.
+bool Viewer2DPanel::RenderToRGBABackBufferFallback(
+    std::vector<unsigned char> &pixels, int width, int height) {
+  wxLogWarning(
+      "Viewer2D RenderToRGBA is using the temporary GL_BACK fallback path");
+
+  struct CaptureSizeOverrideGuard {
+    Viewer2DPanel &panel;
+
+    // Clears the temporary capture framebuffer size override after fallback capture.
+    ~CaptureSizeOverrideGuard() { panel.m_captureFramebufferSizeOverride.reset(); }
+  } captureSizeGuard{*this};
+
+  m_captureFramebufferSizeOverride = wxSize(width, height);
   RenderInternal(false);
-  m_captureFramebufferSizeOverride.reset();
 
   glReadBuffer(GL_BACK);
   glPixelStorei(GL_PACK_ALIGNMENT, 1);
-  glReadPixels(0, 0, w, h, GL_RGBA, GL_UNSIGNED_BYTE, pixels.data());
-#endif
-
-  m_forceOffscreenRender = previousForce;
+  glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, pixels.data());
   return true;
 }
 

--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -208,6 +208,8 @@ private:
   void RequestRepaint(const wxRect &dirtyRect);
   void ResetRepaintCoalescing();
   void TrackRefreshTelemetry();
+  bool RenderToRGBABackBufferFallback(std::vector<unsigned char> &pixels,
+                                      int width, int height);
 
   std::array<float, 3> MapDragDelta(float dxMeters, float dyMeters) const;
   std::optional<std::array<float, 3>> ComputeSelectionDragCenterMeters() const;

--- a/viewer_common/CMakeLists.txt
+++ b/viewer_common/CMakeLists.txt
@@ -1,6 +1,7 @@
 target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/gl_canvas_config.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gl_context_utils.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gl_framebuffer_capture_target.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/glew_init_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/measure_overlay_style.cpp
 )

--- a/viewer_common/gl_framebuffer_capture_target.cpp
+++ b/viewer_common/gl_framebuffer_capture_target.cpp
@@ -139,8 +139,9 @@ void FramebufferCaptureTarget::BindForRendering() const {
   glBindFramebuffer(GL_FRAMEBUFFER, framebuffer_);
 }
 
-// Binds the color attachment as the source for pixel reads.
+// Binds the framebuffer and color attachment as the source for pixel reads.
 void FramebufferCaptureTarget::BindForReading() const {
+  glBindFramebuffer(GL_FRAMEBUFFER, framebuffer_);
   glReadBuffer(GL_COLOR_ATTACHMENT0);
 }
 

--- a/viewer_common/gl_framebuffer_capture_target.cpp
+++ b/viewer_common/gl_framebuffer_capture_target.cpp
@@ -1,0 +1,164 @@
+#include "gl_framebuffer_capture_target.h"
+
+#include <sstream>
+#include <utility>
+
+namespace glcapture {
+namespace {
+
+class ScopedTextureRenderbufferBindingState {
+public:
+  // Captures texture and renderbuffer bindings changed during target creation.
+  ScopedTextureRenderbufferBindingState() {
+    glGetIntegerv(GL_TEXTURE_BINDING_2D, &textureBinding_);
+    glGetIntegerv(GL_RENDERBUFFER_BINDING, &renderbufferBinding_);
+  }
+
+  ScopedTextureRenderbufferBindingState(
+      const ScopedTextureRenderbufferBindingState &) = delete;
+  ScopedTextureRenderbufferBindingState &
+  operator=(const ScopedTextureRenderbufferBindingState &) = delete;
+
+  // Restores texture and renderbuffer bindings after target creation.
+  ~ScopedTextureRenderbufferBindingState() {
+    glBindTexture(GL_TEXTURE_2D, static_cast<GLuint>(textureBinding_));
+    glBindRenderbuffer(GL_RENDERBUFFER,
+                       static_cast<GLuint>(renderbufferBinding_));
+  }
+
+private:
+  GLint textureBinding_ = 0;
+  GLint renderbufferBinding_ = 0;
+};
+
+// Formats an OpenGL framebuffer status code for diagnostics.
+std::string FormatFramebufferStatus(GLenum status) {
+  std::ostringstream stream;
+  stream << "OpenGL framebuffer is incomplete (status 0x" << std::hex
+         << status << ")";
+  return stream.str();
+}
+
+} // namespace
+
+// Deletes OpenGL resources owned by the framebuffer capture target.
+FramebufferCaptureTarget::~FramebufferCaptureTarget() { Reset(); }
+
+// Transfers framebuffer ownership from another capture target.
+FramebufferCaptureTarget::FramebufferCaptureTarget(
+    FramebufferCaptureTarget &&other) noexcept {
+  *this = std::move(other);
+}
+
+// Replaces this capture target with resources owned by another target.
+FramebufferCaptureTarget &FramebufferCaptureTarget::operator=(
+    FramebufferCaptureTarget &&other) noexcept {
+  if (this == &other)
+    return *this;
+
+  Reset();
+  framebuffer_ = other.framebuffer_;
+  colorTexture_ = other.colorTexture_;
+  depthStencilRenderbuffer_ = other.depthStencilRenderbuffer_;
+  width_ = other.width_;
+  height_ = other.height_;
+  complete_ = other.complete_;
+  diagnostic_ = std::move(other.diagnostic_);
+
+  other.framebuffer_ = 0;
+  other.colorTexture_ = 0;
+  other.depthStencilRenderbuffer_ = 0;
+  other.width_ = 0;
+  other.height_ = 0;
+  other.complete_ = false;
+  other.diagnostic_.clear();
+  return *this;
+}
+
+// Creates the framebuffer, color texture, and depth/stencil attachment.
+bool FramebufferCaptureTarget::Initialize(int width, int height) {
+  Reset();
+  width_ = width;
+  height_ = height;
+
+  if (width <= 0 || height <= 0) {
+    diagnostic_ = "Framebuffer capture target size must be positive";
+    return false;
+  }
+
+  ScopedTextureRenderbufferBindingState bindingStateGuard;
+
+  glGenFramebuffers(1, &framebuffer_);
+  if (framebuffer_ == 0) {
+    diagnostic_ = "OpenGL did not create a framebuffer object";
+    return false;
+  }
+  glBindFramebuffer(GL_FRAMEBUFFER, framebuffer_);
+
+  glGenTextures(1, &colorTexture_);
+  if (colorTexture_ == 0) {
+    diagnostic_ = "OpenGL did not create a framebuffer color texture";
+    Reset();
+    return false;
+  }
+  glBindTexture(GL_TEXTURE_2D, colorTexture_);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width_, height_, 0, GL_RGBA,
+               GL_UNSIGNED_BYTE, nullptr);
+  glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
+                         colorTexture_, 0);
+
+  glGenRenderbuffers(1, &depthStencilRenderbuffer_);
+  if (depthStencilRenderbuffer_ == 0) {
+    diagnostic_ = "OpenGL did not create a framebuffer depth/stencil buffer";
+    Reset();
+    return false;
+  }
+  glBindRenderbuffer(GL_RENDERBUFFER, depthStencilRenderbuffer_);
+  glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, width_, height_);
+  glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT,
+                            GL_RENDERBUFFER, depthStencilRenderbuffer_);
+
+  const GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+  if (status != GL_FRAMEBUFFER_COMPLETE) {
+    diagnostic_ = FormatFramebufferStatus(status);
+    Reset();
+    return false;
+  }
+
+  complete_ = true;
+  diagnostic_.clear();
+  return true;
+}
+
+// Binds the framebuffer so callers can render into the capture target.
+void FramebufferCaptureTarget::BindForRendering() const {
+  glBindFramebuffer(GL_FRAMEBUFFER, framebuffer_);
+}
+
+// Binds the color attachment as the source for pixel reads.
+void FramebufferCaptureTarget::BindForReading() const {
+  glReadBuffer(GL_COLOR_ATTACHMENT0);
+}
+
+// Releases any OpenGL objects owned by this target.
+void FramebufferCaptureTarget::Reset() {
+  if (depthStencilRenderbuffer_ != 0)
+    glDeleteRenderbuffers(1, &depthStencilRenderbuffer_);
+  if (colorTexture_ != 0)
+    glDeleteTextures(1, &colorTexture_);
+  if (framebuffer_ != 0)
+    glDeleteFramebuffers(1, &framebuffer_);
+
+  framebuffer_ = 0;
+  colorTexture_ = 0;
+  depthStencilRenderbuffer_ = 0;
+  width_ = 0;
+  height_ = 0;
+  complete_ = false;
+}
+
+} // namespace glcapture

--- a/viewer_common/gl_framebuffer_capture_target.h
+++ b/viewer_common/gl_framebuffer_capture_target.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <string>
+
+#include <GL/glew.h>
+
+namespace glcapture {
+
+class FramebufferCaptureTarget {
+public:
+  FramebufferCaptureTarget() = default;
+  ~FramebufferCaptureTarget();
+
+  FramebufferCaptureTarget(const FramebufferCaptureTarget &) = delete;
+  FramebufferCaptureTarget &operator=(const FramebufferCaptureTarget &) = delete;
+
+  FramebufferCaptureTarget(FramebufferCaptureTarget &&other) noexcept;
+  FramebufferCaptureTarget &operator=(FramebufferCaptureTarget &&other) noexcept;
+
+  // Creates the framebuffer, color texture, and depth/stencil attachment.
+  bool Initialize(int width, int height);
+
+  // Binds the framebuffer so callers can render into the capture target.
+  void BindForRendering() const;
+
+  // Binds the color attachment as the source for pixel reads.
+  void BindForReading() const;
+
+  // Returns whether the framebuffer was created and checked successfully.
+  bool IsComplete() const { return complete_; }
+
+  // Returns the target width in pixels.
+  int Width() const { return width_; }
+
+  // Returns the target height in pixels.
+  int Height() const { return height_; }
+
+  // Returns the most recent creation or completeness diagnostic.
+  const std::string &Diagnostic() const { return diagnostic_; }
+
+private:
+  // Releases any OpenGL objects owned by this target.
+  void Reset();
+
+  GLuint framebuffer_ = 0;
+  GLuint colorTexture_ = 0;
+  GLuint depthStencilRenderbuffer_ = 0;
+  int width_ = 0;
+  int height_ = 0;
+  bool complete_ = false;
+  std::string diagnostic_;
+};
+
+} // namespace glcapture


### PR DESCRIPTION
### Motivation

- Make `Viewer2DPanel::RenderToRGBA(...)` use a proper OpenGL framebuffer/render-target path on all platforms (including Windows) while keeping the existing off-screen wx host and `Viewer2DOffscreenRenderer` architecture and preserving a safe fallback for drivers that cannot provide a complete FBO.

### Description

- Added a focused RAII helper `glcapture::FramebufferCaptureTarget` (`viewer_common/gl_framebuffer_capture_target.{h,cpp}`) that creates and owns an FBO, a color texture, and a depth/stencil renderbuffer, reports diagnostics, is non-copyable, and deletes GL resources safely.
- Refactored `Viewer2DPanel::RenderToRGBA(...)` to prefer the new FBO path: initialize GL, create the `FramebufferCaptureTarget`, set `m_captureFramebufferSizeOverride`, render via `RenderInternal(false)`, read pixels from `GL_COLOR_ATTACHMENT0`, and restore temporary state via local RAII guards (`ForceOffscreenGuard`, `ScopedReadBufferPackAlignmentState`, and `CaptureSizeOverrideGuard`).
- Isolated the legacy back-buffer read into `RenderToRGBABackBufferFallback(...)` and log a diagnostic when falling back; ensured `GL_BACK` usage is limited to that helper and not mixed into the main path.
- Restored OpenGL state robustly (framebuffer, viewport, scissor, read-buffer, pack-alignment) using scoped guards and added small binding-state guards around target creation to avoid binding leaks.
- Registered the new helper in `viewer_common/CMakeLists.txt`, added a deterministic architecture guard `tests/check_viewer2d_render_to_rgba_fbo_boundary.sh` (and wired it into `tests/CMakeLists.txt`), added `docs/viewer2d_render_to_rgba_fbo.md`, and updated `docs/release-notes-draft.md` with an internal notes entry.

### Testing

- Ran `tests/check_viewer2d_render_to_rgba_fbo_boundary.sh` and it passed (verifies helper existence, FBO usage, isolated `GL_BACK` fallback, no new backend dependency, and `Viewer2DOffscreenRenderer` retained).
- Ran existing guard scripts `tests/check_viewer2d_state_ownership_boundary.sh`, `tests/check_opengl_lifecycle_centralized.sh`, `tests/check_layout_2d_rasterization_boundary.sh`, `tests/check_layout_preview_failure_diagnostics.sh`, `tests/check_layout_2d_view_capture_boundary.sh`, `tests/check_no_configmanager_get_in_gui.sh`, and `tests/check_perastage_tree_modules.sh` and they all reported OK.
- Ran `git diff --check` which reported no check failures.
- Attempted a full CMake configure/build with `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug && cmake --build build --target Perastage -j2` but configuration failed because the container lacks `wxWidgets` development files (missing `wxWidgets_LIBRARIES` and `wxWidgets_INCLUDE_DIRS`); this is an environment limitation and not a code error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b8759709c8324bdf6570f03ff07ea)