### PR TITLE
Compose reusable GDTF editor panel

### DIFF
--- a/docs/internal/gdtf_editor_architecture_audit.md
+++ b/docs/internal/gdtf_editor_architecture_audit.md
@@ -198,3 +198,15 @@ Fixture Edit now composes metadata, type/source, physical properties, and modes 
 Truss Edit now composes metadata, manufacturer/model identity, and physical/type fields as reusable GDTF panels. MVR instance fields remain outside common GDTF panels. Truss generation, table and scene update ordering, undo behavior, generated source/model updates, metadata refresh, preview refresh, and viewer refresh remain host-owned.
 
 Checkpoint 05 is complete after these reusable panels. Checkpoint 06 is next: compose the reusable panels into `GdtfEditorPanel` without introducing session/apply adapters yet.
+
+## Checkpoint 06 reusable editor panel composition
+
+Checkpoint 05 is complete and merged. Checkpoint 06 introduces `GdtfEditorPanel` as a reusable wxWidgets composite under `gui/gdtf/` that owns and arranges exactly one `GdtfMetadataPanel`, `GdtfTypeIdentityPanel`, `GdtfPhysicalPropertiesPanel`, and `GdtfModesPanel`.
+
+The composite remains presentation-only. It accepts typed section configuration for visibility, titles, expanded behavior, and single-column or balanced two-column layouts. The stable single-column order is metadata, type identity, physical properties, then modes and channels. The stable two-column arrangement places metadata and type identity on the left, with physical properties and modes and channels on the right. Hidden sections are skipped by layout insertion while their child panel instances remain reusable if shown again.
+
+`GdtfEditorPanelPresentation` aggregates the existing child panel presentation types and keeps metadata availability explicit. Programmatic setters forward to the child panels and must not emit user-change callbacks. `SetUnavailable()` deterministically clears metadata, identity fields, physical fields, mode selection, channel count, and channel rows through the existing child panel contracts.
+
+The panel performs no file loading, archive reading, metadata discovery, GDTF mutation, derivative creation, project apply behavior, undo/redo, viewer refresh, or hoist-load recalculation. Fixture Edit and Truss Edit still own their direct child panel instances and all project/apply semantics in this checkpoint.
+
+Checkpoint 07 is next: migrate `FixtureEditDialog` and `TrussEditDialog` from direct child-panel ownership to `GdtfEditorPanel` while preserving host-owned project, apply, mutation, scene update, and recalculation behavior.

--- a/docs/internal/gdtf_editor_context_boundaries.md
+++ b/docs/internal/gdtf_editor_context_boundaries.md
@@ -157,3 +157,13 @@ Fixture composition after Checkpoint 05: metadata, type/source identity, physica
 Truss composition after Checkpoint 05: metadata, manufacturer/model identity, dimensions/weight/cross-section physical type fields, MVR/project instance fields, preview, and host Apply/OK/Cancel controls. Geometry-only truss behavior and GDTF generation policy remain in the host dialog.
 
 Checkpoint 06 should compose these reusable panels into `GdtfEditorPanel`. Direct `GdtfEditSession` binding and apply adapters remain later controlled migrations.
+
+## Reusable composite boundary after Checkpoint 06
+
+Checkpoint 06 adds `GdtfEditorPanel` as a composition layer above the four reusable GDTF panels. The composite owns one instance of each child panel, groups them into configurable sections, and exposes typed forwarding APIs for presentation updates, callbacks, getters, setters, mode selection, and physical-property validation.
+
+The composite does not change context semantics. `GdtfEditorContext`, `GdtfFieldCapability`, and host-specific configuration still decide whether a field represents a document mutation, context selection, project override, derived value, or read-only value. `GdtfEditorPanel` only displays the aggregate presentation supplied by a host and forwards genuine child-control user events back to that host.
+
+Programmatic composite updates are non-notifying, including configuration changes, aggregate presentation replacement, unavailable-state refreshes, metadata updates, identity or physical field setters, and mode presentation updates. This keeps future Fixture Edit, Truss Edit, standalone read-only, and standalone editable hosts responsible for deciding when user intent should become an apply request.
+
+Current Fixture Edit and Truss Edit dialogs are intentionally not migrated in Checkpoint 06. Checkpoint 07 will migrate those dialogs to the composite while keeping source path resolution, loaders, derivative creation, truss generation, undo/redo, scene updates, viewer refresh, and hoist/load recalculation in the host layer.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -58,6 +58,7 @@ Changes since **v1.4.0**.
 
 ## Internal changes
 
+- Completed the GDTF editor Checkpoint 06 composition step by adding a reusable presentation-only `GdtfEditorPanel` that arranges the existing metadata, type identity, physical properties, and modes panels without changing Fixture Edit or Truss Edit behavior.
 - Completed the GDTF editor Checkpoint 05 panel extraction by adding reusable physical properties, type identity, and modes panels while preserving existing Fixture Edit and Truss Edit apply behavior.
 
 - Improved GDTF geometry loading and symbol-cache validation by sharing one cached geometry build, caching primitive meshes by dimensions, reusing fixture bounds during symbol generation, and switching generated-symbol manifests to a versioned semantic GDTF fingerprint that is stable across ZIP repackaging.

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -35,6 +35,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/fixturetablepanel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fixturetablepanel_ui_helpers.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fixturetablepanel_update_types.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gdtf/gdtf_editor_panel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtf/gdtf_metadata_panel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtf/gdtf_modes_panel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtf/gdtf_physical_properties_panel.cpp

--- a/gui/gdtf/gdtf_editor_panel.cpp
+++ b/gui/gdtf/gdtf_editor_panel.cpp
@@ -1,0 +1,239 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "gdtf/gdtf_editor_panel.h"
+
+#include <utility>
+
+#include <wx/sizer.h>
+#include <wx/statbox.h>
+#include <wx/string.h>
+
+namespace {
+constexpr int kSectionGap = 8;
+constexpr int kSectionPadding = 6;
+}
+
+// Creates the reusable composite GDTF editor panel and its child panels.
+GdtfEditorPanel::GdtfEditorPanel(wxWindow *parent) : wxPanel(parent, wxID_ANY) {
+  BuildSections();
+  RebuildLayout();
+}
+
+// Applies section titles, visibility, and the selected column layout.
+void GdtfEditorPanel::Configure(
+    const GdtfEditorPanelConfiguration &newConfiguration) {
+  configuration = newConfiguration;
+  RebuildLayout();
+}
+
+// Applies a complete aggregate presentation without notifying callbacks.
+void GdtfEditorPanel::SetPresentation(
+    const GdtfEditorPanelPresentation &presentation) {
+  if (presentation.metadataAvailable)
+    metadataPanel->SetMetadata(presentation.metadata);
+  else
+    metadataPanel->SetUnavailable();
+  typeIdentityPanel->ConfigureFields(presentation.identityFields);
+  physicalPropertiesPanel->ConfigureFields(presentation.physicalFields);
+  modesPanel->SetPresentation(presentation.modes);
+}
+
+// Clears all child presentations to their deterministic unavailable state.
+void GdtfEditorPanel::SetUnavailable() {
+  metadataPanel->SetUnavailable();
+  typeIdentityPanel->ConfigureFields({});
+  physicalPropertiesPanel->ConfigureFields({});
+  modesPanel->SetPresentation({});
+}
+
+// Registers the forwarded type identity change callback.
+void GdtfEditorPanel::SetIdentityChangeCallback(
+    GdtfTypeIdentityPanel::ChangeCallback callback) {
+  typeIdentityPanel->SetChangeCallback(std::move(callback));
+}
+
+// Registers the forwarded type identity action callback.
+void GdtfEditorPanel::SetIdentityActionCallback(
+    GdtfTypeIdentityPanel::ActionCallback callback) {
+  typeIdentityPanel->SetActionCallback(std::move(callback));
+}
+
+// Registers the forwarded physical property change callback.
+void GdtfEditorPanel::SetPhysicalPropertyChangeCallback(
+    GdtfPhysicalPropertiesPanel::ChangeCallback callback) {
+  physicalPropertiesPanel->SetChangeCallback(std::move(callback));
+}
+
+// Registers the forwarded mode selection callback.
+void GdtfEditorPanel::SetModeSelectionCallback(
+    GdtfModesPanel::ModeSelectionCallback callback) {
+  modesPanel->SetModeSelectionCallback(std::move(callback));
+}
+
+// Returns the current value for a visible identity field.
+std::optional<std::string>
+GdtfEditorPanel::GetIdentityValue(GdtfTypeIdentityField field) const {
+  return typeIdentityPanel->GetFieldValue(field);
+}
+
+// Returns the current value for a visible physical property field.
+std::optional<std::string> GdtfEditorPanel::GetPhysicalPropertyValue(
+    GdtfPhysicalPropertyField field) const {
+  return physicalPropertiesPanel->GetFieldValue(field);
+}
+
+// Returns the currently selected GDTF mode.
+std::string GdtfEditorPanel::GetSelectedMode() const {
+  return modesPanel->GetSelectedMode();
+}
+
+// Sets one identity field value without notifying callbacks.
+void GdtfEditorPanel::SetIdentityValue(GdtfTypeIdentityField field,
+                                       const std::string &value) {
+  typeIdentityPanel->SetFieldValue(field, value);
+}
+
+// Sets identity field editability for a visible field.
+void GdtfEditorPanel::SetIdentityFieldEditable(GdtfTypeIdentityField field,
+                                               bool editable) {
+  typeIdentityPanel->SetFieldEditable(field, editable);
+}
+
+// Sets one physical property value without notifying callbacks.
+void GdtfEditorPanel::SetPhysicalPropertyValue(GdtfPhysicalPropertyField field,
+                                               const std::string &value) {
+  physicalPropertiesPanel->SetFieldValue(field, value);
+}
+
+// Sets physical property editability for a visible field.
+void GdtfEditorPanel::SetPhysicalPropertyEditable(GdtfPhysicalPropertyField field,
+                                                  bool editable) {
+  physicalPropertiesPanel->SetFieldEditable(field, editable);
+}
+
+// Forwards validation feedback for a visible physical property field.
+void GdtfEditorPanel::SetPhysicalPropertyValidation(
+    GdtfPhysicalPropertyField field, const std::string &message) {
+  physicalPropertiesPanel->SetFieldValidation(field, message);
+}
+
+// Applies modes and channels presentation without notifying callbacks.
+void GdtfEditorPanel::SetModesPresentation(
+    const GdtfModesPresentation &presentation) {
+  modesPanel->SetPresentation(presentation);
+}
+
+// Enables or disables user mode selection.
+void GdtfEditorPanel::SetModeSelectionEnabled(bool enabled) {
+  modesPanel->SetModeSelectionEnabled(enabled);
+}
+
+// Applies metadata presentation to the metadata section.
+void GdtfEditorPanel::SetMetadata(const GdtfMetadataSummary &summary) {
+  metadataPanel->SetMetadata(summary);
+}
+
+// Applies the metadata unavailable fallback presentation.
+void GdtfEditorPanel::SetMetadataUnavailable() {
+  metadataPanel->SetUnavailable();
+}
+
+// Creates each child panel exactly once and places it inside a section box.
+void GdtfEditorPanel::BuildSections() {
+  rootSizer = new wxBoxSizer(wxVERTICAL);
+  twoColumnSizer = new wxBoxSizer(wxHORIZONTAL);
+  leftColumnSizer = new wxBoxSizer(wxVERTICAL);
+  rightColumnSizer = new wxBoxSizer(wxVERTICAL);
+  SetSizer(rootSizer);
+
+  metadataPanel = new GdtfMetadataPanel(this);
+  typeIdentityPanel = new GdtfTypeIdentityPanel(this);
+  physicalPropertiesPanel = new GdtfPhysicalPropertiesPanel(this);
+  modesPanel = new GdtfModesPanel(this);
+
+  metadataSection = new wxStaticBoxSizer(wxVERTICAL, this, wxString());
+  typeIdentitySection = new wxStaticBoxSizer(wxVERTICAL, this, wxString());
+  physicalPropertiesSection = new wxStaticBoxSizer(wxVERTICAL, this, wxString());
+  modesSection = new wxStaticBoxSizer(wxVERTICAL, this, wxString());
+
+  metadataSection->Add(metadataPanel, 0, wxEXPAND | wxALL, kSectionPadding);
+  typeIdentitySection->Add(typeIdentityPanel, 0, wxEXPAND | wxALL, kSectionPadding);
+  physicalPropertiesSection->Add(physicalPropertiesPanel, 0,
+                                 wxEXPAND | wxALL, kSectionPadding);
+  modesSection->Add(modesPanel, 1, wxEXPAND | wxALL, kSectionPadding);
+}
+
+// Applies one section label and window visibility from typed configuration.
+void GdtfEditorPanel::ApplySectionConfiguration(
+    wxStaticBoxSizer *section,
+    const GdtfEditorSectionConfiguration &sectionConfiguration) {
+  section->GetStaticBox()->SetLabel(wxString::FromUTF8(sectionConfiguration.title));
+  section->ShowItems(sectionConfiguration.visible);
+  section->GetStaticBox()->Show(sectionConfiguration.visible);
+}
+
+// Rebuilds only the top-level sizer arrangement while preserving child panels.
+void GdtfEditorPanel::RebuildLayout() {
+  ApplySectionConfiguration(metadataSection, configuration.metadata);
+  ApplySectionConfiguration(typeIdentitySection, configuration.typeIdentity);
+  ApplySectionConfiguration(physicalPropertiesSection,
+                            configuration.physicalProperties);
+  ApplySectionConfiguration(modesSection, configuration.modes);
+
+  rootSizer->Clear(false);
+  twoColumnSizer->Clear(false);
+  leftColumnSizer->Clear(false);
+  rightColumnSizer->Clear(false);
+
+  if (configuration.layout == GdtfEditorPanelLayout::TwoColumn)
+    AddTwoColumnSections(rootSizer);
+  else
+    AddSingleColumnSections(rootSizer);
+
+  Layout();
+}
+
+// Adds a visible section to a target sizer with deterministic grow behavior.
+void GdtfEditorPanel::AddSection(wxBoxSizer *target, wxStaticBoxSizer *section,
+                                 const GdtfEditorSectionConfiguration &sectionConfiguration,
+                                 int growProportion) {
+  if (!sectionConfiguration.visible)
+    return;
+  target->Add(section, sectionConfiguration.expanded ? growProportion : 0,
+              wxEXPAND | wxBOTTOM, kSectionGap);
+}
+
+// Adds visible sections in the documented single-column order.
+void GdtfEditorPanel::AddSingleColumnSections(wxBoxSizer *root) {
+  AddSection(root, metadataSection, configuration.metadata, 0);
+  AddSection(root, typeIdentitySection, configuration.typeIdentity, 0);
+  AddSection(root, physicalPropertiesSection, configuration.physicalProperties, 0);
+  AddSection(root, modesSection, configuration.modes, 1);
+}
+
+// Adds visible sections in the documented balanced two-column arrangement.
+void GdtfEditorPanel::AddTwoColumnSections(wxBoxSizer *root) {
+  AddSection(leftColumnSizer, metadataSection, configuration.metadata, 0);
+  AddSection(leftColumnSizer, typeIdentitySection, configuration.typeIdentity, 0);
+  AddSection(rightColumnSizer, physicalPropertiesSection,
+             configuration.physicalProperties, 0);
+  AddSection(rightColumnSizer, modesSection, configuration.modes, 1);
+  twoColumnSizer->Add(leftColumnSizer, 1, wxEXPAND | wxRIGHT, kSectionGap);
+  twoColumnSizer->Add(rightColumnSizer, 1, wxEXPAND);
+  root->Add(twoColumnSizer, 1, wxEXPAND);
+}

--- a/gui/gdtf/gdtf_editor_panel.h
+++ b/gui/gdtf/gdtf_editor_panel.h
@@ -1,0 +1,121 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include "gdtf_metadata_panel.h"
+#include "gdtf_modes_panel.h"
+#include "gdtf_physical_properties_panel.h"
+#include "gdtf_type_identity_panel.h"
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <wx/panel.h>
+
+class wxBoxSizer;
+class wxStaticBoxSizer;
+
+// Selects the top-level arrangement used by the reusable GDTF editor panel.
+enum class GdtfEditorPanelLayout { SingleColumn, TwoColumn };
+
+// Identifies configurable sections in the reusable GDTF editor panel.
+enum class GdtfEditorSection { Metadata, TypeIdentity, PhysicalProperties, Modes };
+
+struct GdtfEditorSectionConfiguration {
+  bool visible = true;
+  bool expanded = true;
+  std::string title;
+};
+
+struct GdtfEditorPanelConfiguration {
+  GdtfEditorPanelLayout layout = GdtfEditorPanelLayout::SingleColumn;
+  GdtfEditorSectionConfiguration metadata{true, true, "GDTF metadata"};
+  GdtfEditorSectionConfiguration typeIdentity{true, true, "Type identity"};
+  GdtfEditorSectionConfiguration physicalProperties{true, true,
+                                                    "Physical properties"};
+  GdtfEditorSectionConfiguration modes{true, true, "Modes and channels"};
+};
+
+struct GdtfEditorPanelPresentation {
+  bool metadataAvailable = false;
+  GdtfMetadataSummary metadata;
+  std::vector<GdtfTypeIdentityPresentation> identityFields;
+  std::vector<GdtfPhysicalPropertyPresentation> physicalFields;
+  GdtfModesPresentation modes;
+};
+
+class GdtfEditorPanel : public wxPanel {
+public:
+  explicit GdtfEditorPanel(wxWindow *parent);
+
+  void Configure(const GdtfEditorPanelConfiguration &configuration);
+  void SetPresentation(const GdtfEditorPanelPresentation &presentation);
+  void SetUnavailable();
+
+  void SetIdentityChangeCallback(GdtfTypeIdentityPanel::ChangeCallback callback);
+  void SetIdentityActionCallback(GdtfTypeIdentityPanel::ActionCallback callback);
+  void SetPhysicalPropertyChangeCallback(
+      GdtfPhysicalPropertiesPanel::ChangeCallback callback);
+  void SetModeSelectionCallback(GdtfModesPanel::ModeSelectionCallback callback);
+
+  std::optional<std::string> GetIdentityValue(GdtfTypeIdentityField field) const;
+  std::optional<std::string> GetPhysicalPropertyValue(
+      GdtfPhysicalPropertyField field) const;
+  std::string GetSelectedMode() const;
+
+  void SetIdentityValue(GdtfTypeIdentityField field, const std::string &value);
+  void SetIdentityFieldEditable(GdtfTypeIdentityField field, bool editable);
+  void SetPhysicalPropertyValue(GdtfPhysicalPropertyField field,
+                                const std::string &value);
+  void SetPhysicalPropertyEditable(GdtfPhysicalPropertyField field, bool editable);
+  void SetPhysicalPropertyValidation(GdtfPhysicalPropertyField field,
+                                     const std::string &message);
+  void SetModesPresentation(const GdtfModesPresentation &presentation);
+  void SetModeSelectionEnabled(bool enabled);
+  void SetMetadata(const GdtfMetadataSummary &summary);
+  void SetMetadataUnavailable();
+
+private:
+  void BuildSections();
+  void ApplySectionConfiguration(wxStaticBoxSizer *section,
+                                 const GdtfEditorSectionConfiguration &configuration);
+  void RebuildLayout();
+  void AddSection(wxBoxSizer *target, wxStaticBoxSizer *section,
+                  const GdtfEditorSectionConfiguration &configuration,
+                  int growProportion);
+  void AddSingleColumnSections(wxBoxSizer *root);
+  void AddTwoColumnSections(wxBoxSizer *root);
+
+  GdtfMetadataPanel *metadataPanel = nullptr;
+  GdtfTypeIdentityPanel *typeIdentityPanel = nullptr;
+  GdtfPhysicalPropertiesPanel *physicalPropertiesPanel = nullptr;
+  GdtfModesPanel *modesPanel = nullptr;
+
+  wxBoxSizer *rootSizer = nullptr;
+  wxBoxSizer *twoColumnSizer = nullptr;
+  wxBoxSizer *leftColumnSizer = nullptr;
+  wxBoxSizer *rightColumnSizer = nullptr;
+
+  wxStaticBoxSizer *metadataSection = nullptr;
+  wxStaticBoxSizer *typeIdentitySection = nullptr;
+  wxStaticBoxSizer *physicalPropertiesSection = nullptr;
+  wxStaticBoxSizer *modesSection = nullptr;
+
+  GdtfEditorPanelConfiguration configuration;
+};

--- a/gui/gdtf/gdtf_modes_panel.cpp
+++ b/gui/gdtf/gdtf_modes_panel.cpp
@@ -1,4 +1,23 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
 #include "gdtf_modes_panel.h"
+
+#include <utility>
 
 #include <wx/choice.h>
 #include <wx/sizer.h>

--- a/gui/gdtf/gdtf_modes_panel.h
+++ b/gui/gdtf/gdtf_modes_panel.h
@@ -6,6 +6,14 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #pragma once
 

--- a/gui/gdtf/gdtf_physical_properties_panel.cpp
+++ b/gui/gdtf/gdtf_physical_properties_panel.cpp
@@ -1,4 +1,23 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
 #include "gdtf_physical_properties_panel.h"
+
+#include <utility>
 
 #include <wx/sizer.h>
 #include <wx/stattext.h>

--- a/gui/gdtf/gdtf_physical_properties_panel.h
+++ b/gui/gdtf/gdtf_physical_properties_panel.h
@@ -6,6 +6,14 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #pragma once
 

--- a/gui/gdtf/gdtf_type_identity_panel.cpp
+++ b/gui/gdtf/gdtf_type_identity_panel.cpp
@@ -1,4 +1,23 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
 #include "gdtf_type_identity_panel.h"
+
+#include <utility>
 
 #include <wx/button.h>
 #include <wx/sizer.h>

--- a/gui/gdtf/gdtf_type_identity_panel.h
+++ b/gui/gdtf/gdtf_type_identity_panel.h
@@ -6,6 +6,14 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #pragma once
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -59,6 +59,10 @@ if(BASH_EXECUTABLE)
              COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_gdtf_metadata_summary_boundary.sh)
     add_test(NAME GdtfMetadataPanelBoundary
              COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_gdtf_metadata_panel_boundary.sh)
+    add_test(NAME GdtfReusablePanelsBoundary
+             COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_gdtf_reusable_panels_boundary.sh)
+    add_test(NAME GdtfEditorPanelBoundary
+             COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_gdtf_editor_panel_boundary.sh)
     add_test(NAME GdtfEditorCoreBoundary
              COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_gdtf_editor_core_boundary.sh)
     add_test(NAME ProjectRestoreImportOptions

--- a/tests/check_gdtf_editor_panel_boundary.sh
+++ b/tests/check_gdtf_editor_panel_boundary.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+panel_header="gui/gdtf/gdtf_editor_panel.h"
+panel_source="gui/gdtf/gdtf_editor_panel.cpp"
+cmake_file="gui/CMakeLists.txt"
+fixture_header="gui/fixtureeditdialog.h"
+fixture_source="gui/fixtureeditdialog.cpp"
+truss_header="gui/trusseditdialog.h"
+truss_source="gui/trusseditdialog.cpp"
+child_files=(
+  gui/gdtf/gdtf_metadata_panel.h
+  gui/gdtf/gdtf_metadata_panel.cpp
+  gui/gdtf/gdtf_type_identity_panel.h
+  gui/gdtf/gdtf_type_identity_panel.cpp
+  gui/gdtf/gdtf_physical_properties_panel.h
+  gui/gdtf/gdtf_physical_properties_panel.cpp
+  gui/gdtf/gdtf_modes_panel.h
+  gui/gdtf/gdtf_modes_panel.cpp
+)
+
+for file in "$panel_header" "$panel_source" "$cmake_file" "$fixture_header" "$fixture_source" "$truss_header" "$truss_source" "${child_files[@]}"; do
+  [[ -f "$file" ]] || { echo "Missing required file: $file" >&2; exit 1; }
+done
+
+if ! rg -q "class GdtfEditorPanel : public wxPanel" "$panel_header"; then
+  echo "GdtfEditorPanel must derive from wxPanel." >&2
+  exit 1
+fi
+for child in GdtfMetadataPanel GdtfTypeIdentityPanel GdtfPhysicalPropertiesPanel GdtfModesPanel; do
+  if [[ $(rg -c "${child} \*" "$panel_header") -ne 1 ]]; then
+    echo "GdtfEditorPanel must own exactly one ${child} pointer." >&2
+    exit 1
+  fi
+  if ! rg -q "new ${child}\(this\)" "$panel_source"; then
+    echo "GdtfEditorPanel must create ${child} exactly once with wx parent ownership." >&2
+    exit 1
+  fi
+done
+
+for token in GdtfEditorPanelLayout GdtfEditorSectionConfiguration GdtfEditorPanelConfiguration GdtfEditorPanelPresentation metadataAvailable identityFields physicalFields; do
+  if ! rg -q "$token" "$panel_header"; then
+    echo "Missing composite configuration or presentation token: $token" >&2
+    exit 1
+  fi
+done
+for api in Configure SetPresentation SetUnavailable SetIdentityChangeCallback SetIdentityActionCallback SetPhysicalPropertyChangeCallback SetModeSelectionCallback GetIdentityValue GetPhysicalPropertyValue GetSelectedMode SetIdentityValue SetPhysicalPropertyValue SetPhysicalPropertyValidation SetModesPresentation SetMetadata SetMetadataUnavailable; do
+  if ! rg -q "$api" "$panel_header"; then
+    echo "Missing public forwarding API: $api" >&2
+    exit 1
+  fi
+done
+
+if ! rg -q "GDTF metadata" "$panel_header" || ! rg -q "Type identity" "$panel_header" || \
+   ! rg -q "Physical properties" "$panel_header" || ! rg -q "Modes and channels" "$panel_header"; then
+  echo "Default section titles must be declared in the typed configuration." >&2
+  exit 1
+fi
+if ! rg -q "wxStaticBoxSizer" "$panel_header" "$panel_source"; then
+  echo "Composite sections must use static box sizers for visual grouping." >&2
+  exit 1
+fi
+if ! rg -q "AddSingleColumnSections" "$panel_source" || ! rg -q "AddTwoColumnSections" "$panel_source"; then
+  echo "Composite must implement deterministic single-column and two-column layouts." >&2
+  exit 1
+fi
+if ! rg -q "AddSection\(leftColumnSizer, metadataSection" "$panel_source" || \
+   ! rg -q "AddSection\(leftColumnSizer, typeIdentitySection" "$panel_source" || \
+   ! rg -q "AddSection\(rightColumnSizer, physicalPropertiesSection" "$panel_source" || \
+   ! rg -q "AddSection\(rightColumnSizer, modesSection" "$panel_source"; then
+  echo "Two-column layout must keep the documented stable arrangement." >&2
+  exit 1
+fi
+if ! rg -q "AddSection\(root, metadataSection" "$panel_source" || \
+   ! rg -q "AddSection\(root, typeIdentitySection" "$panel_source" || \
+   ! rg -q "AddSection\(root, physicalPropertiesSection" "$panel_source" || \
+   ! rg -q "AddSection\(root, modesSection" "$panel_source"; then
+  echo "Single-column layout must keep the documented stable order." >&2
+  exit 1
+fi
+if ! rg -q "if \(!sectionConfiguration.visible\)" "$panel_source"; then
+  echo "Hidden sections must be skipped by layout insertion." >&2
+  exit 1
+fi
+if ! rg -q "modesSection.*1, wxEXPAND" "$panel_source"; then
+  echo "Modes section must be added with growable vertical proportion inside its section." >&2
+  exit 1
+fi
+if ! rg -q "gdtf/gdtf_editor_panel.cpp" "$cmake_file"; then
+  echo "GdtfEditorPanel source must be registered in gui/CMakeLists.txt." >&2
+  exit 1
+fi
+
+prohibited="ConfigManager|GuiConfigServices|FixtureTablePanel|TrussTablePanel|viewer|Mvr|mvr|LoadGdtf|GetGdtfModes|GdtfArchive|GdtfEditSession|GdtfApplyRequest|SetGdtfProperties|BuildTrussGdtfFromInstance|CreateOrUpdatePerastageLibraryDerivative|canonical|Undo|dirty|Hoist"
+if rg -q "$prohibited" "$panel_header" "$panel_source"; then
+  echo "GdtfEditorPanel must remain presentation-only and avoid project, load, mutation, viewer, and apply dependencies." >&2
+  exit 1
+fi
+if rg -q "gdtf_editor_panel" "${child_files[@]}"; then
+  echo "Reusable child panels must not depend on the composite panel." >&2
+  exit 1
+fi
+if rg -q "GdtfEditorPanel" "$fixture_header" "$fixture_source" "$truss_header" "$truss_source"; then
+  echo "Fixture Edit and Truss Edit must not be migrated to GdtfEditorPanel in Checkpoint 06." >&2
+  exit 1
+fi
+
+if rg -q "Fit\(" "$panel_source"; then
+  echo "Composite layout must not repeatedly fit parent windows." >&2
+  exit 1
+fi
+
+echo "OK: GDTF editor panel composition boundary checks passed."


### PR DESCRIPTION
### Motivation
- Provide a single reusable, presentation-only composite that composes the four existing GDTF panels so hosts can present/edit GDTF data via a stable typed API without changing existing dialog/project behavior.
- Keep composition strictly presentation-oriented and non-notifying so project apply/mutation, loaders, and session/undo remain host-owned.
- Perform small preflight cleanup on the Checkpoint 05 panel sources to ensure consistent license headers and correct includes before adding the composite.

### Description
- Added `GdtfEditorPanel` (`gui/gdtf/gdtf_editor_panel.h` and `gui/gdtf/gdtf_editor_panel.cpp`) which instantiates exactly one `GdtfMetadataPanel`, `GdtfTypeIdentityPanel`, `GdtfPhysicalPropertiesPanel`, and `GdtfModesPanel`, and arranges them into configurable `SingleColumn` or `TwoColumn` layouts using `wxStaticBoxSizer` grouping.
- Introduced typed configuration and presentation types: `GdtfEditorPanelLayout`, `GdtfEditorSectionConfiguration`, `GdtfEditorPanelConfiguration`, and `GdtfEditorPanelPresentation`, and added a forwarding public API (`Configure`, `SetPresentation`, `SetUnavailable`, callback setters, typed getters/setters, and validation forwarding) that delegates to child panels without synthesizing user events.
- Implemented deterministic unavailable/clear behavior and reconfiguration rules so hidden sections consume no layout space, child panels are created once and reused, the modes section grows vertically, and programmatic updates remain non-notifying.
- Performed Checkpoint 05 cleanup (completed GPL headers and added direct `<utility>` includes where `std::move` is used), registered the new source in `gui/CMakeLists.txt`, added `tests/check_gdtf_editor_panel_boundary.sh`, updated `tests/CMakeLists.txt`, and updated internal docs and `docs/release-notes-draft.md` to record Checkpoint 06.

### Testing
- Ran boundary/test guards: `tests/check_gdtf_editor_panel_boundary.sh`, `tests/check_gdtf_reusable_panels_boundary.sh`, `tests/check_gdtf_metadata_panel_boundary.sh`, `tests/check_gdtf_metadata_summary_boundary.sh`, `tests/check_gdtf_editor_core_boundary.sh`, `tests/check_no_configmanager_get_in_gui.sh`, and `tests/check_perastage_tree_modules.sh`, and all returned OK.
- Ran `git diff --check` and it passed with no whitespace or patch errors.
- Attempted `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug` but configure failed due to missing wxWidgets development files in the environment, so a full build/test could not be executed here.
- Confirmations: current `FixtureEditDialog` and `TrussEditDialog` were not migrated in this checkpoint and Checkpoint 06 composition is complete; next step is the host migration in Checkpoint 07.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ea8a1def0832491f6ec56a87bc981)