### PR TITLE
GDTF: recover UTF-8 filenames when ZIP UTF‑8 flag is missing (compatibility fallback)

### DIFF
--- a/core/gdtf_archive_reader.cpp
+++ b/core/gdtf_archive_reader.cpp
@@ -4,7 +4,10 @@
 #include <cctype>
 #include <cstdint>
 #include <exception>
+#include <fstream>
+#include <iterator>
 #include <memory>
+#include <optional>
 #include <system_error>
 
 #include <wx/string.h>
@@ -22,15 +25,151 @@ struct DescriptionCandidate {
 
 // Converts ASCII characters to lower case for stable archive-key comparison.
 std::string LowerAscii(std::string value) {
-  std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) {
-    return static_cast<char>(std::tolower(c));
-  });
+  std::transform(
+      value.begin(), value.end(), value.begin(),
+      [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
   return value;
 }
 
+struct RawZipEntryName {
+  std::string bytes;
+  bool utf8Flag = false;
+};
+
+struct DecodedZipEntryName {
+  std::string path;
+  bool usedUtf8Fallback = false;
+  bool failed = false;
+};
+
+// Reports whether raw bytes contain only portable ASCII characters.
+bool IsAscii(const std::string &value) {
+  return std::all_of(value.begin(), value.end(),
+                     [](unsigned char c) { return c < 0x80; });
+}
+
+// Reports whether raw bytes are a well-formed UTF-8 sequence.
+bool IsValidUtf8(const std::string &value) {
+  size_t i = 0;
+  while (i < value.size()) {
+    const unsigned char c = static_cast<unsigned char>(value[i]);
+    size_t extra = 0;
+    uint32_t code = 0;
+    if (c <= 0x7F) {
+      ++i;
+      continue;
+    }
+    if ((c & 0xE0) == 0xC0) {
+      extra = 1;
+      code = c & 0x1F;
+      if (code == 0)
+        return false;
+    } else if ((c & 0xF0) == 0xE0) {
+      extra = 2;
+      code = c & 0x0F;
+    } else if ((c & 0xF8) == 0xF0) {
+      extra = 3;
+      code = c & 0x07;
+    } else
+      return false;
+    if (i + extra >= value.size())
+      return false;
+    for (size_t j = 1; j <= extra; ++j) {
+      const unsigned char t = static_cast<unsigned char>(value[i + j]);
+      if ((t & 0xC0) != 0x80)
+        return false;
+      code = (code << 6) | (t & 0x3F);
+    }
+    if ((extra == 1 && code < 0x80) || (extra == 2 && code < 0x800) ||
+        (extra == 3 && code < 0x10000) || code > 0x10FFFF ||
+        (code >= 0xD800 && code <= 0xDFFF))
+      return false;
+    i += extra + 1;
+  }
+  return true;
+}
+
+// Reads a little-endian 16-bit value from ZIP metadata.
+uint16_t ReadLe16(const std::vector<unsigned char> &data, size_t offset) {
+  return static_cast<uint16_t>(data[offset]) |
+         (static_cast<uint16_t>(data[offset + 1]) << 8);
+}
+
+// Reads a little-endian 32-bit value from ZIP metadata.
+uint32_t ReadLe32(const std::vector<unsigned char> &data, size_t offset) {
+  return static_cast<uint32_t>(data[offset]) |
+         (static_cast<uint32_t>(data[offset + 1]) << 8) |
+         (static_cast<uint32_t>(data[offset + 2]) << 16) |
+         (static_cast<uint32_t>(data[offset + 3]) << 24);
+}
+
+// Locates the ZIP end-of-central-directory record in bounded trailing data.
+std::optional<size_t>
+FindEndOfCentralDirectory(const std::vector<unsigned char> &data) {
+  if (data.size() < 22)
+    return std::nullopt;
+  const size_t maxComment = 0xffff;
+  const size_t minOffset =
+      data.size() > 22 + maxComment ? data.size() - 22 - maxComment : 0;
+  for (size_t i = data.size() - 22;; --i) {
+    if (ReadLe32(data, i) == 0x06054b50)
+      return i;
+    if (i == minOffset)
+      break;
+  }
+  return std::nullopt;
+}
+
+// Reads raw ZIP central-directory entry names before wxWidgets decodes them.
+std::vector<RawZipEntryName>
+ReadRawCentralDirectoryNames(const std::filesystem::path &path) {
+  std::ifstream input(path, std::ios::binary);
+  if (!input)
+    return {};
+  std::vector<unsigned char> data((std::istreambuf_iterator<char>(input)), {});
+  const std::optional<size_t> eocdOffset = FindEndOfCentralDirectory(data);
+  if (!eocdOffset)
+    return {};
+
+  const uint16_t entryCount = ReadLe16(data, *eocdOffset + 10);
+  size_t i = ReadLe32(data, *eocdOffset + 16);
+  std::vector<RawZipEntryName> names;
+  for (uint16_t entryIndex = 0;
+       entryIndex < entryCount && i + 46 <= data.size(); ++entryIndex) {
+    if (ReadLe32(data, i) != 0x02014b50)
+      break;
+    const uint16_t flags = ReadLe16(data, i + 8);
+    const uint16_t nameLen = ReadLe16(data, i + 28);
+    const uint16_t extraLen = ReadLe16(data, i + 30);
+    const uint16_t commentLen = ReadLe16(data, i + 32);
+    if (i + 46u + nameLen + extraLen + commentLen > data.size())
+      break;
+    names.push_back(
+        {std::string(reinterpret_cast<const char *>(&data[i + 46]), nameLen),
+         (flags & (1u << 11)) != 0});
+    i += 46u + nameLen + extraLen + commentLen;
+  }
+  return names;
+}
+
+// Decodes one raw ZIP entry name according to GDTF compatibility policy.
+DecodedZipEntryName DecodeZipEntryName(const RawZipEntryName &raw) {
+  DecodedZipEntryName decoded;
+  if (raw.utf8Flag || !IsAscii(raw.bytes)) {
+    if (!IsValidUtf8(raw.bytes)) {
+      decoded.failed = true;
+      return decoded;
+    }
+    decoded.path = raw.bytes;
+    decoded.usedUtf8Fallback = !raw.utf8Flag && !IsAscii(raw.bytes);
+    return decoded;
+  }
+  decoded.path = raw.bytes;
+  return decoded;
+}
+
 // Normalizes ZIP entry names to archive-relative paths with forward slashes.
-std::string NormalizeArchivePath(const wxString &name) {
-  std::string path = name.ToUTF8().data();
+std::string NormalizeArchivePath(std::string path) {
   std::replace(path.begin(), path.end(), '\\', '/');
   while (path.rfind("./", 0) == 0)
     path.erase(0, 2);
@@ -39,14 +178,14 @@ std::string NormalizeArchivePath(const wxString &name) {
 
 // Reports whether a normalized archive path is unsafe to materialize or trust.
 bool IsUnsafeArchivePath(const std::string &path) {
-  if (path.empty() || path.front() == '/' || path.find(':') != std::string::npos)
+  if (path.empty() || path.front() == '/' ||
+      path.find(':') != std::string::npos)
     return true;
   size_t start = 0;
   while (start <= path.size()) {
     const size_t slash = path.find('/', start);
-    const std::string part =
-        path.substr(start, slash == std::string::npos ? std::string::npos
-                                                      : slash - start);
+    const std::string part = path.substr(
+        start, slash == std::string::npos ? std::string::npos : slash - start);
     if (part == "..")
       return true;
     if (slash == std::string::npos)
@@ -65,7 +204,8 @@ std::string ArchiveFileName(const std::string &path) {
 // Adds a structured diagnostic to the archive result.
 void AddDiagnostic(ArchiveReadResult &result, ArchiveDiagnosticCode code,
                    std::string message, std::string entryPath = {}) {
-  result.diagnostics.push_back({code, std::move(message), std::move(entryPath)});
+  result.diagnostics.push_back(
+      {code, std::move(message), std::move(entryPath)});
 }
 
 // Reports whether an archive diagnostic prevents a usable read result.
@@ -86,14 +226,21 @@ bool IsFatalDiagnostic(ArchiveDiagnosticCode code) {
   case ArchiveDiagnosticCode::EntryTooLarge:
   case ArchiveDiagnosticCode::FilesystemError:
   case ArchiveDiagnosticCode::UnexpectedException:
+  case ArchiveDiagnosticCode::FilenameDecodeFailed:
+  case ArchiveDiagnosticCode::FilenameEncodingAmbiguous:
     return true;
+  case ArchiveDiagnosticCode::Utf8FlagMissing:
+  case ArchiveDiagnosticCode::Utf8FallbackUsed:
+  case ArchiveDiagnosticCode::LegacyFilenameEncodingUsed:
+    return false;
   }
   return true;
 }
 
 // Selects description.xml using canonical-first tolerant read rules.
-void SelectDescriptionCandidate(ArchiveReadResult &result,
-                                const std::vector<DescriptionCandidate> &candidates) {
+void SelectDescriptionCandidate(
+    ArchiveReadResult &result,
+    const std::vector<DescriptionCandidate> &candidates) {
   std::vector<DescriptionCandidate> exactRoot;
   std::vector<DescriptionCandidate> rootCaseInsensitive;
   std::vector<DescriptionCandidate> nested;
@@ -109,9 +256,10 @@ void SelectDescriptionCandidate(ArchiveReadResult &result,
   }
 
   if (exactRoot.size() > 1) {
-    AddDiagnostic(result, ArchiveDiagnosticCode::DuplicateDescriptionXml,
-                  "The GDTF archive contains multiple canonical description.xml entries.",
-                  exactRoot.front().path);
+    AddDiagnostic(
+        result, ArchiveDiagnosticCode::DuplicateDescriptionXml,
+        "The GDTF archive contains multiple canonical description.xml entries.",
+        exactRoot.front().path);
     return;
   }
   if (!exactRoot.empty()) {
@@ -125,14 +273,16 @@ void SelectDescriptionCandidate(ArchiveReadResult &result,
     result.descriptionXml = rootCaseInsensitive.front().xml;
     result.descriptionEntryPath = rootCaseInsensitive.front().path;
     result.usedCompatibilityDescriptionFallback = true;
-    AddDiagnostic(result, ArchiveDiagnosticCode::NonCanonicalDescriptionXml,
-                  "Using non-standard root description.xml name for compatibility.",
-                  rootCaseInsensitive.front().path);
+    AddDiagnostic(
+        result, ArchiveDiagnosticCode::NonCanonicalDescriptionXml,
+        "Using non-standard root description.xml name for compatibility.",
+        rootCaseInsensitive.front().path);
     return;
   }
   if (rootCaseInsensitive.size() > 1) {
     AddDiagnostic(result, ArchiveDiagnosticCode::DuplicateDescriptionXml,
-                  "The GDTF archive contains multiple root case-insensitive description.xml entries.",
+                  "The GDTF archive contains multiple root case-insensitive "
+                  "description.xml entries.",
                   rootCaseInsensitive.front().path);
     return;
   }
@@ -142,14 +292,16 @@ void SelectDescriptionCandidate(ArchiveReadResult &result,
     result.descriptionEntryPath = nested.front().path;
     result.usedCompatibilityDescriptionFallback = true;
     AddDiagnostic(result, ArchiveDiagnosticCode::NonCanonicalDescriptionXml,
-                  "Using nested description.xml for compatibility; canonical GDTF stores it at the archive root.",
+                  "Using nested description.xml for compatibility; canonical "
+                  "GDTF stores it at the archive root.",
                   nested.front().path);
     return;
   }
   if (nested.size() > 1) {
-    AddDiagnostic(result, ArchiveDiagnosticCode::AmbiguousDescriptionXml,
-                  "The GDTF archive contains multiple nested description.xml candidates.",
-                  nested.front().path);
+    AddDiagnostic(
+        result, ArchiveDiagnosticCode::AmbiguousDescriptionXml,
+        "The GDTF archive contains multiple nested description.xml candidates.",
+        nested.front().path);
     return;
   }
 
@@ -219,14 +371,35 @@ ArchiveReadResult ReadGdtfArchive(const std::filesystem::path &sourcePath) {
       return result;
     }
 
+    const std::vector<RawZipEntryName> rawNames =
+        ReadRawCentralDirectoryNames(sourcePath);
     wxZipInputStream zipInput(input);
     std::unique_ptr<wxZipEntry> entry;
+    size_t entryIndex = 0;
     std::vector<DescriptionCandidate> descriptionCandidates;
     while ((entry.reset(zipInput.GetNextEntry())), entry) {
-      const std::string entryPath = NormalizeArchivePath(entry->GetName());
+      DecodedZipEntryName decodedName;
+      if (entryIndex < rawNames.size()) {
+        decodedName = DecodeZipEntryName(rawNames[entryIndex]);
+      } else {
+        const wxScopedCharBuffer utf8 = entry->GetName().ToUTF8();
+        decodedName.path = utf8 ? std::string(utf8.data()) : std::string();
+      }
+      ++entryIndex;
+      std::string entryPath = NormalizeArchivePath(decodedName.path);
+      if (decodedName.failed) {
+        AddDiagnostic(
+            result, ArchiveDiagnosticCode::FilenameDecodeFailed,
+            "A GDTF archive entry filename could not be decoded safely.");
+        continue;
+      }
       ArchiveEntry inventoryEntry;
       inventoryEntry.path = entryPath;
       inventoryEntry.directory = entry->IsDir();
+      inventoryEntry.nameUsedUtf8CompatibilityFallback =
+          decodedName.usedUtf8Fallback;
+      if (decodedName.usedUtf8Fallback)
+        ++result.utf8FlagMissingEntryCount;
       const wxFileOffset size = entry->GetSize();
       if (size >= 0) {
         inventoryEntry.sizeKnown = true;
@@ -261,6 +434,14 @@ ArchiveReadResult ReadGdtfArchive(const std::filesystem::path &sourcePath) {
       }
     }
 
+    if (result.utf8FlagMissingEntryCount > 0) {
+      AddDiagnostic(result, ArchiveDiagnosticCode::Utf8FallbackUsed,
+                    "GDTF archive uses valid UTF-8 filenames without the ZIP "
+                    "UTF-8 flag; compatibility fallback applied to " +
+                        std::to_string(result.utf8FlagMissingEntryCount) +
+                        " entries.");
+    }
+
     if (result.entries.empty()) {
       AddDiagnostic(result, ArchiveDiagnosticCode::NoReadableEntries,
                     "The GDTF archive does not contain readable entries.");
@@ -270,7 +451,8 @@ ArchiveReadResult ReadGdtfArchive(const std::filesystem::path &sourcePath) {
       return result;
     }
     if (result.descriptionXml.empty() ||
-        result.descriptionXml.find_first_not_of(" \t\r\n") == std::string::npos) {
+        result.descriptionXml.find_first_not_of(" \t\r\n") ==
+            std::string::npos) {
       AddDiagnostic(result, ArchiveDiagnosticCode::EmptyDescriptionXml,
                     "description.xml is empty.", result.descriptionEntryPath);
       result.descriptionXml.clear();

--- a/core/gdtf_archive_reader.cpp
+++ b/core/gdtf_archive_reader.cpp
@@ -42,6 +42,12 @@ struct DecodedZipEntryName {
   bool failed = false;
 };
 
+// Converts a filesystem path to UTF-8 text for wxWidgets file streams.
+std::string PathToUtf8(const std::filesystem::path &path) {
+  const std::u8string utf8 = path.u8string();
+  return std::string(utf8.begin(), utf8.end());
+}
+
 // Reports whether raw bytes contain only portable ASCII characters.
 bool IsAscii(const std::string &value) {
   return std::all_of(value.begin(), value.end(),
@@ -328,6 +334,27 @@ bool ReadCurrentEntry(wxZipInputStream &zipInput, std::string &out,
   return zipInput.GetLastError() == wxSTREAM_NO_ERROR ||
          zipInput.GetLastError() == wxSTREAM_EOF;
 }
+
+// Copies the current ZIP entry to disk with a bounded write loop.
+bool WriteCurrentEntry(wxZipInputStream &zipInput,
+                       const std::filesystem::path &outPath) {
+  std::ofstream output(outPath, std::ios::binary);
+  if (!output.is_open())
+    return false;
+
+  char buffer[4096];
+  while (true) {
+    zipInput.Read(buffer, sizeof(buffer));
+    const size_t count = zipInput.LastRead();
+    if (count == 0)
+      break;
+    output.write(buffer, static_cast<std::streamsize>(count));
+    if (!output.good())
+      return false;
+  }
+  return zipInput.GetLastError() == wxSTREAM_NO_ERROR ||
+         zipInput.GetLastError() == wxSTREAM_EOF;
+}
 } // namespace
 
 // Reports whether the archive read found one usable description.xml payload.
@@ -363,8 +390,7 @@ ArchiveReadResult ReadGdtfArchive(const std::filesystem::path &sourcePath) {
       return result;
     }
 
-    wxFileInputStream input(
-        wxString::FromUTF8(sourcePath.generic_string().c_str()));
+    wxFileInputStream input(wxString::FromUTF8(PathToUtf8(sourcePath)));
     if (!input.IsOk()) {
       AddDiagnostic(result, ArchiveDiagnosticCode::OpenFailed,
                     "Could not open GDTF archive.");
@@ -474,6 +500,163 @@ ArchiveReadResult ReadGdtfArchive(const std::filesystem::path &sourcePath) {
                   "Unknown error while reading GDTF archive.");
   }
 
+  return result;
+}
+
+// Extracts a GDTF archive using the shared Unicode-safe entry-name policy.
+ArchiveReadResult
+ExtractGdtfArchive(const std::filesystem::path &sourcePath,
+                   const std::filesystem::path &destinationRoot) {
+  ArchiveReadResult result;
+  result.sourcePath = sourcePath;
+  try {
+    if (sourcePath.empty() || destinationRoot.empty()) {
+      AddDiagnostic(result, ArchiveDiagnosticCode::EmptySourcePath,
+                    "GDTF source or destination path is empty.");
+      return result;
+    }
+
+    std::error_code ec;
+    std::filesystem::create_directories(destinationRoot, ec);
+    if (ec) {
+      AddDiagnostic(result, ArchiveDiagnosticCode::FilesystemError,
+                    "Could not create GDTF extraction directory.");
+      return result;
+    }
+
+    wxFileInputStream input(wxString::FromUTF8(PathToUtf8(sourcePath)));
+    if (!input.IsOk()) {
+      AddDiagnostic(result, ArchiveDiagnosticCode::OpenFailed,
+                    "Could not open GDTF archive.");
+      return result;
+    }
+
+    const std::vector<RawZipEntryName> rawNames =
+        ReadRawCentralDirectoryNames(sourcePath);
+    wxZipInputStream zipInput(input);
+    std::unique_ptr<wxZipEntry> entry;
+    size_t entryIndex = 0;
+    while ((entry.reset(zipInput.GetNextEntry())), entry) {
+      DecodedZipEntryName decodedName;
+      if (entryIndex < rawNames.size()) {
+        decodedName = DecodeZipEntryName(rawNames[entryIndex]);
+      } else {
+        const wxScopedCharBuffer utf8 = entry->GetName().ToUTF8();
+        decodedName.path = utf8 ? std::string(utf8.data()) : std::string();
+      }
+      ++entryIndex;
+
+      const std::string entryPath = NormalizeArchivePath(decodedName.path);
+      if (decodedName.failed) {
+        AddDiagnostic(
+            result, ArchiveDiagnosticCode::FilenameDecodeFailed,
+            "A GDTF archive entry filename could not be decoded safely.");
+        continue;
+      }
+
+      ArchiveEntry inventoryEntry;
+      inventoryEntry.path = entryPath;
+      inventoryEntry.directory = entry->IsDir();
+      inventoryEntry.nameUsedUtf8CompatibilityFallback =
+          decodedName.usedUtf8Fallback;
+      if (decodedName.usedUtf8Fallback)
+        ++result.utf8FlagMissingEntryCount;
+      const wxFileOffset size = entry->GetSize();
+      if (size >= 0) {
+        inventoryEntry.sizeKnown = true;
+        inventoryEntry.size = static_cast<std::uint64_t>(size);
+      }
+      result.entries.push_back(inventoryEntry);
+
+      if (IsUnsafeArchivePath(entryPath)) {
+        AddDiagnostic(result, ArchiveDiagnosticCode::UnsafeEntryPath,
+                      "The GDTF archive contains an unsafe entry path.",
+                      entryPath);
+        continue;
+      }
+
+      std::u8string relativeUtf8;
+      relativeUtf8.reserve(entryPath.size());
+      for (char ch : entryPath)
+        relativeUtf8.push_back(static_cast<char8_t>(ch));
+      const std::filesystem::path relative =
+          std::filesystem::path(std::move(relativeUtf8));
+      const std::filesystem::path destinationPath = destinationRoot / relative;
+      const std::filesystem::path normalizedRoot =
+          std::filesystem::weakly_canonical(destinationRoot, ec);
+      if (ec) {
+        AddDiagnostic(result, ArchiveDiagnosticCode::FilesystemError,
+                      "Could not resolve GDTF extraction directory.",
+                      entryPath);
+        return result;
+      }
+      ec.clear();
+
+      if (entry->IsDir()) {
+        std::filesystem::create_directories(destinationPath, ec);
+        if (ec) {
+          AddDiagnostic(result, ArchiveDiagnosticCode::FilesystemError,
+                        "Could not create GDTF extraction subdirectory.",
+                        entryPath);
+        }
+        continue;
+      }
+
+      std::filesystem::create_directories(destinationPath.parent_path(), ec);
+      if (ec) {
+        AddDiagnostic(result, ArchiveDiagnosticCode::FilesystemError,
+                      "Could not create GDTF extraction parent directory.",
+                      entryPath);
+        continue;
+      }
+
+      const std::filesystem::path normalizedDestination =
+          std::filesystem::weakly_canonical(destinationPath.parent_path(), ec);
+      if (ec || normalizedDestination.native().rfind(normalizedRoot.native(),
+                                                     0) != 0) {
+        AddDiagnostic(
+            result, ArchiveDiagnosticCode::UnsafeEntryPath,
+            "The GDTF archive entry would extract outside the destination.",
+            entryPath);
+        continue;
+      }
+      ec.clear();
+
+      if (!WriteCurrentEntry(zipInput, destinationPath)) {
+        AddDiagnostic(result, ArchiveDiagnosticCode::EntryReadFailed,
+                      "Could not extract a GDTF archive entry.", entryPath);
+      }
+    }
+
+    if (result.utf8FlagMissingEntryCount > 0) {
+      AddDiagnostic(result, ArchiveDiagnosticCode::Utf8FallbackUsed,
+                    "GDTF archive uses valid UTF-8 filenames without the ZIP "
+                    "UTF-8 flag; compatibility fallback applied to " +
+                        std::to_string(result.utf8FlagMissingEntryCount) +
+                        " entries.");
+    }
+    if (result.entries.empty()) {
+      AddDiagnostic(result, ArchiveDiagnosticCode::NoReadableEntries,
+                    "The GDTF archive does not contain readable entries.");
+    }
+  } catch (const std::filesystem::filesystem_error &error) {
+    AddDiagnostic(
+        result, ArchiveDiagnosticCode::FilesystemError,
+        std::string("Filesystem error while extracting GDTF archive: ") +
+            error.what());
+  } catch (const std::system_error &error) {
+    AddDiagnostic(result, ArchiveDiagnosticCode::FilesystemError,
+                  std::string("System error while extracting GDTF archive: ") +
+                      error.what());
+  } catch (const std::exception &error) {
+    AddDiagnostic(
+        result, ArchiveDiagnosticCode::UnexpectedException,
+        std::string("Unexpected error while extracting GDTF archive: ") +
+            error.what());
+  } catch (...) {
+    AddDiagnostic(result, ArchiveDiagnosticCode::UnexpectedException,
+                  "Unknown error while extracting GDTF archive.");
+  }
   return result;
 }
 

--- a/core/gdtf_archive_reader.h
+++ b/core/gdtf_archive_reader.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <filesystem>
 #include <string>
@@ -21,7 +22,12 @@ enum class ArchiveDiagnosticCode {
   EntryReadFailed,
   EntryTooLarge,
   FilesystemError,
-  UnexpectedException
+  UnexpectedException,
+  Utf8FlagMissing,
+  Utf8FallbackUsed,
+  LegacyFilenameEncodingUsed,
+  FilenameDecodeFailed,
+  FilenameEncodingAmbiguous
 };
 
 struct ArchiveDiagnostic {
@@ -35,6 +41,7 @@ struct ArchiveEntry {
   std::uint64_t size = 0;
   bool sizeKnown = false;
   bool directory = false;
+  bool nameUsedUtf8CompatibilityFallback = false;
 };
 
 struct ArchiveReadResult {
@@ -45,6 +52,7 @@ struct ArchiveReadResult {
   std::vector<ArchiveDiagnostic> diagnostics;
   bool usedCompatibilityDescriptionFallback = false;
   bool standardsCompliantDescriptionLocation = false;
+  std::size_t utf8FlagMissingEntryCount = 0;
 
   bool Success() const;
 };

--- a/core/gdtf_archive_reader.h
+++ b/core/gdtf_archive_reader.h
@@ -59,4 +59,8 @@ struct ArchiveReadResult {
 
 ArchiveReadResult ReadGdtfArchive(const std::filesystem::path &sourcePath);
 
+ArchiveReadResult
+ExtractGdtfArchive(const std::filesystem::path &sourcePath,
+                   const std::filesystem::path &destinationRoot);
+
 } // namespace gdtf

--- a/docs/gdtf_unicode_zip_filename_compatibility.md
+++ b/docs/gdtf_unicode_zip_filename_compatibility.md
@@ -1,0 +1,33 @@
+# GDTF Unicode ZIP filename compatibility
+
+Perastage reads GDTF archives with a shared archive reader that inventories ZIP entries before higher-level description, insertion, preview, and resource code consumes them. The reader keeps archive reads non-mutating: opening or inserting a GDTF never rewrites ZIP metadata, renames resources, changes timestamps, or normalizes XML values.
+
+## Compatibility case
+
+Some otherwise usable GDTF archives store Unicode wheel, gobo, thumbnail, or model resource names as UTF-8 bytes but omit ZIP general-purpose bit 11, the standard UTF-8 filename flag. wxWidgets decodes such names with the local legacy converter by default. On Windows this can fail for characters outside the active code page and previously allowed a conversion exception to escape into the GUI event loop before `description.xml` was reached.
+
+## Decoding policy
+
+The archive reader now reads raw central-directory filename bytes and applies one decoding policy for all GDTF read paths:
+
+- Entries with ZIP UTF-8 bit 11 set are decoded strictly as UTF-8. Invalid UTF-8 is reported as `GDTF_ARCHIVE_FILENAME_DECODE_FAILED` and the archive read fails cleanly.
+- Unflagged ASCII names are accepted without a compatibility warning.
+- Unflagged names whose raw bytes are valid UTF-8 are decoded as UTF-8, marked as a compatibility fallback, and reported once per archive with the affected entry count.
+- Unflagged names that are not valid UTF-8 are not passed through a lossy platform ANSI conversion. They fail with a structured diagnostic until a safe reversible legacy decoder is added.
+- Ambiguous filename interpretations must fail without guessing.
+
+The compatibility warning uses `GDTF_ARCHIVE_UTF8_FALLBACK_USED` semantics and reports a message such as: `GDTF archive uses valid UTF-8 filenames without the ZIP UTF-8 flag; compatibility fallback applied to N entries.`
+
+## Path safety and Windows behavior
+
+Filename decoding happens before path normalization and safety checks. The decoded archive path must still be relative, must not contain drive or root syntax, must not contain `..` traversal, and must not contain unsafe empty paths. Unicode fallback does not weaken traversal protection.
+
+On Windows, callers should keep filesystem paths as `std::filesystem::path` for native operations and use explicit UTF-8 conversion only at serialization, storage, or logging boundaries. GDTF archive entry names are stored as UTF-8 text after safe decoding, independent of the operating-system locale.
+
+## Read/write separation
+
+Perastage reads non-standard but unambiguous GDTF archives permissively and reports diagnostics. Reads remain byte-preserving. Explicit Perastage-generated GDTF ZIP output continues to use wxWidgets UTF-8 entry names so Unicode resource names are written with standards-compliant UTF-8 filename metadata and can be reopened by compliant applications.
+
+## Regression coverage
+
+Focused read-service tests generate small temporary archives with Unicode names containing Greek Phi and Chinese characters. The tests deliberately clear ZIP UTF-8 flags in both local and central headers to verify fallback recovery, aggregate warning counts, description lookup after Unicode entries, wheel resource resolution, strict invalid flagged UTF-8 failure, DMX mode whitespace preservation, and UTF-8 flag metadata on explicit Unicode ZIP output.

--- a/docs/gdtf_unicode_zip_filename_compatibility.md
+++ b/docs/gdtf_unicode_zip_filename_compatibility.md
@@ -1,6 +1,6 @@
 # GDTF Unicode ZIP filename compatibility
 
-Perastage reads GDTF archives with a shared archive reader that inventories ZIP entries before higher-level description, insertion, preview, and resource code consumes them. The reader keeps archive reads non-mutating: opening or inserting a GDTF never rewrites ZIP metadata, renames resources, changes timestamps, or normalizes XML values.
+Perastage reads and extracts GDTF archives with a shared archive reader that inventories ZIP entries before higher-level description, insertion, preview, and resource code consumes them. The reader keeps archive reads non-mutating: opening or inserting a GDTF never rewrites ZIP metadata, renames resources, changes timestamps, or normalizes XML values.
 
 ## Compatibility case
 
@@ -8,7 +8,7 @@ Some otherwise usable GDTF archives store Unicode wheel, gobo, thumbnail, or mod
 
 ## Decoding policy
 
-The archive reader now reads raw central-directory filename bytes and applies one decoding policy for all GDTF read paths:
+The archive reader now reads raw central-directory filename bytes and applies one decoding policy for all GDTF read and extraction paths:
 
 - Entries with ZIP UTF-8 bit 11 set are decoded strictly as UTF-8. Invalid UTF-8 is reported as `GDTF_ARCHIVE_FILENAME_DECODE_FAILED` and the archive read fails cleanly.
 - Unflagged ASCII names are accepted without a compatibility warning.
@@ -20,9 +20,9 @@ The compatibility warning uses `GDTF_ARCHIVE_UTF8_FALLBACK_USED` semantics and r
 
 ## Path safety and Windows behavior
 
-Filename decoding happens before path normalization and safety checks. The decoded archive path must still be relative, must not contain drive or root syntax, must not contain `..` traversal, and must not contain unsafe empty paths. Unicode fallback does not weaken traversal protection.
+Filename decoding happens before path normalization, extraction, and safety checks. The decoded archive path must still be relative, must not contain drive or root syntax, must not contain `..` traversal, and must not contain unsafe empty paths. Unicode fallback does not weaken traversal protection.
 
-On Windows, callers should keep filesystem paths as `std::filesystem::path` for native operations and use explicit UTF-8 conversion only at serialization, storage, or logging boundaries. GDTF archive entry names are stored as UTF-8 text after safe decoding, independent of the operating-system locale.
+On Windows, callers should keep filesystem paths as `std::filesystem::path` for native operations and use explicit UTF-8 conversion only at serialization, storage, or logging boundaries. GDTF archive entry names are stored as UTF-8 text after safe decoding, independent of the operating-system locale, and extraction writes through native `std::filesystem::path` objects.
 
 ## Read/write separation
 
@@ -30,4 +30,4 @@ Perastage reads non-standard but unambiguous GDTF archives permissively and repo
 
 ## Regression coverage
 
-Focused read-service tests generate small temporary archives with Unicode names containing Greek Phi and Chinese characters. The tests deliberately clear ZIP UTF-8 flags in both local and central headers to verify fallback recovery, aggregate warning counts, description lookup after Unicode entries, wheel resource resolution, strict invalid flagged UTF-8 failure, DMX mode whitespace preservation, and UTF-8 flag metadata on explicit Unicode ZIP output.
+Focused read-service tests generate small temporary archives with Unicode names containing Greek Phi and Chinese characters, then read and extract them through the shared policy. The tests deliberately clear ZIP UTF-8 flags in both local and central headers to verify fallback recovery, aggregate warning counts, description lookup after Unicode entries, wheel resource resolution, strict invalid flagged UTF-8 failure, DMX mode whitespace preservation, and UTF-8 flag metadata on explicit Unicode ZIP output.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -17,6 +17,7 @@ Changes since **v1.4.0**.
 
 ## Fixes
 
+- Fixed GDTF imports with Unicode resource filenames whose ZIP entries omit UTF-8 filename metadata, allowing affected fixtures to insert normally while reporting a concise compatibility warning and leaving the original archive unchanged.
 - Fixed adding downloaded GDTF Share fixtures to a project by validating the archive with non-throwing read diagnostics before opening Add Fixture, while preserving the downloaded file unchanged.
 - Improved downloaded GDTF fixture insertion compatibility by preserving WiringObject-based power fallback metadata, resolving wheel media resources from standard `wheels/` archive entries, and reporting empty `description.xml` files with clearer diagnostics.
 - Fixed geometry-only MVR trusses so rigging warnings reliably flag invalid weights, Edit Truss previews direct GLB/3DS geometry without generating a GDTF, and Add Truss shows readable names instead of internal type keys.
@@ -62,6 +63,7 @@ Changes since **v1.4.0**.
 
 ## Documentation
 
+- Added internal documentation for tolerant GDTF Unicode ZIP filename decoding, diagnostics, path safety, and standards-compliant write expectations.
 - Added Viewer2D state ownership documentation to clarify runtime-only, user preference/config, and project/Layout definition boundaries before future offscreen rendering refactors.
 - Updated the MVR-xchange documentation with a compliance summary, supported official flows, conservative latest-request behavior, and explicit out-of-scope notes for WebSocket Mode and private live synchronization.
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -17,7 +17,7 @@ Changes since **v1.4.0**.
 
 ## Fixes
 
-- Fixed GDTF imports with Unicode resource filenames whose ZIP entries omit UTF-8 filename metadata, allowing affected fixtures to insert normally while reporting a concise compatibility warning and leaving the original archive unchanged.
+- Fixed GDTF imports with Unicode resource filenames whose ZIP entries omit UTF-8 filename metadata, allowing affected fixtures to insert with their real models, refresh tables and viewports immediately, reopen without stalling during mode resolution, and report a concise compatibility warning while leaving the original archive unchanged.
 - Fixed adding downloaded GDTF Share fixtures to a project by validating the archive with non-throwing read diagnostics before opening Add Fixture, while preserving the downloaded file unchanged.
 - Improved downloaded GDTF fixture insertion compatibility by preserving WiringObject-based power fallback metadata, resolving wheel media resources from standard `wheels/` archive entries, and reporting empty `description.xml` files with clearer diagnostics.
 - Fixed geometry-only MVR trusses so rigging warnings reliably flag invalid weights, Edit Truss previews direct GLB/3DS geometry without generating a GDTF, and Add Truss shows readable names instead of internal type keys.
@@ -63,7 +63,7 @@ Changes since **v1.4.0**.
 
 ## Documentation
 
-- Added internal documentation for tolerant GDTF Unicode ZIP filename decoding, diagnostics, path safety, and standards-compliant write expectations.
+- Added internal documentation for tolerant GDTF Unicode ZIP filename decoding, extraction, diagnostics, path safety, and standards-compliant write expectations.
 - Added Viewer2D state ownership documentation to clarify runtime-only, user preference/config, and project/Layout definition boundaries before future offscreen rendering refactors.
 - Updated the MVR-xchange documentation with a compliance summary, supported official flows, conservative latest-request behavior, and explicit out-of-scope notes for WebSocket Mode and private live synchronization.
 

--- a/gui/mainwindow_fixture_add_flow.cpp
+++ b/gui/mainwindow_fixture_add_flow.cpp
@@ -143,10 +143,12 @@ void MainWindow::AddFixtureFromGdtfPath(const std::string &gdtfPath,
   std::string base = sceneRef.basePath;
   std::string spec = gdtfPath;
   if (!base.empty()) {
-    fs::path abs = fs::absolute(gdtfPath);
-    fs::path b = fs::absolute(base);
-    if (abs.string().rfind(b.string(), 0) == 0)
-      spec = fs::relative(abs, b).string();
+    fs::path abs = fs::absolute(PathUtils::PathFromUtf8(gdtfPath));
+    fs::path b = fs::absolute(PathUtils::PathFromUtf8(base));
+    const std::string absUtf8 = PathUtils::PathToUtf8(abs);
+    const std::string baseUtf8 = PathUtils::PathToUtf8(b);
+    if (absUtf8.rfind(baseUtf8, 0) == 0)
+      spec = PathUtils::PathToUtf8(fs::relative(abs, b));
   }
 
   auto baseId = std::chrono::steady_clock::now().time_since_epoch().count();
@@ -198,16 +200,7 @@ void MainWindow::AddFixtureFromGdtfPath(const std::string &gdtfPath,
                 .ToStdString()
           : std::string();
 
-  if (fixturePanel)
-    fixturePanel->ReloadData();
-  if (viewportPanel) {
-    viewportPanel->UpdateScene();
-    viewportPanel->Refresh();
-  }
-  if (viewport2DPanel) {
-    viewport2DPanel->UpdateScene();
-    viewport2DPanel->Refresh();
-  }
+  RefreshAfterSceneChange(true);
   if (continuousPlacement) {
     if (viewport2DPanel && viewport2DPanel->IsShownOnScreen())
       viewport2DPanel->BeginContinuousPlacement(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,6 +24,11 @@ add_library(perastage_test_path_utils STATIC
             ../core/filesystem_path_utils.cpp)
 target_include_directories(perastage_test_path_utils PRIVATE ../core)
 
+add_library(perastage_test_gdtf_archive_reader STATIC
+            ../core/gdtf_archive_reader.cpp)
+target_include_directories(perastage_test_gdtf_archive_reader PRIVATE ../core)
+target_link_libraries(perastage_test_gdtf_archive_reader PRIVATE ${wxWidgets_LIBRARIES})
+
 find_program(BASH_EXECUTABLE bash)
 if(BASH_EXECUTABLE)
     add_test(NAME DocsPerastageTreeModules
@@ -1565,6 +1570,12 @@ foreach(PERASTAGE_TEST_TARGET IN LISTS PERASTAGE_TEST_TARGETS)
         "../viewer3d/loader3ds.cpp" IN_LIST PERASTAGE_TEST_SOURCES OR
         "../viewer3d/loaderglb.cpp" IN_LIST PERASTAGE_TEST_SOURCES))
         target_link_libraries(${PERASTAGE_TEST_TARGET} PRIVATE perastage_test_path_utils)
+    endif()
+    if(NOT PERASTAGE_TEST_TARGET STREQUAL "perastage_test_gdtf_archive_reader" AND
+       PERASTAGE_TEST_SOURCES AND
+       "../viewer3d/gdtfloader.cpp" IN_LIST PERASTAGE_TEST_SOURCES AND
+       NOT ("../core/gdtf_archive_reader.cpp" IN_LIST PERASTAGE_TEST_SOURCES))
+        target_link_libraries(${PERASTAGE_TEST_TARGET} PRIVATE perastage_test_gdtf_archive_reader)
     endif()
 endforeach()
 

--- a/tests/gdtf_read_services_test.cpp
+++ b/tests/gdtf_read_services_test.cpp
@@ -506,6 +506,30 @@ static void TestUnicodeZipWriteMetadata(const fs::path &dir) {
   assert(read.utf8FlagMissingEntryCount == 0);
 }
 
+// Verifies Unicode fallback filenames extract to native filesystem paths.
+static void TestUnicodeZipExtractionCompatibility(const fs::path &dir) {
+  const std::string unicodeName =
+      "wheels/191130000002 FINE 360 BEAM Φ113金属图案盘二 02.png";
+  const fs::path archivePath = dir / "unicode_extract_missing_flag.gdtf";
+  assert(WriteArchive(
+      archivePath, {{unicodeName, "png"}, {"description.xml", GdtfXml("")}}));
+  PatchUtf8Flags(archivePath, false);
+
+  const fs::path extractedRoot = dir / "extracted_unicode";
+  gdtf::ArchiveReadResult result =
+      gdtf::ExtractGdtfArchive(archivePath, extractedRoot);
+  assert(!result.entries.empty());
+  assert(result.utf8FlagMissingEntryCount == 1);
+  assert(HasArchiveDiagnostic(result,
+                              gdtf::ArchiveDiagnosticCode::Utf8FallbackUsed));
+  std::u8string relativeUtf8;
+  relativeUtf8.reserve(unicodeName.size());
+  for (char ch : unicodeName)
+    relativeUtf8.push_back(static_cast<char8_t>(ch));
+  assert(fs::is_regular_file(extractedRoot / fs::path(relativeUtf8)));
+  assert(fs::is_regular_file(extractedRoot / "description.xml"));
+}
+
 // Runs focused read-layer regression tests using temporary archives only.
 int main() {
   wxInitializer initializer;
@@ -523,6 +547,7 @@ int main() {
   TestUnknownUnicodeAndSummary(dir);
   TestUnicodeZipFilenameCompatibility(dir);
   TestUnicodeZipWriteMetadata(dir);
+  TestUnicodeZipExtractionCompatibility(dir);
 
   fs::remove_all(dir);
   return 0;

--- a/tests/gdtf_read_services_test.cpp
+++ b/tests/gdtf_read_services_test.cpp
@@ -1,6 +1,9 @@
 #include <cassert>
 #include <cmath>
+#include <cstdint>
 #include <filesystem>
+#include <fstream>
+#include <iterator>
 #include <string>
 #include <vector>
 
@@ -14,9 +17,83 @@
 
 namespace fs = std::filesystem;
 
+// Reads a whole binary file into memory for ZIP metadata assertions.
+static std::vector<unsigned char> ReadBinary(const fs::path &path) {
+  std::ifstream input(path, std::ios::binary);
+  return std::vector<unsigned char>((std::istreambuf_iterator<char>(input)),
+                                    {});
+}
+
+// Writes a whole binary file after in-place ZIP metadata patching.
+static void WriteBinary(const fs::path &path,
+                        const std::vector<unsigned char> &data) {
+  std::ofstream output(path, std::ios::binary | std::ios::trunc);
+  output.write(reinterpret_cast<const char *>(data.data()),
+               static_cast<std::streamsize>(data.size()));
+}
+
+// Reads a little-endian 32-bit integer from ZIP test data.
+static uint32_t ReadLe32(const std::vector<unsigned char> &data,
+                         size_t offset) {
+  return static_cast<uint32_t>(data[offset]) |
+         (static_cast<uint32_t>(data[offset + 1]) << 8) |
+         (static_cast<uint32_t>(data[offset + 2]) << 16) |
+         (static_cast<uint32_t>(data[offset + 3]) << 24);
+}
+
+// Reads a little-endian 16-bit integer from ZIP test data.
+static uint16_t ReadLe16(const std::vector<unsigned char> &data,
+                         size_t offset) {
+  return static_cast<uint16_t>(data[offset]) |
+         (static_cast<uint16_t>(data[offset + 1]) << 8);
+}
+
+// Writes a little-endian 16-bit integer to ZIP test data.
+static void WriteLe16(std::vector<unsigned char> &data, size_t offset,
+                      uint16_t value) {
+  data[offset] = static_cast<unsigned char>(value & 0xff);
+  data[offset + 1] = static_cast<unsigned char>((value >> 8) & 0xff);
+}
+
+// Forces or clears the ZIP UTF-8 filename flag in local and central headers.
+static void PatchUtf8Flags(const fs::path &path, bool enabled) {
+  std::vector<unsigned char> data = ReadBinary(path);
+  for (size_t i = 0; i + 46 <= data.size(); ++i) {
+    const uint32_t signature = ReadLe32(data, i);
+    if (signature != 0x04034b50 && signature != 0x02014b50)
+      continue;
+    const size_t flagOffset = i + (signature == 0x04034b50 ? 6 : 8);
+    uint16_t flags = ReadLe16(data, flagOffset);
+    if (enabled)
+      flags = static_cast<uint16_t>(flags | (1u << 11));
+    else
+      flags = static_cast<uint16_t>(flags & ~(1u << 11));
+    WriteLe16(data, flagOffset, flags);
+  }
+  WriteBinary(path, data);
+}
+
+// Reports whether all ZIP central-directory entries consistently use UTF-8
+// flags.
+static bool CentralDirectoryUtf8FlagsMatch(const fs::path &path,
+                                           bool expected) {
+  const std::vector<unsigned char> data = ReadBinary(path);
+  bool sawCentralEntry = false;
+  for (size_t i = 0; i + 46 <= data.size(); ++i) {
+    if (ReadLe32(data, i) != 0x02014b50)
+      continue;
+    sawCentralEntry = true;
+    const bool hasFlag = (ReadLe16(data, i + 8) & (1u << 11)) != 0;
+    if (hasFlag != expected)
+      return false;
+  }
+  return sawCentralEntry;
+}
+
 // Writes a ZIP/GDTF archive with the requested text entries.
-static bool WriteArchive(const fs::path &path,
-                         const std::vector<std::pair<std::string, std::string>> &entries) {
+static bool
+WriteArchive(const fs::path &path,
+             const std::vector<std::pair<std::string, std::string>> &entries) {
   wxFileOutputStream output(wxString::FromUTF8(path.generic_string().c_str()));
   if (!output.IsOk())
     return false;
@@ -53,9 +130,11 @@ static bool HasArchiveDiagnostic(const gdtf::ArchiveReadResult &read,
   return false;
 }
 
-// Reports whether a description snapshot contains the requested diagnostic code.
-static bool HasDescriptionDiagnostic(const gdtf::GdtfDescriptionSnapshot &snapshot,
-                                     gdtf::DescriptionDiagnosticCode code) {
+// Reports whether a description snapshot contains the requested diagnostic
+// code.
+static bool
+HasDescriptionDiagnostic(const gdtf::GdtfDescriptionSnapshot &snapshot,
+                         gdtf::DescriptionDiagnosticCode code) {
   for (const auto &diagnostic : snapshot.diagnostics) {
     if (diagnostic.code == code)
       return true;
@@ -63,7 +142,8 @@ static bool HasDescriptionDiagnostic(const gdtf::GdtfDescriptionSnapshot &snapsh
   return false;
 }
 
-// Verifies two floating point values are close enough for parsed metadata tests.
+// Verifies two floating point values are close enough for parsed metadata
+// tests.
 static bool NearlyEqual(float left, float right) {
   return std::fabs(left - right) < 0.001f;
 }
@@ -106,8 +186,8 @@ static void TestArchiveLookup(const fs::path &dir) {
   assert(!read.Success());
   bool foundAmbiguous = false;
   for (const auto &diagnostic : read.diagnostics)
-    foundAmbiguous |= diagnostic.code ==
-                      gdtf::ArchiveDiagnosticCode::AmbiguousDescriptionXml;
+    foundAmbiguous |=
+        diagnostic.code == gdtf::ArchiveDiagnosticCode::AmbiguousDescriptionXml;
   assert(foundAmbiguous);
 
   const fs::path zeroBytes = dir / "zero_bytes.gdtf";
@@ -115,16 +195,20 @@ static void TestArchiveLookup(const fs::path &dir) {
   read = gdtf::ReadGdtfArchive(zeroBytes);
   assert(!read.Success());
   assert(read.descriptionEntryPath == "description.xml");
-  assert(HasArchiveDiagnostic(read, gdtf::ArchiveDiagnosticCode::EmptyDescriptionXml));
-  assert(!HasArchiveDiagnostic(read, gdtf::ArchiveDiagnosticCode::MissingDescriptionXml));
+  assert(HasArchiveDiagnostic(
+      read, gdtf::ArchiveDiagnosticCode::EmptyDescriptionXml));
+  assert(!HasArchiveDiagnostic(
+      read, gdtf::ArchiveDiagnosticCode::MissingDescriptionXml));
 
   const fs::path whitespace = dir / "whitespace.gdtf";
   assert(WriteArchive(whitespace, {{"description.xml", " \n\t"}}));
   read = gdtf::ReadGdtfArchive(whitespace);
   assert(!read.Success());
   assert(read.descriptionEntryPath == "description.xml");
-  assert(HasArchiveDiagnostic(read, gdtf::ArchiveDiagnosticCode::EmptyDescriptionXml));
-  assert(!HasArchiveDiagnostic(read, gdtf::ArchiveDiagnosticCode::MissingDescriptionXml));
+  assert(HasArchiveDiagnostic(
+      read, gdtf::ArchiveDiagnosticCode::EmptyDescriptionXml));
+  assert(!HasArchiveDiagnostic(
+      read, gdtf::ArchiveDiagnosticCode::MissingDescriptionXml));
 }
 
 // Verifies malformed and incomplete description documents are diagnosed.
@@ -154,18 +238,17 @@ static void TestPowerParsing() {
     return gdtf::ReadGdtfDescription(GdtfXml(content));
   };
 
-  gdtf::GdtfDescriptionSnapshot snapshot = readPower(
-      "<PhysicalDescriptions><Properties>"
-      "<PowerConsumption Value=\"120\"/>"
-      "</Properties></PhysicalDescriptions>");
+  gdtf::GdtfDescriptionSnapshot snapshot =
+      readPower("<PhysicalDescriptions><Properties>"
+                "<PowerConsumption Value=\"120\"/>"
+                "</Properties></PhysicalDescriptions>");
   assert(snapshot.powerConsumptionWPresent);
   assert(NearlyEqual(snapshot.powerConsumptionW, 120.0f));
 
-  snapshot = readPower(
-      "<PhysicalDescriptions><Properties>"
-      "<PowerConsumption Value=\"120\"/>"
-      "<PowerConsumption Value=\"30.5\"/>"
-      "</Properties></PhysicalDescriptions>");
+  snapshot = readPower("<PhysicalDescriptions><Properties>"
+                       "<PowerConsumption Value=\"120\"/>"
+                       "<PowerConsumption Value=\"30.5\"/>"
+                       "</Properties></PhysicalDescriptions>");
   assert(snapshot.powerConsumptionWPresent);
   assert(NearlyEqual(snapshot.powerConsumptionW, 150.5f));
 
@@ -208,12 +291,15 @@ static void TestPowerParsing() {
 
 // Verifies ordered metadata, revisions, and DMX modes are preserved.
 static void TestOrderedDocumentData() {
-  const std::string xml = GdtfXml(
-      "<Revisions>"
-      "<Revision Text=\"Initial\" Date=\"2026-01-03T04:05:06\" UserID=\"7\" ModifiedBy=\"A\"/>"
-      "<Revision Text=\"Updated\" Date=\"2026-01-04T05:06:07Z\" UserID=\"8\" ModifiedBy=\"B\"/>"
-      "</Revisions>"
-      "<DMXModes><DMXMode Name=\"Standard\"/><DMXMode Name=\"Extended\"/></DMXModes>");
+  const std::string xml =
+      GdtfXml("<Revisions>"
+              "<Revision Text=\"Initial\" Date=\"2026-01-03T04:05:06\" "
+              "UserID=\"7\" ModifiedBy=\"A\"/>"
+              "<Revision Text=\"Updated\" Date=\"2026-01-04T05:06:07Z\" "
+              "UserID=\"8\" ModifiedBy=\"B\"/>"
+              "</Revisions>"
+              "<DMXModes><DMXMode Name=\"Standard\"/><DMXMode "
+              "Name=\"Extended\"/></DMXModes>");
   gdtf::GdtfDescriptionSnapshot snapshot = gdtf::ReadGdtfDescription(xml);
   assert(snapshot.Success());
   assert(snapshot.dataVersion == "1.2");
@@ -222,22 +308,23 @@ static void TestOrderedDocumentData() {
   assert(snapshot.revisions.size() == 2);
   assert(snapshot.revisions[0].text == "Initial");
   assert(snapshot.revisions[1].modifiedBy == "B");
-  assert((snapshot.dmxModeNames == std::vector<std::string>{"Standard", "Extended"}));
+  assert((snapshot.dmxModeNames ==
+          std::vector<std::string>{"Standard", "Extended"}));
 }
 
 // Verifies repeated wheels and ordered gobo slot references remain independent.
 static void TestGoboWheelCollections() {
-  const std::string xml = GdtfXml(
-      "<Wheels>"
-      "<Wheel Name=\"Gobo Wheel A\">"
-      "<Slot Name=\"Open A\" MediaFileName=\"a_open\"/>"
-      "<Slot Name=\"Breakup A\" MediaFileName=\"a_breakup\"/>"
-      "</Wheel>"
-      "<Wheel Name=\"Gobo Wheel B\">"
-      "<Slot Name=\"Open B\" MediaFileName=\"b_open\"/>"
-      "<Slot Name=\"Dots B\" MediaFileName=\"b_dots\"/>"
-      "</Wheel>"
-      "</Wheels>");
+  const std::string xml =
+      GdtfXml("<Wheels>"
+              "<Wheel Name=\"Gobo Wheel A\">"
+              "<Slot Name=\"Open A\" MediaFileName=\"a_open\"/>"
+              "<Slot Name=\"Breakup A\" MediaFileName=\"a_breakup\"/>"
+              "</Wheel>"
+              "<Wheel Name=\"Gobo Wheel B\">"
+              "<Slot Name=\"Open B\" MediaFileName=\"b_open\"/>"
+              "<Slot Name=\"Dots B\" MediaFileName=\"b_dots\"/>"
+              "</Wheel>"
+              "</Wheels>");
   gdtf::GdtfDescriptionSnapshot snapshot = gdtf::ReadGdtfDescription(
       xml, {"description.xml", "wheels/a_open.png", "wheels/a_breakup.png",
             "wheels/b_open.png", "wheels/b_dots.png"});
@@ -249,62 +336,68 @@ static void TestGoboWheelCollections() {
   assert(snapshot.wheels[1].slots.size() == 2);
   assert(snapshot.wheels[0].slots[1].mediaFileName == "a_breakup");
   assert(snapshot.wheels[1].slots[1].mediaFileName == "b_dots");
-  assert(!HasDescriptionDiagnostic(snapshot,
-                                   gdtf::DescriptionDiagnosticCode::MissingWheelMediaResource));
+  assert(!HasDescriptionDiagnostic(
+      snapshot, gdtf::DescriptionDiagnosticCode::MissingWheelMediaResource));
 }
 
 // Verifies GDTF wheel MediaFileName resource lookup uses wheels basenames.
 static void TestWheelMediaResolution() {
-  const std::string xml = GdtfXml(
-      "<Wheels><Wheel Name=\"Gobo\"><Slot Name=\"Slot\" MediaFileName=\"Gobo1\"/>"
-      "</Wheel></Wheels>");
+  const std::string xml = GdtfXml("<Wheels><Wheel Name=\"Gobo\"><Slot "
+                                  "Name=\"Slot\" MediaFileName=\"Gobo1\"/>"
+                                  "</Wheel></Wheels>");
 
   gdtf::GdtfDescriptionSnapshot snapshot =
       gdtf::ReadGdtfDescription(xml, {"description.xml", "wheels/Gobo1.png"});
   assert(snapshot.Success());
-  assert(!HasDescriptionDiagnostic(snapshot,
-                                   gdtf::DescriptionDiagnosticCode::MissingWheelMediaResource));
+  assert(!HasDescriptionDiagnostic(
+      snapshot, gdtf::DescriptionDiagnosticCode::MissingWheelMediaResource));
   assert(snapshot.wheels[0].slots[0].mediaFileName == "Gobo1");
 
   snapshot =
       gdtf::ReadGdtfDescription(xml, {"description.xml", "wheels/Gobo1.svg"});
   assert(snapshot.Success());
-  assert(!HasDescriptionDiagnostic(snapshot,
-                                   gdtf::DescriptionDiagnosticCode::MissingWheelMediaResource));
+  assert(!HasDescriptionDiagnostic(
+      snapshot, gdtf::DescriptionDiagnosticCode::MissingWheelMediaResource));
 
-  snapshot =
-      gdtf::ReadGdtfDescription(xml, {"description.xml", "resources/Gobo1.png"});
-  assert(HasDescriptionDiagnostic(snapshot,
-                                  gdtf::DescriptionDiagnosticCode::MissingWheelMediaResource));
+  snapshot = gdtf::ReadGdtfDescription(
+      xml, {"description.xml", "resources/Gobo1.png"});
+  assert(HasDescriptionDiagnostic(
+      snapshot, gdtf::DescriptionDiagnosticCode::MissingWheelMediaResource));
 
   snapshot = gdtf::ReadGdtfDescription(
       xml, {"description.xml", "wheels/Gobo1.png", "wheels/Gobo1.svg"});
-  assert(HasDescriptionDiagnostic(snapshot,
-                                  gdtf::DescriptionDiagnosticCode::AmbiguousWheelMediaResource));
+  assert(HasDescriptionDiagnostic(
+      snapshot, gdtf::DescriptionDiagnosticCode::AmbiguousWheelMediaResource));
 
   snapshot =
       gdtf::ReadGdtfDescription(xml, {"description.xml", "wheels/gobo1.png"});
   assert(HasDescriptionDiagnostic(
-      snapshot, gdtf::DescriptionDiagnosticCode::NonCanonicalWheelMediaCaseMatch));
+      snapshot,
+      gdtf::DescriptionDiagnosticCode::NonCanonicalWheelMediaCaseMatch));
 }
 
-// Verifies unknown content remains non-fatal and metadata summary stays compatible.
+// Verifies unknown content remains non-fatal and metadata summary stays
+// compatible.
 static void TestUnknownUnicodeAndSummary(const fs::path &dir) {
-  const std::string xml = GdtfXml(
-      "<CustomVendorNode CustomAttribute=\"kept\"/>"
-      "<Revisions>"
-      "<Revision Text=\"Initial\" Date=\"2026-01-03T04:05:06\" UserID=\"42\" ModifiedBy=\"Tester\"/>"
-      "<Revision Text=\"Updated\" Date=\"2026-01-04T05:06:07Z\" UserID=\"43\" ModifiedBy=\"Maintainer\"/>"
-      "</Revisions>");
+  const std::string xml =
+      GdtfXml("<CustomVendorNode CustomAttribute=\"kept\"/>"
+              "<Revisions>"
+              "<Revision Text=\"Initial\" Date=\"2026-01-03T04:05:06\" "
+              "UserID=\"42\" ModifiedBy=\"Tester\"/>"
+              "<Revision Text=\"Updated\" Date=\"2026-01-04T05:06:07Z\" "
+              "UserID=\"43\" ModifiedBy=\"Maintainer\"/>"
+              "</Revisions>");
   gdtf::GdtfDescriptionSnapshot snapshot = gdtf::ReadGdtfDescription(xml);
   assert(snapshot.Success());
   bool foundUnknown = false;
   for (const auto &diagnostic : snapshot.diagnostics)
-    foundUnknown |= diagnostic.code == gdtf::DescriptionDiagnosticCode::UnknownElement;
+    foundUnknown |=
+        diagnostic.code == gdtf::DescriptionDiagnosticCode::UnknownElement;
   assert(foundUnknown);
 
   const fs::path unicodePath = dir / std::string("metadata_ñ_测试.gdtf");
-  assert(WriteArchive(unicodePath, {{std::string("assets/ñ.txt"), "ok"}, {"description.xml", xml}}));
+  assert(WriteArchive(unicodePath, {{std::string("assets/ñ.txt"), "ok"},
+                                    {"description.xml", xml}}));
   gdtf::ArchiveReadResult read = gdtf::ReadGdtfArchive(unicodePath);
   assert(read.Success());
   bool foundUnicodeEntry = false;
@@ -324,6 +417,95 @@ static void TestUnknownUnicodeAndSummary(const fs::path &dir) {
   assert(summary.version == "1.2");
 }
 
+// Verifies ZIP filename UTF-8 compatibility fallback and strict invalid-name
+// diagnostics.
+static void TestUnicodeZipFilenameCompatibility(const fs::path &dir) {
+  const std::string unicodeName =
+      "wheels/191130000002 FINE 360 BEAM Φ113金属图案盘二 02.png";
+  const std::string mediaName =
+      "191130000002 FINE 360 BEAM Φ113金属图案盘二 02";
+  const std::string xml = GdtfXml(
+      "<Wheels><Wheel Name=\"Gobo\"><Slot Name=\"Unicode\" MediaFileName=\"" +
+      mediaName +
+      "\"/></Wheel></Wheels>"
+      "<DMXModes><DMXMode Name=\"16BT \"/></DMXModes>");
+
+  const fs::path missingFlag = dir / "unicode_missing_flag.gdtf";
+  assert(WriteArchive(missingFlag,
+                      {{unicodeName, "png"}, {"description.xml", xml}}));
+  PatchUtf8Flags(missingFlag, false);
+  gdtf::ArchiveReadResult read = gdtf::ReadGdtfArchive(missingFlag);
+  assert(read.Success());
+  assert(read.utf8FlagMissingEntryCount == 1);
+  assert(HasArchiveDiagnostic(read,
+                              gdtf::ArchiveDiagnosticCode::Utf8FallbackUsed));
+  bool foundUnicodeEntry = false;
+  for (const auto &entry : read.entries) {
+    foundUnicodeEntry |=
+        entry.path == unicodeName && entry.nameUsedUtf8CompatibilityFallback;
+  }
+  assert(foundUnicodeEntry);
+  assert(read.descriptionEntryPath == "description.xml");
+
+  std::vector<std::string> paths;
+  for (const auto &entry : read.entries)
+    paths.push_back(entry.path);
+  gdtf::GdtfDescriptionSnapshot snapshot =
+      gdtf::ReadGdtfDescription(read.descriptionXml, paths);
+  assert(snapshot.Success());
+  assert(snapshot.dmxModeNames.size() == 1);
+  assert(snapshot.dmxModeNames[0] == "16BT ");
+  assert(!HasDescriptionDiagnostic(
+      snapshot, gdtf::DescriptionDiagnosticCode::MissingWheelMediaResource));
+
+  const fs::path utf8Flag = dir / "unicode_with_flag.gdtf";
+  assert(
+      WriteArchive(utf8Flag, {{unicodeName, "png"}, {"description.xml", xml}}));
+  PatchUtf8Flags(utf8Flag, true);
+  read = gdtf::ReadGdtfArchive(utf8Flag);
+  assert(read.Success());
+  assert(read.utf8FlagMissingEntryCount == 0);
+  assert(!HasArchiveDiagnostic(read,
+                               gdtf::ArchiveDiagnosticCode::Utf8FallbackUsed));
+
+  const fs::path asciiNoFlag = dir / "ascii_no_flag.gdtf";
+  assert(WriteArchive(asciiNoFlag, {{"wheels/plain.png", "png"},
+                                    {"description.xml", GdtfXml("")}}));
+  PatchUtf8Flags(asciiNoFlag, false);
+  read = gdtf::ReadGdtfArchive(asciiNoFlag);
+  assert(read.Success());
+  assert(read.utf8FlagMissingEntryCount == 0);
+  assert(!HasArchiveDiagnostic(read,
+                               gdtf::ArchiveDiagnosticCode::Utf8FallbackUsed));
+
+  const fs::path invalidFlagged = dir / "invalid_flagged.gdtf";
+  assert(WriteArchive(invalidFlagged,
+                      {{unicodeName, "png"}, {"description.xml", xml}}));
+  std::vector<unsigned char> data = ReadBinary(invalidFlagged);
+  for (size_t i = 0; i + unicodeName.size() <= data.size(); ++i) {
+    if (std::equal(unicodeName.begin(), unicodeName.end(), data.begin() + i))
+      data[i] = 0xff;
+  }
+  WriteBinary(invalidFlagged, data);
+  PatchUtf8Flags(invalidFlagged, true);
+  read = gdtf::ReadGdtfArchive(invalidFlagged);
+  assert(!read.Success());
+  assert(HasArchiveDiagnostic(
+      read, gdtf::ArchiveDiagnosticCode::FilenameDecodeFailed));
+}
+
+// Verifies Perastage-created ZIP entries carry UTF-8 filename metadata for
+// Unicode names.
+static void TestUnicodeZipWriteMetadata(const fs::path &dir) {
+  const fs::path path = dir / "unicode_written.gdtf";
+  assert(WriteArchive(path, {{"wheels/Φ113金属图案盘二.png", "png"},
+                             {"description.xml", GdtfXml("")}}));
+  assert(CentralDirectoryUtf8FlagsMatch(path, true));
+  gdtf::ArchiveReadResult read = gdtf::ReadGdtfArchive(path);
+  assert(read.Success());
+  assert(read.utf8FlagMissingEntryCount == 0);
+}
+
 // Runs focused read-layer regression tests using temporary archives only.
 int main() {
   wxInitializer initializer;
@@ -339,6 +521,8 @@ int main() {
   TestGoboWheelCollections();
   TestWheelMediaResolution();
   TestUnknownUnicodeAndSummary(dir);
+  TestUnicodeZipFilenameCompatibility(dir);
+  TestUnicodeZipWriteMetadata(dir);
 
   fs::remove_all(dir);
   return 0;

--- a/viewer3d/gdtfloader.cpp
+++ b/viewer3d/gdtfloader.cpp
@@ -17,6 +17,7 @@
  */
 #include "gdtfloader.h"
 #include "filesystem_path_utils.h"
+#include "gdtf_archive_reader.h"
 #include "gdtf_mutation_audit.h"
 #include "gdtf_canonicalizer.h"
 #include "loader3ds.h"
@@ -428,67 +429,39 @@ private:
 // Extracts a ZIP archive into a destination directory while skipping unsafe paths.
 static bool ExtractZip(const std::string& zipPath, const std::string& destDir)
 {
-    std::error_code ec;
-    if (!fs::exists(PathUtils::PathFromUtf8(zipPath), ec) || ec) {
-        if (ConsolePanel::Instance()) {
-            wxString msg = wxString::Format("GDTF: cannot open %s", wxString::FromUTF8(zipPath));
+    const fs::path sourcePath = PathUtils::PathFromUtf8(zipPath);
+    const fs::path destinationRoot = PathUtils::PathFromUtf8(destDir);
+    const gdtf::ArchiveReadResult result =
+        gdtf::ExtractGdtfArchive(sourcePath, destinationRoot);
+    if (ConsolePanel::Instance()) {
+        for (const gdtf::ArchiveDiagnostic& diagnostic : result.diagnostics) {
+            if (diagnostic.code == gdtf::ArchiveDiagnosticCode::None)
+                continue;
+            wxString msg = wxString::Format(
+                "GDTF: %s%s",
+                wxString::FromUTF8(diagnostic.message),
+                diagnostic.entryPath.empty()
+                    ? wxString()
+                    : wxString::Format(" (%s)",
+                                       wxString::FromUTF8(diagnostic.entryPath)));
             ConsolePanel::Instance()->AppendMessage(msg);
         }
-        return false;
     }
-    wxLogNull logNo;
-    wxFileInputStream input(zipPath);
-    if (!input.IsOk()) {
-        if (ConsolePanel::Instance()) {
-            wxString msg = wxString::Format("GDTF: cannot open %s", wxString::FromUTF8(zipPath));
-            ConsolePanel::Instance()->AppendMessage(msg);
-        }
-        return false;
-    }
-    wxZipInputStream zipStream(input);
-    std::unique_ptr<wxZipEntry> entry;
-    while ((entry.reset(zipStream.GetNextEntry())), entry) {
-        std::string filename = entry->GetName().ToStdString();
-        std::replace(filename.begin(), filename.end(), '\\', '/');
-        fs::path relativeEntryPath = PathUtils::PathFromUtf8(filename);
-        if (filename.empty() || relativeEntryPath.is_absolute() ||
-            relativeEntryPath.has_root_name() ||
-            filename.find(':') != std::string::npos ||
-            std::any_of(relativeEntryPath.begin(), relativeEntryPath.end(),
-                        [](const fs::path& part) { return part == ".."; })) {
-            if (ConsolePanel::Instance()) {
-                wxString msg = wxString::Format("GDTF: skipped unsafe archive entry %s", wxString::FromUTF8(filename));
-                ConsolePanel::Instance()->AppendMessage(msg);
-            }
-            continue;
-        }
-        fs::path destinationPath = PathUtils::PathFromUtf8(destDir) / relativeEntryPath;
-        std::string fullPath = destinationPath.string();
-        
-        if (entry->IsDir()) {
-            wxFileName::Mkdir(fullPath, wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
-            continue;
-        }
-        wxFileName::Mkdir(wxFileName(fullPath).GetPath(), wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
-        std::ofstream output(fullPath, std::ios::binary);
-        if (!output.is_open()) {
-            if (ConsolePanel::Instance()) {
-                wxString msg = wxString::Format("GDTF: cannot create %s", wxString::FromUTF8(fullPath));
-                ConsolePanel::Instance()->AppendMessage(msg);
-            }
-            return false;
-        }
-        char buffer[4096];
-        while (true) {
-            zipStream.Read(buffer, sizeof(buffer));
-            size_t bytes = zipStream.LastRead();
-            if (bytes == 0)
-                break;
-            output.write(buffer, bytes);
-        }
-        output.close();
-    }
-    return true;
+    const bool hasFatalDiagnostic =
+        std::any_of(result.diagnostics.begin(), result.diagnostics.end(),
+                    [](const gdtf::ArchiveDiagnostic& diagnostic) {
+                        switch (diagnostic.code) {
+                        case gdtf::ArchiveDiagnosticCode::None:
+                        case gdtf::ArchiveDiagnosticCode::NonCanonicalDescriptionXml:
+                        case gdtf::ArchiveDiagnosticCode::Utf8FlagMissing:
+                        case gdtf::ArchiveDiagnosticCode::Utf8FallbackUsed:
+                        case gdtf::ArchiveDiagnosticCode::LegacyFilenameEncodingUsed:
+                            return false;
+                        default:
+                            return true;
+                        }
+                    });
+    return !result.entries.empty() && !hasFatalDiagnostic;
 }
 
 // Finds the extracted description.xml using the tolerant read priority.
@@ -1193,7 +1166,7 @@ static bool ComputeGdtfContentHash(const fs::path& absPath, uint64_t& hash)
 static std::string BuildGdtfStableCacheKey(const fs::path& absPath, uint64_t hash)
 {
     std::ostringstream oss;
-    oss << absPath.filename().string() << '|'
+    oss << PathUtils::PathToUtf8(absPath.filename()) << '|'
         << std::hex << std::setw(16) << std::setfill('0') << hash;
     return oss.str();
 }
@@ -1221,7 +1194,7 @@ static GdtfCacheEntry* GetCachedGdtf(const std::string& gdtfPath,
     }
 
     std::error_code ec;
-    fs::path absPath = fs::absolute(gdtfPath, ec);
+    fs::path absPath = fs::absolute(PathUtils::PathFromUtf8(gdtfPath), ec);
     if (ec)
     {
         setReason("Cannot resolve absolute GDTF path");
@@ -1284,7 +1257,7 @@ static GdtfCacheEntry* GetCachedGdtf(const std::string& gdtfPath,
 
     GdtfCacheEntry entry;
     entry.timestamp = timestamp;
-    TempExtraction extraction(absPath.string());
+    TempExtraction extraction(PathUtils::PathToUtf8(absPath));
     if (!extraction.IsValid()) {
         g_failedGdtfCache[stableKey] = timestamp;
         setReason("Unable to extract GDTF archive (corrupted or unreadable file)");


### PR DESCRIPTION
### Motivation
- The archive reader could throw or mis-decode Unicode resource filenames when a GDTF ZIP contained UTF‑8 bytes but omitted the ZIP UTF‑8 filename flag, causing insertion failures and exceptions on Windows; the change implements a tolerant, non‑mutating read policy to recover valid UTF‑8 names safely.
- Apply a single decoding policy used by all read paths so description lookup, resource resolution, previews, and later filesystem operations observe the same behavior and no decoding exception escapes the public reader boundary.

### Description
- Added raw central‑directory parsing and a shared entry-name decoder that reads raw filename bytes, inspects the ZIP UTF‑8 flag, validates UTF‑8, and applies the compatibility fallback policy (strict UTF‑8 if flagged, accept ASCII unflagged silently, accept valid UTF‑8 bytes without the flag and mark as fallback, reject undecodable/ambiguous names); integrated decoding into `ReadGdtfArchive` before path normalization and safety checks.
- Introduced structured diagnostics and result metadata for the new cases, including aggregate `utf8FlagMissingEntryCount`, `Utf8FallbackUsed`/`FilenameDecodeFailed` diagnostics, and per‑entry `nameUsedUtf8CompatibilityFallback` tracking so callers can report one concise warning per archive.
- Kept reads non‑mutating and preserved path safety; updated tests and documentation: added generated‑archive regression coverage in `tests/gdtf_read_services_test.cpp`, new doc `docs/gdtf_unicode_zip_filename_compatibility.md`, and a release‑note entry in `docs/release-notes-draft.md`.
- Changed files: `core/gdtf_archive_reader.cpp`, `core/gdtf_archive_reader.h`, `tests/gdtf_read_services_test.cpp`, `docs/gdtf_unicode_zip_filename_compatibility.md`, and `docs/release-notes-draft.md`.

### Testing
- Ran `bash tests/check_perastage_tree_modules.sh` and `bash tests/check_no_configmanager_get_in_gui.sh`; both succeeded.
- Ran `git diff --check` to ensure no whitespace/overlap issues; this passed.
- Attempted to configure and build tests with `cmake -S . -B build -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DPERASTAGE_ENABLE_MVR_XCHANGE_MDNS=OFF`, but configuration could not complete in this environment because the wxWidgets development files are not installed, so the new/modified `gdtf_read_services_test` binary was not built or executed here.
- Added deterministic regression tests that exercise: ASCII/no‑flag, flagged UTF‑8, valid UTF‑8 without flag (fallback), Greek/Chinese name recovery, single aggregate warning emission, `description.xml` after Unicode entries, wheel resource resolution via fallback, invalid flagged UTF‑8 failing with a diagnostic, and that Perastage‑written Unicode ZIPs include UTF‑8 filename metadata; these tests are included in the PR but were not run in this container due to missing wxWidgets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e4dfce1e48324be141a58df67d652)