### PR TITLE
Move perastage_tree.md into docs/ and update repository references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Keep Perastage clean and modular while continuing to deliver new features, follo
 
 3. **Architecture and build conventions**
    - Keep explicit source ownership in CMake (no `GLOB_RECURSE` for project source registration).
-   - Respect module boundaries described in `docs/architecture.md` and `perastage_tree.md`.
+   - Respect module boundaries described in `docs/architecture.md` and `docs/perastage_tree.md`.
 
 4. **Mandatory checks before closing changes**
    - Run and keep green:

--- a/docs/code_health_review_2026-02-13.md
+++ b/docs/code_health_review_2026-02-13.md
@@ -14,7 +14,7 @@ What was reviewed:
 ## What is in a good place
 
 1. **Repository layout is coherent and documented.**
-   - The top-level map and module responsibilities are clearly defined in `perastage_tree.md` and aligned with `docs/architecture.md`.
+   - The top-level map and module responsibilities are clearly defined in `docs/perastage_tree.md` and aligned with `docs/architecture.md`.
    - Main domains (`core`, `gui`, `viewer2d`, `viewer3d`, `models`, `mvr`) are separated cleanly.
 
 2. **Build organization follows modular conventions.**

--- a/docs/perastage_tree.md
+++ b/docs/perastage_tree.md
@@ -13,7 +13,7 @@ Perastage/
 |-- CMakePresets.json            # Supported local configure/build presets.
 |-- README.md                    # Product overview, features, and entry links.
 |-- help.md                      # In-app help content.
-|-- perastage_tree.md            # High-level repository map.
+|-- docs/                        # User documentation, architecture notes, repository map, and docs website assets.
 |-- AGENTS.md                    # Repository guidance for automated coding agents.
 |-- VERSION                      # Single project version source.
 |-- cmake/                       # CMake templates and helper scripts.
@@ -37,7 +37,6 @@ Perastage/
 |-- mvr/                         # MVR format import/export modules and MVR-xchange networking.
 |-- packaging/                   # Installer, desktop integration, and package metadata.
 |-- tests/                       # Automated tests and lightweight checks.
-|-- docs/                        # User documentation, architecture notes, and docs website assets.
 |-- library/                     # Packaged runtime content (fixtures, trusses, etc.).
 |-- resources/                   # Visual/platform resources (icons, fonts, .rc).
 |-- third_party/                 # Vendored third-party headers.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -127,6 +127,7 @@ If you encounter any problems installing or running Perastage, please open an is
 
 ## Internal changes
 
+- Moved the high-level repository map into the documentation tree and aligned repository layout references and guard checks with the current module structure.
 - Documented Viewer2D state ownership boundaries to prepare for separating runtime state, user preferences, and project/Layout persistent state.
 - Unified and hardened Viewer2D RGBA capture around a real framebuffer target on all platforms while keeping the existing hidden-host offscreen preview architecture and a conservative back-buffer fallback.
 - Centralized wxGLCanvas attribute selection, OpenGL context binding diagnostics, and GLEW initialization ownership across shared viewer components for the 3D, 2D, Layout, and Fixture Preview panels.

--- a/docs/repository_layout.md
+++ b/docs/repository_layout.md
@@ -1,6 +1,6 @@
 # Repository Layout
 
-This page provides a concise map of the main Perastage repository areas. For the broader high-level tree, see [perastage_tree.md](../perastage_tree.md). For architectural boundaries and contribution rules, see [Architecture](architecture.md).
+This page provides a concise map of the main Perastage repository areas. For the broader high-level tree, see [perastage_tree.md](perastage_tree.md). For architectural boundaries and contribution rules, see [Architecture](architecture.md).
 
 ## Top-level structure
 
@@ -48,7 +48,7 @@ Perastage documentation is intentionally split by audience and responsibility:
 |------|---------|
 | `README.md` | Short project overview, highlights, and entry links. |
 | `help.md` | In-app help content. |
-| [perastage_tree.md](../perastage_tree.md) | Root-level high-level repository map used by architecture guard scripts. |
+| [perastage_tree.md](perastage_tree.md) | High-level repository map used by architecture guard scripts. |
 | `docs/build.md` | Build requirements, dependency setup, and local CMake workflows. |
 | `docs/packaging.md` | Release packaging, installers, desktop integration, and platform distribution notes. |
 | `docs/troubleshooting.md` | Known failure modes and practical fixes. |
@@ -62,7 +62,7 @@ Avoid duplicating long sections across documentation files. Prefer one source of
 
 ## Related documents
 
-- [perastage_tree.md](../perastage_tree.md)
+- [perastage_tree.md](perastage_tree.md)
 - [Architecture](architecture.md)
 - [Documentation Policy](documentation_policy.md)
 - [Build and dependency guide](build.md)

--- a/tests/check_perastage_tree_modules.sh
+++ b/tests/check_perastage_tree_modules.sh
@@ -2,15 +2,18 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-TREE_DOC="$ROOT_DIR/perastage_tree.md"
+TREE_DOC="$ROOT_DIR/docs/perastage_tree.md"
 
 required_dirs=(
   core
   gui
   viewer2d
   viewer3d
+  viewer_common
   models
   mvr
+  packaging
+  cmake
   library
   resources
   third_party
@@ -36,7 +39,7 @@ for dir in "${required_dirs[@]}"; do
 done
 
 if [[ ${#missing_sections[@]} -gt 0 ]]; then
-  echo "ERROR: perastage_tree.md is missing sections for existing modules: ${missing_sections[*]}" >&2
+  echo "ERROR: docs/perastage_tree.md is missing sections for existing modules: ${missing_sections[*]}" >&2
   exit 1
 fi
 
@@ -50,4 +53,4 @@ if ! rg -q "rg --files" "$TREE_DOC"; then
   exit 1
 fi
 
-echo "OK: perastage_tree.md keeps module sections and scope note aligned."
+echo "OK: docs/perastage_tree.md keeps module sections and scope note aligned."


### PR DESCRIPTION
### Motivation
- Reduce root-level documentation clutter by placing the high-level repository map under `docs/` while keeping documentation website and tooling links working. 
- Prevent broken documentation and guard-script checks by updating all references and ensuring the docs website routing continues to resolve the moved file.

### Description
- Moved `perastage_tree.md` to `docs/perastage_tree.md` and removed the root duplicate so Markdown remains the single source of truth. 
- Updated references to the moved file in `AGENTS.md`, `docs/repository_layout.md`, and `docs/code_health_review_2026-02-13.md` to point at `docs/perastage_tree.md` or use docs-local links. 
- Updated `tests/check_perastage_tree_modules.sh` to reference `docs/perastage_tree.md` and to include stable top-level directories (`viewer_common`, `packaging`, and `cmake`) in its required list. 
- Added a concise entry to `docs/release-notes-draft.md` and reviewed `docs/assets/js/docs-shell.js` (no navigation entry required because `docs/perastage_tree.md` remains reachable from `docs/repository_layout.md`). 
- Kept root `help.md` and `THIRD_PARTY_LICENSES.md` in place because CMake and packaging copy/expect those files from the repository root. 

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed. 
- Ran `rg "perastage_tree\.md|\.\./perastage_tree\.md"` to verify there are no stale root-level references and found none.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c2465e3b08324bc02ff538f77ca1f)