### PR TITLE
Fix geometry-only truss handling: rigging warnings, preview dispatch, and Add Truss labels

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -17,7 +17,7 @@ Changes since **v1.4.0**.
 
 ## Fixes
 
-- Fixed geometry-only MVR trusses so rigging warnings flag invalid weights, Edit Truss previews direct GLB/3DS geometry without generating a GDTF, and Add Truss shows readable names instead of internal type keys.
+- Fixed geometry-only MVR trusses so rigging warnings reliably flag invalid weights, Edit Truss previews direct GLB/3DS geometry without generating a GDTF, and Add Truss shows readable names instead of internal type keys.
 - Fixed Layout View so opening another project cannot briefly reuse the previous project's cached layout preview before the new layout rebuilds.
 - Fixed table selection highlights so sorting fixtures, trusses, hoists, or scene objects keeps the same UUID-backed elements selected, and fixture multi-selection actions preserve the original selection order after sorting.
 - Fixed Layers visibility checkbox double-clicks so they only toggle visibility and no longer open the layer rename dialog.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -17,6 +17,7 @@ Changes since **v1.4.0**.
 
 ## Fixes
 
+- Fixed geometry-only MVR trusses so rigging warnings flag invalid weights, Edit Truss previews direct GLB/3DS geometry without generating a GDTF, and Add Truss shows readable names instead of internal type keys.
 - Fixed Layout View so opening another project cannot briefly reuse the previous project's cached layout preview before the new layout rebuilds.
 - Fixed table selection highlights so sorting fixtures, trusses, hoists, or scene objects keeps the same UUID-backed elements selected, and fixture multi-selection actions preserve the original selection order after sorting.
 - Fixed Layers visibility checkbox double-clicks so they only toggle visibility and no longer open the layer rename dialog.

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -86,6 +86,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/mvrxchange/mvr_xchange_dialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_print.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/preferencesdialog.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/preview_resource.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/preferences/gdtf_credentials_panel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/resource_reference_sync.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/resource_path_utils.cpp

--- a/gui/fixturepreviewpanel.cpp
+++ b/gui/fixturepreviewpanel.cpp
@@ -35,12 +35,16 @@
 
 #include <wx/wx.h>
 #include "fixturepreviewpanel.h"
+#include "preview_resource.h"
+#include "loader3ds.h"
+#include "loaderglb.h"
 #include "../viewer_common/gl_canvas_config.h"
 #include "ui_render_size.h"
 #include <cfloat>
 #include <array>
 #include <algorithm>
 #include <cmath>
+#include <utility>
 
 static constexpr float RENDER_SCALE = 0.001f;
 
@@ -205,14 +209,55 @@ void FixturePreviewPanel::InitGL()
     glClearColor(0.08f,0.08f,0.08f,1.0f);
 }
 
-void FixturePreviewPanel::LoadFixture(const std::string& gdtfPath)
+// Loads a direct GLB or 3DS model into the preview object list.
+bool FixturePreviewPanel::LoadDirectModel(const std::string& modelPath)
+{
+    Mesh mesh;
+    const gui::PreviewResourceKind kind = gui::GetPreviewResourceKind(modelPath);
+    bool loaded = false;
+    if (kind == gui::PreviewResourceKind::Glb)
+        loaded = LoadGLB(modelPath, mesh);
+    else if (kind == gui::PreviewResourceKind::ThreeDs)
+        loaded = Load3DS(modelPath, mesh);
+
+    if (!loaded || mesh.vertices.empty() || mesh.indices.empty())
+        return false;
+
+    GdtfObject object;
+    object.mesh = std::move(mesh);
+    object.transform = Matrix{};
+    m_objects.push_back(std::move(object));
+    return true;
+}
+
+// Loads a supported preview resource and falls back to a cube on failure.
+void FixturePreviewPanel::LoadResource(const std::string& resourcePath)
 {
     m_objects.clear();
     m_hasModel = false;
-    if(!gdtfPath.empty()){
-        m_hasModel = LoadGdtf(gdtfPath, m_objects);
+    const gui::PreviewResourceKind kind = gui::GetPreviewResourceKind(resourcePath);
+    if(!resourcePath.empty()){
+        if (kind == gui::PreviewResourceKind::Gdtf)
+            m_hasModel = LoadGdtf(resourcePath, m_objects);
+        else if (kind == gui::PreviewResourceKind::Glb ||
+                 kind == gui::PreviewResourceKind::ThreeDs)
+            m_hasModel = LoadDirectModel(resourcePath);
     }
+    UpdateBoundsAndCamera();
+    Refresh();
+}
+
+// Loads a GDTF fixture model into the preview panel.
+void FixturePreviewPanel::LoadFixture(const std::string& gdtfPath)
+{
+    LoadResource(gdtfPath);
+}
+
+// Updates the preview bounding box and camera framing for current objects.
+void FixturePreviewPanel::UpdateBoundsAndCamera()
+{
     if(m_hasModel){
+        bool hasBounds = false;
         m_bbMin[0]=m_bbMin[1]=m_bbMin[2]=FLT_MAX;
         m_bbMax[0]=m_bbMax[1]=m_bbMax[2]=-FLT_MAX;
         for(const auto& obj : m_objects){
@@ -227,9 +272,13 @@ void FixturePreviewPanel::LoadFixture(const std::string& gdtfPath)
                     m_bbMin[j] = std::min(m_bbMin[j], p[j]);
                     m_bbMax[j] = std::max(m_bbMax[j], p[j]);
                 }
+                hasBounds = true;
             }
         }
-    } else {
+        if (!hasBounds)
+            m_hasModel = false;
+    }
+    if(!m_hasModel){
         m_bbMin[0]=m_bbMin[1]=m_bbMin[2]=-0.1f;
         m_bbMax[0]=m_bbMax[1]=m_bbMax[2]=0.1f;
     }
@@ -243,7 +292,6 @@ void FixturePreviewPanel::LoadFixture(const std::string& gdtfPath)
     float radius = std::max({sizeX,sizeY,sizeZ})*0.5f;
     if(radius < 0.1f) radius = 0.1f;
     m_camera.SetDistance(radius*3.0f);
-    Refresh();
 }
 
 void FixturePreviewPanel::Render()

--- a/gui/fixturepreviewpanel.h
+++ b/gui/fixturepreviewpanel.h
@@ -33,6 +33,9 @@ public:
     // simple cube will be displayed instead.
     void LoadFixture(const std::string& gdtfPath);
 
+    // Loads a supported preview resource and falls back to a cube on failure.
+    void LoadResource(const std::string& resourcePath);
+
 private:
     void OnPaint(wxPaintEvent& evt);
     void OnResize(wxSizeEvent& evt);
@@ -44,6 +47,8 @@ private:
 
     void InitGL();
     void Render();
+    bool LoadDirectModel(const std::string& modelPath);
+    void UpdateBoundsAndCamera();
 
     wxGLContext* m_glContext = nullptr;
     bool m_glInitialized = false;

--- a/gui/preview_resource.cpp
+++ b/gui/preview_resource.cpp
@@ -1,0 +1,64 @@
+#include "preview_resource.h"
+
+#include <algorithm>
+#include <cctype>
+
+#include "filesystem_path_utils.h"
+
+namespace gui {
+namespace {
+
+// Returns the lower-case extension for a UTF-8 file path.
+std::string LowerExtension(const std::string &path) {
+  std::string ext = PathUtils::PathFromUtf8(path).extension().string();
+  std::transform(ext.begin(), ext.end(), ext.begin(), [](unsigned char ch) {
+    return static_cast<char>(std::tolower(ch));
+  });
+  return ext;
+}
+
+// Resolves a non-empty resource reference against the scene directory.
+std::string ResolveResourcePath(const std::string &reference,
+                                const std::filesystem::path &sceneBasePath) {
+  if (reference.empty() || !IsRenderablePreviewResource(reference))
+    return {};
+
+  std::filesystem::path path = PathUtils::PathFromUtf8(reference);
+  if (path.is_relative())
+    path = sceneBasePath / path;
+  return PathUtils::PathToUtf8(path.lexically_normal());
+}
+
+} // namespace
+
+// Classifies a preview resource path by renderable file extension.
+PreviewResourceKind GetPreviewResourceKind(const std::string &path) {
+  const std::string ext = LowerExtension(path);
+  if (ext == ".gdtf")
+    return PreviewResourceKind::Gdtf;
+  if (ext == ".glb")
+    return PreviewResourceKind::Glb;
+  if (ext == ".3ds")
+    return PreviewResourceKind::ThreeDs;
+  return PreviewResourceKind::Unsupported;
+}
+
+// Reports whether a preview resource path can be loaded by the preview panel.
+bool IsRenderablePreviewResource(const std::string &path) {
+  return GetPreviewResourceKind(path) != PreviewResourceKind::Unsupported;
+}
+
+// Resolves a truss preview resource without mutating the truss representation.
+std::string ResolveTrussPreviewResourcePath(const Truss &truss,
+                                            const std::string &sceneBasePath) {
+  const std::filesystem::path basePath = PathUtils::PathFromUtf8(sceneBasePath);
+  for (const std::string *reference :
+       {&truss.gdtfSpec, &truss.symbolFile, &truss.modelFile}) {
+    std::string resolved = ResolveResourcePath(*reference, basePath);
+    if (!resolved.empty())
+      return resolved;
+  }
+  return {};
+}
+
+} // namespace gui

--- a/gui/preview_resource.h
+++ b/gui/preview_resource.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+
+#include "truss.h"
+
+namespace gui {
+
+enum class PreviewResourceKind { Unsupported, Gdtf, Glb, ThreeDs };
+
+// Classifies a preview resource path by renderable file extension.
+PreviewResourceKind GetPreviewResourceKind(const std::string &path);
+
+// Reports whether a preview resource path can be loaded by the preview panel.
+bool IsRenderablePreviewResource(const std::string &path);
+
+// Resolves a truss preview resource without mutating the truss representation.
+std::string ResolveTrussPreviewResourcePath(const Truss &truss,
+                                            const std::string &sceneBasePath);
+
+} // namespace gui

--- a/gui/rigging_weight_validation.h
+++ b/gui/rigging_weight_validation.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <cmath>
+
+namespace gui {
+namespace rigging {
+
+// Reports whether a physical weight is usable for rigging totals.
+inline bool IsValidPhysicalWeightKg(float weightKg) {
+  return std::isfinite(weightKg) && weightKg > 0.0f;
+}
+
+// Adds a physical weight to a total only when it is valid for rigging.
+inline bool AccumulateValidPhysicalWeightKg(float weightKg, float &totalKg) {
+  if (!IsValidPhysicalWeightKg(weightKg))
+    return false;
+  totalKg += weightKg;
+  return true;
+}
+
+} // namespace rigging
+} // namespace gui

--- a/gui/riggingpanel.cpp
+++ b/gui/riggingpanel.cpp
@@ -30,6 +30,7 @@
 #include "hoist_load_recalculation_prompt.h"
 #include "mainwindow.h"
 #include "rigging_extra_weight_settings.h"
+#include "rigging_weight_validation.h"
 #include "table_column_indices.h"
 #include "units/unit_label_utils.h"
 #include "units/units.h"
@@ -274,8 +275,8 @@ void RiggingPanel::RefreshData() {
                                                    : fixture.positionName;
     auto &entry = rows[pos];
     entry.fixtures++;
-    entry.fixtureWeight += fixture.weightKg;
-    if (fixture.weightKg <= 0.0f)
+    if (!gui::rigging::AccumulateValidPhysicalWeightKg(
+            fixture.weightKg, entry.fixtureWeight))
       entry.hasZeroWeightFixture = true;
   }
 
@@ -284,8 +285,8 @@ void RiggingPanel::RefreshData() {
         truss.positionName.empty() ? UNASSIGNED_POSITION : truss.positionName;
     auto &entry = rows[pos];
     entry.trusses++;
-    entry.trussWeight += truss.weightKg;
-    if (truss.weightKg <= 0.0f)
+    if (!gui::rigging::AccumulateValidPhysicalWeightKg(truss.weightKg,
+                                                       entry.trussWeight))
       entry.hasZeroWeightTruss = true;
   }
 
@@ -294,8 +295,8 @@ void RiggingPanel::RefreshData() {
                                                    : support.positionName;
     auto &entry = rows[pos];
     entry.hoists++;
-    entry.hoistWeight += support.weightKg;
-    if (support.weightKg <= 0.0f)
+    if (!gui::rigging::AccumulateValidPhysicalWeightKg(support.weightKg,
+                                                       entry.hoistWeight))
       entry.hasZeroWeightHoist = true;
   }
 
@@ -306,10 +307,9 @@ void RiggingPanel::RefreshData() {
     }
   }
 
-  // Ensure both the view and the custom store start from a clean state so
-  // text colours get recalculated on every refresh.
+  // Clear the custom store through one path so rows and colour attributes stay
+  // synchronized.
   store->DeleteAllItems();
-  table->DeleteAllItems();
   rowPositions.clear();
   rowPositions.reserve(rows.size());
   for (const auto &[position, totals] : rows) {
@@ -343,22 +343,30 @@ void RiggingPanel::RefreshData() {
     const bool hoistWeightZero = totals.hasZeroWeightHoist;
 
     if (fixtureWeightZero)
-      store->SetCellTextColour(rowIndex, 4, *wxRED);
+      store->SetCellTextColour(
+          rowIndex, ColumnIndex(RiggingColumn::FixtureWeight), *wxRED);
     if (trussWeightZero)
-      store->SetCellTextColour(rowIndex, 5, *wxRED);
+      store->SetCellTextColour(
+          rowIndex, ColumnIndex(RiggingColumn::TrussWeight), *wxRED);
     if (hoistWeightZero)
-      store->SetCellTextColour(rowIndex, 6, *wxRED);
+      store->SetCellTextColour(
+          rowIndex, ColumnIndex(RiggingColumn::HoistWeight), *wxRED);
 
     if (totals.hasAutoUnvalidatedExtraWeight)
-      store->SetCellTextColour(rowIndex, 7, *wxRED);
+      store->SetCellTextColour(
+          rowIndex, ColumnIndex(RiggingColumn::ExtraWeight), *wxRED);
 
     if (fixtureWeightZero || trussWeightZero || hoistWeightZero) {
-      store->SetCellTextColour(rowIndex, 8, *wxRED);
-      store->SetCellTextColour(rowIndex, 9, *wxRED);
+      store->SetCellTextColour(
+          rowIndex, ColumnIndex(RiggingColumn::TotalWeight), *wxRED);
+      store->SetCellTextColour(
+          rowIndex, ColumnIndex(RiggingColumn::RoundedTotalWeight), *wxRED);
     }
     if (totals.hasAutoUnvalidatedExtraWeight) {
-      store->SetCellTextColour(rowIndex, 8, *wxRED);
-      store->SetCellTextColour(rowIndex, 9, *wxRED);
+      store->SetCellTextColour(
+          rowIndex, ColumnIndex(RiggingColumn::TotalWeight), *wxRED);
+      store->SetCellTextColour(
+          rowIndex, ColumnIndex(RiggingColumn::RoundedTotalWeight), *wxRED);
     }
   }
 

--- a/gui/riggingpanel.cpp
+++ b/gui/riggingpanel.cpp
@@ -334,8 +334,8 @@ void RiggingPanel::RefreshData() {
     row.push_back(wxString::FromUTF8(
         Units::FormatWeightFromKilograms(roundedFivePercentIncrease, weightUnit,
         Units::ValueFormatContext::Table)));
-    unsigned int rowIndex = table->GetItemCount();
-    table->AppendItem(row);
+    unsigned int rowIndex = store->GetItemCount();
+    store->AppendItem(row);
     rowPositions.push_back(position);
 
     const bool fixtureWeightZero = totals.hasZeroWeightFixture;

--- a/gui/truss_creation_source.cpp
+++ b/gui/truss_creation_source.cpp
@@ -1,27 +1,40 @@
 #include "truss_creation_source.h"
 
+#include <algorithm>
+#include <cctype>
 #include <filesystem>
 #include <map>
 
 #include "filesystem_path_utils.h"
-#include "trussloader.h"
 
 namespace gui {
 namespace {
 
-// Returns the stable type label shown when reusing a truss from the scene.
-std::string GetTrussTypeDisplayName(const Truss &truss) {
-  if (!truss.model.empty())
-    return truss.model;
-  if (!truss.perastageTypeKey.empty())
-    return truss.perastageTypeKey;
-  return truss.name;
+// Reports whether text is safe to show as a concise user-facing label.
+bool IsUsableDisplayName(const std::string &value) {
+  if (value.empty())
+    return false;
+  for (unsigned char ch : value) {
+    if (std::iscntrl(ch) || ch == '/' || ch == '\\' || ch == '{' || ch == '}')
+      return false;
+  }
+  return true;
+}
+
+
+// Reports whether a resource extension can define a reusable truss.
+bool IsSupportedDefinitionExtension(const std::string &path) {
+  std::string ext = PathUtils::PathFromUtf8(path).extension().string();
+  std::transform(ext.begin(), ext.end(), ext.begin(), [](unsigned char ch) {
+    return static_cast<char>(std::tolower(ch));
+  });
+  return ext == ".gdtf" || ext == ".gtruss" || ext == ".glb" || ext == ".3ds";
 }
 
 // Resolves a supported truss definition reference against the scene directory.
 std::string ResolveDefinitionPath(const std::string &reference,
                                   const std::filesystem::path &sceneBasePath) {
-  if (reference.empty() || !IsSupportedTrussDefinitionExtension(reference))
+  if (reference.empty() || !IsSupportedDefinitionExtension(reference))
     return {};
 
   std::filesystem::path path = PathUtils::PathFromUtf8(reference);
@@ -42,25 +55,64 @@ std::string GetTrussDefinitionPath(const Truss &truss,
   return {};
 }
 
+// Builds the readable type label shown when reusing a truss from the scene.
+std::string GetTrussTypeDisplayName(const Truss &truss,
+                                    const std::string &definitionPath) {
+  if (!truss.gdtfSpec.empty() && IsUsableDisplayName(truss.model))
+    return truss.model;
+  if (truss.gdtfSpec.empty()) {
+    if (IsUsableDisplayName(truss.name))
+      return truss.name;
+    const std::string stem =
+        PathUtils::PathFromUtf8(definitionPath).stem().string();
+    if (IsUsableDisplayName(stem))
+      return stem;
+  }
+  if (IsUsableDisplayName(truss.model))
+    return truss.model;
+  if (IsUsableDisplayName(truss.name))
+    return truss.name;
+  return "Unnamed truss";
+}
+
+// Builds a stable source identity that is independent from display text.
+std::string BuildSourceIdentityKey(const Truss &truss,
+                                   const std::string &definitionPath) {
+  if (!definitionPath.empty())
+    return "path:" + definitionPath;
+  if (!truss.perastageTypeKey.empty())
+    return "type:" + truss.perastageTypeKey;
+  return {};
+}
+
 } // namespace
 
-// Collects one reusable creation entry per available truss type.
+// Collects one reusable creation entry per available truss definition.
 std::vector<TrussCreationSource> CollectTrussCreationSources(
     const std::unordered_map<std::string, Truss> &trusses,
     const std::string &sceneBasePath) {
   const std::filesystem::path basePath = PathUtils::PathFromUtf8(sceneBasePath);
-  std::map<std::string, std::string> sourceByType;
+  std::map<std::string, TrussCreationSource> sourceByIdentity;
   for (const auto &[uuid, truss] : trusses) {
-    const std::string displayName = GetTrussTypeDisplayName(truss);
     const std::string definitionPath = GetTrussDefinitionPath(truss, basePath);
-    if (!displayName.empty() && !definitionPath.empty())
-      sourceByType.try_emplace(displayName, definitionPath);
+    const std::string identityKey = BuildSourceIdentityKey(truss, definitionPath);
+    if (identityKey.empty() || definitionPath.empty())
+      continue;
+    const std::string displayName = GetTrussTypeDisplayName(truss, definitionPath);
+    sourceByIdentity.try_emplace(identityKey,
+                                 TrussCreationSource{identityKey, displayName,
+                                                     definitionPath});
   }
 
   std::vector<TrussCreationSource> sources;
-  sources.reserve(sourceByType.size());
-  for (const auto &[displayName, definitionPath] : sourceByType)
-    sources.push_back({displayName, definitionPath});
+  sources.reserve(sourceByIdentity.size());
+  for (const auto &[identityKey, source] : sourceByIdentity)
+    sources.push_back(source);
+  std::sort(sources.begin(), sources.end(), [](const auto &lhs, const auto &rhs) {
+    if (lhs.displayName != rhs.displayName)
+      return lhs.displayName < rhs.displayName;
+    return lhs.identityKey < rhs.identityKey;
+  });
   return sources;
 }
 

--- a/gui/truss_creation_source.h
+++ b/gui/truss_creation_source.h
@@ -9,6 +9,7 @@
 namespace gui {
 
 struct TrussCreationSource {
+  std::string identityKey;
   std::string displayName;
   std::string definitionPath;
 };

--- a/gui/trusseditdialog.cpp
+++ b/gui/trusseditdialog.cpp
@@ -23,6 +23,7 @@
 #include "gdtfdictionary.h"
 #include "guiconfigservices.h"
 #include "projectutils.h"
+#include "preview_resource.h"
 #include "table_column_indices.h"
 #include "truss_gdtf_builder.h"
 #include "trusstablepanel.h"
@@ -242,10 +243,22 @@ void TrussEditDialog::UpdateMetadataSummary() {
   Layout();
 }
 
-// Updates the embedded 3D preview from the current GDTF.
+// Updates the embedded 3D preview from the best available renderable resource.
 void TrussEditDialog::UpdatePreview() {
-  if (preview)
-    preview->LoadFixture(ResolveCurrentGdtfPath());
+  if (!preview || !panel || row < 0 ||
+      static_cast<size_t>(row) >= panel->rowUuids.size())
+    return;
+
+  const auto &scene =
+      GetDefaultGuiConfigServices().LegacyConfigManager().GetScene();
+  auto it = scene.trusses.find(panel->rowUuids[static_cast<size_t>(row)]);
+  if (it == scene.trusses.end()) {
+    preview->LoadResource({});
+    return;
+  }
+
+  preview->LoadResource(
+      gui::ResolveTrussPreviewResourcePath(it->second, scene.basePath));
 }
 
 // Creates or refreshes the Perastage-authored truss GDTF.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -81,9 +81,6 @@ add_test(NAME PlatformLocaleSetup COMMAND platform_locale_test)
 
 add_executable(trussloader_validation_test
                trussloader_validation_test.cpp
-               ../core/trussloader.cpp
-               ../core/truss_gdtf_builder.cpp
-               ../core/logger.cpp
                ../models/truss.cpp)
 target_include_directories(trussloader_validation_test PRIVATE
                            . ../core ../models ../third_party)
@@ -94,17 +91,25 @@ add_test(NAME TrussLoaderValidation COMMAND trussloader_validation_test)
 add_executable(truss_creation_source_test
                truss_creation_source_test.cpp
                ../gui/truss_creation_source.cpp
-               ../core/trussloader.cpp
-               ../core/truss_gdtf_builder.cpp
-               ../core/logger.cpp
                ../core/filesystem_path_utils.cpp
                ../models/truss.cpp)
 target_include_directories(truss_creation_source_test PRIVATE
                            . ../core ../gui ../models ../third_party)
-target_link_libraries(truss_creation_source_test PRIVATE
-                      ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
 add_test(NAME TrussCreationSource COMMAND truss_creation_source_test)
 
+add_executable(rigging_weight_validation_test
+               rigging_weight_validation_test.cpp)
+target_include_directories(rigging_weight_validation_test PRIVATE ../gui)
+add_test(NAME RiggingWeightValidation COMMAND rigging_weight_validation_test)
+
+add_executable(preview_resource_test
+               preview_resource_test.cpp
+               ../gui/preview_resource.cpp
+               ../core/filesystem_path_utils.cpp
+               ../models/truss.cpp)
+target_include_directories(preview_resource_test PRIVATE
+                           . ../core ../gui ../models)
+add_test(NAME PreviewResourceDispatch COMMAND preview_resource_test)
 
 add_executable(mvr_merge_analyzer_applier_test
                mvr_merge_analyzer_applier_test.cpp
@@ -296,9 +301,6 @@ add_executable(dictionary_seed_merge_backup_test
                ../core/layouts/LayoutCollection.cpp
                ../core/layouts/LayoutTemplateSerializer.cpp
                ../core/trussdictionary.cpp
-               ../core/trussloader.cpp
-               ../core/truss_gdtf_builder.cpp
-               ../core/logger.cpp
                ../models/truss.cpp
                ../models/mvrscene.cpp)
 target_include_directories(dictionary_seed_merge_backup_test PRIVATE
@@ -470,9 +472,6 @@ add_executable(truss_path_encoding_regression_test
                ../core/filesystem_path_utils.cpp
                ../core/library/library_bootstrap.cpp
                ../core/trussdictionary.cpp
-               ../core/trussloader.cpp
-               ../core/truss_gdtf_builder.cpp
-               ../core/logger.cpp
                ../models/truss.cpp)
 target_include_directories(truss_path_encoding_regression_test PRIVATE
                            . ../core ../models ../third_party)

--- a/tests/preview_resource_test.cpp
+++ b/tests/preview_resource_test.cpp
@@ -1,0 +1,34 @@
+#include <cassert>
+#include <filesystem>
+
+#include "preview_resource.h"
+
+namespace fs = std::filesystem;
+
+// Verifies preview resource extension dispatch and truss source precedence.
+int main() {
+  assert(gui::GetPreviewResourceKind("fixture.gdtf") ==
+         gui::PreviewResourceKind::Gdtf);
+  assert(gui::GetPreviewResourceKind("model.GLB") ==
+         gui::PreviewResourceKind::Glb);
+  assert(gui::GetPreviewResourceKind("model.3ds") ==
+         gui::PreviewResourceKind::ThreeDs);
+  assert(gui::GetPreviewResourceKind("symbol.svg") ==
+         gui::PreviewResourceKind::Unsupported);
+
+  const fs::path sceneBase = fs::path("projects") / "show";
+  Truss geometryOnly;
+  geometryOnly.symbolFile = "symbols/truss.glb";
+  geometryOnly.modelFile = "models/truss.3ds";
+  const std::string beforeGdtf = geometryOnly.gdtfSpec;
+  assert(fs::path(gui::ResolveTrussPreviewResourcePath(
+             geometryOnly, sceneBase.generic_string())) ==
+         sceneBase / "symbols" / "truss.glb");
+  assert(geometryOnly.gdtfSpec == beforeGdtf);
+
+  Truss gdtfBacked = geometryOnly;
+  gdtfBacked.gdtfSpec = "trusses/type.gdtf";
+  assert(fs::path(gui::ResolveTrussPreviewResourcePath(
+             gdtfBacked, sceneBase.generic_string())) ==
+         sceneBase / "trusses" / "type.gdtf");
+}

--- a/tests/rigging_weight_validation_test.cpp
+++ b/tests/rigging_weight_validation_test.cpp
@@ -1,0 +1,18 @@
+#include <cassert>
+#include <limits>
+
+#include "rigging_weight_validation.h"
+
+// Verifies invalid rigging weights are detected and excluded from totals.
+int main() {
+  float total = 0.0f;
+  assert(gui::rigging::AccumulateValidPhysicalWeightKg(12.5f, total));
+  assert(total == 12.5f);
+  assert(!gui::rigging::AccumulateValidPhysicalWeightKg(0.0f, total));
+  assert(!gui::rigging::AccumulateValidPhysicalWeightKg(-1.0f, total));
+  assert(!gui::rigging::AccumulateValidPhysicalWeightKg(
+      std::numeric_limits<float>::quiet_NaN(), total));
+  assert(!gui::rigging::AccumulateValidPhysicalWeightKg(
+      std::numeric_limits<float>::infinity(), total));
+  assert(total == 12.5f);
+}

--- a/tests/truss_creation_source_test.cpp
+++ b/tests/truss_creation_source_test.cpp
@@ -7,32 +7,53 @@
 
 namespace fs = std::filesystem;
 
+// Finds a creation source by display name and definition path suffix.
+static const gui::TrussCreationSource *FindSource(
+    const std::vector<gui::TrussCreationSource> &sources,
+    const std::string &displayName, const fs::path &definitionPath) {
+  for (const auto &source : sources) {
+    if (source.displayName == displayName &&
+        fs::path(source.definitionPath) == definitionPath)
+      return &source;
+  }
+  return nullptr;
+}
+
 // Verifies that scene instances collapse into reusable truss-type entries.
 int main() {
   std::unordered_map<std::string, Truss> trusses;
+  const fs::path sceneBase = fs::path("projects") / "show";
 
-  Truss first;
-  first.name = "FK40Q H-300 1";
-  first.model = "FK40Q H-300";
-  first.gdtfSpec = "trusses/FK40Q_H-300.gdtf";
-  first.symbolFile = "cache/main.svg";
-  trusses.emplace("first", first);
+  Truss gdtf;
+  gdtf.name = "FK40Q H-300 1";
+  gdtf.model = "FK40Q H-300";
+  gdtf.gdtfSpec = "trusses/FK40Q_H-300.gdtf";
+  gdtf.symbolFile = "cache/main.svg";
+  trusses.emplace("gdtf", gdtf);
 
-  Truss second = first;
-  second.name = "FK40Q H-300 2";
-  trusses.emplace("second", second);
+  Truss directNamed;
+  directNamed.name = "Custom truss 1";
+  directNamed.model = "Internal model should not win";
+  directNamed.modelFile = "models/custom.glb";
+  directNamed.perastageTypeKey = "type\x1fserialized{matrix}";
+  trusses.emplace("directNamed", directNamed);
 
-  Truss third = first;
-  third.name = "FK40Q H-300 3";
-  third.parentGroupUuid = "bridge";
-  trusses.emplace("third", third);
+  Truss directNamedDuplicate = directNamed;
+  trusses.emplace("directNamedDuplicate", directNamedDuplicate);
 
-  Truss directModel;
-  directModel.name = "Custom truss 1";
-  directModel.model = "Custom truss";
-  directModel.modelFile = "models/custom.glb";
-  directModel.symbolFile = "cache/custom.svg";
-  trusses.emplace("direct", directModel);
+  Truss directStem;
+  directStem.modelFile = "models/stem_name.3ds";
+  directStem.perastageTypeKey = "bad\x1fkey";
+  trusses.emplace("directStem", directStem);
+
+  Truss sameNameDifferentPathA;
+  sameNameDifferentPathA.name = "Shared label";
+  sameNameDifferentPathA.modelFile = "models/a.glb";
+  trusses.emplace("sameNameA", sameNameDifferentPathA);
+
+  Truss sameNameDifferentPathB = sameNameDifferentPathA;
+  sameNameDifferentPathB.modelFile = "models/b.glb";
+  trusses.emplace("sameNameB", sameNameDifferentPathB);
 
   Truss unusable;
   unusable.name = "Unusable";
@@ -40,15 +61,23 @@ int main() {
   unusable.symbolFile = "cache/unusable.svg";
   trusses.emplace("unusable", unusable);
 
-  const fs::path sceneBase = fs::path("projects") / "show";
   const auto sources =
       gui::CollectTrussCreationSources(trusses, sceneBase.generic_string());
 
-  assert(sources.size() == 2);
-  assert(sources[0].displayName == "Custom truss");
-  assert(fs::path(sources[0].definitionPath) ==
-         sceneBase / "models" / "custom.glb");
-  assert(sources[1].displayName == "FK40Q H-300");
-  assert(fs::path(sources[1].definitionPath) ==
-         sceneBase / "trusses" / "FK40Q_H-300.gdtf");
+  assert(sources.size() == 5);
+  assert(FindSource(sources, "FK40Q H-300",
+                    sceneBase / "trusses" / "FK40Q_H-300.gdtf"));
+  assert(FindSource(sources, "Custom truss 1",
+                    sceneBase / "models" / "custom.glb"));
+  assert(FindSource(sources, "stem_name",
+                    sceneBase / "models" / "stem_name.3ds"));
+  assert(FindSource(sources, "Shared label", sceneBase / "models" / "a.glb"));
+  assert(FindSource(sources, "Shared label", sceneBase / "models" / "b.glb"));
+
+  for (const auto &source : sources) {
+    assert(source.displayName.find('\x1f') == std::string::npos);
+    assert(source.displayName.find("serialized") == std::string::npos);
+    assert(!source.identityKey.empty());
+    assert(!source.definitionPath.empty());
+  }
 }


### PR DESCRIPTION
### Motivation
- Ensure geometry-only MVR trusses remain geometry-only for import/display/preview/export and only produce a Perastage GDTF when the user edits GDTF-specific type fields.
- Root cause — Rigging warning: totals used raw weight accumulation and tested only `<= 0`, so NaN/infinity were counted and the custom store/view delete path could desynchronize color attributes from rows.
- Root cause — Edit Truss preview: the preview code resolved only `gdtfSpec` and the preview panel only loaded GDTF, so GLB/3DS geometry-only trusses had no real model shown.
- Root cause — Add Truss list: creation sources used display text as the deduplication key and preferred `perastageTypeKey` before `name`, exposing internal keys/control characters and collapsing distinct resources with the same readable name.

### Description
- Rigging validation: added `gui::rigging::IsValidPhysicalWeightKg` and `AccumulateValidPhysicalWeightKg` (`gui/rigging_weight_validation.h`) and updated `gui/riggingpanel.cpp` to only sum finite positive weights, set per-position invalid-weight flags when any weight is non-finite or <= 0, use `ColumnIndex(RiggingColumn::...)` for columns, and clear/append rows through the custom store path to keep attributes synchronized. (files changed: `gui/rigging_weight_validation.h`, `gui/riggingpanel.cpp`)
- Preview dispatch: added a small preview resolver and kind classifier (`gui/preview_resource.{h,cpp}`) and extended `FixturePreviewPanel` with `LoadResource`, `LoadDirectModel`, and `UpdateBoundsAndCamera` so the embedded preview can load `.gdtf`, `.glb`, and `.3ds` without generating a GDTF; updated `TrussEditDialog::UpdatePreview()` to call the resolver and not mutate the truss. (files changed: `gui/preview_resource.h`, `gui/preview_resource.cpp`, `gui/fixturepreviewpanel.h`, `gui/fixturepreviewpanel.cpp`, `gui/trusseditdialog.cpp`)
- Truss creation source: refactored `TrussCreationSource` to separate `identityKey`, `displayName`, and `definitionPath`, added safe display-name logic (prefer `truss.name`, fall back to filename stem, never show `perastageTypeKey`), and deduplicate by stable identity (path/type) rather than by UI text. (files changed: `gui/truss_creation_source.h`, `gui/truss_creation_source.cpp`)
- Tests and build: added focused unit tests for creation-source labels/deduplication (`tests/truss_creation_source_test.cpp`), rigging weight validation (`tests/rigging_weight_validation_test.cpp`), and preview resource dispatch (`tests/preview_resource_test.cpp`), plus small `tests/CMakeLists.txt` updates and a `gui/CMakeLists.txt` entry for the preview resolver. Also updated `docs/release-notes-draft.md` with the user-facing fix. (files changed: `tests/truss_creation_source_test.cpp`, `tests/preview_resource_test.cpp`, `tests/rigging_weight_validation_test.cpp`, `tests/CMakeLists.txt`, `gui/CMakeLists.txt`, `docs/release-notes-draft.md`)

Modified files (complete list):
- docs/release-notes-draft.md
- gui/CMakeLists.txt
- gui/fixturepreviewpanel.cpp
- gui/fixturepreviewpanel.h
- gui/preview_resource.cpp
- gui/preview_resource.h
- gui/rigging_weight_validation.h
- gui/riggingpanel.cpp
- gui/truss_creation_source.cpp
- gui/truss_creation_source.h
- gui/trusseditdialog.cpp
- tests/CMakeLists.txt
- tests/preview_resource_test.cpp
- tests/rigging_weight_validation_test.cpp
- tests/truss_creation_source_test.cpp

### Testing
- Ran code-health checks: `tests/check_perastage_tree_modules.sh` (OK) and `tests/check_no_configmanager_get_in_gui.sh` (OK).
- Built and executed focused unit tests by compiling and running them directly in the container: `truss_creation_source_test`, `rigging_weight_validation_test`, and `preview_resource_test`; all three executed successfully. (I compiled them with `g++` because `cmake` config in this container failed due to missing wxWidgets development packages.)
- Note: a full `cmake -S tests -B build-tests` configure/build could not complete in this environment because `wxWidgets` dev headers/libraries are not installed; this is an environment limitation and not a regression in the change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4cbc98d188832491850147a303f8d2)