### PR TITLE
Complete reusable GDTF editor panels (Checkpoint 05B–D)

### DIFF
--- a/docs/internal/gdtf_editor_architecture_audit.md
+++ b/docs/internal/gdtf_editor_architecture_audit.md
@@ -182,3 +182,19 @@ Checkpoint 05A starts the reusable GUI migration without creating the complete `
 Metadata source-path resolution remains owned by the existing host dialogs. `FixtureEditDialog` still resolves the current fixture GDTF path from its edit control or table row, and `TrussEditDialog` still resolves the current truss GDTF path through the scene truss resource reference. Metadata loading remains in `core/` through `LoadGdtfMetadataSummary(...)`; the reusable panel receives an already loaded `GdtfMetadataSummary` or an unavailable-state command.
 
 Fixture Edit and Truss Edit now share one metadata presentation component. Their Apply/OK behavior, physical-property mutation, derivative creation, truss GDTF generation, table writes, undo state, previews, viewer refresh, and hoist/load recalculation behavior are unchanged. The next approved reusable panel extraction is `GdtfPhysicalPropertiesPanel`.
+
+## Checkpoint 05 completion: reusable editor panels
+
+Checkpoint 05A introduced the reusable read-only `GdtfMetadataPanel`. Checkpoint 05B, 05C, and 05D complete the remaining reusable GDTF panel extraction for the current Fixture Edit and Truss Edit dialogs.
+
+- `GdtfPhysicalPropertiesPanel` presents typed physical/type fields using `GdtfPhysicalPropertyField` values for power consumption, weight, length, width, height, and cross section.
+- `GdtfTypeIdentityPanel` presents typed identity/source fields using `GdtfTypeIdentityField` values for fixture type name, manufacturer, model name, and source file reference.
+- `GdtfModesPanel` presents ordered mode selection, derived channel count, and read-only channel rows. It keeps exact mode strings and exposes only user mode-selection callbacks.
+
+Programmatic setters and panel configuration are non-notifying so dialog initialization, metadata refresh, source browsing updates, and post-apply refreshes do not create false modifications. User edits are reported through typed field callbacks and are translated by the host dialogs to the existing fixture or truss column semantics.
+
+Fixture Edit now composes metadata, type/source, physical properties, and modes as reusable GDTF panels. Category, visual color, MVR color, patch, transform, layer, hang position, fixture ID, and instance name remain host/project fields. Fixture physical writes, derivative creation, revision audit, shared type propagation, mode application, table resync, scene updates, hoist recalculation, and viewer refresh remain host-owned.
+
+Truss Edit now composes metadata, manufacturer/model identity, and physical/type fields as reusable GDTF panels. MVR instance fields remain outside common GDTF panels. Truss generation, table and scene update ordering, undo behavior, generated source/model updates, metadata refresh, preview refresh, and viewer refresh remain host-owned.
+
+Checkpoint 05 is complete after these reusable panels. Checkpoint 06 is next: compose the reusable panels into `GdtfEditorPanel` without introducing session/apply adapters yet.

--- a/docs/internal/gdtf_editor_context_boundaries.md
+++ b/docs/internal/gdtf_editor_context_boundaries.md
@@ -145,3 +145,15 @@ Checkpoint 05A begins the reusable GUI migration by extracting `GdtfMetadataPane
 Host dialogs continue to own source-path resolution and call `LoadGdtfMetadataSummary(...)` from `core/`. Fixture Edit and Truss Edit then pass the loaded `GdtfMetadataSummary` into the panel or call `SetUnavailable()` when loading fails. No mutation or apply semantics changed in this checkpoint, and the complete `GdtfEditorPanel` remains out of scope.
 
 The next approved panel extraction is `GdtfPhysicalPropertiesPanel`, keeping the existing project-host apply semantics intact until a later context-adapter migration.
+
+## Reusable GUI panel boundary after Checkpoint 05
+
+Checkpoint 05 is complete with four reusable GUI panels under `gui/gdtf/`: the previously merged `GdtfMetadataPanel` plus the new physical properties, type identity, and modes panels. These panels are wxWidgets presentation/input components only. They own controls, local presentation state, typed field IDs, non-notifying programmatic setters, and user-change/action callbacks.
+
+The panels do not own project context, table rows, write policy, undo, GDTF mutation, derivative creation, truss generation, viewer refresh, MVR behavior, or `GdtfEditSession` binding. Fixture Edit and Truss Edit remain responsible for translating typed panel callbacks into existing project/table fields and for preserving all current apply semantics.
+
+Fixture composition after Checkpoint 05: metadata, type/source identity, physical power/weight, modes/count/channels, fixture/project fields, preview, symbols, thumbnail, and host Apply/OK/Cancel controls. Category, colors, MVR fields, patch, transform, layer, hang position, fixture ID, and instance name remain outside reusable GDTF panels.
+
+Truss composition after Checkpoint 05: metadata, manufacturer/model identity, dimensions/weight/cross-section physical type fields, MVR/project instance fields, preview, and host Apply/OK/Cancel controls. Geometry-only truss behavior and GDTF generation policy remain in the host dialog.
+
+Checkpoint 06 should compose these reusable panels into `GdtfEditorPanel`. Direct `GdtfEditSession` binding and apply adapters remain later controlled migrations.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -58,6 +58,8 @@ Changes since **v1.4.0**.
 
 ## Internal changes
 
+- Completed the GDTF editor Checkpoint 05 panel extraction by adding reusable physical properties, type identity, and modes panels while preserving existing Fixture Edit and Truss Edit apply behavior.
+
 - Improved GDTF geometry loading and symbol-cache validation by sharing one cached geometry build, caching primitive meshes by dimensions, reusing fixture bounds during symbol generation, and switching generated-symbol manifests to a versioned semantic GDTF fingerprint that is stable across ZIP repackaging.
 
 - Started the reusable GDTF editor GUI migration by sharing the read-only metadata panel between Fixture Edit and Truss Edit, without changing metadata loading, apply behavior, or GDTF mutation paths.

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -36,6 +36,9 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/fixturetablepanel_ui_helpers.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fixturetablepanel_update_types.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtf/gdtf_metadata_panel.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gdtf/gdtf_modes_panel.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gdtf/gdtf_physical_properties_panel.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gdtf/gdtf_type_identity_panel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtfsearchdialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/highlight_status_bar.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/hoist_load_limit_utils.cpp

--- a/gui/fixtureeditdialog.cpp
+++ b/gui/fixtureeditdialog.cpp
@@ -22,6 +22,9 @@
 #include "fixturetable/fixture_table_columns.h"
 #include "fixturetablepanel.h"
 #include "gdtf/gdtf_metadata_panel.h"
+#include "gdtf/gdtf_modes_panel.h"
+#include "gdtf/gdtf_physical_properties_panel.h"
+#include "gdtf/gdtf_type_identity_panel.h"
 #include "gdtf_mutation_audit.h"
 #include "gdtf_metadata_summary.h"
 #include "gdtfdictionary.h"
@@ -280,8 +283,6 @@ FixtureEditDialog::FixtureEditDialog(FixtureTablePanel *p, int r)
       wxVERTICAL, this, "GDTF (shared for this fixture type)");
   wxFlexGridSizer *fixtureGrid = new wxFlexGridSizer(2, 5, 5);
   fixtureGrid->AddGrowableCol(1, 1);
-  wxFlexGridSizer *gdtfGrid = new wxFlexGridSizer(2, 5, 5);
-  gdtfGrid->AddGrowableCol(1, 1);
 
   auto *table = panel->table; // friend access
   ctrls.resize(panel->columnLabels.size(), nullptr);
@@ -291,17 +292,17 @@ FixtureEditDialog::FixtureEditDialog(FixtureTablePanel *p, int r)
   table->GetValue(initType, row, 2);
   originalType = initType.GetString();
 
-  const std::set<size_t> gdtfColumns = {2, 7, 8, 9, 16, 17, 18};
+  const std::set<size_t> gdtfColumns = {};
   auto addLabeledControl = [&](size_t index, wxWindow *controlWindow,
                                wxSizer *nestedSizer, bool isGdtfField) {
-    wxFlexGridSizer *targetGrid = isGdtfField ? gdtfGrid : fixtureGrid;
-    targetGrid->Add(
+    (void)isGdtfField;
+    fixtureGrid->Add(
         new wxStaticText(this, wxID_ANY, panel->columnLabels[index]), 0,
                     wxALIGN_CENTER_VERTICAL);
     if (nestedSizer)
-      targetGrid->Add(nestedSizer, 1, wxEXPAND);
+      fixtureGrid->Add(nestedSizer, 1, wxEXPAND);
     else
-      targetGrid->Add(controlWindow, 1, wxEXPAND);
+      fixtureGrid->Add(controlWindow, 1, wxEXPAND);
   };
 
   for (size_t i = 0; i < panel->columnLabels.size(); ++i) {
@@ -309,42 +310,8 @@ FixtureEditDialog::FixtureEditDialog(FixtureTablePanel *p, int r)
     table->GetValue(v, row, i);
     wxWindow *controlWindow = nullptr;
     wxSizer *nestedSizer = nullptr;
-    if (i == 7) {
-      wxString gdtfPath;
-      if ((size_t)row < panel->gdtfPaths.size())
-        gdtfPath = panel->gdtfPaths[row];
-      modeChoice = new wxChoice(this, wxID_ANY);
-      auto modes = GetGdtfModes(gdtfPath.ToStdString());
-      for (const auto &m : modes)
-        modeChoice->Append(wxString::FromUTF8(m));
-      int sel = modeChoice->FindString(v.GetString());
-      if (sel != wxNOT_FOUND)
-        modeChoice->SetSelection(sel);
-      modeChoice->Bind(wxEVT_CHOICE, [this, i](wxCommandEvent &) {
-        MarkColumnModified(i);
-        UpdateChannels(true);
-      });
-      ctrls[i] = modeChoice;
-      controlWindow = modeChoice;
-    } else if (i == 8) {
-      chCountCtrl =
-          new wxTextCtrl(this, wxID_ANY, v.GetString(), wxDefaultPosition,
-                         wxDefaultSize, wxTE_READONLY);
-      ctrls[i] = chCountCtrl;
-      controlWindow = chCountCtrl;
-    } else if (i == 9) {
-      wxBoxSizer *hs = new wxBoxSizer(wxHORIZONTAL);
-      modelCtrl = new wxTextCtrl(this, wxID_ANY);
-      if ((size_t)row < panel->gdtfPaths.size())
-        modelCtrl->SetValue(panel->gdtfPaths[row]);
-      modelCtrl->Bind(wxEVT_TEXT,
-                      [this, i](wxCommandEvent &) { MarkColumnModified(i); });
-      hs->Add(modelCtrl, 1, wxEXPAND | wxRIGHT, 5);
-      wxButton *browse = new wxButton(this, wxID_ANY, "...");
-      hs->Add(browse, 0);
-      browse->Bind(wxEVT_BUTTON, &FixtureEditDialog::OnBrowse, this);
-      ctrls[i] = modelCtrl;
-      nestedSizer = hs;
+    if (i == 2 || i == 7 || i == 8 || i == 9 || i == 16 || i == 17) {
+      continue;
     } else if (i == 18) {
       auto *category = new wxChoice(this, wxID_ANY);
       const wxArrayString values = {
@@ -390,33 +357,88 @@ FixtureEditDialog::FixtureEditDialog(FixtureTablePanel *p, int r)
     addLabeledControl(i, controlWindow, nestedSizer, gdtfColumns.count(i) > 0);
   }
 
-  if (ctrls.size() > 16) {
-    if (auto *powerCtrl = wxDynamicCast(ctrls[16], wxTextCtrl))
-      ParseFloatOrDefault(powerCtrl->GetValue(), originalPowerW);
-  }
-  if (ctrls.size() > 17) {
-    if (auto *weightCtrl = wxDynamicCast(ctrls[17], wxTextCtrl))
-      ParseFloatOrDefault(weightCtrl->GetValue(), originalWeightKg);
-  }
+
+  wxString initialGdtfPath;
+  if (static_cast<size_t>(row) < panel->gdtfPaths.size())
+    initialGdtfPath = panel->gdtfPaths[row];
+
+  wxVariant typeValue;
+  table->GetValue(typeValue, row, 2);
+  typeIdentityPanel = new GdtfTypeIdentityPanel(this);
+  typeIdentityPanel->ConfigureFields({
+      {GdtfTypeIdentityField::FixtureTypeName, "Type",
+       std::string(typeValue.GetString().ToUTF8())},
+      {GdtfTypeIdentityField::SourceFileReference, "Model file",
+       std::string(initialGdtfPath.ToUTF8()), true, true, true, "..."},
+  });
+  typeIdentityPanel->SetChangeCallback(
+      [this](GdtfTypeIdentityField field, const std::string &) {
+        if (field == GdtfTypeIdentityField::FixtureTypeName)
+          MarkColumnModified(FixtureTableColumns::ToIndex(
+              FixtureTableColumns::Column::Type));
+        else if (field == GdtfTypeIdentityField::SourceFileReference)
+          MarkColumnModified(FixtureTableColumns::ToIndex(
+              FixtureTableColumns::Column::ModelFile));
+      });
+  typeIdentityPanel->SetActionCallback(
+      [this](GdtfTypeIdentityField field) {
+        if (field == GdtfTypeIdentityField::SourceFileReference) {
+          wxCommandEvent event;
+          OnBrowse(event);
+        }
+      });
+
+  wxVariant powerValue;
+  wxVariant weightValue;
+  table->GetValue(powerValue, row, FixtureTableColumns::ToIndex(
+                                FixtureTableColumns::Column::Power));
+  table->GetValue(weightValue, row, FixtureTableColumns::ToIndex(
+                                 FixtureTableColumns::Column::Weight));
+  ParseFloatOrDefault(powerValue.GetString(), originalPowerW);
+  ParseFloatOrDefault(weightValue.GetString(), originalWeightKg);
+  physicalPropertiesPanel = new GdtfPhysicalPropertiesPanel(this);
+  physicalPropertiesPanel->ConfigureFields({
+      {GdtfPhysicalPropertyField::PowerConsumption, "Power",
+       std::string(powerValue.GetString().ToUTF8())},
+      {GdtfPhysicalPropertyField::Weight, "Weight",
+       std::string(weightValue.GetString().ToUTF8())},
+  });
+  physicalPropertiesPanel->SetChangeCallback(
+      [this](GdtfPhysicalPropertyField field, const std::string &) {
+        if (field == GdtfPhysicalPropertyField::PowerConsumption)
+          MarkColumnModified(FixtureTableColumns::ToIndex(
+              FixtureTableColumns::Column::Power));
+        else if (field == GdtfPhysicalPropertyField::Weight)
+          MarkColumnModified(FixtureTableColumns::ToIndex(
+              FixtureTableColumns::Column::Weight));
+      });
+
+  wxVariant modeValue;
+  table->GetValue(modeValue, row, FixtureTableColumns::ToIndex(
+                               FixtureTableColumns::Column::Mode));
+  modesPanel = new GdtfModesPanel(this);
+  modesPanel->SetModes(GetGdtfModes(std::string(initialGdtfPath.ToUTF8())));
+  modesPanel->SetSelectedMode(std::string(modeValue.GetString().ToUTF8()));
+  modesPanel->SetModeSelectionCallback([this](const std::string &) {
+    MarkColumnModified(FixtureTableColumns::ToIndex(
+        FixtureTableColumns::Column::Mode));
+    UpdateChannels(true);
+  });
 
   fixtureSpecificSizer->Add(fixtureGrid, 1, wxEXPAND | wxALL, 6);
 
   metadataPanel = new GdtfMetadataPanel(this);
   metadataSizer->Add(metadataPanel, 1, wxEXPAND | wxALL, 6);
 
-  gdtfGeneralSizer->Add(gdtfGrid, 1, wxEXPAND | wxALL, 6);
-  gdtfGeneralSizer->Add(
-      new wxStaticText(this, wxID_ANY,
-                       "Changes in this column update the GDTF file and append "
-                       "a GDTF revision entry."),
-      0, wxLEFT | wxRIGHT | wxBOTTOM, 6);
-
-  channelList = new wxTextCtrl(this, wxID_ANY, "", wxDefaultPosition,
-                               wxSize(-1, 150), wxTE_MULTILINE | wxTE_READONLY);
-  gdtfGeneralSizer->Add(new wxStaticText(this, wxID_ANY, "Mode channels"), 0,
-                        wxLEFT | wxRIGHT | wxTOP, 6);
-  gdtfGeneralSizer->Add(channelList, 1, wxLEFT | wxRIGHT | wxBOTTOM | wxEXPAND,
-                        6);
+  gdtfGeneralSizer->Add(typeIdentityPanel, 0, wxEXPAND | wxALL, 6);
+  gdtfGeneralSizer->Add(new wxStaticText(this, wxID_ANY,
+                                         "Type, source, and mode controls select project fixture context."),
+                        0, wxLEFT | wxRIGHT | wxBOTTOM, 6);
+  gdtfGeneralSizer->Add(physicalPropertiesPanel, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 6);
+  gdtfGeneralSizer->Add(new wxStaticText(this, wxID_ANY,
+                                         "Power and weight edits update the GDTF file and append a revision entry."),
+                        0, wxLEFT | wxRIGHT | wxBOTTOM, 6);
+  gdtfGeneralSizer->Add(modesPanel, 1, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 6);
 
   wxBoxSizer *formSizer = new wxBoxSizer(wxHORIZONTAL);
   wxBoxSizer *leftColumnSizer = new wxBoxSizer(wxVERTICAL);
@@ -493,7 +515,7 @@ void FixtureEditDialog::OnBrowse(wxCommandEvent &) {
   if (fdlg.ShowModal() != wxID_OK)
     return;
   wxString path = fdlg.GetPath();
-  modelCtrl->SetValue(path);
+  typeIdentityPanel->SetFieldValue(GdtfTypeIdentityField::SourceFileReference, std::string(path.ToUTF8()));
   MarkColumnModified(9);
   if (preview)
     preview->LoadFixture(std::string(path.ToUTF8()));
@@ -503,30 +525,31 @@ void FixtureEditDialog::OnBrowse(wxCommandEvent &) {
         wxString::FromUTF8(GetGdtfFixtureName(std::string(path.ToUTF8())));
     if (typeName.empty())
       typeName = fdlg.GetFilename();
-    static_cast<wxTextCtrl *>(ctrls[2])->SetValue(typeName);
+    typeIdentityPanel->SetFieldValue(GdtfTypeIdentityField::FixtureTypeName, std::string(typeName.ToUTF8()));
     MarkColumnModified(2);
     float w = 0.f, p = 0.f;
     GetGdtfProperties(std::string(path.ToUTF8()), w, p);
     if (ctrls.size() > 16)
-      static_cast<wxTextCtrl *>(ctrls[16])->SetValue(
-          wxString::Format("%.1f", p));
+      physicalPropertiesPanel->SetFieldValue(
+          GdtfPhysicalPropertyField::PowerConsumption,
+          std::string(wxString::Format("%.1f", p).ToUTF8()));
     if (ctrls.size() > 16)
       MarkColumnModified(16);
     if (ctrls.size() > 17)
-      static_cast<wxTextCtrl *>(ctrls[17])->SetValue(
-          wxString::Format("%.2f", w));
+      physicalPropertiesPanel->SetFieldValue(
+          GdtfPhysicalPropertyField::Weight,
+          std::string(wxString::Format("%.2f", w).ToUTF8()));
     if (ctrls.size() > 17)
       MarkColumnModified(17);
   }
   // repopulate modes
-  if (modeChoice) {
-    modeChoice->Clear();
+  if (modesPanel) {
     auto modes = GetGdtfModes(std::string(path.ToUTF8()));
-    for (const auto &m : modes)
-      modeChoice->Append(wxString::FromUTF8(m));
-    if (!modeChoice->IsEmpty()) {
-      modeChoice->SetSelection(0);
-      MarkColumnModified(7);
+    modesPanel->SetModes(modes);
+    if (!modes.empty()) {
+      modesPanel->SetSelectedMode(modes.front());
+      MarkColumnModified(FixtureTableColumns::ToIndex(
+          FixtureTableColumns::Column::Mode));
     }
   }
   UpdateChannels(true);
@@ -625,7 +648,7 @@ void FixtureEditDialog::OnSymbolPreviewPaint(wxPaintEvent &evt) {
 }
 
 void FixtureEditDialog::UpdateVisualizers() {
-  wxString gdtfPath = modelCtrl ? modelCtrl->GetValue() : wxString();
+  wxString gdtfPath = typeIdentityPanel ? wxString::FromUTF8(typeIdentityPanel->GetFieldValue(GdtfTypeIdentityField::SourceFileReference).value_or(std::string())) : wxString();
   if (gdtfPath.empty() && panel && row >= 0 &&
       static_cast<size_t>(row) < panel->gdtfPaths.size()) {
     gdtfPath = panel->gdtfPaths[row];
@@ -664,7 +687,7 @@ void FixtureEditDialog::UpdateVisualizers() {
 }
 
 void FixtureEditDialog::UpdateMetadataSummary() {
-  wxString gdtfPath = modelCtrl ? modelCtrl->GetValue() : wxString();
+  wxString gdtfPath = typeIdentityPanel ? wxString::FromUTF8(typeIdentityPanel->GetFieldValue(GdtfTypeIdentityField::SourceFileReference).value_or(std::string())) : wxString();
   if (gdtfPath.empty() && panel && row >= 0 &&
       static_cast<size_t>(row) < panel->gdtfPaths.size()) {
     gdtfPath = panel->gdtfPaths[row];
@@ -681,56 +704,38 @@ void FixtureEditDialog::UpdateMetadataSummary() {
 }
 
 void FixtureEditDialog::UpdateChannels(bool markChannelCountDirty) {
-  wxString gdtfPath = modelCtrl ? modelCtrl->GetValue() : wxString();
+  wxString gdtfPath = typeIdentityPanel ? wxString::FromUTF8(typeIdentityPanel->GetFieldValue(GdtfTypeIdentityField::SourceFileReference).value_or(std::string())) : wxString();
   if (gdtfPath.empty() && panel && row >= 0 &&
       static_cast<size_t>(row) < panel->gdtfPaths.size()) {
     gdtfPath = panel->gdtfPaths[row];
   }
-  wxString mode = modeChoice ? modeChoice->GetStringSelection() : wxString();
+  wxString mode = modesPanel ? wxString::FromUTF8(modesPanel->GetSelectedMode()) : wxString();
   if (preview)
     preview->LoadFixture(std::string(gdtfPath.ToUTF8()));
   if (gdtfPath.empty() || mode.empty()) {
-    channelList->SetValue("");
-    if (chCountCtrl)
-      chCountCtrl->SetValue("");
+    if (modesPanel)
+      modesPanel->ClearModeDetails();
     return;
   }
   auto channels = GetGdtfModeChannels(std::string(gdtfPath.ToUTF8()),
                                       std::string(mode.ToUTF8()));
-  wxString msg;
+  std::vector<GdtfModeChannelPresentation> channelRows;
   for (const auto &ch : channels) {
-    wxString func = wxString::FromUTF8(ch.function);
-    while (true) {
-      const int sectionStart = func.Find('[');
-      if (sectionStart == wxNOT_FOUND)
-        break;
-      const wxString remainder = func.Mid(static_cast<size_t>(sectionStart));
-      const int sectionEndRelative = remainder.Find(']');
-      if (sectionEndRelative == wxNOT_FOUND) {
-        func = func.Left(static_cast<size_t>(sectionStart));
-        break;
-      }
-      const size_t sectionEnd =
-          static_cast<size_t>(sectionStart + sectionEndRelative);
-      func = func.Left(static_cast<size_t>(sectionStart)) +
-             func.Mid(sectionEnd + 1);
-    }
-    func.Trim(true).Trim(false);
-    if (func.empty())
-      func = "-";
-    const wxString channelLabel =
-        ch.isVirtual ? wxString("V") : wxString::Format("%d", ch.channel);
-    msg += channelLabel + ": " + func + "\n";
+    channelRows.push_back({
+        ch.isVirtual ? std::string("V") :
+                       std::string(wxString::Format("%d", ch.channel).ToUTF8()),
+        FormatGdtfModeFunctionLabel(ch.function),
+    });
   }
-  channelList->SetValue(msg);
+  if (modesPanel)
+    modesPanel->SetChannels(channelRows);
   int chCount = GetGdtfModeChannelCount(std::string(gdtfPath.ToUTF8()),
                                         std::string(mode.ToUTF8()));
-  if (chCountCtrl) {
-    chCountCtrl->SetValue(chCount >= 0 ? wxString::Format("%d", chCount)
-                                       : wxString());
-    if (markChannelCountDirty)
-      MarkColumnModified(8);
-  }
+  if (modesPanel)
+    modesPanel->SetChannelCount(chCount >= 0 ? std::string(wxString::Format("%d", chCount).ToUTF8()) : std::string());
+  if (markChannelCountDirty)
+    MarkColumnModified(FixtureTableColumns::ToIndex(
+        FixtureTableColumns::Column::ChannelCount));
 }
 
 void FixtureEditDialog::OnApply(wxCommandEvent &) { ApplyChanges(); }
@@ -746,7 +751,7 @@ void FixtureEditDialog::ApplyChanges() {
   if (!panel)
     return;
   auto *table = panel->table;
-  wxString gdtfPath = modelCtrl ? modelCtrl->GetValue() : wxString();
+  wxString gdtfPath = typeIdentityPanel ? wxString::FromUTF8(typeIdentityPanel->GetFieldValue(GdtfTypeIdentityField::SourceFileReference).value_or(std::string())) : wxString();
 
   std::vector<std::string> oldOrder = panel->rowUuids;
   std::vector<std::string> selectedUuids;
@@ -762,16 +767,38 @@ void FixtureEditDialog::ApplyChanges() {
   for (size_t i = 0; i < ctrls.size(); ++i) {
     if (i >= modifiedColumns.size() || !modifiedColumns[i])
       continue;
-    if (i == 7 && modeChoice) {
-      table->SetValue(wxVariant(modeChoice->GetStringSelection()), row, i);
-    } else if (i == 8 && chCountCtrl) {
-      table->SetValue(wxVariant(chCountCtrl->GetValue()), row, i);
-    } else if (i == 9 && modelCtrl) {
+    if (i == 7 && modesPanel) {
+      table->SetValue(wxVariant(wxString::FromUTF8(modesPanel->GetSelectedMode())), row, i);
+    } else if (i == 8 && modesPanel) {
+      int chCount = GetGdtfModeChannelCount(std::string(gdtfPath.ToUTF8()),
+                                            modesPanel->GetSelectedMode());
+      table->SetValue(wxVariant(chCount >= 0 ? wxString::Format("%d", chCount)
+                                             : wxString()),
+                      row, i);
+    } else if (i == 9 && typeIdentityPanel) {
       wxFileName fn(gdtfPath);
       table->SetValue(wxVariant(fn.GetFullName()), row, i);
       if ((size_t)row >= panel->gdtfPaths.size())
         panel->gdtfPaths.resize(row + 1);
       panel->gdtfPaths[row] = gdtfPath;
+    } else if (i == 2 && typeIdentityPanel) {
+      auto value = typeIdentityPanel->GetFieldValue(
+          GdtfTypeIdentityField::FixtureTypeName);
+      table->SetValue(
+          wxVariant(wxString::FromUTF8(value.value_or(std::string()).c_str())), row,
+          i);
+    } else if (i == 16 && physicalPropertiesPanel) {
+      auto value = physicalPropertiesPanel->GetFieldValue(
+          GdtfPhysicalPropertyField::PowerConsumption);
+      table->SetValue(
+          wxVariant(wxString::FromUTF8(value.value_or(std::string()).c_str())), row,
+          i);
+    } else if (i == 17 && physicalPropertiesPanel) {
+      auto value = physicalPropertiesPanel->GetFieldValue(
+          GdtfPhysicalPropertyField::Weight);
+      table->SetValue(
+          wxVariant(wxString::FromUTF8(value.value_or(std::string()).c_str())), row,
+          i);
     } else if (i == 18) {
       auto *category = wxDynamicCast(ctrls[i], wxChoice);
       if (category)
@@ -844,10 +871,18 @@ void FixtureEditDialog::ApplyChanges() {
     if (ctrls.size() > 17) {
       float newPowerW = originalPowerW;
       float newWeightKg = originalWeightKg;
-      if (auto *powerCtrl = wxDynamicCast(ctrls[16], wxTextCtrl))
-        ParseFloatOrDefault(powerCtrl->GetValue(), newPowerW);
-      if (auto *weightCtrl = wxDynamicCast(ctrls[17], wxTextCtrl))
-        ParseFloatOrDefault(weightCtrl->GetValue(), newWeightKg);
+      if (physicalPropertiesPanel) {
+        ParseFloatOrDefault(
+            wxString::FromUTF8(physicalPropertiesPanel
+                                   ->GetFieldValue(GdtfPhysicalPropertyField::PowerConsumption)
+                                   .value_or(std::string())),
+            newPowerW);
+        ParseFloatOrDefault(
+            wxString::FromUTF8(physicalPropertiesPanel
+                                   ->GetFieldValue(GdtfPhysicalPropertyField::Weight)
+                                   .value_or(std::string())),
+            newWeightKg);
+      }
       const bool gdtfPhysicalChanged =
           std::fabs(newPowerW - originalPowerW) > 0.01f ||
           std::fabs(newWeightKg - originalWeightKg) > 0.01f;
@@ -860,8 +895,10 @@ void FixtureEditDialog::ApplyChanges() {
           if (derivative && !derivative->path.empty()) {
             writableGdtfPath = derivative->path;
             gdtfPath = wxString::FromUTF8(derivative->path);
-            if (modelCtrl)
-              modelCtrl->SetValue(gdtfPath);
+            if (typeIdentityPanel)
+              typeIdentityPanel->SetFieldValue(
+                  GdtfTypeIdentityField::SourceFileReference,
+                  std::string(gdtfPath.ToUTF8()));
             if (panel && row >= 0) {
               if (static_cast<size_t>(row) >= panel->gdtfPaths.size())
                 panel->gdtfPaths.resize(static_cast<size_t>(row) + 1);
@@ -890,11 +927,10 @@ void FixtureEditDialog::ApplyChanges() {
 
     if (gdtfMetadataChanged) {
       std::string mode =
-          modeChoice ? std::string(modeChoice->GetStringSelection().ToUTF8())
-                     : std::string();
+          modesPanel ? modesPanel->GetSelectedMode() : std::string();
       // Project fixture metadata edits stay project-scoped and do not promote
       // files into the user library.
-      panel->ApplyModeForGdtf(gdtfPath, wxString::FromUTF8(mode));
+      panel->ApplyModeForGdtf(gdtfPath, wxString::FromUTF8(mode.c_str()));
     }
   }
   if (fixtureColorChanged) {

--- a/gui/fixtureeditdialog.h
+++ b/gui/fixtureeditdialog.h
@@ -29,6 +29,9 @@ class FixturePreviewPanel;
 class wxStaticBitmap;
 class wxPanel;
 class GdtfMetadataPanel;
+class GdtfModesPanel;
+class GdtfPhysicalPropertiesPanel;
+class GdtfTypeIdentityPanel;
 
 class FixtureEditDialog : public wxDialog {
 public:
@@ -51,10 +54,9 @@ private:
     FixtureTablePanel* panel;
     int row;
     std::vector<wxControl*> ctrls;
-    wxChoice* modeChoice = nullptr;
-    wxTextCtrl* chCountCtrl = nullptr;
-    wxTextCtrl* modelCtrl = nullptr;
-    wxTextCtrl* channelList = nullptr;
+    GdtfTypeIdentityPanel* typeIdentityPanel = nullptr;
+    GdtfPhysicalPropertiesPanel* physicalPropertiesPanel = nullptr;
+    GdtfModesPanel* modesPanel = nullptr;
     GdtfMetadataPanel* metadataPanel = nullptr;
     FixturePreviewPanel* preview = nullptr;
     wxStaticBitmap* fixtureImagePreview = nullptr;

--- a/gui/gdtf/gdtf_modes_panel.cpp
+++ b/gui/gdtf/gdtf_modes_panel.cpp
@@ -1,0 +1,136 @@
+#include "gdtf_modes_panel.h"
+
+#include <wx/choice.h>
+#include <wx/sizer.h>
+#include <wx/stattext.h>
+#include <wx/textctrl.h>
+
+// Formats a raw GDTF channel function label for display.
+std::string FormatGdtfModeFunctionLabel(const std::string &functionText) {
+  wxString function = wxString::FromUTF8(functionText);
+  while (true) {
+    const int sectionStart = function.Find('[');
+    if (sectionStart == wxNOT_FOUND)
+      break;
+    const wxString remainder = function.Mid(static_cast<size_t>(sectionStart));
+    const int sectionEndRelative = remainder.Find(']');
+    if (sectionEndRelative == wxNOT_FOUND) {
+      function = function.Left(static_cast<size_t>(sectionStart));
+      break;
+    }
+    const size_t sectionEnd =
+        static_cast<size_t>(sectionStart + sectionEndRelative);
+    function = function.Left(static_cast<size_t>(sectionStart)) +
+               function.Mid(sectionEnd + 1);
+  }
+  function.Trim(true).Trim(false);
+  if (function.empty())
+    function = "-";
+  return std::string(function.ToUTF8());
+}
+
+// Creates the reusable modes and channels layout.
+GdtfModesPanel::GdtfModesPanel(wxWindow *parent) : wxPanel(parent, wxID_ANY) {
+  auto *root = new wxBoxSizer(wxVERTICAL);
+  auto *grid = new wxFlexGridSizer(2, 5, 5);
+  grid->AddGrowableCol(1, 1);
+  modeChoice = new wxChoice(this, wxID_ANY);
+  channelCountCtrl = new wxTextCtrl(this, wxID_ANY, wxString(),
+                                    wxDefaultPosition, wxDefaultSize,
+                                    wxTE_READONLY);
+  grid->Add(new wxStaticText(this, wxID_ANY, "Mode"), 0,
+            wxALIGN_CENTER_VERTICAL);
+  grid->Add(modeChoice, 1, wxEXPAND);
+  grid->Add(new wxStaticText(this, wxID_ANY, "Channel count"), 0,
+            wxALIGN_CENTER_VERTICAL);
+  grid->Add(channelCountCtrl, 1, wxEXPAND);
+  root->Add(grid, 0, wxEXPAND | wxBOTTOM, 6);
+  root->Add(new wxStaticText(this, wxID_ANY, "Mode channels"), 0,
+            wxBOTTOM, 3);
+  channelListCtrl = new wxTextCtrl(this, wxID_ANY, wxString(),
+                                   wxDefaultPosition, wxSize(-1, 150),
+                                   wxTE_MULTILINE | wxTE_READONLY);
+  root->Add(channelListCtrl, 1, wxEXPAND);
+  modeChoice->Bind(wxEVT_CHOICE, [this](wxCommandEvent &) {
+    NotifyModeChanged();
+  });
+  SetSizer(root);
+}
+
+// Applies a complete modes presentation without notifying the host.
+void GdtfModesPanel::SetPresentation(const GdtfModesPresentation &presentation) {
+  SetModes(presentation.modes);
+  SetSelectedMode(presentation.selectedMode);
+  SetChannelCount(presentation.channelCount);
+  SetChannels(presentation.channels);
+}
+
+// Replaces the ordered mode list without notifying the host.
+void GdtfModesPanel::SetModes(const std::vector<std::string> &modes) {
+  updating = true;
+  modeChoice->Clear();
+  for (const auto &mode : modes)
+    modeChoice->Append(wxString::FromUTF8(mode));
+  updating = false;
+}
+
+// Selects a mode without notifying the host.
+void GdtfModesPanel::SetSelectedMode(const std::string &mode) {
+  updating = true;
+  const int selection = modeChoice->FindString(wxString::FromUTF8(mode));
+  if (selection != wxNOT_FOUND)
+    modeChoice->SetSelection(selection);
+  else
+    modeChoice->SetSelection(wxNOT_FOUND);
+  updating = false;
+}
+
+// Returns the selected mode exactly as shown by the choice control.
+std::string GdtfModesPanel::GetSelectedMode() const {
+  return std::string(modeChoice->GetStringSelection().ToUTF8());
+}
+
+// Registers the host mode-selection callback.
+void GdtfModesPanel::SetModeSelectionCallback(ModeSelectionCallback callback) {
+  selectionCallback = std::move(callback);
+}
+
+// Sets the derived channel count text.
+void GdtfModesPanel::SetChannelCount(const std::string &channelCount) {
+  updating = true;
+  channelCountCtrl->SetValue(wxString::FromUTF8(channelCount));
+  updating = false;
+}
+
+// Sets the ordered channel display rows.
+void GdtfModesPanel::SetChannels(
+    const std::vector<GdtfModeChannelPresentation> &channels) {
+  wxString text;
+  for (const auto &channel : channels) {
+    text += wxString::FromUTF8(channel.channelLabel) + ": " +
+            wxString::FromUTF8(channel.functionLabel) + "\n";
+  }
+  updating = true;
+  channelListCtrl->SetValue(text);
+  updating = false;
+}
+
+// Clears the derived channel presentation.
+void GdtfModesPanel::ClearModeDetails() {
+  updating = true;
+  channelCountCtrl->SetValue(wxString());
+  channelListCtrl->SetValue(wxString());
+  updating = false;
+}
+
+// Enables or disables mode selection.
+void GdtfModesPanel::SetModeSelectionEnabled(bool enabled) {
+  modeChoice->Enable(enabled);
+}
+
+// Notifies the host about a genuine user mode selection.
+void GdtfModesPanel::NotifyModeChanged() {
+  if (updating || !selectionCallback)
+    return;
+  selectionCallback(GetSelectedMode());
+}

--- a/gui/gdtf/gdtf_modes_panel.h
+++ b/gui/gdtf/gdtf_modes_panel.h
@@ -1,0 +1,60 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+#pragma once
+
+#include <functional>
+#include <string>
+#include <vector>
+
+#include <wx/panel.h>
+#include <wx/string.h>
+
+class wxChoice;
+class wxTextCtrl;
+
+struct GdtfModeChannelPresentation {
+  std::string channelLabel;
+  std::string functionLabel;
+};
+
+struct GdtfModesPresentation {
+  std::vector<std::string> modes;
+  std::string selectedMode;
+  std::string channelCount;
+  std::vector<GdtfModeChannelPresentation> channels;
+};
+
+std::string FormatGdtfModeFunctionLabel(const std::string &functionText);
+
+class GdtfModesPanel : public wxPanel {
+public:
+  using ModeSelectionCallback = std::function<void(const std::string &mode)>;
+
+  explicit GdtfModesPanel(wxWindow *parent);
+
+  void SetPresentation(const GdtfModesPresentation &presentation);
+  void SetModes(const std::vector<std::string> &modes);
+  void SetSelectedMode(const std::string &mode);
+  std::string GetSelectedMode() const;
+  void SetModeSelectionCallback(ModeSelectionCallback callback);
+  void SetChannelCount(const std::string &channelCount);
+  void SetChannels(const std::vector<GdtfModeChannelPresentation> &channels);
+  void ClearModeDetails();
+  void SetModeSelectionEnabled(bool enabled);
+
+private:
+  void NotifyModeChanged();
+
+  wxChoice *modeChoice = nullptr;
+  wxTextCtrl *channelCountCtrl = nullptr;
+  wxTextCtrl *channelListCtrl = nullptr;
+  ModeSelectionCallback selectionCallback;
+  bool updating = false;
+};

--- a/gui/gdtf/gdtf_physical_properties_panel.cpp
+++ b/gui/gdtf/gdtf_physical_properties_panel.cpp
@@ -1,0 +1,109 @@
+#include "gdtf_physical_properties_panel.h"
+
+#include <wx/sizer.h>
+#include <wx/stattext.h>
+#include <wx/textctrl.h>
+
+// Creates the physical properties panel layout.
+GdtfPhysicalPropertiesPanel::GdtfPhysicalPropertiesPanel(wxWindow *parent)
+    : wxPanel(parent, wxID_ANY) {
+  grid = new wxFlexGridSizer(3, 5, 5);
+  grid->AddGrowableCol(1, 1);
+  auto *root = new wxBoxSizer(wxVERTICAL);
+  root->Add(grid, 0, wxEXPAND);
+  SetSizer(root);
+}
+
+// Configures the visible physical property controls.
+void GdtfPhysicalPropertiesPanel::ConfigureFields(
+    const std::vector<GdtfPhysicalPropertyPresentation> &fields) {
+  updating = true;
+  ClearFields();
+  for (const auto &field : fields) {
+    if (!field.visible)
+      continue;
+    FieldControls row;
+    row.label = new wxStaticText(this, wxID_ANY, wxString::FromUTF8(field.label));
+    row.value = new wxTextCtrl(this, wxID_ANY, wxString::FromUTF8(field.value));
+    row.value->Enable(field.editable);
+    row.value->Bind(wxEVT_TEXT, [this, id = field.field](wxCommandEvent &) {
+      NotifyFieldChanged(id);
+    });
+    row.suffix = new wxStaticText(this, wxID_ANY, wxString::FromUTF8(field.unitSuffix));
+    if (!field.helpText.empty())
+      row.value->SetToolTip(wxString::FromUTF8(field.helpText));
+    grid->Add(row.label, 0, wxALIGN_CENTER_VERTICAL);
+    grid->Add(row.value, 1, wxEXPAND);
+    grid->Add(row.suffix, 0, wxALIGN_CENTER_VERTICAL);
+    controls.emplace(field.field, row);
+  }
+  updating = false;
+  Layout();
+}
+
+// Sets one field value without notifying the host.
+void GdtfPhysicalPropertiesPanel::SetFieldValue(
+    GdtfPhysicalPropertyField field, const std::string &value) {
+  auto it = controls.find(field);
+  if (it == controls.end() || !it->second.value)
+    return;
+  updating = true;
+  it->second.value->SetValue(wxString::FromUTF8(value));
+  updating = false;
+}
+
+// Returns one current field value when the field is visible.
+std::optional<std::string> GdtfPhysicalPropertiesPanel::GetFieldValue(
+    GdtfPhysicalPropertyField field) const {
+  auto it = controls.find(field);
+  if (it == controls.end() || !it->second.value)
+    return std::nullopt;
+  return std::string(it->second.value->GetValue().ToUTF8());
+}
+
+// Returns all currently visible field values.
+std::map<GdtfPhysicalPropertyField, std::string>
+GdtfPhysicalPropertiesPanel::GetValues() const {
+  std::map<GdtfPhysicalPropertyField, std::string> values;
+  for (const auto &[field, row] : controls) {
+    if (row.value)
+      values[field] = std::string(row.value->GetValue().ToUTF8());
+  }
+  return values;
+}
+
+// Updates editability for one visible field.
+void GdtfPhysicalPropertiesPanel::SetFieldEditable(
+    GdtfPhysicalPropertyField field, bool editable) {
+  auto it = controls.find(field);
+  if (it != controls.end() && it->second.value)
+    it->second.value->Enable(editable);
+}
+
+// Displays validation feedback supplied by the host as a tooltip.
+void GdtfPhysicalPropertiesPanel::SetFieldValidation(
+    GdtfPhysicalPropertyField field, const std::string &message) {
+  auto it = controls.find(field);
+  if (it != controls.end() && it->second.value)
+    it->second.value->SetToolTip(wxString::FromUTF8(message));
+}
+
+// Registers the host field-change callback.
+void GdtfPhysicalPropertiesPanel::SetChangeCallback(ChangeCallback callback) {
+  changeCallback = std::move(callback);
+}
+
+// Removes existing controls before rebuilding the field list.
+void GdtfPhysicalPropertiesPanel::ClearFields() {
+  controls.clear();
+  grid->Clear(true);
+}
+
+// Notifies the host about a genuine user edit.
+void GdtfPhysicalPropertiesPanel::NotifyFieldChanged(
+    GdtfPhysicalPropertyField field) {
+  if (updating || !changeCallback)
+    return;
+  auto value = GetFieldValue(field);
+  changeCallback(field, value.value_or(std::string()));
+}

--- a/gui/gdtf/gdtf_physical_properties_panel.h
+++ b/gui/gdtf/gdtf_physical_properties_panel.h
@@ -1,0 +1,74 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+#pragma once
+
+#include <functional>
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <wx/panel.h>
+
+class wxFlexGridSizer;
+class wxStaticText;
+class wxTextCtrl;
+
+// Identifies supported reusable GDTF physical/type property fields.
+enum class GdtfPhysicalPropertyField {
+  PowerConsumption,
+  Weight,
+  Length,
+  Width,
+  Height,
+  CrossSection
+};
+
+struct GdtfPhysicalPropertyPresentation {
+  GdtfPhysicalPropertyField field;
+  std::string label;
+  std::string value;
+  bool visible = true;
+  bool editable = true;
+  std::string unitSuffix;
+  std::string helpText;
+};
+
+class GdtfPhysicalPropertiesPanel : public wxPanel {
+public:
+  using ChangeCallback =
+      std::function<void(GdtfPhysicalPropertyField field, const std::string &value)>;
+
+  explicit GdtfPhysicalPropertiesPanel(wxWindow *parent);
+
+  void ConfigureFields(const std::vector<GdtfPhysicalPropertyPresentation> &fields);
+  void SetFieldValue(GdtfPhysicalPropertyField field, const std::string &value);
+  std::optional<std::string> GetFieldValue(GdtfPhysicalPropertyField field) const;
+  std::map<GdtfPhysicalPropertyField, std::string> GetValues() const;
+  void SetFieldEditable(GdtfPhysicalPropertyField field, bool editable);
+  void SetFieldValidation(GdtfPhysicalPropertyField field, const std::string &message);
+  void SetChangeCallback(ChangeCallback callback);
+
+private:
+  struct FieldControls {
+    wxStaticText *label = nullptr;
+    wxTextCtrl *value = nullptr;
+    wxStaticText *suffix = nullptr;
+    wxStaticText *validation = nullptr;
+  };
+
+  void ClearFields();
+  void NotifyFieldChanged(GdtfPhysicalPropertyField field);
+
+  wxFlexGridSizer *grid = nullptr;
+  std::map<GdtfPhysicalPropertyField, FieldControls> controls;
+  ChangeCallback changeCallback;
+  bool updating = false;
+};

--- a/gui/gdtf/gdtf_type_identity_panel.cpp
+++ b/gui/gdtf/gdtf_type_identity_panel.cpp
@@ -1,0 +1,117 @@
+#include "gdtf_type_identity_panel.h"
+
+#include <wx/button.h>
+#include <wx/sizer.h>
+#include <wx/stattext.h>
+#include <wx/textctrl.h>
+
+// Creates the type identity panel layout.
+GdtfTypeIdentityPanel::GdtfTypeIdentityPanel(wxWindow *parent)
+    : wxPanel(parent, wxID_ANY) {
+  grid = new wxFlexGridSizer(2, 5, 5);
+  grid->AddGrowableCol(1, 1);
+  auto *root = new wxBoxSizer(wxVERTICAL);
+  root->Add(grid, 0, wxEXPAND);
+  SetSizer(root);
+}
+
+// Configures the visible identity controls.
+void GdtfTypeIdentityPanel::ConfigureFields(
+    const std::vector<GdtfTypeIdentityPresentation> &fields) {
+  updating = true;
+  ClearFields();
+  for (const auto &field : fields) {
+    if (!field.visible)
+      continue;
+    FieldControls row;
+    row.label = new wxStaticText(this, wxID_ANY, wxString::FromUTF8(field.label));
+    row.value = new wxTextCtrl(this, wxID_ANY, wxString::FromUTF8(field.value));
+    row.value->Enable(field.editable);
+    row.value->Bind(wxEVT_TEXT, [this, id = field.field](wxCommandEvent &) {
+      NotifyFieldChanged(id);
+    });
+    grid->Add(row.label, 0, wxALIGN_CENTER_VERTICAL);
+    if (field.showActionButton) {
+      auto *line = new wxBoxSizer(wxHORIZONTAL);
+      line->Add(row.value, 1, wxEXPAND | wxRIGHT, 5);
+      auto *button = new wxButton(this, wxID_ANY,
+                                  field.actionLabel.empty()
+                                      ? wxString("...")
+                                      : wxString::FromUTF8(field.actionLabel));
+      button->Bind(wxEVT_BUTTON, [this, id = field.field](wxCommandEvent &) {
+        if (actionCallback)
+          actionCallback(id);
+      });
+      line->Add(button, 0);
+      grid->Add(line, 1, wxEXPAND);
+    } else {
+      grid->Add(row.value, 1, wxEXPAND);
+    }
+    controls.emplace(field.field, row);
+  }
+  updating = false;
+  Layout();
+}
+
+// Sets one identity value without notifying the host.
+void GdtfTypeIdentityPanel::SetFieldValue(GdtfTypeIdentityField field,
+                                          const std::string &value) {
+  auto it = controls.find(field);
+  if (it == controls.end() || !it->second.value)
+    return;
+  updating = true;
+  it->second.value->SetValue(wxString::FromUTF8(value));
+  updating = false;
+}
+
+// Returns one current identity value when visible.
+std::optional<std::string> GdtfTypeIdentityPanel::GetFieldValue(
+    GdtfTypeIdentityField field) const {
+  auto it = controls.find(field);
+  if (it == controls.end() || !it->second.value)
+    return std::nullopt;
+  return std::string(it->second.value->GetValue().ToUTF8());
+}
+
+// Returns all currently visible identity values.
+std::map<GdtfTypeIdentityField, std::string> GdtfTypeIdentityPanel::GetValues()
+    const {
+  std::map<GdtfTypeIdentityField, std::string> values;
+  for (const auto &[field, row] : controls) {
+    if (row.value)
+      values[field] = std::string(row.value->GetValue().ToUTF8());
+  }
+  return values;
+}
+
+// Updates editability for one visible field.
+void GdtfTypeIdentityPanel::SetFieldEditable(GdtfTypeIdentityField field,
+                                             bool editable) {
+  auto it = controls.find(field);
+  if (it != controls.end() && it->second.value)
+    it->second.value->Enable(editable);
+}
+
+// Registers the host field-change callback.
+void GdtfTypeIdentityPanel::SetChangeCallback(ChangeCallback callback) {
+  changeCallback = std::move(callback);
+}
+
+// Registers the host action callback.
+void GdtfTypeIdentityPanel::SetActionCallback(ActionCallback callback) {
+  actionCallback = std::move(callback);
+}
+
+// Removes existing controls before rebuilding the field list.
+void GdtfTypeIdentityPanel::ClearFields() {
+  controls.clear();
+  grid->Clear(true);
+}
+
+// Notifies the host about a genuine user edit.
+void GdtfTypeIdentityPanel::NotifyFieldChanged(GdtfTypeIdentityField field) {
+  if (updating || !changeCallback)
+    return;
+  auto value = GetFieldValue(field);
+  changeCallback(field, value.value_or(std::string()));
+}

--- a/gui/gdtf/gdtf_type_identity_panel.h
+++ b/gui/gdtf/gdtf_type_identity_panel.h
@@ -1,0 +1,72 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+#pragma once
+
+#include <functional>
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <wx/panel.h>
+
+class wxFlexGridSizer;
+class wxStaticText;
+class wxTextCtrl;
+
+// Identifies supported reusable GDTF type identity fields.
+enum class GdtfTypeIdentityField {
+  FixtureTypeName,
+  Manufacturer,
+  ModelName,
+  SourceFileReference
+};
+
+struct GdtfTypeIdentityPresentation {
+  GdtfTypeIdentityField field;
+  std::string label;
+  std::string value;
+  bool visible = true;
+  bool editable = true;
+  bool showActionButton = false;
+  std::string actionLabel;
+};
+
+class GdtfTypeIdentityPanel : public wxPanel {
+public:
+  using ChangeCallback =
+      std::function<void(GdtfTypeIdentityField field, const std::string &value)>;
+  using ActionCallback = std::function<void(GdtfTypeIdentityField field)>;
+
+  explicit GdtfTypeIdentityPanel(wxWindow *parent);
+
+  void ConfigureFields(const std::vector<GdtfTypeIdentityPresentation> &fields);
+  void SetFieldValue(GdtfTypeIdentityField field, const std::string &value);
+  std::optional<std::string> GetFieldValue(GdtfTypeIdentityField field) const;
+  std::map<GdtfTypeIdentityField, std::string> GetValues() const;
+  void SetFieldEditable(GdtfTypeIdentityField field, bool editable);
+  void SetChangeCallback(ChangeCallback callback);
+  void SetActionCallback(ActionCallback callback);
+
+private:
+  struct FieldControls {
+    wxStaticText *label = nullptr;
+    wxTextCtrl *value = nullptr;
+  };
+
+  void ClearFields();
+  void NotifyFieldChanged(GdtfTypeIdentityField field);
+
+  wxFlexGridSizer *grid = nullptr;
+  std::map<GdtfTypeIdentityField, FieldControls> controls;
+  ChangeCallback changeCallback;
+  ActionCallback actionCallback;
+  bool updating = false;
+};

--- a/gui/trusseditdialog.cpp
+++ b/gui/trusseditdialog.cpp
@@ -20,6 +20,8 @@
 #include "configmanager.h"
 #include "fixturepreviewpanel.h"
 #include "gdtf/gdtf_metadata_panel.h"
+#include "gdtf/gdtf_physical_properties_panel.h"
+#include "gdtf/gdtf_type_identity_panel.h"
 #include "gdtf_metadata_summary.h"
 #include "gdtfdictionary.h"
 #include "guiconfigservices.h"
@@ -33,6 +35,7 @@
 
 #include <algorithm>
 #include <filesystem>
+#include <optional>
 
 namespace {
 using TrussColumn = TrussTableColumns::Column;
@@ -80,25 +83,24 @@ TrussEditDialog::TrussEditDialog(TrussTablePanel *p, int r)
   wxStaticBoxSizer *metadataSizer =
       new wxStaticBoxSizer(wxVERTICAL, this, "GDTF metadata");
   wxFlexGridSizer *mvrGrid = new wxFlexGridSizer(2, 5, 5);
-  wxFlexGridSizer *gdtfGrid = new wxFlexGridSizer(2, 5, 5);
   mvrGrid->AddGrowableCol(1, 1);
-  gdtfGrid->AddGrowableCol(1, 1);
 
   auto *table = panel->table;
   ctrls.resize(panel->columnLabels.size(), nullptr);
   modifiedColumns.assign(panel->columnLabels.size(), false);
 
   for (size_t i = 0; i < panel->columnLabels.size(); ++i) {
+    if (IsGdtfTrussColumn(i))
+      continue;
     wxVariant value;
     table->GetValue(value, row, static_cast<unsigned int>(i));
     wxTextCtrl *control = new wxTextCtrl(this, wxID_ANY, value.GetString());
     control->Bind(wxEVT_TEXT,
                   [this, i](wxCommandEvent &) { MarkColumnModified(i); });
     ctrls[i] = control;
-    wxFlexGridSizer *grid = IsGdtfTrussColumn(i) ? gdtfGrid : mvrGrid;
-    grid->Add(new wxStaticText(this, wxID_ANY, panel->columnLabels[i]), 0,
-              wxALIGN_CENTER_VERTICAL);
-    grid->Add(control, 1, wxEXPAND);
+    mvrGrid->Add(new wxStaticText(this, wxID_ANY, panel->columnLabels[i]), 0,
+                 wxALIGN_CENTER_VERTICAL);
+    mvrGrid->Add(control, 1, wxEXPAND);
   }
 
   wxString crossSection;
@@ -109,19 +111,60 @@ TrussEditDialog::TrussEditDialog(TrussTablePanel *p, int r)
     if (it != scene.trusses.end())
       crossSection = wxString::FromUTF8(it->second.crossSection);
   }
-  crossSectionCtrl = new wxTextCtrl(this, wxID_ANY, crossSection);
-  crossSectionCtrl->Bind(
-      wxEVT_TEXT, [this](wxCommandEvent &) { crossSectionModified = true; });
-  gdtfGrid->Add(new wxStaticText(this, wxID_ANY, "Cross section"), 0,
-                wxALIGN_CENTER_VERTICAL);
-  gdtfGrid->Add(crossSectionCtrl, 1, wxEXPAND);
+
+  auto tableValue = [&](TrussColumn column) {
+    wxVariant value;
+    table->GetValue(value, row, ColumnIndex(column));
+    return std::string(value.GetString().ToUTF8());
+  };
+
+  typeIdentityPanel = new GdtfTypeIdentityPanel(this);
+  typeIdentityPanel->ConfigureFields({
+      {GdtfTypeIdentityField::Manufacturer, "Manufacturer",
+       tableValue(TrussColumn::Manufacturer)},
+      {GdtfTypeIdentityField::ModelName, "Model", tableValue(TrussColumn::Model)},
+  });
+  typeIdentityPanel->SetChangeCallback(
+      [this](GdtfTypeIdentityField field, const std::string &) {
+        if (field == GdtfTypeIdentityField::Manufacturer)
+          MarkColumnModified(ColumnIndex(TrussColumn::Manufacturer));
+        else if (field == GdtfTypeIdentityField::ModelName)
+          MarkColumnModified(ColumnIndex(TrussColumn::Model));
+      });
+
+  physicalPropertiesPanel = new GdtfPhysicalPropertiesPanel(this);
+  physicalPropertiesPanel->ConfigureFields({
+      {GdtfPhysicalPropertyField::Length, "Length",
+       tableValue(TrussColumn::Length)},
+      {GdtfPhysicalPropertyField::Width, "Width", tableValue(TrussColumn::Width)},
+      {GdtfPhysicalPropertyField::Height, "Height",
+       tableValue(TrussColumn::Height)},
+      {GdtfPhysicalPropertyField::Weight, "Weight",
+       tableValue(TrussColumn::Weight)},
+      {GdtfPhysicalPropertyField::CrossSection, "Cross section",
+       std::string(crossSection.ToUTF8())},
+  });
+  physicalPropertiesPanel->SetChangeCallback(
+      [this](GdtfPhysicalPropertyField field, const std::string &) {
+        if (field == GdtfPhysicalPropertyField::Length)
+          MarkColumnModified(ColumnIndex(TrussColumn::Length));
+        else if (field == GdtfPhysicalPropertyField::Width)
+          MarkColumnModified(ColumnIndex(TrussColumn::Width));
+        else if (field == GdtfPhysicalPropertyField::Height)
+          MarkColumnModified(ColumnIndex(TrussColumn::Height));
+        else if (field == GdtfPhysicalPropertyField::Weight)
+          MarkColumnModified(ColumnIndex(TrussColumn::Weight));
+        else if (field == GdtfPhysicalPropertyField::CrossSection)
+          crossSectionModified = true;
+      });
 
   metadataPanel = new GdtfMetadataPanel(this);
   metadataSizer->SetMinSize(wxSize(360, 190));
   metadataSizer->Add(metadataPanel, 1, wxEXPAND | wxALL, 6);
 
   mvrSizer->Add(mvrGrid, 1, wxEXPAND | wxALL, 6);
-  gdtfSizer->Add(gdtfGrid, 1, wxEXPAND | wxALL, 6);
+  gdtfSizer->Add(typeIdentityPanel, 0, wxEXPAND | wxALL, 6);
+  gdtfSizer->Add(physicalPropertiesPanel, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 6);
   gdtfSizer->Add(
       new wxStaticText(this, wxID_ANY,
                        "Editing these fields creates or updates the truss "
@@ -287,9 +330,35 @@ void TrussEditDialog::ApplyChanges() {
   for (size_t i = 0; i < ctrls.size(); ++i) {
     if (!modifiedColumns[i])
       continue;
-    if (auto *control = wxDynamicCast(ctrls[i], wxTextCtrl))
+    if (i == static_cast<size_t>(ColumnIndex(TrussColumn::Manufacturer)) &&
+        typeIdentityPanel) {
+      auto value = typeIdentityPanel->GetFieldValue(
+          GdtfTypeIdentityField::Manufacturer);
+      panel->table->SetValue(
+          wxVariant(wxString::FromUTF8(value.value_or(std::string()).c_str())), row,
+          static_cast<unsigned int>(i));
+    } else if (i == static_cast<size_t>(ColumnIndex(TrussColumn::Model)) &&
+               typeIdentityPanel) {
+      auto value = typeIdentityPanel->GetFieldValue(GdtfTypeIdentityField::ModelName);
+      panel->table->SetValue(
+          wxVariant(wxString::FromUTF8(value.value_or(std::string()).c_str())), row,
+          static_cast<unsigned int>(i));
+    } else if (physicalPropertiesPanel && IsGdtfTrussColumn(i)) {
+      const auto field = i == static_cast<size_t>(ColumnIndex(TrussColumn::Length))
+                             ? GdtfPhysicalPropertyField::Length
+                         : i == static_cast<size_t>(ColumnIndex(TrussColumn::Width))
+                             ? GdtfPhysicalPropertyField::Width
+                         : i == static_cast<size_t>(ColumnIndex(TrussColumn::Height))
+                             ? GdtfPhysicalPropertyField::Height
+                             : GdtfPhysicalPropertyField::Weight;
+      auto value = physicalPropertiesPanel->GetFieldValue(field);
+      panel->table->SetValue(
+          wxVariant(wxString::FromUTF8(value.value_or(std::string()).c_str())), row,
+          static_cast<unsigned int>(i));
+    } else if (auto *control = wxDynamicCast(ctrls[i], wxTextCtrl)) {
       panel->table->SetValue(wxVariant(control->GetValue()), row,
                              static_cast<unsigned int>(i));
+    }
   }
 
   panel->UpdateSceneData(true);
@@ -303,8 +372,11 @@ void TrussEditDialog::ApplyChanges() {
       if (!hasTableChanges)
         GetDefaultGuiConfigServices().LegacyConfigManager().PushUndoState(
             "edit truss GDTF metadata");
-      it->second.crossSection =
-          std::string(crossSectionCtrl->GetValue().ToUTF8());
+      auto value = physicalPropertiesPanel
+                       ? physicalPropertiesPanel->GetFieldValue(
+                             GdtfPhysicalPropertyField::CrossSection)
+                       : std::optional<std::string>();
+      it->second.crossSection = value.value_or(std::string());
     }
   }
 

--- a/gui/trusseditdialog.h
+++ b/gui/trusseditdialog.h
@@ -25,6 +25,8 @@
 
 class FixturePreviewPanel;
 class GdtfMetadataPanel;
+class GdtfPhysicalPropertiesPanel;
+class GdtfTypeIdentityPanel;
 class TrussTablePanel;
 
 class TrussEditDialog : public wxDialog {
@@ -46,7 +48,8 @@ private:
   TrussTablePanel *panel = nullptr;
   int row = -1;
   std::vector<wxControl *> ctrls;
-  wxTextCtrl *crossSectionCtrl = nullptr;
+  GdtfTypeIdentityPanel *typeIdentityPanel = nullptr;
+  GdtfPhysicalPropertiesPanel *physicalPropertiesPanel = nullptr;
   GdtfMetadataPanel *metadataPanel = nullptr;
   FixturePreviewPanel *preview = nullptr;
   std::vector<bool> modifiedColumns;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1610,3 +1610,5 @@ if(WIN32)
     target_link_libraries(mvr_xchange_protocol_test PRIVATE iphlpapi ws2_32)
 endif()
 add_test(NAME MvrXchangeProtocol COMMAND mvr_xchange_protocol_test)
+
+add_test(NAME GdtfReusablePanelsBoundary COMMAND ${CMAKE_SOURCE_DIR}/tests/check_gdtf_reusable_panels_boundary.sh)

--- a/tests/check_gdtf_reusable_panels_boundary.sh
+++ b/tests/check_gdtf_reusable_panels_boundary.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+panel_files=(
+  gui/gdtf/gdtf_physical_properties_panel.h
+  gui/gdtf/gdtf_physical_properties_panel.cpp
+  gui/gdtf/gdtf_type_identity_panel.h
+  gui/gdtf/gdtf_type_identity_panel.cpp
+  gui/gdtf/gdtf_modes_panel.h
+  gui/gdtf/gdtf_modes_panel.cpp
+)
+for file in "${panel_files[@]}"; do
+  [[ -f "$file" ]] || { echo "Missing reusable panel file: $file" >&2; exit 1; }
+done
+
+if ! rg -q "class GdtfPhysicalPropertiesPanel : public wxPanel" gui/gdtf/gdtf_physical_properties_panel.h; then
+  echo "Physical properties panel must derive from wxPanel." >&2
+  exit 1
+fi
+if ! rg -q "class GdtfTypeIdentityPanel : public wxPanel" gui/gdtf/gdtf_type_identity_panel.h; then
+  echo "Type identity panel must derive from wxPanel." >&2
+  exit 1
+fi
+if ! rg -q "class GdtfModesPanel : public wxPanel" gui/gdtf/gdtf_modes_panel.h; then
+  echo "Modes panel must derive from wxPanel." >&2
+  exit 1
+fi
+if rg -q "ConfigManager|GuiConfigServices|FixtureTablePanel|TrussTablePanel|scene\.|Viewer[23]D|mvr|GdtfEditSession|GdtfApplyRequest|SetGdtfProperties|BuildTrussGdtfFromInstance|CreateOrUpdatePerastageLibraryDerivative|canonical" "${panel_files[@]}"; then
+  echo "Reusable GDTF panels must not depend on project, table, viewer, mutation, or editor-session services." >&2
+  exit 1
+fi
+if ! rg -q "GdtfPhysicalPropertiesPanel\* physicalPropertiesPanel" gui/fixtureeditdialog.h gui/trusseditdialog.h; then
+  echo "Fixture and Truss edit dialogs must own the reusable physical properties panel." >&2
+  exit 1
+fi
+if ! rg -q "GdtfTypeIdentityPanel\* typeIdentityPanel|GdtfTypeIdentityPanel \*typeIdentityPanel" gui/fixtureeditdialog.h gui/trusseditdialog.h; then
+  echo "Fixture and Truss edit dialogs must own the reusable type identity panel." >&2
+  exit 1
+fi
+if ! rg -q "GdtfModesPanel\* modesPanel" gui/fixtureeditdialog.h; then
+  echo "Fixture edit dialog must own the reusable modes panel." >&2
+  exit 1
+fi
+if rg -q "modeChoice|chCountCtrl|modelCtrl|channelList|crossSectionCtrl" gui/fixtureeditdialog.h gui/trusseditdialog.h; then
+  echo "Host dialog headers must not retain duplicate reusable GDTF controls." >&2
+  exit 1
+fi
+for source in gdtf_modes_panel.cpp gdtf_physical_properties_panel.cpp gdtf_type_identity_panel.cpp; do
+  if ! rg -q "gdtf/$source" gui/CMakeLists.txt; then
+    echo "Missing gui/CMakeLists.txt registration for $source." >&2
+    exit 1
+  fi
+done
+
+echo "OK: reusable GDTF panel boundaries passed."


### PR DESCRIPTION
### Motivation
- Finish Checkpoint 05 by extracting the remaining reusable GDTF UI sections (physical properties, type identity, and modes) so the panels can later be composed into a `GdtfEditorPanel` while preserving existing host-owned apply/write behavior.
- Reduce dialog duplication and enforce clear GUI-to-host boundaries so panels remain presentation-only and avoid project/table/viewer/mutation dependencies.
- Prepare deterministic guards and documentation that confirm the new panels are safe to compose in a future checkpoint without changing current apply semantics.

### Description
- Added three reusable wxWidgets panels under `gui/gdtf/`: `GdtfPhysicalPropertiesPanel` (fields and presentation model + typed `GdtfPhysicalPropertyField`), `GdtfTypeIdentityPanel` (identity/source presentation + typed `GdtfTypeIdentityField`), and `GdtfModesPanel` (ordered modes, selected mode, derived channel count and read-only channel rows) together with small helper `FormatGdtfModeFunctionLabel`. Files added: `gui/gdtf/gdtf_physical_properties_panel.{h,cpp}`, `gui/gdtf/gdtf_type_identity_panel.{h,cpp}`, and `gui/gdtf/gdtf_modes_panel.{h,cpp}`. 
- Integrated the panels into hosts: `FixtureEditDialog` now composes `GdtfMetadataPanel`, `GdtfTypeIdentityPanel`, `GdtfPhysicalPropertiesPanel`, and `GdtfModesPanel`; `TrussEditDialog` composes `GdtfMetadataPanel`, `GdtfTypeIdentityPanel`, and `GdtfPhysicalPropertiesPanel`; duplicate direct controls were removed from dialog headers and replaced by typed panel ownership. 
- Preserved existing host behavior: programmatic setters and panel configuration are non-notifying, user edits invoke typed callbacks which hosts translate to existing table/column identities, and all apply/derivative/generation/undo/scene/viewer behavior remains host-owned and unchanged. 
- Build/test infra and docs: registered new sources in `gui/CMakeLists.txt`, added boundary guard `tests/check_gdtf_reusable_panels_boundary.sh` and added test registration in `tests/CMakeLists.txt`, and updated internal docs and `docs/release-notes-draft.md` to mark Checkpoint 05 completion and describe APIs and boundaries.

### Testing
- Ran new and existing static/guard scripts: `tests/check_gdtf_reusable_panels_boundary.sh` (OK), `tests/check_gdtf_metadata_panel_boundary.sh` (OK), `tests/check_gdtf_metadata_summary_boundary.sh` (OK), `tests/check_gdtf_editor_core_boundary.sh` (OK), `tests/check_no_configmanager_get_in_gui.sh` (OK), and `tests/check_perastage_tree_modules.sh` (OK). 
- Ran `git diff --check` and boundary scripts; no diff-check failures were reported and the new boundary test passed. 
- Attempted a full CMake configure/build but the environment lacks wxWidgets development libraries so the configure step failed; this prevented a full build/GUI smoke test in this environment (configure error reported: missing wxWidgets include/libraries).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ea3259bf48324820007cf3b2e7a39)