### PR TITLE
Add low-noise Viewer2D FBO capture diagnostics

### DIFF
--- a/core/diagnostics/DiagnosticReport.cpp
+++ b/core/diagnostics/DiagnosticReport.cpp
@@ -26,6 +26,30 @@ namespace diagnostics {
 namespace {
 std::mutex g_openGlMutex;
 OpenGLInfo g_openGlInfo;
+std::mutex g_viewer2DCaptureMutex;
+Viewer2DCaptureInfo g_viewer2DCaptureInfo;
+
+// Formats a capture size for diagnostics without including scene data.
+std::string FormatCaptureSize(int width, int height) {
+  std::ostringstream stream;
+  stream << width << 'x' << height;
+  return stream.str();
+}
+
+// Returns true when a backend transition should be logged.
+bool ShouldLogViewer2DBackendTransition(Viewer2DCaptureBackend previous,
+                                        Viewer2DCaptureBackend current,
+                                        std::uint64_t currentCount) {
+  if (current == Viewer2DCaptureBackend::Fbo && currentCount == 1)
+    return true;
+  if (current == Viewer2DCaptureBackend::BackBufferFallback &&
+      currentCount == 1)
+    return true;
+  return (previous == Viewer2DCaptureBackend::Fbo &&
+          current == Viewer2DCaptureBackend::BackBufferFallback) ||
+         (previous == Viewer2DCaptureBackend::BackBufferFallback &&
+          current == Viewer2DCaptureBackend::Fbo);
+}
 
 // Converts a wxString value into UTF-8 text for reports.
 std::string ToUtf8(const wxString &text) {
@@ -117,6 +141,31 @@ void AppendSystemInfo(std::ostringstream &stream) {
   }
 }
 
+// Appends Viewer2D RGBA capture diagnostics to a diagnostic text stream.
+void AppendViewer2DCaptureInfo(std::ostringstream &stream) {
+  const Viewer2DCaptureInfo captureInfo =
+      DiagnosticReport::GetViewer2DCaptureInfo();
+  stream << "Viewer2D RGBA capture backend: "
+         << DiagnosticReport::Viewer2DCaptureBackendName(captureInfo.backend)
+         << '\n';
+  stream << "Viewer2D FBO captures: " << captureInfo.fboSuccessCount << '\n';
+  stream << "Viewer2D fallback captures: " << captureInfo.fallbackCount << '\n';
+  stream << "Viewer2D capture failures: " << captureInfo.failureCount << '\n';
+  if (captureInfo.backend == Viewer2DCaptureBackend::NotUsed) {
+    stream << "Viewer2D last capture size: not used\n";
+  } else {
+    stream << "Viewer2D last capture size: "
+           << FormatCaptureSize(captureInfo.lastWidth, captureInfo.lastHeight)
+           << '\n';
+  }
+  stream << "Viewer2D fallback ever used: "
+         << (captureInfo.fallbackEverUsed ? "yes" : "no") << '\n';
+  stream << "Viewer2D last capture diagnostic: "
+         << (captureInfo.lastDiagnostic.empty() ? "none"
+                                                : captureInfo.lastDiagnostic)
+         << '\n';
+}
+
 } // namespace
 
 // Stores OpenGL driver details after a valid context is initialized.
@@ -129,6 +178,85 @@ void DiagnosticReport::SetOpenGLInfo(OpenGLInfo info) {
 OpenGLInfo DiagnosticReport::GetOpenGLInfo() {
   std::lock_guard<std::mutex> lock(g_openGlMutex);
   return g_openGlInfo;
+}
+
+// Records a successful Viewer2D RGBA capture through the FBO path.
+void DiagnosticReport::RecordViewer2DFboCapture(int width, int height) {
+  bool shouldLog = false;
+  {
+    std::lock_guard<std::mutex> lock(g_viewer2DCaptureMutex);
+    const Viewer2DCaptureBackend previous = g_viewer2DCaptureInfo.backend;
+    g_viewer2DCaptureInfo.backend = Viewer2DCaptureBackend::Fbo;
+    ++g_viewer2DCaptureInfo.fboSuccessCount;
+    g_viewer2DCaptureInfo.lastWidth = width;
+    g_viewer2DCaptureInfo.lastHeight = height;
+    g_viewer2DCaptureInfo.lastDiagnostic.clear();
+    shouldLog = ShouldLogViewer2DBackendTransition(
+        previous, Viewer2DCaptureBackend::Fbo,
+        g_viewer2DCaptureInfo.fboSuccessCount);
+  }
+  if (shouldLog) {
+    DiagnosticLogger::Info("Viewer2D RGBA capture backend=FBO size=" +
+                           FormatCaptureSize(width, height));
+  }
+}
+
+// Records a Viewer2D RGBA capture through the GL_BACK fallback path.
+void DiagnosticReport::RecordViewer2DBackBufferFallback(
+    int width, int height, const std::string &reason) {
+  bool shouldLog = false;
+  {
+    std::lock_guard<std::mutex> lock(g_viewer2DCaptureMutex);
+    const Viewer2DCaptureBackend previous = g_viewer2DCaptureInfo.backend;
+    g_viewer2DCaptureInfo.backend = Viewer2DCaptureBackend::BackBufferFallback;
+    ++g_viewer2DCaptureInfo.fallbackCount;
+    g_viewer2DCaptureInfo.lastWidth = width;
+    g_viewer2DCaptureInfo.lastHeight = height;
+    g_viewer2DCaptureInfo.lastDiagnostic = reason;
+    g_viewer2DCaptureInfo.fallbackEverUsed = true;
+    shouldLog = ShouldLogViewer2DBackendTransition(
+        previous, Viewer2DCaptureBackend::BackBufferFallback,
+        g_viewer2DCaptureInfo.fallbackCount);
+  }
+  if (shouldLog) {
+    DiagnosticLogger::Warning(
+        "Viewer2D RGBA capture backend=GL_BACK fallback size=" +
+        FormatCaptureSize(width, height) + " reason=" +
+        (reason.empty() ? "unspecified" : reason));
+  }
+}
+
+// Records a definitive Viewer2D RGBA capture failure.
+void DiagnosticReport::RecordViewer2DCaptureFailure(
+    int width, int height, const std::string &reason) {
+  std::lock_guard<std::mutex> lock(g_viewer2DCaptureMutex);
+  g_viewer2DCaptureInfo.backend = Viewer2DCaptureBackend::Failed;
+  ++g_viewer2DCaptureInfo.failureCount;
+  g_viewer2DCaptureInfo.lastWidth = width;
+  g_viewer2DCaptureInfo.lastHeight = height;
+  g_viewer2DCaptureInfo.lastDiagnostic = reason;
+}
+
+// Returns the latest Viewer2D RGBA capture diagnostics.
+Viewer2DCaptureInfo DiagnosticReport::GetViewer2DCaptureInfo() {
+  std::lock_guard<std::mutex> lock(g_viewer2DCaptureMutex);
+  return g_viewer2DCaptureInfo;
+}
+
+// Converts a Viewer2D RGBA capture backend to stable report text.
+std::string DiagnosticReport::Viewer2DCaptureBackendName(
+    Viewer2DCaptureBackend backend) {
+  switch (backend) {
+  case Viewer2DCaptureBackend::NotUsed:
+    return "Not used";
+  case Viewer2DCaptureBackend::Fbo:
+    return "FBO";
+  case Viewer2DCaptureBackend::BackBufferFallback:
+    return "GL_BACK fallback";
+  case Viewer2DCaptureBackend::Failed:
+    return "Failed";
+  }
+  return "Unknown";
 }
 
 // Builds a complete plain-text diagnostic report for crashes or manual export.
@@ -147,6 +275,10 @@ std::string DiagnosticReport::BuildTextReport(const std::string &reason,
   stream << "Build and system information\n";
   stream << "----------------------------\n";
   AppendSystemInfo(stream);
+
+  stream << "\nViewer2D capture diagnostics\n";
+  stream << "----------------------------\n";
+  AppendViewer2DCaptureInfo(stream);
 
   if (!eventDetails.empty()) {
     stream << "\nEvent details\n";

--- a/core/diagnostics/DiagnosticReport.h
+++ b/core/diagnostics/DiagnosticReport.h
@@ -2,6 +2,7 @@
 
 #include <filesystem>
 #include <string>
+#include <cstdint>
 
 namespace diagnostics {
 
@@ -12,11 +13,38 @@ struct OpenGLInfo {
   std::string version;
 };
 
+// Identifies the most recent Viewer2D RGBA capture backend.
+enum class Viewer2DCaptureBackend {
+  NotUsed,
+  Fbo,
+  BackBufferFallback,
+  Failed,
+};
+
+// Stores local Viewer2D RGBA capture diagnostics for manual reports.
+struct Viewer2DCaptureInfo {
+  Viewer2DCaptureBackend backend = Viewer2DCaptureBackend::NotUsed;
+  std::uint64_t fboSuccessCount = 0;
+  std::uint64_t fallbackCount = 0;
+  std::uint64_t failureCount = 0;
+  int lastWidth = 0;
+  int lastHeight = 0;
+  std::string lastDiagnostic;
+  bool fallbackEverUsed = false;
+};
+
 // Builds and exports local diagnostic reports without sending data anywhere.
 class DiagnosticReport {
 public:
   static void SetOpenGLInfo(OpenGLInfo info);
   static OpenGLInfo GetOpenGLInfo();
+  static void RecordViewer2DFboCapture(int width, int height);
+  static void RecordViewer2DBackBufferFallback(int width, int height,
+                                               const std::string &reason);
+  static void RecordViewer2DCaptureFailure(int width, int height,
+                                           const std::string &reason);
+  static Viewer2DCaptureInfo GetViewer2DCaptureInfo();
+  static std::string Viewer2DCaptureBackendName(Viewer2DCaptureBackend backend);
   static std::string BuildTextReport(const std::string &reason,
                                      const std::string &eventDetails = {},
                                      const std::string &stackTrace = {});

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -45,6 +45,7 @@ Changes since **v1.4.0**.
 
 ## Stability and diagnostics
 
+- Added local, low-noise diagnostics that identify the Viewer2D RGBA capture backend in manual diagnostic reports, including capture counts, last size, and fallback or failure reasons without changing rendering behavior.
 - Hardened MVR-xchange TCP Mode protocol handling with stricter UUID validation, safer malformed-message responses, bounded latest-revision requests, non-empty payload checks, archive sanity checks, clearer transfer diagnostics, and additional deterministic protocol tests.
 - Disabled optional depth-read picking by default and skipped it on Windows Intel OpenGL drivers to avoid unsafe depth-buffer reads during normal selection.
 - Hardened 3D hover picking plus hover, group, and selected highlight rendering to avoid unsafe OpenGL pixel reads and restore critical render state after overlay highlights on Intel Windows drivers and macOS.

--- a/docs/viewer2d_render_to_rgba_fbo.md
+++ b/docs/viewer2d_render_to_rgba_fbo.md
@@ -7,7 +7,15 @@
 - `Viewer2DPanel::RenderToRGBA(...)` resolves the requested framebuffer size, enables the existing offscreen-render flag temporarily, renders into a dedicated framebuffer capture target, and reads pixels from `GL_COLOR_ATTACHMENT0`.
 - The framebuffer capture target owns only OpenGL objects: a framebuffer, a color texture attachment, and a depth/stencil renderbuffer. It does not create or own an OpenGL context.
 - The capture path preserves temporary Viewer2D state by restoring the offscreen-render flag, the capture framebuffer size override, framebuffer binding, viewport, scissor state, read buffer, and pixel pack alignment after capture.
-- If framebuffer creation or completeness checks fail on a driver, `RenderToRGBA(...)` logs the diagnostic and uses the legacy `GL_BACK` read path as a conservative fallback.
+- If framebuffer creation or completeness checks fail on a driver, `RenderToRGBA(...)` records the FBO diagnostic reason and uses the legacy `GL_BACK` read path as a conservative fallback.
+
+## Local diagnostics
+
+- Manual diagnostic reports include the active or most recent Viewer2D RGBA capture backend: not used, FBO, GL_BACK fallback, or failed.
+- The report also includes FBO capture count, fallback count, failure count, the last capture size, and the latest fallback or failure diagnostic when one exists.
+- Successful FBO capture is logged with low noise: the first FBO success is recorded, and later backend transitions are recorded without logging every capture.
+- Fallback use is recorded with the framebuffer failure or completeness reason, but repeated fallback captures update counters silently instead of producing per-frame log spam.
+- Diagnostics remain local to the application and exported reports are never sent automatically.
 
 ## Architecture boundaries
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,6 +40,8 @@ if(BASH_EXECUTABLE)
              COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_viewer2d_state_ownership_boundary.sh)
     add_test(NAME Viewer2DRenderToRGBAFboBoundary
              COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_viewer2d_render_to_rgba_fbo_boundary.sh)
+    add_test(NAME Viewer2DFboCaptureDiagnostics
+             COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_viewer2d_fbo_capture_diagnostics.sh)
     add_test(NAME LayoutPreviewFailureDiagnostics
              COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_layout_preview_failure_diagnostics.sh)
     add_test(NAME LayoutProjectLoadCacheReset

--- a/tests/check_viewer2d_fbo_capture_diagnostics.sh
+++ b/tests/check_viewer2d_fbo_capture_diagnostics.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+panel_cpp="$repo_root/viewer2d/viewer2dpanel.cpp"
+panel_h="$repo_root/viewer2d/viewer2dpanel.h"
+report_h="$repo_root/core/diagnostics/DiagnosticReport.h"
+report_cpp="$repo_root/core/diagnostics/DiagnosticReport.cpp"
+offscreen_cpp="$repo_root/viewer2d/viewer2doffscreenrenderer.cpp"
+cmake_tests="$repo_root/tests/CMakeLists.txt"
+
+for required in "$panel_cpp" "$panel_h" "$report_h" "$report_cpp" "$offscreen_cpp"; do
+  if [[ ! -f "$required" ]]; then
+    echo "Missing required Viewer2D FBO capture diagnostics file: ${required#$repo_root/}" >&2
+    exit 1
+  fi
+done
+
+for token in \
+  "Viewer2DCaptureInfo" \
+  "Viewer2DCaptureBackend" \
+  "RecordViewer2DFboCapture" \
+  "RecordViewer2DBackBufferFallback" \
+  "RecordViewer2DCaptureFailure" \
+  "GetViewer2DCaptureInfo"; do
+  if ! rg -n "$token" "$report_h" "$report_cpp" >/dev/null; then
+    echo "Viewer2D capture diagnostic state is missing expected token: $token" >&2
+    exit 1
+  fi
+done
+
+render_body="$(python3 - "$panel_cpp" <<'PY'
+import re
+import sys
+text = open(sys.argv[1], encoding='utf-8').read()
+match = re.search(r'bool Viewer2DPanel::RenderToRGBA\([\s\S]*?\n}\n\n// Captures RGBA pixels from the legacy back buffer path', text)
+if not match:
+    sys.exit(1)
+print(match.group(0))
+PY
+)"
+
+if [[ "$render_body" != *"RecordViewer2DFboCapture"* || "$render_body" != *"glReadPixels"* ]]; then
+  echo "RenderToRGBA must record FBO success after GL_COLOR_ATTACHMENT0 readback" >&2
+  exit 1
+fi
+
+if [[ "$render_body" != *"RecordViewer2DBackBufferFallback"* || "$render_body" != *"target.Diagnostic()"* ]]; then
+  echo "RenderToRGBA must record fallback usage with the FBO diagnostic reason" >&2
+  exit 1
+fi
+
+if [[ "$render_body" != *"RecordViewer2DCaptureFailure"* ]]; then
+  echo "RenderToRGBA must record definitive capture failures" >&2
+  exit 1
+fi
+
+for token in \
+  "Viewer2D RGBA capture backend" \
+  "Viewer2D FBO captures" \
+  "Viewer2D fallback captures" \
+  "Viewer2D capture failures" \
+  "Viewer2D last capture size" \
+  "Viewer2D last capture diagnostic"; do
+  if ! rg -n "$token" "$report_cpp" >/dev/null; then
+    echo "DiagnosticReport must include the Viewer2D capture summary token: $token" >&2
+    exit 1
+  fi
+done
+
+for token in "DiagnosticLogger::Info" "DiagnosticLogger::Warning" "ShouldLogViewer2DBackendTransition"; do
+  if ! rg -n "$token" "$report_cpp" >/dev/null; then
+    echo "Viewer2D capture diagnostics must use low-noise DiagnosticLogger messages: $token" >&2
+    exit 1
+  fi
+done
+
+if ! rg -n "Viewer2DOffscreenRenderer" "$offscreen_cpp" "$repo_root/viewer2d/viewer2doffscreenrenderer.h" >/dev/null; then
+  echo "Viewer2DOffscreenRenderer must remain present" >&2
+  exit 1
+fi
+
+fallback_body="$(python3 - "$panel_cpp" <<'PY'
+import re
+import sys
+text = open(sys.argv[1], encoding='utf-8').read()
+match = re.search(r'bool Viewer2DPanel::RenderToRGBABackBufferFallback\([\s\S]*?\n}\n\n(?:// .*\n)?void Viewer2DPanel::OnPaint', text)
+if not match:
+    sys.exit(1)
+print(match.group(0))
+PY
+)"
+
+if [[ "$fallback_body" != *"GL_BACK"* ]]; then
+  echo "GL_BACK must remain isolated in RenderToRGBABackBufferFallback" >&2
+  exit 1
+fi
+
+if [[ "$render_body" == *"GL_BACK"* ]]; then
+  echo "The main RenderToRGBA FBO path must not read from GL_BACK" >&2
+  exit 1
+fi
+
+if rg -n "analytics|upload|HTTP|HTTPS|curl|asio|socket" \
+    "$report_h" "$report_cpp" "$panel_cpp" "$panel_h" >/dev/null; then
+  echo "Viewer2D capture diagnostics must not introduce networking or external telemetry" >&2
+  exit 1
+fi
+
+if ! rg -n "Viewer2DFboCaptureDiagnostics" "$cmake_tests" >/dev/null; then
+  echo "Viewer2D FBO capture diagnostics guard is not registered in tests/CMakeLists.txt" >&2
+  exit 1
+fi

--- a/tests/check_viewer2d_render_to_rgba_fbo_boundary.sh
+++ b/tests/check_viewer2d_render_to_rgba_fbo_boundary.sh
@@ -102,7 +102,7 @@ fallback_body="$(python3 - "$panel_cpp" <<'PY'
 import re
 import sys
 text = open(sys.argv[1], encoding='utf-8').read()
-match = re.search(r'bool Viewer2DPanel::RenderToRGBABackBufferFallback\([\s\S]*?\n}\n\nvoid Viewer2DPanel::OnPaint', text)
+match = re.search(r'bool Viewer2DPanel::RenderToRGBABackBufferFallback\([\s\S]*?\n}\n\n(?:// .*\n)?void Viewer2DPanel::OnPaint', text)
 if not match:
     sys.exit(1)
 print(match.group(0))

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -45,6 +45,7 @@
 #include "editable_focus_utils.h"
 #include "configmanager.h"
 #include "continuous_placement_scene.h"
+#include "diagnostics/DiagnosticReport.h"
 #include "selection_movement_settings.h"
 #include "scene_grouping.h"
 #include "canvas2d.h"
@@ -1363,11 +1364,17 @@ bool Viewer2DPanel::RenderToRGBA(std::vector<unsigned char> &pixels, int &width,
   }
   const int w = renderSize.width;
   const int h = renderSize.height;
-  if (w <= 0 || h <= 0)
+  if (w <= 0 || h <= 0) {
+    diagnostics::DiagnosticReport::RecordViewer2DCaptureFailure(
+        w, h, "Invalid capture target size");
     return false;
+  }
 
-  if (!TryAllocateCaptureBuffer(pixels, w, h))
+  if (!TryAllocateCaptureBuffer(pixels, w, h)) {
+    diagnostics::DiagnosticReport::RecordViewer2DCaptureFailure(
+        w, h, "Unable to allocate capture buffer");
     return false;
+  }
   width = w;
   height = h;
 
@@ -1381,17 +1388,19 @@ bool Viewer2DPanel::RenderToRGBA(std::vector<unsigned char> &pixels, int &width,
   m_forceOffscreenRender = true;
 
   InitGL();
-  if (!m_glInitialized)
+  if (!m_glInitialized) {
+    diagnostics::DiagnosticReport::RecordViewer2DCaptureFailure(
+        w, h, "OpenGL initialization failed");
     return false;
+  }
 
   glcapture::FramebufferCaptureTarget target;
   ScopedReadBufferPackAlignmentState readStateGuard;
   glstate::ScopedFramebufferViewportScissorState framebufferStateGuard;
   if (!target.Initialize(w, h) || !target.IsComplete()) {
-    wxLogWarning(wxString::Format(
-        "Viewer2D RenderToRGBA FBO capture unavailable; using "
-        "back-buffer fallback. %s",
-        wxString::FromUTF8(target.Diagnostic())));
+    const std::string diagnostic = target.Diagnostic();
+    diagnostics::DiagnosticReport::RecordViewer2DBackBufferFallback(
+        w, h, diagnostic.empty() ? "FBO unavailable" : diagnostic);
     return RenderToRGBABackBufferFallback(pixels, w, h);
   }
 
@@ -1413,6 +1422,7 @@ bool Viewer2DPanel::RenderToRGBA(std::vector<unsigned char> &pixels, int &width,
   target.BindForReading();
   glPixelStorei(GL_PACK_ALIGNMENT, 1);
   glReadPixels(0, 0, w, h, GL_RGBA, GL_UNSIGNED_BYTE, pixels.data());
+  diagnostics::DiagnosticReport::RecordViewer2DFboCapture(w, h);
 
   return true;
 }
@@ -1420,9 +1430,6 @@ bool Viewer2DPanel::RenderToRGBA(std::vector<unsigned char> &pixels, int &width,
 // Captures RGBA pixels from the legacy back buffer path when FBO capture fails.
 bool Viewer2DPanel::RenderToRGBABackBufferFallback(
     std::vector<unsigned char> &pixels, int width, int height) {
-  wxLogWarning(
-      "Viewer2D RenderToRGBA is using the temporary GL_BACK fallback path");
-
   struct CaptureSizeOverrideGuard {
     Viewer2DPanel &panel;
 
@@ -1439,6 +1446,7 @@ bool Viewer2DPanel::RenderToRGBABackBufferFallback(
   return true;
 }
 
+// Handles paint events by refreshing interaction state and rendering the view.
 void Viewer2DPanel::OnPaint(wxPaintEvent &WXUNUSED(event)) {
   wxPaintDC dc(this);
   ResetRepaintCoalescing();


### PR DESCRIPTION
### Motivation

- Improve observability of the `Viewer2DPanel::RenderToRGBA(...)` capture path by providing a concise, low-noise diagnostic summary of which RGBA capture backend was used (FBO, GL_BACK fallback, failed, or not used) without changing rendering behavior. 
- Make manual diagnostic reports clearly state capture counters, last capture size, and the latest fallback/failure reason to aid debugging across drivers and platforms.

### Description

- Added a small typed diagnostic model: `Viewer2DCaptureBackend` and `Viewer2DCaptureInfo` and public helpers on `diagnostics::DiagnosticReport`: `RecordViewer2DFboCapture`, `RecordViewer2DBackBufferFallback`, `RecordViewer2DCaptureFailure`, `GetViewer2DCaptureInfo`, and `Viewer2DCaptureBackendName` in `core/diagnostics/DiagnosticReport.{h,cpp}`. 
- Implemented low-noise logging and thread-safe state: counters, last size, last diagnostic text, and `fallbackEverUsed`, with logging only for first FBO success, first fallback, and backend transitions using `diagnostics::DiagnosticLogger`. 
- Integrated diagnostics into `viewer2d/viewer2dpanel.cpp` so `RenderToRGBA` records definitive failures (invalid size, allocation, GL init), records the FBO diagnostic reason when falling back to the back-buffer path, and records successful FBO captures only after `glReadPixels` completes on the FBO read path; the `GL_BACK` fallback helper remains isolated and its read behavior is unchanged. 
- Added a deterministic guard test `tests/check_viewer2d_fbo_capture_diagnostics.sh` and registered it in `tests/CMakeLists.txt`, and updated `docs/viewer2d_render_to_rgba_fbo.md` and `docs/release-notes-draft.md` to document the new local diagnostics. 
- Added a one-line function comment above `Viewer2DPanel::OnPaint` to satisfy the repository comment policy for C++ functions.

### Testing

- Ran the new diagnostics guard and all related repository checks: `tests/check_viewer2d_fbo_capture_diagnostics.sh`, `tests/check_viewer2d_render_to_rgba_fbo_boundary.sh`, `tests/check_viewer2d_state_ownership_boundary.sh`, `tests/check_opengl_lifecycle_centralized.sh`, `tests/check_layout_2d_rasterization_boundary.sh`, `tests/check_layout_preview_failure_diagnostics.sh`, `tests/check_layout_2d_view_capture_boundary.sh`, `tests/check_no_configmanager_get_in_gui.sh`, and `tests/check_perastage_tree_modules.sh`, and they all succeeded. 
- Verified `git diff --check` passed with no whitespace errors. 
- Attempted a CMake configure (`cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug`) but configure was blocked due to missing `wxWidgets` libraries/include directories in this environment, so a full build was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4cc7f583308324aa7e9c935a0addf4)