### PR TITLE
Add GDTF editor context architecture

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -20,6 +20,14 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtf_catalog_service.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtf_canonicalizer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtf_mutation_audit.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gdtf/editor/gdtf_document.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gdtf/editor/gdtf_edit_session.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gdtf/editor/gdtf_editable_values.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gdtf/editor/gdtf_editor_context.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gdtf/editor/gdtf_field_registry.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gdtf/editor/project_fixture_gdtf_context.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gdtf/editor/project_truss_gdtf_context.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gdtf/editor/standalone_gdtf_context.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtfnet.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/geometry/RdpSimplifier.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/guiconfigservices.cpp

--- a/core/gdtf/editor/gdtf_document.cpp
+++ b/core/gdtf/editor/gdtf_document.cpp
@@ -1,0 +1,77 @@
+#include "gdtf_document.h"
+
+#include <filesystem>
+
+namespace gdtf {
+namespace {
+
+// Builds future-safe summaries for repeated GDTF families already exposed by
+// the read model.
+std::vector<GdtfRepeatedFamilySummary>
+BuildRepeatedFamilies(const GdtfDescriptionSnapshot &description) {
+  std::vector<GdtfRepeatedFamilySummary> families;
+  GdtfRepeatedFamilySummary wheels;
+  wheels.familyKind = "wheel";
+  for (const auto &wheel : description.wheels)
+    wheels.names.push_back(wheel.name);
+  families.push_back(std::move(wheels));
+  return families;
+}
+
+} // namespace
+
+// Creates a document from shared archive and description read-service results.
+GdtfDocument::GdtfDocument(ArchiveReadResult archive,
+                           GdtfDescriptionSnapshot description)
+    : archive_(std::move(archive)), description_(std::move(description)),
+      repeatedFamilies_(BuildRepeatedFamilies(description_)) {}
+
+// Returns the path used to load this document.
+const std::filesystem::path &GdtfDocument::SourcePath() const {
+  return archive_.sourcePath;
+}
+
+// Returns archive-level read data and diagnostics.
+const ArchiveReadResult &GdtfDocument::Archive() const { return archive_; }
+
+// Returns the serialization-neutral description snapshot.
+const GdtfDescriptionSnapshot &GdtfDocument::Description() const {
+  return description_;
+}
+
+// Returns the available DMX mode names from the shared read model.
+const std::vector<std::string> &GdtfDocument::Modes() const {
+  return description_.dmxModeNames;
+}
+
+// Returns repeated-family summaries without collapsing them into singleton
+// fields.
+const std::vector<GdtfRepeatedFamilySummary> &
+GdtfDocument::RepeatedFamilies() const {
+  return repeatedFamilies_;
+}
+
+// Reports whether the source file exists on disk.
+bool GdtfDocument::SourceFilePresent() const {
+  return !archive_.sourcePath.empty() &&
+         std::filesystem::exists(archive_.sourcePath);
+}
+
+// Reports whether both archive and description reads succeeded.
+bool GdtfDocument::Valid() const {
+  return archive_.Success() && description_.Success();
+}
+
+// Loads a GDTF document through the shared read-only services.
+GdtfDocument LoadGdtfDocument(const std::filesystem::path &sourcePath) {
+  auto archive = ReadGdtfArchive(sourcePath);
+  auto description = ReadGdtfDescription(archive.descriptionXml, [&archive] {
+    std::vector<std::string> paths;
+    for (const auto &entry : archive.entries)
+      paths.push_back(entry.path);
+    return paths;
+  }());
+  return GdtfDocument(std::move(archive), std::move(description));
+}
+
+} // namespace gdtf

--- a/core/gdtf/editor/gdtf_document.h
+++ b/core/gdtf/editor/gdtf_document.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "gdtf_archive_reader.h"
+#include "gdtf_description_reader.h"
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace gdtf {
+
+struct GdtfRepeatedFamilySummary {
+  std::string familyKind;
+  std::vector<std::string> names;
+};
+
+class GdtfDocument {
+public:
+  GdtfDocument() = default;
+  GdtfDocument(ArchiveReadResult archive, GdtfDescriptionSnapshot description);
+
+  const std::filesystem::path &SourcePath() const;
+  const ArchiveReadResult &Archive() const;
+  const GdtfDescriptionSnapshot &Description() const;
+  const std::vector<std::string> &Modes() const;
+  const std::vector<GdtfRepeatedFamilySummary> &RepeatedFamilies() const;
+  bool SourceFilePresent() const;
+  bool Valid() const;
+
+private:
+  ArchiveReadResult archive_;
+  GdtfDescriptionSnapshot description_;
+  std::vector<GdtfRepeatedFamilySummary> repeatedFamilies_;
+};
+
+GdtfDocument LoadGdtfDocument(const std::filesystem::path &sourcePath);
+
+} // namespace gdtf

--- a/core/gdtf/editor/gdtf_edit_session.cpp
+++ b/core/gdtf/editor/gdtf_edit_session.cpp
@@ -1,0 +1,128 @@
+#include "gdtf_edit_session.h"
+
+#include <array>
+
+namespace gdtf {
+namespace {
+
+constexpr std::array<GdtfFieldId, 11> kEditableFields = {
+    GdtfFieldId::FixtureTypeName,
+    GdtfFieldId::Manufacturer,
+    GdtfFieldId::ModelName,
+    GdtfFieldId::ModeName,
+    GdtfFieldId::Weight,
+    GdtfFieldId::PowerConsumption,
+    GdtfFieldId::TrussLength,
+    GdtfFieldId::TrussWidth,
+    GdtfFieldId::TrussHeight,
+    GdtfFieldId::TrussCrossSection,
+    GdtfFieldId::SourceFileReference};
+
+// Reports whether a numeric optional value is negative.
+bool IsNegative(const std::optional<float> &value) {
+  return value.has_value() && *value < 0.0f;
+}
+
+} // namespace
+
+// Creates a non-GUI edit session from explicit host context data.
+GdtfEditSession::GdtfEditSession(GdtfEditorContext context)
+    : context_(std::move(context)), initialValues_(context_.initialValues),
+      currentValues_(context_.initialValues) {}
+
+// Returns the immutable GDTF document associated with the session.
+const GdtfDocument &GdtfEditSession::Document() const {
+  return context_.document;
+}
+
+// Returns the initial editable value snapshot.
+const GdtfEditableValues &GdtfEditSession::InitialValues() const {
+  return initialValues_;
+}
+
+// Returns the current editable value snapshot.
+const GdtfEditableValues &GdtfEditSession::CurrentValues() const {
+  return currentValues_;
+}
+
+// Returns host context metadata without exposing GUI objects.
+const GdtfEditorContext &GdtfEditSession::Context() const { return context_; }
+
+// Applies a user edit and updates field-level dirty tracking.
+bool GdtfEditSession::SetValue(GdtfFieldId fieldId, const std::string &value) {
+  if (!context_.editingAllowed)
+    return false;
+  if (!SetEditableValue(currentValues_, fieldId, value))
+    return false;
+  RecomputeDirtyFields();
+  return true;
+}
+
+// Reports whether any editable field differs from its initial value.
+bool GdtfEditSession::IsDirty() const { return !dirtyFields_.empty(); }
+
+// Reports whether a specific field differs from its initial value.
+bool GdtfEditSession::IsFieldDirty(GdtfFieldId fieldId) const {
+  return dirtyFields_.count(fieldId) > 0;
+}
+
+// Returns the current field-level dirty set.
+const std::set<GdtfFieldId> &GdtfEditSession::DirtyFields() const {
+  return dirtyFields_;
+}
+
+// Reports whether an explicit host apply/save operation is needed.
+bool GdtfEditSession::RequiresApply() const { return IsDirty(); }
+
+// Validates current values without using GUI or project services.
+std::vector<GdtfValidationDiagnostic> GdtfEditSession::Validate() const {
+  std::vector<GdtfValidationDiagnostic> diagnostics;
+  if (IsNegative(currentValues_.weightKg))
+    diagnostics.push_back({GdtfFieldId::Weight, "Weight cannot be negative."});
+  if (IsNegative(currentValues_.powerConsumptionW))
+    diagnostics.push_back({GdtfFieldId::PowerConsumption,
+                           "Power consumption cannot be negative."});
+  if (IsNegative(currentValues_.trussLengthMm))
+    diagnostics.push_back(
+        {GdtfFieldId::TrussLength, "Truss length cannot be negative."});
+  if (IsNegative(currentValues_.trussWidthMm))
+    diagnostics.push_back(
+        {GdtfFieldId::TrussWidth, "Truss width cannot be negative."});
+  if (IsNegative(currentValues_.trussHeightMm))
+    diagnostics.push_back(
+        {GdtfFieldId::TrussHeight, "Truss height cannot be negative."});
+  if (currentValues_.fixtureTypeName && currentValues_.fixtureTypeName->empty())
+    diagnostics.push_back(
+        {GdtfFieldId::FixtureTypeName, "Fixture type name cannot be empty."});
+  return diagnostics;
+}
+
+// Restores current values to the initial snapshot and clears dirty tracking.
+void GdtfEditSession::Reset() {
+  currentValues_ = initialValues_;
+  dirtyFields_.clear();
+}
+
+// Builds a GUI-independent apply request for the host adapter.
+GdtfApplyRequest GdtfEditSession::BuildApplyRequest() const {
+  GdtfApplyRequest request;
+  request.contextKind = context_.kind;
+  request.sourcePath = context_.sourcePath;
+  request.writePolicy = context_.writePolicy;
+  request.values = currentValues_;
+  request.changedFields = dirtyFields_;
+  return request;
+}
+
+// Recomputes dirty fields from the initial and current editable value
+// snapshots.
+void GdtfEditSession::RecomputeDirtyFields() {
+  dirtyFields_.clear();
+  for (const auto fieldId : kEditableFields) {
+    if (GetEditableValue(initialValues_, fieldId) !=
+        GetEditableValue(currentValues_, fieldId))
+      dirtyFields_.insert(fieldId);
+  }
+}
+
+} // namespace gdtf

--- a/core/gdtf/editor/gdtf_edit_session.h
+++ b/core/gdtf/editor/gdtf_edit_session.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "gdtf_editor_context.h"
+
+#include <set>
+#include <string>
+#include <vector>
+
+namespace gdtf {
+
+struct GdtfValidationDiagnostic {
+  GdtfFieldId fieldId = GdtfFieldId::FixtureTypeName;
+  std::string message;
+};
+
+class GdtfEditSession {
+public:
+  explicit GdtfEditSession(GdtfEditorContext context);
+
+  const GdtfDocument &Document() const;
+  const GdtfEditableValues &InitialValues() const;
+  const GdtfEditableValues &CurrentValues() const;
+  const GdtfEditorContext &Context() const;
+  bool SetValue(GdtfFieldId fieldId, const std::string &value);
+  bool IsDirty() const;
+  bool IsFieldDirty(GdtfFieldId fieldId) const;
+  const std::set<GdtfFieldId> &DirtyFields() const;
+  bool RequiresApply() const;
+  std::vector<GdtfValidationDiagnostic> Validate() const;
+  void Reset();
+  GdtfApplyRequest BuildApplyRequest() const;
+
+private:
+  void RecomputeDirtyFields();
+
+  GdtfEditorContext context_;
+  GdtfEditableValues initialValues_;
+  GdtfEditableValues currentValues_;
+  std::set<GdtfFieldId> dirtyFields_;
+};
+
+} // namespace gdtf

--- a/core/gdtf/editor/gdtf_editable_values.cpp
+++ b/core/gdtf/editor/gdtf_editable_values.cpp
@@ -1,0 +1,148 @@
+#include "gdtf_editable_values.h"
+
+#include <charconv>
+
+namespace gdtf {
+namespace {
+
+// Parses a floating-point value for editable numeric GDTF fields.
+std::optional<float> ParseFloat(const std::string &text) {
+  float value = 0.0f;
+  const auto *begin = text.data();
+  const auto *end = text.data() + text.size();
+  const auto result = std::from_chars(begin, end, value);
+  if (result.ec != std::errc() || result.ptr != end)
+    return std::nullopt;
+  return value;
+}
+
+// Formats a floating-point value for stable session comparisons.
+std::string FormatFloat(float value) { return std::to_string(value); }
+
+} // namespace
+
+// Assigns an editable value when the field belongs to the GDTF editor model.
+bool SetEditableValue(GdtfEditableValues &values, GdtfFieldId fieldId,
+                      const std::string &value) {
+  if (!IsGdtfFieldIndependentlyEditable(fieldId))
+    return false;
+  switch (fieldId) {
+  case GdtfFieldId::FixtureTypeName:
+    values.fixtureTypeName = value;
+    return true;
+  case GdtfFieldId::Manufacturer:
+    values.manufacturer = value;
+    return true;
+  case GdtfFieldId::ModelName:
+    values.modelName = value;
+    return true;
+  case GdtfFieldId::ModeName:
+    values.modeName = value;
+    return true;
+  case GdtfFieldId::Weight:
+    if (auto parsed = ParseFloat(value)) {
+      values.weightKg = *parsed;
+      return true;
+    }
+    return false;
+  case GdtfFieldId::PowerConsumption:
+    if (auto parsed = ParseFloat(value)) {
+      values.powerConsumptionW = *parsed;
+      return true;
+    }
+    return false;
+  case GdtfFieldId::TrussLength:
+    if (auto parsed = ParseFloat(value)) {
+      values.trussLengthMm = *parsed;
+      return true;
+    }
+    return false;
+  case GdtfFieldId::TrussWidth:
+    if (auto parsed = ParseFloat(value)) {
+      values.trussWidthMm = *parsed;
+      return true;
+    }
+    return false;
+  case GdtfFieldId::TrussHeight:
+    if (auto parsed = ParseFloat(value)) {
+      values.trussHeightMm = *parsed;
+      return true;
+    }
+    return false;
+  case GdtfFieldId::TrussCrossSection:
+    values.trussCrossSection = value;
+    return true;
+  case GdtfFieldId::SourceFileReference:
+    values.sourceFileReference = value;
+    return true;
+  default:
+    values.presentationValues[fieldId] = value;
+    return true;
+  }
+}
+
+// Reads an editable field as a string for validation and host adapters.
+std::optional<std::string> GetEditableValue(const GdtfEditableValues &values,
+                                            GdtfFieldId fieldId) {
+  switch (fieldId) {
+  case GdtfFieldId::FixtureTypeName:
+    return values.fixtureTypeName;
+  case GdtfFieldId::Manufacturer:
+    return values.manufacturer;
+  case GdtfFieldId::ModelName:
+    return values.modelName;
+  case GdtfFieldId::ModeName:
+    return values.modeName;
+  case GdtfFieldId::Weight:
+    return values.weightKg
+               ? std::optional<std::string>(FormatFloat(*values.weightKg))
+               : std::nullopt;
+  case GdtfFieldId::PowerConsumption:
+    return values.powerConsumptionW ? std::optional<std::string>(FormatFloat(
+                                          *values.powerConsumptionW))
+                                    : std::nullopt;
+  case GdtfFieldId::TrussLength:
+    return values.trussLengthMm
+               ? std::optional<std::string>(FormatFloat(*values.trussLengthMm))
+               : std::nullopt;
+  case GdtfFieldId::TrussWidth:
+    return values.trussWidthMm
+               ? std::optional<std::string>(FormatFloat(*values.trussWidthMm))
+               : std::nullopt;
+  case GdtfFieldId::TrussHeight:
+    return values.trussHeightMm
+               ? std::optional<std::string>(FormatFloat(*values.trussHeightMm))
+               : std::nullopt;
+  case GdtfFieldId::TrussCrossSection:
+    return values.trussCrossSection;
+  case GdtfFieldId::SourceFileReference:
+    return values.sourceFileReference;
+  default:
+    if (auto it = values.presentationValues.find(fieldId);
+        it != values.presentationValues.end())
+      return it->second;
+    return std::nullopt;
+  }
+}
+
+// Compares two editable value sets for session dirty tracking.
+bool operator==(const GdtfEditableValues &lhs, const GdtfEditableValues &rhs) {
+  return lhs.fixtureTypeName == rhs.fixtureTypeName &&
+         lhs.manufacturer == rhs.manufacturer &&
+         lhs.modelName == rhs.modelName && lhs.modeName == rhs.modeName &&
+         lhs.weightKg == rhs.weightKg &&
+         lhs.powerConsumptionW == rhs.powerConsumptionW &&
+         lhs.trussLengthMm == rhs.trussLengthMm &&
+         lhs.trussWidthMm == rhs.trussWidthMm &&
+         lhs.trussHeightMm == rhs.trussHeightMm &&
+         lhs.trussCrossSection == rhs.trussCrossSection &&
+         lhs.sourceFileReference == rhs.sourceFileReference &&
+         lhs.presentationValues == rhs.presentationValues;
+}
+
+// Compares two editable value sets for inequality.
+bool operator!=(const GdtfEditableValues &lhs, const GdtfEditableValues &rhs) {
+  return !(lhs == rhs);
+}
+
+} // namespace gdtf

--- a/core/gdtf/editor/gdtf_editable_values.h
+++ b/core/gdtf/editor/gdtf_editable_values.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "gdtf_field_registry.h"
+
+#include <map>
+#include <optional>
+#include <string>
+
+namespace gdtf {
+
+struct GdtfEditableValues {
+  std::optional<std::string> fixtureTypeName;
+  std::optional<std::string> manufacturer;
+  std::optional<std::string> modelName;
+  std::optional<std::string> modeName;
+  std::optional<float> weightKg;
+  std::optional<float> powerConsumptionW;
+  std::optional<float> trussLengthMm;
+  std::optional<float> trussWidthMm;
+  std::optional<float> trussHeightMm;
+  std::optional<std::string> trussCrossSection;
+  std::optional<std::string> sourceFileReference;
+  std::map<GdtfFieldId, std::string> presentationValues;
+};
+
+bool SetEditableValue(GdtfEditableValues &values, GdtfFieldId fieldId,
+                      const std::string &value);
+std::optional<std::string> GetEditableValue(const GdtfEditableValues &values,
+                                            GdtfFieldId fieldId);
+bool operator==(const GdtfEditableValues &lhs, const GdtfEditableValues &rhs);
+bool operator!=(const GdtfEditableValues &lhs, const GdtfEditableValues &rhs);
+
+} // namespace gdtf

--- a/core/gdtf/editor/gdtf_editor_context.cpp
+++ b/core/gdtf/editor/gdtf_editor_context.cpp
@@ -1,0 +1,45 @@
+#include "gdtf_editor_context.h"
+
+namespace gdtf {
+
+// Converts a source-kind enum to a stable diagnostic string.
+const char *ToString(GdtfSourceKind kind) {
+  switch (kind) {
+  case GdtfSourceKind::StandaloneExternalFile:
+    return "standalone external file";
+  case GdtfSourceKind::PerastageFixtureLibraryFile:
+    return "Perastage fixture library file";
+  case GdtfSourceKind::PerastageTrussLibraryFile:
+    return "Perastage truss library file";
+  case GdtfSourceKind::EmbeddedOrExtractedFromMvr:
+    return "GDTF embedded/extracted from MVR";
+  case GdtfSourceKind::PerastageGeneratedDerivative:
+    return "Perastage-generated derivative";
+  case GdtfSourceKind::TemporaryGeneratedFile:
+    return "temporary/generated file";
+  case GdtfSourceKind::Unknown:
+    return "unknown source";
+  }
+  return "unknown source";
+}
+
+// Converts a write-policy enum to a stable diagnostic string.
+const char *ToString(GdtfWritePolicy policy) {
+  switch (policy) {
+  case GdtfWritePolicy::ReadOnly:
+    return "read-only";
+  case GdtfWritePolicy::OverwriteOwnedFile:
+    return "overwrite owned file";
+  case GdtfWritePolicy::CreateDerivativeBeforeMutation:
+    return "create derivative before mutation";
+  case GdtfWritePolicy::SaveAsNewStandaloneFile:
+    return "save as new standalone file";
+  case GdtfWritePolicy::ProjectControlledGeneration:
+    return "project-controlled generation";
+  case GdtfWritePolicy::UnsupportedNotYetAvailable:
+    return "unsupported/not yet available";
+  }
+  return "unsupported/not yet available";
+}
+
+} // namespace gdtf

--- a/core/gdtf/editor/gdtf_editor_context.h
+++ b/core/gdtf/editor/gdtf_editor_context.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include "gdtf_document.h"
+#include "gdtf_editable_values.h"
+
+#include <filesystem>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace gdtf {
+
+enum class GdtfSourceKind {
+  StandaloneExternalFile,
+  PerastageFixtureLibraryFile,
+  PerastageTrussLibraryFile,
+  EmbeddedOrExtractedFromMvr,
+  PerastageGeneratedDerivative,
+  TemporaryGeneratedFile,
+  Unknown
+};
+
+enum class GdtfWritePolicy {
+  ReadOnly,
+  OverwriteOwnedFile,
+  CreateDerivativeBeforeMutation,
+  SaveAsNewStandaloneFile,
+  ProjectControlledGeneration,
+  UnsupportedNotYetAvailable
+};
+
+enum class GdtfEditorContextKind {
+  StandaloneFile,
+  ProjectFixture,
+  ProjectTruss,
+  FutureProjectObject
+};
+
+struct GdtfEditorContext {
+  GdtfEditorContextKind kind = GdtfEditorContextKind::StandaloneFile;
+  std::filesystem::path sourcePath;
+  GdtfSourceKind sourceKind = GdtfSourceKind::Unknown;
+  GdtfWritePolicy writePolicy = GdtfWritePolicy::ReadOnly;
+  GdtfDocument document;
+  GdtfEditableValues initialValues;
+  bool editingAllowed = false;
+  std::string stableHostId;
+  std::string hostLabel;
+  std::vector<std::string> diagnostics;
+};
+
+struct GdtfApplyRequest {
+  GdtfEditorContextKind contextKind = GdtfEditorContextKind::StandaloneFile;
+  std::filesystem::path sourcePath;
+  GdtfWritePolicy writePolicy = GdtfWritePolicy::ReadOnly;
+  GdtfEditableValues values;
+  std::set<GdtfFieldId> changedFields;
+};
+
+struct GdtfApplyResult {
+  bool success = false;
+  std::vector<std::string> validationErrors;
+  std::set<GdtfFieldId> changedGdtfFields;
+  std::filesystem::path resultingGdtfPath;
+  bool derivativeCreated = false;
+  bool projectInstanceResynchronizationRequired = false;
+  bool viewerRefreshRequired = false;
+  bool hoistLoadRecalculationRequired = false;
+  bool projectDirtyStateMustBeUpdated = false;
+  std::vector<std::string> diagnostics;
+};
+
+const char *ToString(GdtfSourceKind kind);
+const char *ToString(GdtfWritePolicy policy);
+
+} // namespace gdtf

--- a/core/gdtf/editor/gdtf_field_registry.cpp
+++ b/core/gdtf/editor/gdtf_field_registry.cpp
@@ -1,0 +1,156 @@
+#include "gdtf_field_registry.h"
+
+#include <array>
+
+namespace gdtf {
+namespace {
+
+constexpr std::array<GdtfFieldDescriptor, 29> kDescriptors = {{
+    {GdtfFieldId::FixtureId, GdtfFieldOwnership::MvrProjectInstanceLevel,
+     "fixture_id", "Fixture ID", true, false},
+    {GdtfFieldId::FixtureInstanceName,
+     GdtfFieldOwnership::MvrProjectInstanceLevel, "fixture_instance_name",
+     "Name", true, false},
+    {GdtfFieldId::FixtureTypeName, GdtfFieldOwnership::GdtfTypeLevel,
+     "fixture_type_name", "Type", true, false},
+    {GdtfFieldId::Layer, GdtfFieldOwnership::MvrProjectInstanceLevel, "layer",
+     "Layer", true, false},
+    {GdtfFieldId::HangPosition, GdtfFieldOwnership::MvrProjectInstanceLevel,
+     "hang_position", "Hang position", true, false},
+    {GdtfFieldId::Universe, GdtfFieldOwnership::MvrProjectInstanceLevel,
+     "universe", "Universe", true, false},
+    {GdtfFieldId::DmxAddress, GdtfFieldOwnership::MvrProjectInstanceLevel,
+     "dmx_address", "Channel", true, false},
+    {GdtfFieldId::ModeName, GdtfFieldOwnership::ContextSpecific, "mode_name",
+     "Mode", true, false},
+    {GdtfFieldId::ChannelCount, GdtfFieldOwnership::DerivedReadOnly,
+     "channel_count", "Ch Count", false, false},
+    {GdtfFieldId::SourceFileReference, GdtfFieldOwnership::ContextSpecific,
+     "source_file_reference", "Model File", true, false},
+    {GdtfFieldId::PositionX, GdtfFieldOwnership::MvrProjectInstanceLevel,
+     "position_x", "Position X", true, false},
+    {GdtfFieldId::PositionY, GdtfFieldOwnership::MvrProjectInstanceLevel,
+     "position_y", "Position Y", true, false},
+    {GdtfFieldId::PositionZ, GdtfFieldOwnership::MvrProjectInstanceLevel,
+     "position_z", "Position Z", true, false},
+    {GdtfFieldId::Roll, GdtfFieldOwnership::MvrProjectInstanceLevel, "roll",
+     "Roll", true, false},
+    {GdtfFieldId::Pitch, GdtfFieldOwnership::MvrProjectInstanceLevel, "pitch",
+     "Pitch", true, false},
+    {GdtfFieldId::Yaw, GdtfFieldOwnership::MvrProjectInstanceLevel, "yaw",
+     "Yaw", true, false},
+    {GdtfFieldId::PowerConsumption, GdtfFieldOwnership::GdtfTypeLevel,
+     "power_consumption", "Power", true, false},
+    {GdtfFieldId::Weight, GdtfFieldOwnership::GdtfTypeLevel, "weight", "Weight",
+     true, false},
+    {GdtfFieldId::FixtureCategory,
+     GdtfFieldOwnership::ProjectClassificationOverride, "fixture_category",
+     "Category", true, false},
+    {GdtfFieldId::VisualColor,
+     GdtfFieldOwnership::ProjectClassificationOverride, "visual_color",
+     "Visual color", true, false},
+    {GdtfFieldId::MvrFixtureColor, GdtfFieldOwnership::MvrProjectInstanceLevel,
+     "mvr_fixture_color", "MVR color", true, false},
+    {GdtfFieldId::Manufacturer, GdtfFieldOwnership::GdtfTypeLevel,
+     "manufacturer", "Manufacturer", true, false},
+    {GdtfFieldId::ModelName, GdtfFieldOwnership::GdtfTypeLevel, "model_name",
+     "Model", true, false},
+    {GdtfFieldId::TrussName, GdtfFieldOwnership::MvrProjectInstanceLevel,
+     "truss_name", "Name", true, false},
+    {GdtfFieldId::TrussLength, GdtfFieldOwnership::GdtfTypeLevel,
+     "truss_length", "Length", true, false},
+    {GdtfFieldId::TrussWidth, GdtfFieldOwnership::GdtfTypeLevel, "truss_width",
+     "Width", true, false},
+    {GdtfFieldId::TrussHeight, GdtfFieldOwnership::GdtfTypeLevel,
+     "truss_height", "Height", true, false},
+    {GdtfFieldId::TrussCrossSection, GdtfFieldOwnership::GdtfTypeLevel,
+     "truss_cross_section", "Cross section", true, false},
+    {GdtfFieldId::TrussLoad, GdtfFieldOwnership::DerivedReadOnly, "truss_load",
+     "Load", false, false},
+}};
+
+} // namespace
+
+// Finds the descriptor for a stable GDTF editor field identifier.
+const GdtfFieldDescriptor *FindGdtfFieldDescriptor(GdtfFieldId id) {
+  for (const auto &descriptor : kDescriptors) {
+    if (descriptor.id == id)
+      return &descriptor;
+  }
+  return nullptr;
+}
+
+// Returns the fields currently shown by Edit Fixture in table-column order.
+std::vector<GdtfFieldDescriptor> CurrentFixtureEditFieldDescriptors() {
+  return {{*FindGdtfFieldDescriptor(GdtfFieldId::FixtureId),
+           *FindGdtfFieldDescriptor(GdtfFieldId::FixtureInstanceName),
+           *FindGdtfFieldDescriptor(GdtfFieldId::FixtureTypeName),
+           *FindGdtfFieldDescriptor(GdtfFieldId::Layer),
+           *FindGdtfFieldDescriptor(GdtfFieldId::HangPosition),
+           *FindGdtfFieldDescriptor(GdtfFieldId::Universe),
+           *FindGdtfFieldDescriptor(GdtfFieldId::DmxAddress),
+           *FindGdtfFieldDescriptor(GdtfFieldId::ModeName),
+           *FindGdtfFieldDescriptor(GdtfFieldId::ChannelCount),
+           *FindGdtfFieldDescriptor(GdtfFieldId::SourceFileReference),
+           *FindGdtfFieldDescriptor(GdtfFieldId::PositionX),
+           *FindGdtfFieldDescriptor(GdtfFieldId::PositionY),
+           *FindGdtfFieldDescriptor(GdtfFieldId::PositionZ),
+           *FindGdtfFieldDescriptor(GdtfFieldId::Roll),
+           *FindGdtfFieldDescriptor(GdtfFieldId::Pitch),
+           *FindGdtfFieldDescriptor(GdtfFieldId::Yaw),
+           *FindGdtfFieldDescriptor(GdtfFieldId::PowerConsumption),
+           *FindGdtfFieldDescriptor(GdtfFieldId::Weight),
+           *FindGdtfFieldDescriptor(GdtfFieldId::FixtureCategory),
+           *FindGdtfFieldDescriptor(GdtfFieldId::VisualColor),
+           *FindGdtfFieldDescriptor(GdtfFieldId::MvrFixtureColor)}};
+}
+
+// Returns the fields currently shown by Edit Truss in table-column order plus
+// cross section.
+std::vector<GdtfFieldDescriptor> CurrentTrussEditFieldDescriptors() {
+  return {{*FindGdtfFieldDescriptor(GdtfFieldId::TrussName),
+           *FindGdtfFieldDescriptor(GdtfFieldId::Layer),
+           *FindGdtfFieldDescriptor(GdtfFieldId::SourceFileReference),
+           *FindGdtfFieldDescriptor(GdtfFieldId::HangPosition),
+           *FindGdtfFieldDescriptor(GdtfFieldId::PositionX),
+           *FindGdtfFieldDescriptor(GdtfFieldId::PositionY),
+           *FindGdtfFieldDescriptor(GdtfFieldId::PositionZ),
+           *FindGdtfFieldDescriptor(GdtfFieldId::Roll),
+           *FindGdtfFieldDescriptor(GdtfFieldId::Pitch),
+           *FindGdtfFieldDescriptor(GdtfFieldId::Yaw),
+           *FindGdtfFieldDescriptor(GdtfFieldId::Manufacturer),
+           *FindGdtfFieldDescriptor(GdtfFieldId::ModelName),
+           *FindGdtfFieldDescriptor(GdtfFieldId::TrussLength),
+           *FindGdtfFieldDescriptor(GdtfFieldId::TrussWidth),
+           *FindGdtfFieldDescriptor(GdtfFieldId::TrussHeight),
+           *FindGdtfFieldDescriptor(GdtfFieldId::Weight),
+           *FindGdtfFieldDescriptor(GdtfFieldId::TrussLoad),
+           *FindGdtfFieldDescriptor(GdtfFieldId::TrussCrossSection)}};
+}
+
+// Reports whether a field may be edited as independent session state.
+bool IsGdtfFieldIndependentlyEditable(GdtfFieldId id) {
+  const auto *descriptor = FindGdtfFieldDescriptor(id);
+  return descriptor && descriptor->independentlyEditable;
+}
+
+// Converts a field ownership enum to a stable diagnostic string.
+const char *ToString(GdtfFieldOwnership ownership) {
+  switch (ownership) {
+  case GdtfFieldOwnership::GdtfTypeLevel:
+    return "GDTF type-level";
+  case GdtfFieldOwnership::MvrProjectInstanceLevel:
+    return "MVR/project instance-level";
+  case GdtfFieldOwnership::DerivedReadOnly:
+    return "derived/read-only";
+  case GdtfFieldOwnership::ProjectClassificationOverride:
+    return "project classification/override";
+  case GdtfFieldOwnership::ContextSpecific:
+    return "context-specific";
+  case GdtfFieldOwnership::UnsupportedFuture:
+    return "unsupported/future";
+  }
+  return "unknown";
+}
+
+} // namespace gdtf

--- a/core/gdtf/editor/gdtf_field_registry.h
+++ b/core/gdtf/editor/gdtf_field_registry.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace gdtf {
+
+enum class GdtfFieldId {
+  FixtureId,
+  FixtureInstanceName,
+  FixtureTypeName,
+  Layer,
+  HangPosition,
+  Universe,
+  DmxAddress,
+  ModeName,
+  ChannelCount,
+  SourceFileReference,
+  PositionX,
+  PositionY,
+  PositionZ,
+  Roll,
+  Pitch,
+  Yaw,
+  PowerConsumption,
+  Weight,
+  FixtureCategory,
+  VisualColor,
+  MvrFixtureColor,
+  Manufacturer,
+  ModelName,
+  TrussName,
+  TrussLength,
+  TrussWidth,
+  TrussHeight,
+  TrussCrossSection,
+  TrussLoad
+};
+
+enum class GdtfFieldOwnership {
+  GdtfTypeLevel,
+  MvrProjectInstanceLevel,
+  DerivedReadOnly,
+  ProjectClassificationOverride,
+  ContextSpecific,
+  UnsupportedFuture
+};
+
+struct GdtfFieldDescriptor {
+  GdtfFieldId id;
+  GdtfFieldOwnership ownership;
+  const char *stableName;
+  const char *displayName;
+  bool independentlyEditable = false;
+  bool repeatedFamily = false;
+};
+
+const GdtfFieldDescriptor *FindGdtfFieldDescriptor(GdtfFieldId id);
+std::vector<GdtfFieldDescriptor> CurrentFixtureEditFieldDescriptors();
+std::vector<GdtfFieldDescriptor> CurrentTrussEditFieldDescriptors();
+bool IsGdtfFieldIndependentlyEditable(GdtfFieldId id);
+const char *ToString(GdtfFieldOwnership ownership);
+
+} // namespace gdtf

--- a/core/gdtf/editor/project_fixture_gdtf_context.cpp
+++ b/core/gdtf/editor/project_fixture_gdtf_context.cpp
@@ -1,0 +1,37 @@
+#include "project_fixture_gdtf_context.h"
+
+namespace gdtf {
+
+// Builds a non-mutating project-fixture editor context from stable fixture
+// data.
+GdtfEditorContext BuildProjectFixtureGdtfEditorContext(
+    const ProjectFixtureGdtfContextInput &input) {
+  GdtfEditorContext context;
+  context.kind = GdtfEditorContextKind::ProjectFixture;
+  context.sourcePath = input.resolvedGdtfPath;
+  context.sourceKind = input.sourceKind;
+  context.writePolicy = input.writePolicy;
+  context.document = input.document;
+  context.editingAllowed =
+      input.writePolicy != GdtfWritePolicy::ReadOnly &&
+      input.writePolicy != GdtfWritePolicy::UnsupportedNotYetAvailable;
+  context.stableHostId = input.fixture.uuid;
+  context.hostLabel = input.fixture.instanceName.empty()
+                          ? input.fixture.typeName
+                          : input.fixture.instanceName;
+  context.initialValues.fixtureTypeName = input.fixture.typeName;
+  context.initialValues.modeName = input.fixture.gdtfMode;
+  context.initialValues.weightKg = input.fixture.weightKg;
+  context.initialValues.powerConsumptionW = input.fixture.powerConsumptionW;
+  context.initialValues.sourceFileReference = input.fixture.gdtfSpec;
+  return context;
+}
+
+// Builds a non-GUI edit session for a project fixture without mutating scene
+// state.
+GdtfEditSession BuildProjectFixtureGdtfEditSession(
+    const ProjectFixtureGdtfContextInput &input) {
+  return GdtfEditSession(BuildProjectFixtureGdtfEditorContext(input));
+}
+
+} // namespace gdtf

--- a/core/gdtf/editor/project_fixture_gdtf_context.h
+++ b/core/gdtf/editor/project_fixture_gdtf_context.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "fixture.h"
+#include "gdtf_edit_session.h"
+
+namespace gdtf {
+
+struct ProjectFixtureGdtfContextInput {
+  Fixture fixture;
+  std::filesystem::path resolvedGdtfPath;
+  GdtfSourceKind sourceKind = GdtfSourceKind::Unknown;
+  GdtfWritePolicy writePolicy = GdtfWritePolicy::CreateDerivativeBeforeMutation;
+  GdtfDocument document;
+};
+
+GdtfEditorContext BuildProjectFixtureGdtfEditorContext(
+    const ProjectFixtureGdtfContextInput &input);
+GdtfEditSession
+BuildProjectFixtureGdtfEditSession(const ProjectFixtureGdtfContextInput &input);
+
+} // namespace gdtf

--- a/core/gdtf/editor/project_truss_gdtf_context.cpp
+++ b/core/gdtf/editor/project_truss_gdtf_context.cpp
@@ -1,0 +1,40 @@
+#include "project_truss_gdtf_context.h"
+
+namespace gdtf {
+
+// Builds a non-mutating project-truss editor context from stable truss data.
+GdtfEditorContext
+BuildProjectTrussGdtfEditorContext(const ProjectTrussGdtfContextInput &input) {
+  GdtfEditorContext context;
+  context.kind = GdtfEditorContextKind::ProjectTruss;
+  context.sourcePath = input.resolvedGdtfPath;
+  context.sourceKind = input.sourceKind;
+  context.writePolicy = input.writePolicy;
+  context.document = input.document;
+  context.editingAllowed =
+      input.writePolicy == GdtfWritePolicy::ProjectControlledGeneration ||
+      input.writePolicy == GdtfWritePolicy::OverwriteOwnedFile;
+  context.stableHostId = input.truss.uuid;
+  context.hostLabel =
+      input.truss.name.empty() ? input.truss.model : input.truss.name;
+  context.initialValues.manufacturer = input.truss.manufacturer;
+  context.initialValues.modelName = input.truss.model;
+  context.initialValues.modeName = input.truss.gdtfMode;
+  context.initialValues.weightKg = input.truss.weightKg;
+  context.initialValues.trussLengthMm = input.truss.lengthMm;
+  context.initialValues.trussWidthMm = input.truss.widthMm;
+  context.initialValues.trussHeightMm = input.truss.heightMm;
+  context.initialValues.trussCrossSection = input.truss.crossSection;
+  context.initialValues.sourceFileReference = input.truss.gdtfSpec.empty()
+                                                  ? input.truss.modelFile
+                                                  : input.truss.gdtfSpec;
+  return context;
+}
+
+// Builds a non-GUI edit session for a project truss without generating a GDTF.
+GdtfEditSession
+BuildProjectTrussGdtfEditSession(const ProjectTrussGdtfContextInput &input) {
+  return GdtfEditSession(BuildProjectTrussGdtfEditorContext(input));
+}
+
+} // namespace gdtf

--- a/core/gdtf/editor/project_truss_gdtf_context.h
+++ b/core/gdtf/editor/project_truss_gdtf_context.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "gdtf_edit_session.h"
+#include "truss.h"
+
+namespace gdtf {
+
+struct ProjectTrussGdtfContextInput {
+  Truss truss;
+  std::filesystem::path resolvedGdtfPath;
+  GdtfSourceKind sourceKind = GdtfSourceKind::PerastageGeneratedDerivative;
+  GdtfWritePolicy writePolicy = GdtfWritePolicy::ProjectControlledGeneration;
+  GdtfDocument document;
+};
+
+GdtfEditorContext
+BuildProjectTrussGdtfEditorContext(const ProjectTrussGdtfContextInput &input);
+GdtfEditSession
+BuildProjectTrussGdtfEditSession(const ProjectTrussGdtfContextInput &input);
+
+} // namespace gdtf

--- a/core/gdtf/editor/standalone_gdtf_context.cpp
+++ b/core/gdtf/editor/standalone_gdtf_context.cpp
@@ -1,0 +1,43 @@
+#include "standalone_gdtf_context.h"
+
+namespace gdtf {
+
+// Builds a standalone-file context through shared read services without project
+// dependencies.
+GdtfEditorContext
+BuildStandaloneGdtfEditorContext(const std::filesystem::path &sourcePath,
+                                 GdtfWritePolicy writePolicy) {
+  GdtfEditorContext context;
+  context.kind = GdtfEditorContextKind::StandaloneFile;
+  context.sourcePath = sourcePath;
+  context.sourceKind = GdtfSourceKind::StandaloneExternalFile;
+  context.writePolicy = writePolicy;
+  context.document = LoadGdtfDocument(sourcePath);
+  context.editingAllowed =
+      writePolicy != GdtfWritePolicy::ReadOnly &&
+      writePolicy != GdtfWritePolicy::UnsupportedNotYetAvailable;
+  context.stableHostId = sourcePath.generic_string();
+  context.hostLabel = sourcePath.filename().generic_string();
+  const auto &description = context.document.Description();
+  context.initialValues.fixtureTypeName = description.fixtureTypeName;
+  context.initialValues.manufacturer = description.manufacturer;
+  context.initialValues.modelName = description.shortName.empty()
+                                        ? description.longName
+                                        : description.shortName;
+  if (!description.dmxModeNames.empty())
+    context.initialValues.modeName = description.dmxModeNames.front();
+  context.initialValues.sourceFileReference =
+      sourcePath.filename().generic_string();
+  return context;
+}
+
+// Builds a standalone edit session without creating windows or registering file
+// associations.
+GdtfEditSession
+BuildStandaloneGdtfEditSession(const std::filesystem::path &sourcePath,
+                               GdtfWritePolicy writePolicy) {
+  return GdtfEditSession(
+      BuildStandaloneGdtfEditorContext(sourcePath, writePolicy));
+}
+
+} // namespace gdtf

--- a/core/gdtf/editor/standalone_gdtf_context.h
+++ b/core/gdtf/editor/standalone_gdtf_context.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "gdtf_edit_session.h"
+
+namespace gdtf {
+
+GdtfEditorContext BuildStandaloneGdtfEditorContext(
+    const std::filesystem::path &sourcePath,
+    GdtfWritePolicy writePolicy = GdtfWritePolicy::ReadOnly);
+GdtfEditSession BuildStandaloneGdtfEditSession(
+    const std::filesystem::path &sourcePath,
+    GdtfWritePolicy writePolicy = GdtfWritePolicy::ReadOnly);
+
+} // namespace gdtf

--- a/docs/internal/gdtf_editor_architecture_audit.md
+++ b/docs/internal/gdtf_editor_architecture_audit.md
@@ -143,3 +143,12 @@ The missing-gobo runtime symptom is not fixed in this checkpoint. Evidence from 
 - Added focused tests for valid archives, case-insensitive `description.xml` lookup, missing and duplicate description entries, malformed XML, missing root/FixtureType, ordered revisions, ordered DMX modes, repeated gobo wheels/slots, unknown elements, metadata-summary compatibility, and Unicode archive paths/entry names.
 - Added `tests/check_gdtf_metadata_summary_boundary.sh` to keep `gdtf_metadata_summary.cpp` from reintroducing direct ZIP traversal or direct `description.xml` archive lookup.
 - No GDTF or MVR write path was changed.
+
+
+## Checkpoint 03 editing-domain boundary update
+
+Checkpoint 03 introduces non-GUI GDTF editor architecture types under `core/gdtf/editor/`. The new layer formalizes a read-only `gdtf::GdtfDocument`, separate `gdtf::GdtfEditableValues`, `gdtf::GdtfEditSession` dirty tracking and validation, explicit `GdtfSourceKind` and `GdtfWritePolicy` values, field ownership descriptors, standalone/project fixture/project truss context adapters, and GUI-independent apply request/result structures.
+
+The exact current Fixture Edit and Truss Edit field ownership classifications, ambiguous field decisions, context adapter behavior, and remaining unmigrated dialog responsibilities are documented in `docs/internal/gdtf_editor_context_boundaries.md`. Existing Fixture Edit and Truss Edit runtime behavior remains unchanged in this checkpoint: apply logic, table updates, approved physical-property mutation, truss GDTF generation, previews, dirty state updates, viewer refreshes, and hoist/load prompts are still owned by the existing GUI/table-panel code paths.
+
+The next approved checkpoint remains reusable panel extraction from the existing dialogs. Startup routing, standalone `.gdtf` windows, `.gdtf` command-line opening, installer file associations, raw XML editing, new GDTF attributes, rendering changes, and MVR/GDTF write-path replacements remain out of scope.

--- a/docs/internal/gdtf_editor_context_boundaries.md
+++ b/docs/internal/gdtf_editor_context_boundaries.md
@@ -1,0 +1,103 @@
+# GDTF editor context boundaries
+
+Checkpoint 03 adds non-GUI editing-domain models for future reusable GDTF editing. It does not add a new editor window, reusable wx panel, startup route, file association, visual simulation feature, GDTF writer, or MVR writer.
+
+## Document model
+
+`gdtf::GdtfDocument` wraps the existing read-only archive and description services. It exposes the source path, archive diagnostics, description diagnostics, identity metadata, DMX mode names, repeated-family summaries, source-file presence, and validity. It intentionally does not expose project rows, UUIDs, table indices, wxWidgets controls, `ConfigManager`, renderer state, mutable XML nodes, or MVR write state.
+
+Repeated or future GDTF families are represented as collections. Wheels remain a collection in the shared read snapshot and are summarized as a repeated family instead of being promoted to singleton editor fields.
+
+## Editable value model
+
+`gdtf::GdtfEditableValues` stores only candidate GDTF type/editor values used by a future common editor:
+
+- fixture type name;
+- manufacturer;
+- model/name presentation value;
+- mode name when the host treats mode selection as editor state;
+- weight;
+- power consumption;
+- truss length, width, and height;
+- truss cross section;
+- source file reference as a context-owned presentation adapter.
+
+It does not store project row indices, GUI controls, fixture positions, DMX addresses, fixture visual colors, MVR fixture colors, calculated channel count, or calculated truss load.
+
+## Edit session
+
+`gdtf::GdtfEditSession` owns a context, initial editable values, current editable values, validation diagnostics, and field-level dirty tracking. It distinguishes user edits from derived values by refusing independently editable writes to fields registered as derived/read-only. It never mutates a project, writes a `.gdtf`, refreshes viewers, recalculates hoists, opens dialogs, or reads global configuration.
+
+## Source kind and write policy
+
+Source classification and write policy are separate enums:
+
+- `GdtfSourceKind` covers standalone external files, Perastage fixture library files, Perastage truss library files, GDTF extracted or embedded from MVR, Perastage-generated derivatives, temporary/generated files, and unknown sources.
+- `GdtfWritePolicy` covers read-only, overwrite owned file, create derivative before mutation, save as a new standalone file, project-controlled generation, and unsupported/not-yet-available.
+
+The session receives both values from its host context and does not infer policy from GUI state.
+
+## Context kinds and adapters
+
+`gdtf::GdtfEditorContextKind` defines `StandaloneFile`, `ProjectFixture`, `ProjectTruss`, and `FutureProjectObject`.
+
+- The standalone factory opens through shared read services, creates a read-only context by default, has no project/MVR dependency, creates no windows, registers no file associations, and writes nothing.
+- The project fixture adapter accepts stable fixture data and a resolved source path, builds a session from current model values, records the fixture UUID as host identity, and does not mutate the scene during construction.
+- The project truss adapter accepts stable truss data and a resolved source path, records the truss UUID as host identity, represents Perastage truss generation as project-controlled write policy, and does not generate or rewrite a GDTF during construction.
+
+Existing `FixtureEditDialog` and `TrussEditDialog` remain unmigrated in this checkpoint. Their current apply paths, preview wiring, table updates, physical-property write path, truss builder calls, dirty state updates, viewer refreshes, and hoist recalculation prompts remain owned by the existing dialogs and table panels until the next checkpoint.
+
+## Apply request/result boundary
+
+`GdtfApplyRequest` carries the context kind, source path, write policy, current values, and changed field IDs. `GdtfApplyResult` can independently report validation errors, changed GDTF fields, resulting GDTF path/reference, derivative creation, project instance resynchronization, viewer refresh, hoist/load recalculation, project dirty state, and diagnostics. It is intentionally GUI-independent and does not implement physical writes in this checkpoint.
+
+## Field ownership classification
+
+The authoritative code registry is `core/gdtf/editor/gdtf_field_registry.*`.
+
+### Current Edit Fixture fields
+
+| Field | Current source of truth | Ownership decision |
+| --- | --- | --- |
+| Fixture ID | MVR/project fixture instance | MVR/project instance-level |
+| Name | MVR/project fixture instance | MVR/project instance-level |
+| Type | Fixture type/name mirrored from GDTF/dictionary/project row | GDTF type-level for common editor purposes |
+| Layer | Project layer assignment | MVR/project instance-level |
+| Hang position | Project/MVR position reference | MVR/project instance-level |
+| Universe | Project patch data | MVR/project instance-level |
+| Channel | Project patch data | MVR/project instance-level |
+| Mode | GDTF mode name selected for the project fixture | Context-specific |
+| Ch Count | Derived from selected GDTF mode channels | Derived/read-only |
+| Model File | Host source/reference selection | Context-specific |
+| Position X/Y/Z | Project/MVR transform | MVR/project instance-level |
+| Roll/Pitch/Yaw | Project/MVR transform | MVR/project instance-level |
+| Power | Existing approved physical-property mutation path writes GDTF `PowerConsumption` when allowed | GDTF type-level |
+| Weight | Existing approved physical-property mutation path writes GDTF `Weight` when allowed | GDTF type-level |
+| Category | Perastage classification/dictionary/project override, not a direct GDTF semantic edit | Project classification/override |
+| Visual color | Perastage visual classification propagated by type | Project classification/override |
+| MVR color | Official MVR fixture color on the project instance | MVR/project instance-level |
+
+Ambiguous fixture decisions: mode is context-specific because the current dialog selects a project fixture mode from GDTF modes rather than editing the GDTF mode definitions; model file is context-specific because it is a host source/reference selection; category and visual color can look like type metadata in the UI but are Perastage classification values, not direct GDTF semantic fields; channel count is derived and never independently editable.
+
+### Current Edit Truss fields
+
+| Field | Current source of truth | Ownership decision |
+| --- | --- | --- |
+| Name | MVR/project truss instance | MVR/project instance-level |
+| Layer | Project layer assignment | MVR/project instance-level |
+| Model File | Host source/reference selection | Context-specific |
+| Hang position | Project/MVR position reference | MVR/project instance-level |
+| Position X/Y/Z | Project/MVR transform | MVR/project instance-level |
+| Roll/Pitch/Yaw | Project/MVR transform | MVR/project instance-level |
+| Manufacturer | Truss type metadata used by Perastage truss GDTF generation | GDTF type-level |
+| Model | Truss type metadata used by Perastage truss GDTF generation | GDTF type-level |
+| Length/Width/Height | Truss type dimensions used by Perastage truss GDTF generation | GDTF type-level |
+| Weight | Truss type weight used by Perastage truss GDTF generation | GDTF type-level |
+| Load | Calculated/manual project load state | Derived/read-only |
+| Cross section | Truss type metadata used by Perastage truss GDTF generation | GDTF type-level |
+
+Ambiguous truss decisions: model file is context-specific because the host may point to a source model archive or an active generated GDTF; load is project load state and must not become GDTF editor state; truss type edits currently cause the existing dialog to call the truss GDTF builder, but the new session only represents that policy and does not generate files.
+
+## Next checkpoint
+
+The next approved checkpoint is reusable panel extraction from the existing `FixtureEditDialog` and `TrussEditDialog`. That work should keep the apply semantics in the existing project hosts while moving reusable field presentation into shared panels.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -131,6 +131,7 @@ If you encounter any problems installing or running Perastage, please open an is
 - Isolated volatile build version and diagnostic metadata into a dedicated build-info translation unit so version-only changes no longer force broad C++ recompilation.
 - Moved GDTF metadata summary loading into the shared core layer and documented the current GDTF editor architecture boundaries for future reusable editor work.
 - Added a centralized read-only GDTF archive and description snapshot foundation in core, including ordered wheel/slot preservation and focused regression coverage for future editor work.
+- Added non-GUI GDTF editor architecture models for document snapshots, editable values, edit sessions, source/write policy, field ownership, project fixture/truss contexts, standalone contexts, and apply-result side effects while keeping existing dialogs and write paths unchanged.
 
 - Moved the high-level repository map into the documentation tree and aligned repository layout references and guard checks with the current module structure.
 - Documented Viewer2D state ownership boundaries to prepare for separating runtime state, user preferences, and project/Layout persistent state.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -52,6 +52,8 @@ if(BASH_EXECUTABLE)
              COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_dictionary_paths.sh)
     add_test(NAME GdtfMetadataSummaryBoundary
              COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_gdtf_metadata_summary_boundary.sh)
+    add_test(NAME GdtfEditorCoreBoundary
+             COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_gdtf_editor_core_boundary.sh)
     add_test(NAME ProjectRestoreImportOptions
              COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_project_restore_import_options.sh)
 endif()
@@ -257,6 +259,22 @@ add_executable(gdtf_read_services_test
 target_include_directories(gdtf_read_services_test PRIVATE ../core)
 target_link_libraries(gdtf_read_services_test PRIVATE ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
 add_test(NAME GdtfReadServices COMMAND gdtf_read_services_test)
+
+add_executable(gdtf_editor_context_test
+               gdtf_editor_context_test.cpp
+               ../core/gdtf_archive_reader.cpp
+               ../core/gdtf_description_reader.cpp
+               ../core/gdtf/editor/gdtf_document.cpp
+               ../core/gdtf/editor/gdtf_edit_session.cpp
+               ../core/gdtf/editor/gdtf_editable_values.cpp
+               ../core/gdtf/editor/gdtf_editor_context.cpp
+               ../core/gdtf/editor/gdtf_field_registry.cpp
+               ../core/gdtf/editor/project_fixture_gdtf_context.cpp
+               ../core/gdtf/editor/project_truss_gdtf_context.cpp
+               ../core/gdtf/editor/standalone_gdtf_context.cpp)
+target_include_directories(gdtf_editor_context_test PRIVATE .. ../core)
+target_link_libraries(gdtf_editor_context_test PRIVATE ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
+add_test(NAME GdtfEditorContext COMMAND gdtf_editor_context_test)
 
 add_executable(gdtf_fixture_category_test
                gdtf_fixture_category_test.cpp

--- a/tests/check_gdtf_editor_core_boundary.sh
+++ b/tests/check_gdtf_editor_core_boundary.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+editor_dir="$repo_root/core/gdtf/editor"
+
+if rg -n '#include <wx/|#include "gui/|#include "fixturetablepanel|#include "trusstablepanel|ConfigManager::Get|GetDefaultGuiConfigServices' "$editor_dir"; then
+  echo "GDTF editor core boundary must not include GUI widgets or global config access." >&2
+  exit 1
+fi

--- a/tests/gdtf_editor_context_test.cpp
+++ b/tests/gdtf_editor_context_test.cpp
@@ -1,0 +1,157 @@
+#include "gdtf/editor/gdtf_edit_session.h"
+#include "gdtf/editor/project_fixture_gdtf_context.h"
+#include "gdtf/editor/project_truss_gdtf_context.h"
+#include "gdtf/editor/standalone_gdtf_context.h"
+
+#include <cassert>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+namespace {
+
+// Writes a minimal GDTF-like archive placeholder for missing-file independent
+// tests.
+void AssertFixtureFieldOwnership() {
+  const auto fields = gdtf::CurrentFixtureEditFieldDescriptors();
+  assert(fields.size() == 21);
+  assert(fields[2].id == gdtf::GdtfFieldId::FixtureTypeName);
+  assert(fields[2].ownership == gdtf::GdtfFieldOwnership::GdtfTypeLevel);
+  assert(fields[8].id == gdtf::GdtfFieldId::ChannelCount);
+  assert(fields[8].ownership == gdtf::GdtfFieldOwnership::DerivedReadOnly);
+  assert(fields[18].ownership ==
+         gdtf::GdtfFieldOwnership::ProjectClassificationOverride);
+}
+
+// Verifies truss field ownership matches the current Edit Truss split.
+void AssertTrussFieldOwnership() {
+  const auto fields = gdtf::CurrentTrussEditFieldDescriptors();
+  assert(fields.size() == 18);
+  assert(fields[10].id == gdtf::GdtfFieldId::Manufacturer);
+  assert(fields[10].ownership == gdtf::GdtfFieldOwnership::GdtfTypeLevel);
+  assert(fields[16].id == gdtf::GdtfFieldId::TrussLoad);
+  assert(fields[16].ownership == gdtf::GdtfFieldOwnership::DerivedReadOnly);
+  assert(fields[17].id == gdtf::GdtfFieldId::TrussCrossSection);
+}
+
+// Verifies dirty tracking, validation, reset, and derived-field protection.
+void AssertSessionBehavior() {
+  gdtf::GdtfEditorContext context;
+  context.editingAllowed = true;
+  context.initialValues.fixtureTypeName = "Spot";
+  context.initialValues.weightKg = 10.0f;
+  gdtf::GdtfEditSession session(context);
+  assert(!session.IsDirty());
+  assert(!session.SetValue(gdtf::GdtfFieldId::ChannelCount, "8"));
+  assert(!session.IsDirty());
+  assert(session.SetValue(gdtf::GdtfFieldId::Weight, "12.5"));
+  assert(session.IsDirty());
+  assert(session.IsFieldDirty(gdtf::GdtfFieldId::Weight));
+  assert(session.DirtyFields().size() == 1);
+  assert(session.Validate().empty());
+  assert(session.SetValue(gdtf::GdtfFieldId::Weight, "-1"));
+  assert(!session.Validate().empty());
+  session.Reset();
+  assert(!session.IsDirty());
+}
+
+// Verifies source kind and write policy are separate independent values.
+void AssertPolicySeparation() {
+  gdtf::GdtfEditorContext context;
+  context.sourceKind = gdtf::GdtfSourceKind::EmbeddedOrExtractedFromMvr;
+  context.writePolicy = gdtf::GdtfWritePolicy::CreateDerivativeBeforeMutation;
+  assert(std::string(gdtf::ToString(context.sourceKind)).find("MVR") !=
+         std::string::npos);
+  assert(std::string(gdtf::ToString(context.writePolicy)).find("derivative") !=
+         std::string::npos);
+}
+
+// Verifies project adapters use stable IDs and do not mutate copied scene
+// models.
+void AssertProjectAdapters() {
+  Fixture fixture;
+  fixture.uuid = "fixture-uuid";
+  fixture.instanceName = "Fixture A";
+  fixture.typeName = "Profile";
+  fixture.gdtfSpec = "profile.gdtf";
+  fixture.gdtfMode = "Mode 1";
+  fixture.weightKg = 20.0f;
+  fixture.powerConsumptionW = 500.0f;
+  gdtf::ProjectFixtureGdtfContextInput fixtureInput;
+  fixtureInput.fixture = fixture;
+  fixtureInput.resolvedGdtfPath = "/tmp/profile.gdtf";
+  auto fixtureSession = gdtf::BuildProjectFixtureGdtfEditSession(fixtureInput);
+  assert(fixtureSession.Context().stableHostId == "fixture-uuid");
+  assert(fixture.gdtfSpec == "profile.gdtf");
+
+  Truss truss;
+  truss.uuid = "truss-uuid";
+  truss.name = "Truss A";
+  truss.manufacturer = "Perastage";
+  truss.model = "Box";
+  truss.gdtfSpec = "truss.gdtf";
+  truss.lengthMm = 3000.0f;
+  truss.widthMm = 290.0f;
+  truss.heightMm = 290.0f;
+  truss.weightKg = 35.0f;
+  truss.crossSection = "box";
+  gdtf::ProjectTrussGdtfContextInput trussInput;
+  trussInput.truss = truss;
+  auto trussSession = gdtf::BuildProjectTrussGdtfEditSession(trussInput);
+  assert(trussSession.Context().stableHostId == "truss-uuid");
+  assert(truss.gdtfSpec == "truss.gdtf");
+}
+
+// Verifies apply results express host side effects independently.
+void AssertApplyResultFlags() {
+  gdtf::GdtfApplyResult result;
+  result.derivativeCreated = true;
+  result.viewerRefreshRequired = true;
+  result.projectDirtyStateMustBeUpdated = true;
+  result.hoistLoadRecalculationRequired = false;
+  result.projectInstanceResynchronizationRequired = true;
+  assert(result.derivativeCreated);
+  assert(result.viewerRefreshRequired);
+  assert(result.projectDirtyStateMustBeUpdated);
+  assert(result.projectInstanceResynchronizationRequired);
+}
+
+// Verifies repeated families are exposed as collections, not hardcoded
+// singleton fields.
+void AssertRepeatedFamilies() {
+  gdtf::GdtfDescriptionSnapshot snapshot;
+  snapshot.wheels.push_back({"Gobo 1", {}});
+  snapshot.wheels.push_back({"Gobo 2", {}});
+  gdtf::ArchiveReadResult archive;
+  gdtf::GdtfDocument document(std::move(archive), std::move(snapshot));
+  assert(document.RepeatedFamilies().size() == 1);
+  assert(document.RepeatedFamilies()[0].names.size() == 2);
+}
+
+// Verifies the standalone context remains project-independent and read-only by
+// default.
+void AssertStandaloneContext() {
+  const auto path = std::filesystem::temp_directory_path() /
+                    "perastage_missing_standalone_context.gdtf";
+  auto context = gdtf::BuildStandaloneGdtfEditorContext(path);
+  assert(context.kind == gdtf::GdtfEditorContextKind::StandaloneFile);
+  assert(context.writePolicy == gdtf::GdtfWritePolicy::ReadOnly);
+  assert(!context.editingAllowed);
+  assert(context.stableHostId.find("perastage_missing_standalone_context") !=
+         std::string::npos);
+}
+
+} // namespace
+
+// Runs focused unit checks for the GDTF editor architecture checkpoint.
+int main() {
+  AssertFixtureFieldOwnership();
+  AssertTrussFieldOwnership();
+  AssertSessionBehavior();
+  AssertPolicySeparation();
+  AssertProjectAdapters();
+  AssertApplyResultFlags();
+  AssertRepeatedFamilies();
+  AssertStandaloneContext();
+  return 0;
+}


### PR DESCRIPTION
### Motivation

- Separate GDTF document read services, editable editor state, and host/project boundaries so a reusable editor panel can be added later without GUI coupling.
- Make source/ownership and write-policy explicit so session behavior is driven by host context rather than GUI heuristics.
- Provide a non-GUI edit session with field-level dirty tracking and validation to enable safe adapters for project fixtures, project trusses, and standalone files.

### Description

- Added a new non-GUI core layer under `core/gdtf/editor/` including `GdtfDocument`, `GdtfEditableValues`, `GdtfEditSession`, `gdtf::GdtfEditorContext` / `GdtfApplyRequest` / `GdtfApplyResult`, `GdtfSourceKind`, and `GdtfWritePolicy` to model document, session, policy, and apply boundaries.
- Introduced an authoritative field ownership registry (`gdtf_field_registry.*`) and helper query APIs to classify current Fixture and Truss editor fields (GDTF type-level, project/MVR instance-level, derived/read-only, etc.).
- Implemented non-mutating adapters/factories: `project_fixture_gdtf_context.*`, `project_truss_gdtf_context.*`, and `standalone_gdtf_context.*` that construct `GdtfEditorContext`/`GdtfEditSession` from stable model data without touching GUI or scene state.
- Added `core` CMake entries to compile the new files, added unit test `tests/gdtf_editor_context_test.cpp`, a boundary check `tests/check_gdtf_editor_core_boundary.sh`, and documentation `docs/internal/gdtf_editor_context_boundaries.md`; also updated `docs/release-notes-draft.md` and the internal audit file.

### Testing

- Ran repository checks: `tests/check_perastage_tree_modules.sh` — passed; `tests/check_no_configmanager_get_in_gui.sh` — passed; `tests/check_gdtf_editor_core_boundary.sh` — passed.
- Built and executed the focused unit test using local read-service stubs with the command shown in CI (`g++ -std=c++20 -Icore -Imodels ... /tmp/gdtf_read_stubs.cpp ... && /tmp/gdtf_editor_context_test`) and the test binary passed all assertions.
- Added CMake test target `GdtfEditorContext` in `tests/CMakeLists.txt` for CI, but a full `cmake` build in this environment could not complete because the container lacks `wxWidgets` development libraries (`find_package(wxWidgets)` failed); this is an environment limitation and not a functional regression.
- Confirmed new public headers do not include GUI headers and that editor core files avoid `ConfigManager::Get()` / GUI-only dependencies via the boundary check script.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4cdf0104708324b10d426ce8fd03a9)