### PR TITLE
Checkpoint 07: Migrate FixtureEditDialog and TrussEditDialog to GdtfEditorPanel composite

### DIFF
--- a/docs/internal/gdtf_editor_architecture_audit.md
+++ b/docs/internal/gdtf_editor_architecture_audit.md
@@ -210,3 +210,13 @@ The composite remains presentation-only. It accepts typed section configuration 
 The panel performs no file loading, archive reading, metadata discovery, GDTF mutation, derivative creation, project apply behavior, undo/redo, viewer refresh, or hoist-load recalculation. Fixture Edit and Truss Edit still own their direct child panel instances and all project/apply semantics in this checkpoint.
 
 Checkpoint 07 is next: migrate `FixtureEditDialog` and `TrussEditDialog` from direct child-panel ownership to `GdtfEditorPanel` while preserving host-owned project, apply, mutation, scene update, and recalculation behavior.
+
+## Checkpoint 07 host composition migration
+
+Checkpoint 07 is complete. `FixtureEditDialog` and `TrussEditDialog` now instantiate one `GdtfEditorPanel` each instead of directly owning `GdtfMetadataPanel`, `GdtfTypeIdentityPanel`, `GdtfPhysicalPropertiesPanel`, or `GdtfModesPanel` instances.
+
+Fixture Edit uses the composite with metadata, fixture type/source identity, physical power/weight, and modes/channels visible. Truss Edit uses the same composite with metadata, truss manufacturer/model identity, dimensions/weight/cross-section physical fields, and the modes section hidden. The composite gained only narrow presentation-only forwarding for incremental modes updates used by the fixture host.
+
+The composite remains presentation-only. It has no project, table, MVR, loader, mutation, derivative, truss-generation, undo, viewer, or `GdtfEditSession` responsibilities. Host dialogs still translate typed callbacks into their existing modified-column flags and continue to own Apply/OK/Cancel behavior, table updates, scene updates, previews, metadata loading, fixture derivative handling, truss generation, undo, and viewer refresh.
+
+This checkpoint does not implement direct `.gdtf` startup routing, standalone GDTF windows, direct edit-session binding, or `GdtfApplyRequest` adapters. Checkpoint 08 remains the next controlled architecture step.

--- a/docs/internal/gdtf_editor_context_boundaries.md
+++ b/docs/internal/gdtf_editor_context_boundaries.md
@@ -167,3 +167,13 @@ The composite does not change context semantics. `GdtfEditorContext`, `GdtfField
 Programmatic composite updates are non-notifying, including configuration changes, aggregate presentation replacement, unavailable-state refreshes, metadata updates, identity or physical field setters, and mode presentation updates. This keeps future Fixture Edit, Truss Edit, standalone read-only, and standalone editable hosts responsible for deciding when user intent should become an apply request.
 
 Current Fixture Edit and Truss Edit dialogs are intentionally not migrated in Checkpoint 06. Checkpoint 07 will migrate those dialogs to the composite while keeping source path resolution, loaders, derivative creation, truss generation, undo/redo, scene updates, viewer refresh, and hoist/load recalculation in the host layer.
+
+## Host composition boundary after Checkpoint 07
+
+Checkpoint 07 migrates Fixture Edit and Truss Edit from direct reusable child-panel ownership to `GdtfEditorPanel`. Each host dialog now owns exactly one composite panel, while the composite remains the only GUI owner of the metadata, type identity, physical properties, and modes child panels.
+
+Fixture Edit configures metadata, fixture type/source identity, power/weight physical properties, and modes/channels as visible composite sections. Truss Edit configures metadata, manufacturer/model identity, and physical dimensions/weight/cross-section sections while hiding modes/channels. Hidden sections consume no host layout space, and programmatic composite updates remain non-notifying.
+
+The migration does not move host context decisions into the composite. Fixture Edit still owns fixture source-path fallback, GDTF browsing, preview, symbols, thumbnail, mode application, table writes, derivative creation, physical-property mutation, revision/audit behavior, shared-property propagation, undo, hoist/load recalculation prompts, and Viewer2D/Viewer3D refresh. Truss Edit still owns resource resolution, geometry-only preview behavior, truss GDTF generation policy, model/source updates, scene mutation, undo, table reload, and viewer refresh.
+
+Direct `GdtfEditSession` binding and context/apply adapters remain intentionally deferred. Checkpoint 08 is the next controlled step and should introduce the adapter migration without changing the Checkpoint 07 host-composition ownership boundary.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -59,6 +59,7 @@ Changes since **v1.4.0**.
 ## Internal changes
 
 - Completed the GDTF editor Checkpoint 06 composition step by adding a reusable presentation-only `GdtfEditorPanel` that arranges the existing metadata, type identity, physical properties, and modes panels without changing Fixture Edit or Truss Edit behavior.
+- Completed the GDTF editor Checkpoint 07 host-composition migration by moving Fixture Edit and Truss Edit onto the reusable presentation-only `GdtfEditorPanel` while keeping project apply, mutation, preview, undo, and viewer behavior host-owned.
 - Completed the GDTF editor Checkpoint 05 panel extraction by adding reusable physical properties, type identity, and modes panels while preserving existing Fixture Edit and Truss Edit apply behavior.
 
 - Improved GDTF geometry loading and symbol-cache validation by sharing one cached geometry build, caching primitive meshes by dimensions, reusing fixture bounds during symbol generation, and switching generated-symbol manifests to a versioned semantic GDTF fingerprint that is stable across ZIP repackaging.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -59,7 +59,7 @@ Changes since **v1.4.0**.
 ## Internal changes
 
 - Completed the GDTF editor Checkpoint 06 composition step by adding a reusable presentation-only `GdtfEditorPanel` that arranges the existing metadata, type identity, physical properties, and modes panels without changing Fixture Edit or Truss Edit behavior.
-- Completed the GDTF editor Checkpoint 07 host-composition migration by moving Fixture Edit and Truss Edit onto the reusable presentation-only `GdtfEditorPanel` while keeping project apply, mutation, preview, undo, and viewer behavior host-owned.
+- Completed the GDTF editor Checkpoint 07 host-composition migration by moving Fixture Edit and Truss Edit onto the reusable presentation-only `GdtfEditorPanel` while keeping project apply, mutation, preview, undo, and viewer behavior host-owned, and corrected static-box parenting so the migrated dialogs open without wxWidgets containment warnings.
 - Completed the GDTF editor Checkpoint 05 panel extraction by adding reusable physical properties, type identity, and modes panels while preserving existing Fixture Edit and Truss Edit apply behavior.
 
 - Improved GDTF geometry loading and symbol-cache validation by sharing one cached geometry build, caching primitive meshes by dimensions, reusing fixture bounds during symbol generation, and switching generated-symbol manifests to a versioned semantic GDTF fingerprint that is stable across ZIP repackaging.

--- a/gui/fixtureeditdialog.cpp
+++ b/gui/fixtureeditdialog.cpp
@@ -371,7 +371,7 @@ FixtureEditDialog::FixtureEditDialog(FixtureTablePanel *p, int r)
   table->GetValue(modeValue, row, FixtureTableColumns::ToIndex(
                                FixtureTableColumns::Column::Mode));
 
-  gdtfEditorPanel = new GdtfEditorPanel(this);
+  gdtfEditorPanel = new GdtfEditorPanel(gdtfGeneralSizer->GetStaticBox());
   GdtfEditorPanelConfiguration gdtfConfiguration;
   gdtfConfiguration.layout = GdtfEditorPanelLayout::SingleColumn;
   gdtfConfiguration.metadata.title = "GDTF metadata";

--- a/gui/fixtureeditdialog.cpp
+++ b/gui/fixtureeditdialog.cpp
@@ -21,10 +21,7 @@
 #include "fixturepreviewpanel.h"
 #include "fixturetable/fixture_table_columns.h"
 #include "fixturetablepanel.h"
-#include "gdtf/gdtf_metadata_panel.h"
-#include "gdtf/gdtf_modes_panel.h"
-#include "gdtf/gdtf_physical_properties_panel.h"
-#include "gdtf/gdtf_type_identity_panel.h"
+#include "gdtf/gdtf_editor_panel.h"
 #include "gdtf_mutation_audit.h"
 #include "gdtf_metadata_summary.h"
 #include "gdtfdictionary.h"
@@ -277,8 +274,6 @@ FixtureEditDialog::FixtureEditDialog(FixtureTablePanel *p, int r)
   wxBoxSizer *hSizer = new wxBoxSizer(wxHORIZONTAL);
   wxStaticBoxSizer *fixtureSpecificSizer =
       new wxStaticBoxSizer(wxVERTICAL, this, "Fixture-specific");
-  wxStaticBoxSizer *metadataSizer =
-      new wxStaticBoxSizer(wxVERTICAL, this, "GDTF metadata");
   wxStaticBoxSizer *gdtfGeneralSizer = new wxStaticBoxSizer(
       wxVERTICAL, this, "GDTF (shared for this fixture type)");
   wxFlexGridSizer *fixtureGrid = new wxFlexGridSizer(2, 5, 5);
@@ -364,30 +359,6 @@ FixtureEditDialog::FixtureEditDialog(FixtureTablePanel *p, int r)
 
   wxVariant typeValue;
   table->GetValue(typeValue, row, 2);
-  typeIdentityPanel = new GdtfTypeIdentityPanel(this);
-  typeIdentityPanel->ConfigureFields({
-      {GdtfTypeIdentityField::FixtureTypeName, "Type",
-       std::string(typeValue.GetString().ToUTF8())},
-      {GdtfTypeIdentityField::SourceFileReference, "Model file",
-       std::string(initialGdtfPath.ToUTF8()), true, true, true, "..."},
-  });
-  typeIdentityPanel->SetChangeCallback(
-      [this](GdtfTypeIdentityField field, const std::string &) {
-        if (field == GdtfTypeIdentityField::FixtureTypeName)
-          MarkColumnModified(FixtureTableColumns::ToIndex(
-              FixtureTableColumns::Column::Type));
-        else if (field == GdtfTypeIdentityField::SourceFileReference)
-          MarkColumnModified(FixtureTableColumns::ToIndex(
-              FixtureTableColumns::Column::ModelFile));
-      });
-  typeIdentityPanel->SetActionCallback(
-      [this](GdtfTypeIdentityField field) {
-        if (field == GdtfTypeIdentityField::SourceFileReference) {
-          wxCommandEvent event;
-          OnBrowse(event);
-        }
-      });
-
   wxVariant powerValue;
   wxVariant weightValue;
   table->GetValue(powerValue, row, FixtureTableColumns::ToIndex(
@@ -396,14 +367,54 @@ FixtureEditDialog::FixtureEditDialog(FixtureTablePanel *p, int r)
                                  FixtureTableColumns::Column::Weight));
   ParseFloatOrDefault(powerValue.GetString(), originalPowerW);
   ParseFloatOrDefault(weightValue.GetString(), originalWeightKg);
-  physicalPropertiesPanel = new GdtfPhysicalPropertiesPanel(this);
-  physicalPropertiesPanel->ConfigureFields({
-      {GdtfPhysicalPropertyField::PowerConsumption, "Power",
-       std::string(powerValue.GetString().ToUTF8())},
-      {GdtfPhysicalPropertyField::Weight, "Weight",
-       std::string(weightValue.GetString().ToUTF8())},
-  });
-  physicalPropertiesPanel->SetChangeCallback(
+  wxVariant modeValue;
+  table->GetValue(modeValue, row, FixtureTableColumns::ToIndex(
+                               FixtureTableColumns::Column::Mode));
+
+  gdtfEditorPanel = new GdtfEditorPanel(this);
+  GdtfEditorPanelConfiguration gdtfConfiguration;
+  gdtfConfiguration.layout = GdtfEditorPanelLayout::SingleColumn;
+  gdtfConfiguration.metadata.title = "GDTF metadata";
+  gdtfConfiguration.typeIdentity.title = "Fixture type";
+  gdtfConfiguration.physicalProperties.title = "Physical properties";
+  gdtfConfiguration.modes.title = "Modes and channels";
+  gdtfEditorPanel->Configure(gdtfConfiguration);
+  gdtfEditorPanel->SetPresentation({
+      false,
+      {},
+      {
+          {GdtfTypeIdentityField::FixtureTypeName, "Type",
+           std::string(typeValue.GetString().ToUTF8())},
+          {GdtfTypeIdentityField::SourceFileReference, "Model file",
+           std::string(initialGdtfPath.ToUTF8()), true, true, true, "..."},
+      },
+      {
+          {GdtfPhysicalPropertyField::PowerConsumption, "Power",
+           std::string(powerValue.GetString().ToUTF8())},
+          {GdtfPhysicalPropertyField::Weight, "Weight",
+           std::string(weightValue.GetString().ToUTF8())},
+      },
+      {GetGdtfModes(std::string(initialGdtfPath.ToUTF8())),
+       std::string(modeValue.GetString().ToUTF8()),
+       std::string(),
+       {}}});
+  gdtfEditorPanel->SetIdentityChangeCallback(
+      [this](GdtfTypeIdentityField field, const std::string &) {
+        if (field == GdtfTypeIdentityField::FixtureTypeName)
+          MarkColumnModified(FixtureTableColumns::ToIndex(
+              FixtureTableColumns::Column::Type));
+        else if (field == GdtfTypeIdentityField::SourceFileReference)
+          MarkColumnModified(FixtureTableColumns::ToIndex(
+              FixtureTableColumns::Column::ModelFile));
+      });
+  gdtfEditorPanel->SetIdentityActionCallback(
+      [this](GdtfTypeIdentityField field) {
+        if (field == GdtfTypeIdentityField::SourceFileReference) {
+          wxCommandEvent event;
+          OnBrowse(event);
+        }
+      });
+  gdtfEditorPanel->SetPhysicalPropertyChangeCallback(
       [this](GdtfPhysicalPropertyField field, const std::string &) {
         if (field == GdtfPhysicalPropertyField::PowerConsumption)
           MarkColumnModified(FixtureTableColumns::ToIndex(
@@ -412,14 +423,7 @@ FixtureEditDialog::FixtureEditDialog(FixtureTablePanel *p, int r)
           MarkColumnModified(FixtureTableColumns::ToIndex(
               FixtureTableColumns::Column::Weight));
       });
-
-  wxVariant modeValue;
-  table->GetValue(modeValue, row, FixtureTableColumns::ToIndex(
-                               FixtureTableColumns::Column::Mode));
-  modesPanel = new GdtfModesPanel(this);
-  modesPanel->SetModes(GetGdtfModes(std::string(initialGdtfPath.ToUTF8())));
-  modesPanel->SetSelectedMode(std::string(modeValue.GetString().ToUTF8()));
-  modesPanel->SetModeSelectionCallback([this](const std::string &) {
+  gdtfEditorPanel->SetModeSelectionCallback([this](const std::string &) {
     MarkColumnModified(FixtureTableColumns::ToIndex(
         FixtureTableColumns::Column::Mode));
     UpdateChannels(true);
@@ -427,23 +431,14 @@ FixtureEditDialog::FixtureEditDialog(FixtureTablePanel *p, int r)
 
   fixtureSpecificSizer->Add(fixtureGrid, 1, wxEXPAND | wxALL, 6);
 
-  metadataPanel = new GdtfMetadataPanel(this);
-  metadataSizer->Add(metadataPanel, 1, wxEXPAND | wxALL, 6);
-
-  gdtfGeneralSizer->Add(typeIdentityPanel, 0, wxEXPAND | wxALL, 6);
+  gdtfGeneralSizer->Add(gdtfEditorPanel, 1, wxEXPAND | wxALL, 6);
   gdtfGeneralSizer->Add(new wxStaticText(this, wxID_ANY,
-                                         "Type, source, and mode controls select project fixture context."),
+                                         "Type, source, and mode controls select project fixture context. Power and weight edits update the GDTF file and append a revision entry."),
                         0, wxLEFT | wxRIGHT | wxBOTTOM, 6);
-  gdtfGeneralSizer->Add(physicalPropertiesPanel, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 6);
-  gdtfGeneralSizer->Add(new wxStaticText(this, wxID_ANY,
-                                         "Power and weight edits update the GDTF file and append a revision entry."),
-                        0, wxLEFT | wxRIGHT | wxBOTTOM, 6);
-  gdtfGeneralSizer->Add(modesPanel, 1, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 6);
 
   wxBoxSizer *formSizer = new wxBoxSizer(wxHORIZONTAL);
   wxBoxSizer *leftColumnSizer = new wxBoxSizer(wxVERTICAL);
   leftColumnSizer->SetMinSize(wxSize(320, -1));
-  leftColumnSizer->Add(metadataSizer, 0, wxEXPAND | wxBOTTOM, 8);
   leftColumnSizer->Add(fixtureSpecificSizer, 1, wxEXPAND);
   gdtfGeneralSizer->SetMinSize(wxSize(320, -1));
   formSizer->Add(leftColumnSizer, 1, wxRIGHT | wxEXPAND, 8);
@@ -515,7 +510,7 @@ void FixtureEditDialog::OnBrowse(wxCommandEvent &) {
   if (fdlg.ShowModal() != wxID_OK)
     return;
   wxString path = fdlg.GetPath();
-  typeIdentityPanel->SetFieldValue(GdtfTypeIdentityField::SourceFileReference, std::string(path.ToUTF8()));
+  gdtfEditorPanel->SetIdentityValue(GdtfTypeIdentityField::SourceFileReference, std::string(path.ToUTF8()));
   MarkColumnModified(9);
   if (preview)
     preview->LoadFixture(std::string(path.ToUTF8()));
@@ -525,29 +520,29 @@ void FixtureEditDialog::OnBrowse(wxCommandEvent &) {
         wxString::FromUTF8(GetGdtfFixtureName(std::string(path.ToUTF8())));
     if (typeName.empty())
       typeName = fdlg.GetFilename();
-    typeIdentityPanel->SetFieldValue(GdtfTypeIdentityField::FixtureTypeName, std::string(typeName.ToUTF8()));
+    gdtfEditorPanel->SetIdentityValue(GdtfTypeIdentityField::FixtureTypeName, std::string(typeName.ToUTF8()));
     MarkColumnModified(2);
     float w = 0.f, p = 0.f;
     GetGdtfProperties(std::string(path.ToUTF8()), w, p);
     if (ctrls.size() > 16)
-      physicalPropertiesPanel->SetFieldValue(
+      gdtfEditorPanel->SetPhysicalPropertyValue(
           GdtfPhysicalPropertyField::PowerConsumption,
           std::string(wxString::Format("%.1f", p).ToUTF8()));
     if (ctrls.size() > 16)
       MarkColumnModified(16);
     if (ctrls.size() > 17)
-      physicalPropertiesPanel->SetFieldValue(
+      gdtfEditorPanel->SetPhysicalPropertyValue(
           GdtfPhysicalPropertyField::Weight,
           std::string(wxString::Format("%.2f", w).ToUTF8()));
     if (ctrls.size() > 17)
       MarkColumnModified(17);
   }
   // repopulate modes
-  if (modesPanel) {
+  if (gdtfEditorPanel) {
     auto modes = GetGdtfModes(std::string(path.ToUTF8()));
-    modesPanel->SetModes(modes);
+    gdtfEditorPanel->SetModes(modes);
     if (!modes.empty()) {
-      modesPanel->SetSelectedMode(modes.front());
+      gdtfEditorPanel->SetSelectedMode(modes.front());
       MarkColumnModified(FixtureTableColumns::ToIndex(
           FixtureTableColumns::Column::Mode));
     }
@@ -648,7 +643,7 @@ void FixtureEditDialog::OnSymbolPreviewPaint(wxPaintEvent &evt) {
 }
 
 void FixtureEditDialog::UpdateVisualizers() {
-  wxString gdtfPath = typeIdentityPanel ? wxString::FromUTF8(typeIdentityPanel->GetFieldValue(GdtfTypeIdentityField::SourceFileReference).value_or(std::string())) : wxString();
+  wxString gdtfPath = gdtfEditorPanel ? wxString::FromUTF8(gdtfEditorPanel->GetIdentityValue(GdtfTypeIdentityField::SourceFileReference).value_or(std::string())) : wxString();
   if (gdtfPath.empty() && panel && row >= 0 &&
       static_cast<size_t>(row) < panel->gdtfPaths.size()) {
     gdtfPath = panel->gdtfPaths[row];
@@ -687,7 +682,7 @@ void FixtureEditDialog::UpdateVisualizers() {
 }
 
 void FixtureEditDialog::UpdateMetadataSummary() {
-  wxString gdtfPath = typeIdentityPanel ? wxString::FromUTF8(typeIdentityPanel->GetFieldValue(GdtfTypeIdentityField::SourceFileReference).value_or(std::string())) : wxString();
+  wxString gdtfPath = gdtfEditorPanel ? wxString::FromUTF8(gdtfEditorPanel->GetIdentityValue(GdtfTypeIdentityField::SourceFileReference).value_or(std::string())) : wxString();
   if (gdtfPath.empty() && panel && row >= 0 &&
       static_cast<size_t>(row) < panel->gdtfPaths.size()) {
     gdtfPath = panel->gdtfPaths[row];
@@ -695,26 +690,26 @@ void FixtureEditDialog::UpdateMetadataSummary() {
   const std::string path = std::string(gdtfPath.ToUTF8());
   GdtfMetadataSummary metadata;
   if (LoadGdtfMetadataSummary(path, metadata)) {
-    if (metadataPanel)
-      metadataPanel->SetMetadata(metadata);
-  } else if (metadataPanel) {
-    metadataPanel->SetUnavailable();
+    if (gdtfEditorPanel)
+      gdtfEditorPanel->SetMetadata(metadata);
+  } else if (gdtfEditorPanel) {
+    gdtfEditorPanel->SetMetadataUnavailable();
   }
   Layout();
 }
 
 void FixtureEditDialog::UpdateChannels(bool markChannelCountDirty) {
-  wxString gdtfPath = typeIdentityPanel ? wxString::FromUTF8(typeIdentityPanel->GetFieldValue(GdtfTypeIdentityField::SourceFileReference).value_or(std::string())) : wxString();
+  wxString gdtfPath = gdtfEditorPanel ? wxString::FromUTF8(gdtfEditorPanel->GetIdentityValue(GdtfTypeIdentityField::SourceFileReference).value_or(std::string())) : wxString();
   if (gdtfPath.empty() && panel && row >= 0 &&
       static_cast<size_t>(row) < panel->gdtfPaths.size()) {
     gdtfPath = panel->gdtfPaths[row];
   }
-  wxString mode = modesPanel ? wxString::FromUTF8(modesPanel->GetSelectedMode()) : wxString();
+  wxString mode = gdtfEditorPanel ? wxString::FromUTF8(gdtfEditorPanel->GetSelectedMode()) : wxString();
   if (preview)
     preview->LoadFixture(std::string(gdtfPath.ToUTF8()));
   if (gdtfPath.empty() || mode.empty()) {
-    if (modesPanel)
-      modesPanel->ClearModeDetails();
+    if (gdtfEditorPanel)
+      gdtfEditorPanel->ClearModeDetails();
     return;
   }
   auto channels = GetGdtfModeChannels(std::string(gdtfPath.ToUTF8()),
@@ -727,12 +722,12 @@ void FixtureEditDialog::UpdateChannels(bool markChannelCountDirty) {
         FormatGdtfModeFunctionLabel(ch.function),
     });
   }
-  if (modesPanel)
-    modesPanel->SetChannels(channelRows);
+  if (gdtfEditorPanel)
+    gdtfEditorPanel->SetChannels(channelRows);
   int chCount = GetGdtfModeChannelCount(std::string(gdtfPath.ToUTF8()),
                                         std::string(mode.ToUTF8()));
-  if (modesPanel)
-    modesPanel->SetChannelCount(chCount >= 0 ? std::string(wxString::Format("%d", chCount).ToUTF8()) : std::string());
+  if (gdtfEditorPanel)
+    gdtfEditorPanel->SetChannelCount(chCount >= 0 ? std::string(wxString::Format("%d", chCount).ToUTF8()) : std::string());
   if (markChannelCountDirty)
     MarkColumnModified(FixtureTableColumns::ToIndex(
         FixtureTableColumns::Column::ChannelCount));
@@ -751,7 +746,7 @@ void FixtureEditDialog::ApplyChanges() {
   if (!panel)
     return;
   auto *table = panel->table;
-  wxString gdtfPath = typeIdentityPanel ? wxString::FromUTF8(typeIdentityPanel->GetFieldValue(GdtfTypeIdentityField::SourceFileReference).value_or(std::string())) : wxString();
+  wxString gdtfPath = gdtfEditorPanel ? wxString::FromUTF8(gdtfEditorPanel->GetIdentityValue(GdtfTypeIdentityField::SourceFileReference).value_or(std::string())) : wxString();
 
   std::vector<std::string> oldOrder = panel->rowUuids;
   std::vector<std::string> selectedUuids;
@@ -767,34 +762,34 @@ void FixtureEditDialog::ApplyChanges() {
   for (size_t i = 0; i < ctrls.size(); ++i) {
     if (i >= modifiedColumns.size() || !modifiedColumns[i])
       continue;
-    if (i == 7 && modesPanel) {
-      table->SetValue(wxVariant(wxString::FromUTF8(modesPanel->GetSelectedMode())), row, i);
-    } else if (i == 8 && modesPanel) {
+    if (i == 7 && gdtfEditorPanel) {
+      table->SetValue(wxVariant(wxString::FromUTF8(gdtfEditorPanel->GetSelectedMode())), row, i);
+    } else if (i == 8 && gdtfEditorPanel) {
       int chCount = GetGdtfModeChannelCount(std::string(gdtfPath.ToUTF8()),
-                                            modesPanel->GetSelectedMode());
+                                            gdtfEditorPanel->GetSelectedMode());
       table->SetValue(wxVariant(chCount >= 0 ? wxString::Format("%d", chCount)
                                              : wxString()),
                       row, i);
-    } else if (i == 9 && typeIdentityPanel) {
+    } else if (i == 9 && gdtfEditorPanel) {
       wxFileName fn(gdtfPath);
       table->SetValue(wxVariant(fn.GetFullName()), row, i);
       if ((size_t)row >= panel->gdtfPaths.size())
         panel->gdtfPaths.resize(row + 1);
       panel->gdtfPaths[row] = gdtfPath;
-    } else if (i == 2 && typeIdentityPanel) {
-      auto value = typeIdentityPanel->GetFieldValue(
+    } else if (i == 2 && gdtfEditorPanel) {
+      auto value = gdtfEditorPanel->GetIdentityValue(
           GdtfTypeIdentityField::FixtureTypeName);
       table->SetValue(
           wxVariant(wxString::FromUTF8(value.value_or(std::string()).c_str())), row,
           i);
-    } else if (i == 16 && physicalPropertiesPanel) {
-      auto value = physicalPropertiesPanel->GetFieldValue(
+    } else if (i == 16 && gdtfEditorPanel) {
+      auto value = gdtfEditorPanel->GetPhysicalPropertyValue(
           GdtfPhysicalPropertyField::PowerConsumption);
       table->SetValue(
           wxVariant(wxString::FromUTF8(value.value_or(std::string()).c_str())), row,
           i);
-    } else if (i == 17 && physicalPropertiesPanel) {
-      auto value = physicalPropertiesPanel->GetFieldValue(
+    } else if (i == 17 && gdtfEditorPanel) {
+      auto value = gdtfEditorPanel->GetPhysicalPropertyValue(
           GdtfPhysicalPropertyField::Weight);
       table->SetValue(
           wxVariant(wxString::FromUTF8(value.value_or(std::string()).c_str())), row,
@@ -871,15 +866,15 @@ void FixtureEditDialog::ApplyChanges() {
     if (ctrls.size() > 17) {
       float newPowerW = originalPowerW;
       float newWeightKg = originalWeightKg;
-      if (physicalPropertiesPanel) {
+      if (gdtfEditorPanel) {
         ParseFloatOrDefault(
-            wxString::FromUTF8(physicalPropertiesPanel
-                                   ->GetFieldValue(GdtfPhysicalPropertyField::PowerConsumption)
+            wxString::FromUTF8(gdtfEditorPanel
+                                   ->GetPhysicalPropertyValue(GdtfPhysicalPropertyField::PowerConsumption)
                                    .value_or(std::string())),
             newPowerW);
         ParseFloatOrDefault(
-            wxString::FromUTF8(physicalPropertiesPanel
-                                   ->GetFieldValue(GdtfPhysicalPropertyField::Weight)
+            wxString::FromUTF8(gdtfEditorPanel
+                                   ->GetPhysicalPropertyValue(GdtfPhysicalPropertyField::Weight)
                                    .value_or(std::string())),
             newWeightKg);
       }
@@ -895,8 +890,8 @@ void FixtureEditDialog::ApplyChanges() {
           if (derivative && !derivative->path.empty()) {
             writableGdtfPath = derivative->path;
             gdtfPath = wxString::FromUTF8(derivative->path);
-            if (typeIdentityPanel)
-              typeIdentityPanel->SetFieldValue(
+            if (gdtfEditorPanel)
+              gdtfEditorPanel->SetIdentityValue(
                   GdtfTypeIdentityField::SourceFileReference,
                   std::string(gdtfPath.ToUTF8()));
             if (panel && row >= 0) {
@@ -927,7 +922,7 @@ void FixtureEditDialog::ApplyChanges() {
 
     if (gdtfMetadataChanged) {
       std::string mode =
-          modesPanel ? modesPanel->GetSelectedMode() : std::string();
+          gdtfEditorPanel ? gdtfEditorPanel->GetSelectedMode() : std::string();
       // Project fixture metadata edits stay project-scoped and do not promote
       // files into the user library.
       panel->ApplyModeForGdtf(gdtfPath, wxString::FromUTF8(mode.c_str()));

--- a/gui/fixtureeditdialog.cpp
+++ b/gui/fixtureeditdialog.cpp
@@ -432,7 +432,7 @@ FixtureEditDialog::FixtureEditDialog(FixtureTablePanel *p, int r)
   fixtureSpecificSizer->Add(fixtureGrid, 1, wxEXPAND | wxALL, 6);
 
   gdtfGeneralSizer->Add(gdtfEditorPanel, 1, wxEXPAND | wxALL, 6);
-  gdtfGeneralSizer->Add(new wxStaticText(this, wxID_ANY,
+  gdtfGeneralSizer->Add(new wxStaticText(gdtfGeneralSizer->GetStaticBox(), wxID_ANY,
                                          "Type, source, and mode controls select project fixture context. Power and weight edits update the GDTF file and append a revision entry."),
                         0, wxLEFT | wxRIGHT | wxBOTTOM, 6);
 

--- a/gui/fixtureeditdialog.cpp
+++ b/gui/fixtureeditdialog.cpp
@@ -278,6 +278,7 @@ FixtureEditDialog::FixtureEditDialog(FixtureTablePanel *p, int r)
       wxVERTICAL, this, "GDTF (shared for this fixture type)");
   wxFlexGridSizer *fixtureGrid = new wxFlexGridSizer(2, 5, 5);
   fixtureGrid->AddGrowableCol(1, 1);
+  wxWindow *fixtureSpecificParent = fixtureSpecificSizer->GetStaticBox();
 
   auto *table = panel->table; // friend access
   ctrls.resize(panel->columnLabels.size(), nullptr);
@@ -291,9 +292,9 @@ FixtureEditDialog::FixtureEditDialog(FixtureTablePanel *p, int r)
   auto addLabeledControl = [&](size_t index, wxWindow *controlWindow,
                                wxSizer *nestedSizer, bool isGdtfField) {
     (void)isGdtfField;
-    fixtureGrid->Add(
-        new wxStaticText(this, wxID_ANY, panel->columnLabels[index]), 0,
-                    wxALIGN_CENTER_VERTICAL);
+    fixtureGrid->Add(new wxStaticText(fixtureSpecificParent, wxID_ANY,
+                                       panel->columnLabels[index]),
+                     0, wxALIGN_CENTER_VERTICAL);
     if (nestedSizer)
       fixtureGrid->Add(nestedSizer, 1, wxEXPAND);
     else
@@ -308,7 +309,7 @@ FixtureEditDialog::FixtureEditDialog(FixtureTablePanel *p, int r)
     if (i == 2 || i == 7 || i == 8 || i == 9 || i == 16 || i == 17) {
       continue;
     } else if (i == 18) {
-      auto *category = new wxChoice(this, wxID_ANY);
+      auto *category = new wxChoice(fixtureSpecificParent, wxID_ANY);
       const wxArrayString values = {
           "Beam",         "Blinder", "Conventional", "FX",    "Hoist",
           "Hybrid",       "Laser",   "LED",          "Smoke", "Spot",
@@ -337,13 +338,15 @@ FixtureEditDialog::FixtureEditDialog(FixtureTablePanel *p, int r)
       wxColour initial(colorString);
       if (colorString.IsEmpty() || !initial.IsOk())
         initial = *wxWHITE;
-      auto *picker = new wxColourPickerCtrl(this, wxID_ANY, initial);
+      auto *picker =
+          new wxColourPickerCtrl(fixtureSpecificParent, wxID_ANY, initial);
       picker->Bind(wxEVT_COLOURPICKER_CHANGED,
                    [this, i](wxColourPickerEvent &) { MarkColumnModified(i); });
       ctrls[i] = picker;
       controlWindow = picker;
     } else {
-      wxTextCtrl *tc = new wxTextCtrl(this, wxID_ANY, v.GetString());
+      wxTextCtrl *tc =
+          new wxTextCtrl(fixtureSpecificParent, wxID_ANY, v.GetString());
       tc->Bind(wxEVT_TEXT,
                [this, i](wxCommandEvent &) { MarkColumnModified(i); });
       ctrls[i] = tc;
@@ -453,12 +456,13 @@ FixtureEditDialog::FixtureEditDialog(FixtureTablePanel *p, int r)
 
   wxStaticBoxSizer *symbolSizer =
       new wxStaticBoxSizer(wxHORIZONTAL, this, "Symbols");
+  wxWindow *symbolParent = symbolSizer->GetStaticBox();
   const std::array<wxString, 3> symbolLabels = {"Top", "Front", "Side"};
   for (size_t i = 0; i < symbolPanels.size(); ++i) {
     wxBoxSizer *symbolColumn = new wxBoxSizer(wxVERTICAL);
-    symbolColumn->Add(new wxStaticText(this, wxID_ANY, symbolLabels[i]), 0,
-                      wxALIGN_CENTER_HORIZONTAL | wxBOTTOM, 3);
-    symbolPanels[i] = new wxPanel(this, wxID_ANY, wxDefaultPosition,
+    symbolColumn->Add(new wxStaticText(symbolParent, wxID_ANY, symbolLabels[i]),
+                      0, wxALIGN_CENTER_HORIZONTAL | wxBOTTOM, 3);
+    symbolPanels[i] = new wxPanel(symbolParent, wxID_ANY, wxDefaultPosition,
                                   wxSize(90, 70), wxBORDER_SIMPLE);
     symbolPanels[i]->SetBackgroundStyle(wxBG_STYLE_PAINT);
     symbolPanels[i]->Bind(wxEVT_PAINT, &FixtureEditDialog::OnSymbolPreviewPaint,
@@ -470,7 +474,8 @@ FixtureEditDialog::FixtureEditDialog(FixtureTablePanel *p, int r)
 
   wxStaticBoxSizer *imageSizer =
       new wxStaticBoxSizer(wxVERTICAL, this, "Fixture image");
-  fixtureImagePreview = new wxStaticBitmap(this, wxID_ANY, wxBitmap(220, 220));
+  fixtureImagePreview = new wxStaticBitmap(imageSizer->GetStaticBox(), wxID_ANY,
+                                           wxBitmap(220, 220));
   imageSizer->Add(fixtureImagePreview, 0, wxALIGN_CENTER | wxALL, 4);
   rightSizer->Add(imageSizer, 0, wxEXPAND | wxBOTTOM, 5);
   rightSizer->SetMinSize(wxSize(280, -1));

--- a/gui/fixtureeditdialog.h
+++ b/gui/fixtureeditdialog.h
@@ -28,10 +28,7 @@ class FixtureTablePanel;
 class FixturePreviewPanel;
 class wxStaticBitmap;
 class wxPanel;
-class GdtfMetadataPanel;
-class GdtfModesPanel;
-class GdtfPhysicalPropertiesPanel;
-class GdtfTypeIdentityPanel;
+class GdtfEditorPanel;
 
 class FixtureEditDialog : public wxDialog {
 public:
@@ -54,10 +51,7 @@ private:
     FixtureTablePanel* panel;
     int row;
     std::vector<wxControl*> ctrls;
-    GdtfTypeIdentityPanel* typeIdentityPanel = nullptr;
-    GdtfPhysicalPropertiesPanel* physicalPropertiesPanel = nullptr;
-    GdtfModesPanel* modesPanel = nullptr;
-    GdtfMetadataPanel* metadataPanel = nullptr;
+    GdtfEditorPanel* gdtfEditorPanel = nullptr;
     FixturePreviewPanel* preview = nullptr;
     wxStaticBitmap* fixtureImagePreview = nullptr;
     std::array<wxPanel*, 3> symbolPanels{};

--- a/gui/gdtf/gdtf_editor_panel.cpp
+++ b/gui/gdtf/gdtf_editor_panel.cpp
@@ -215,6 +215,28 @@ void GdtfEditorPanel::ApplySectionConfiguration(
   section->GetStaticBox()->Show(sectionConfiguration.visible);
 }
 
+// Detaches reusable child sizers before rebuilding the layout arrangement.
+void GdtfEditorPanel::DetachReusableLayoutSizers() {
+  rootSizer->Detach(metadataSection);
+  rootSizer->Detach(typeIdentitySection);
+  rootSizer->Detach(physicalPropertiesSection);
+  rootSizer->Detach(modesSection);
+  rootSizer->Detach(twoColumnSizer);
+
+  twoColumnSizer->Detach(leftColumnSizer);
+  twoColumnSizer->Detach(rightColumnSizer);
+
+  leftColumnSizer->Detach(metadataSection);
+  leftColumnSizer->Detach(typeIdentitySection);
+  leftColumnSizer->Detach(physicalPropertiesSection);
+  leftColumnSizer->Detach(modesSection);
+
+  rightColumnSizer->Detach(metadataSection);
+  rightColumnSizer->Detach(typeIdentitySection);
+  rightColumnSizer->Detach(physicalPropertiesSection);
+  rightColumnSizer->Detach(modesSection);
+}
+
 // Rebuilds only the top-level sizer arrangement while preserving child panels.
 void GdtfEditorPanel::RebuildLayout() {
   ApplySectionConfiguration(metadataSection, configuration.metadata);
@@ -223,10 +245,7 @@ void GdtfEditorPanel::RebuildLayout() {
                             configuration.physicalProperties);
   ApplySectionConfiguration(modesSection, configuration.modes);
 
-  rootSizer->Clear(false);
-  twoColumnSizer->Clear(false);
-  leftColumnSizer->Clear(false);
-  rightColumnSizer->Clear(false);
+  DetachReusableLayoutSizers();
 
   if (configuration.layout == GdtfEditorPanelLayout::TwoColumn)
     AddTwoColumnSections(rootSizer);

--- a/gui/gdtf/gdtf_editor_panel.cpp
+++ b/gui/gdtf/gdtf_editor_panel.cpp
@@ -187,15 +187,17 @@ void GdtfEditorPanel::BuildSections() {
   rightColumnSizer = new wxBoxSizer(wxVERTICAL);
   SetSizer(rootSizer);
 
-  metadataPanel = new GdtfMetadataPanel(this);
-  typeIdentityPanel = new GdtfTypeIdentityPanel(this);
-  physicalPropertiesPanel = new GdtfPhysicalPropertiesPanel(this);
-  modesPanel = new GdtfModesPanel(this);
-
   metadataSection = new wxStaticBoxSizer(wxVERTICAL, this, wxString());
   typeIdentitySection = new wxStaticBoxSizer(wxVERTICAL, this, wxString());
   physicalPropertiesSection = new wxStaticBoxSizer(wxVERTICAL, this, wxString());
   modesSection = new wxStaticBoxSizer(wxVERTICAL, this, wxString());
+
+  metadataPanel = new GdtfMetadataPanel(metadataSection->GetStaticBox());
+  typeIdentityPanel =
+      new GdtfTypeIdentityPanel(typeIdentitySection->GetStaticBox());
+  physicalPropertiesPanel = new GdtfPhysicalPropertiesPanel(
+      physicalPropertiesSection->GetStaticBox());
+  modesPanel = new GdtfModesPanel(modesSection->GetStaticBox());
 
   metadataSection->Add(metadataPanel, 0, wxEXPAND | wxALL, kSectionPadding);
   typeIdentitySection->Add(typeIdentityPanel, 0, wxEXPAND | wxALL, kSectionPadding);

--- a/gui/gdtf/gdtf_editor_panel.cpp
+++ b/gui/gdtf/gdtf_editor_panel.cpp
@@ -204,6 +204,10 @@ void GdtfEditorPanel::BuildSections() {
   physicalPropertiesSection->Add(physicalPropertiesPanel, 0,
                                  wxEXPAND | wxALL, kSectionPadding);
   modesSection->Add(modesPanel, 1, wxEXPAND | wxALL, kSectionPadding);
+
+  twoColumnSizer->Add(leftColumnSizer, 1, wxEXPAND | wxRIGHT, kSectionGap);
+  twoColumnSizer->Add(rightColumnSizer, 1, wxEXPAND);
+  rootSizer->Add(twoColumnSizer, 1, wxEXPAND);
 }
 
 // Applies one section label and window visibility from typed configuration.
@@ -215,16 +219,12 @@ void GdtfEditorPanel::ApplySectionConfiguration(
   section->GetStaticBox()->Show(sectionConfiguration.visible);
 }
 
-// Detaches reusable child sizers before rebuilding the layout arrangement.
+// Detaches reusable section sizers before rebuilding the layout arrangement.
 void GdtfEditorPanel::DetachReusableLayoutSizers() {
   rootSizer->Detach(metadataSection);
   rootSizer->Detach(typeIdentitySection);
   rootSizer->Detach(physicalPropertiesSection);
   rootSizer->Detach(modesSection);
-  rootSizer->Detach(twoColumnSizer);
-
-  twoColumnSizer->Detach(leftColumnSizer);
-  twoColumnSizer->Detach(rightColumnSizer);
 
   leftColumnSizer->Detach(metadataSection);
   leftColumnSizer->Detach(typeIdentitySection);
@@ -267,6 +267,7 @@ void GdtfEditorPanel::AddSection(wxBoxSizer *target, wxStaticBoxSizer *section,
 
 // Adds visible sections in the documented single-column order.
 void GdtfEditorPanel::AddSingleColumnSections(wxBoxSizer *root) {
+  root->Show(twoColumnSizer, false, true);
   AddSection(root, metadataSection, configuration.metadata, 0);
   AddSection(root, typeIdentitySection, configuration.typeIdentity, 0);
   AddSection(root, physicalPropertiesSection, configuration.physicalProperties, 0);
@@ -280,7 +281,5 @@ void GdtfEditorPanel::AddTwoColumnSections(wxBoxSizer *root) {
   AddSection(rightColumnSizer, physicalPropertiesSection,
              configuration.physicalProperties, 0);
   AddSection(rightColumnSizer, modesSection, configuration.modes, 1);
-  twoColumnSizer->Add(leftColumnSizer, 1, wxEXPAND | wxRIGHT, kSectionGap);
-  twoColumnSizer->Add(rightColumnSizer, 1, wxEXPAND);
-  root->Add(twoColumnSizer, 1, wxEXPAND);
+  root->Show(twoColumnSizer, true, true);
 }

--- a/gui/gdtf/gdtf_editor_panel.cpp
+++ b/gui/gdtf/gdtf_editor_panel.cpp
@@ -138,6 +138,32 @@ void GdtfEditorPanel::SetModesPresentation(
   modesPanel->SetPresentation(presentation);
 }
 
+// Replaces the mode list without notifying callbacks.
+void GdtfEditorPanel::SetModes(const std::vector<std::string> &modes) {
+  modesPanel->SetModes(modes);
+}
+
+// Selects a mode without notifying callbacks.
+void GdtfEditorPanel::SetSelectedMode(const std::string &mode) {
+  modesPanel->SetSelectedMode(mode);
+}
+
+// Sets the derived channel count without notifying callbacks.
+void GdtfEditorPanel::SetChannelCount(const std::string &channelCount) {
+  modesPanel->SetChannelCount(channelCount);
+}
+
+// Sets the visible channel rows without notifying callbacks.
+void GdtfEditorPanel::SetChannels(
+    const std::vector<GdtfModeChannelPresentation> &channels) {
+  modesPanel->SetChannels(channels);
+}
+
+// Clears derived mode details without notifying callbacks.
+void GdtfEditorPanel::ClearModeDetails() {
+  modesPanel->ClearModeDetails();
+}
+
 // Enables or disables user mode selection.
 void GdtfEditorPanel::SetModeSelectionEnabled(bool enabled) {
   modesPanel->SetModeSelectionEnabled(enabled);

--- a/gui/gdtf/gdtf_editor_panel.h
+++ b/gui/gdtf/gdtf_editor_panel.h
@@ -34,9 +34,6 @@ class wxStaticBoxSizer;
 // Selects the top-level arrangement used by the reusable GDTF editor panel.
 enum class GdtfEditorPanelLayout { SingleColumn, TwoColumn };
 
-// Identifies configurable sections in the reusable GDTF editor panel.
-enum class GdtfEditorSection { Metadata, TypeIdentity, PhysicalProperties, Modes };
-
 struct GdtfEditorSectionConfiguration {
   bool visible = true;
   bool expanded = true;
@@ -87,6 +84,11 @@ public:
   void SetPhysicalPropertyValidation(GdtfPhysicalPropertyField field,
                                      const std::string &message);
   void SetModesPresentation(const GdtfModesPresentation &presentation);
+  void SetModes(const std::vector<std::string> &modes);
+  void SetSelectedMode(const std::string &mode);
+  void SetChannelCount(const std::string &channelCount);
+  void SetChannels(const std::vector<GdtfModeChannelPresentation> &channels);
+  void ClearModeDetails();
   void SetModeSelectionEnabled(bool enabled);
   void SetMetadata(const GdtfMetadataSummary &summary);
   void SetMetadataUnavailable();

--- a/gui/gdtf/gdtf_editor_panel.h
+++ b/gui/gdtf/gdtf_editor_panel.h
@@ -97,6 +97,7 @@ private:
   void BuildSections();
   void ApplySectionConfiguration(wxStaticBoxSizer *section,
                                  const GdtfEditorSectionConfiguration &configuration);
+  void DetachReusableLayoutSizers();
   void RebuildLayout();
   void AddSection(wxBoxSizer *target, wxStaticBoxSizer *section,
                   const GdtfEditorSectionConfiguration &configuration,

--- a/gui/trusseditdialog.cpp
+++ b/gui/trusseditdialog.cpp
@@ -168,7 +168,7 @@ TrussEditDialog::TrussEditDialog(TrussTablePanel *p, int r)
   mvrSizer->Add(mvrGrid, 1, wxEXPAND | wxALL, 6);
   gdtfSizer->Add(gdtfEditorPanel, 1, wxEXPAND | wxALL, 6);
   gdtfSizer->Add(
-      new wxStaticText(this, wxID_ANY,
+      new wxStaticText(gdtfSizer->GetStaticBox(), wxID_ANY,
                        "Editing these fields creates or updates the truss "
                        "GDTF. MVR-only fields remain project-scoped."),
       0, wxLEFT | wxRIGHT | wxBOTTOM, 6);

--- a/gui/trusseditdialog.cpp
+++ b/gui/trusseditdialog.cpp
@@ -19,9 +19,7 @@
 
 #include "configmanager.h"
 #include "fixturepreviewpanel.h"
-#include "gdtf/gdtf_metadata_panel.h"
-#include "gdtf/gdtf_physical_properties_panel.h"
-#include "gdtf/gdtf_type_identity_panel.h"
+#include "gdtf/gdtf_editor_panel.h"
 #include "gdtf_metadata_summary.h"
 #include "gdtfdictionary.h"
 #include "guiconfigservices.h"
@@ -80,8 +78,6 @@ TrussEditDialog::TrussEditDialog(TrussTablePanel *p, int r)
       new wxStaticBoxSizer(wxVERTICAL, this, "MVR instance");
   wxStaticBoxSizer *gdtfSizer =
       new wxStaticBoxSizer(wxVERTICAL, this, "GDTF truss type");
-  wxStaticBoxSizer *metadataSizer =
-      new wxStaticBoxSizer(wxVERTICAL, this, "GDTF metadata");
   wxFlexGridSizer *mvrGrid = new wxFlexGridSizer(2, 5, 5);
   mvrGrid->AddGrowableCol(1, 1);
 
@@ -118,33 +114,44 @@ TrussEditDialog::TrussEditDialog(TrussTablePanel *p, int r)
     return std::string(value.GetString().ToUTF8());
   };
 
-  typeIdentityPanel = new GdtfTypeIdentityPanel(this);
-  typeIdentityPanel->ConfigureFields({
-      {GdtfTypeIdentityField::Manufacturer, "Manufacturer",
-       tableValue(TrussColumn::Manufacturer)},
-      {GdtfTypeIdentityField::ModelName, "Model", tableValue(TrussColumn::Model)},
-  });
-  typeIdentityPanel->SetChangeCallback(
+  gdtfEditorPanel = new GdtfEditorPanel(this);
+  GdtfEditorPanelConfiguration gdtfConfiguration;
+  gdtfConfiguration.layout = GdtfEditorPanelLayout::SingleColumn;
+  gdtfConfiguration.metadata.title = "GDTF metadata";
+  gdtfConfiguration.typeIdentity.title = "Truss type";
+  gdtfConfiguration.physicalProperties.title = "Physical properties";
+  gdtfConfiguration.modes.visible = false;
+  gdtfEditorPanel->Configure(gdtfConfiguration);
+  gdtfEditorPanel->SetPresentation({
+      false,
+      {},
+      {
+          {GdtfTypeIdentityField::Manufacturer, "Manufacturer",
+           tableValue(TrussColumn::Manufacturer)},
+          {GdtfTypeIdentityField::ModelName, "Model",
+           tableValue(TrussColumn::Model)},
+      },
+      {
+          {GdtfPhysicalPropertyField::Length, "Length",
+           tableValue(TrussColumn::Length)},
+          {GdtfPhysicalPropertyField::Width, "Width",
+           tableValue(TrussColumn::Width)},
+          {GdtfPhysicalPropertyField::Height, "Height",
+           tableValue(TrussColumn::Height)},
+          {GdtfPhysicalPropertyField::Weight, "Weight",
+           tableValue(TrussColumn::Weight)},
+          {GdtfPhysicalPropertyField::CrossSection, "Cross section",
+           std::string(crossSection.ToUTF8())},
+      },
+      {}});
+  gdtfEditorPanel->SetIdentityChangeCallback(
       [this](GdtfTypeIdentityField field, const std::string &) {
         if (field == GdtfTypeIdentityField::Manufacturer)
           MarkColumnModified(ColumnIndex(TrussColumn::Manufacturer));
         else if (field == GdtfTypeIdentityField::ModelName)
           MarkColumnModified(ColumnIndex(TrussColumn::Model));
       });
-
-  physicalPropertiesPanel = new GdtfPhysicalPropertiesPanel(this);
-  physicalPropertiesPanel->ConfigureFields({
-      {GdtfPhysicalPropertyField::Length, "Length",
-       tableValue(TrussColumn::Length)},
-      {GdtfPhysicalPropertyField::Width, "Width", tableValue(TrussColumn::Width)},
-      {GdtfPhysicalPropertyField::Height, "Height",
-       tableValue(TrussColumn::Height)},
-      {GdtfPhysicalPropertyField::Weight, "Weight",
-       tableValue(TrussColumn::Weight)},
-      {GdtfPhysicalPropertyField::CrossSection, "Cross section",
-       std::string(crossSection.ToUTF8())},
-  });
-  physicalPropertiesPanel->SetChangeCallback(
+  gdtfEditorPanel->SetPhysicalPropertyChangeCallback(
       [this](GdtfPhysicalPropertyField field, const std::string &) {
         if (field == GdtfPhysicalPropertyField::Length)
           MarkColumnModified(ColumnIndex(TrussColumn::Length));
@@ -158,13 +165,8 @@ TrussEditDialog::TrussEditDialog(TrussTablePanel *p, int r)
           crossSectionModified = true;
       });
 
-  metadataPanel = new GdtfMetadataPanel(this);
-  metadataSizer->SetMinSize(wxSize(360, 190));
-  metadataSizer->Add(metadataPanel, 1, wxEXPAND | wxALL, 6);
-
   mvrSizer->Add(mvrGrid, 1, wxEXPAND | wxALL, 6);
-  gdtfSizer->Add(typeIdentityPanel, 0, wxEXPAND | wxALL, 6);
-  gdtfSizer->Add(physicalPropertiesPanel, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 6);
+  gdtfSizer->Add(gdtfEditorPanel, 1, wxEXPAND | wxALL, 6);
   gdtfSizer->Add(
       new wxStaticText(this, wxID_ANY,
                        "Editing these fields creates or updates the truss "
@@ -177,7 +179,6 @@ TrussEditDialog::TrussEditDialog(TrussTablePanel *p, int r)
   preview->SetMinSize(wxSize(320, 160));
   previewSizer->Add(preview, 1, wxEXPAND | wxALL, 6);
 
-  topRowSizer->Add(metadataSizer, 1, wxEXPAND | wxALL, 10);
   topRowSizer->Add(previewSizer, 1, wxEXPAND | wxALL, 10);
   bottomRowSizer->Add(mvrSizer, 1, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 10);
   bottomRowSizer->Add(gdtfSizer, 1, wxEXPAND | wxRIGHT | wxBOTTOM, 10);
@@ -237,10 +238,10 @@ std::string TrussEditDialog::ResolveCurrentGdtfPath() const {
 void TrussEditDialog::UpdateMetadataSummary() {
   GdtfMetadataSummary metadata;
   if (LoadGdtfMetadataSummary(ResolveCurrentGdtfPath(), metadata)) {
-    if (metadataPanel)
-      metadataPanel->SetMetadata(metadata);
-  } else if (metadataPanel) {
-    metadataPanel->SetUnavailable();
+    if (gdtfEditorPanel)
+      gdtfEditorPanel->SetMetadata(metadata);
+  } else if (gdtfEditorPanel) {
+    gdtfEditorPanel->SetMetadataUnavailable();
   }
   Layout();
 }
@@ -331,19 +332,19 @@ void TrussEditDialog::ApplyChanges() {
     if (!modifiedColumns[i])
       continue;
     if (i == static_cast<size_t>(ColumnIndex(TrussColumn::Manufacturer)) &&
-        typeIdentityPanel) {
-      auto value = typeIdentityPanel->GetFieldValue(
+        gdtfEditorPanel) {
+      auto value = gdtfEditorPanel->GetIdentityValue(
           GdtfTypeIdentityField::Manufacturer);
       panel->table->SetValue(
           wxVariant(wxString::FromUTF8(value.value_or(std::string()).c_str())), row,
           static_cast<unsigned int>(i));
     } else if (i == static_cast<size_t>(ColumnIndex(TrussColumn::Model)) &&
-               typeIdentityPanel) {
-      auto value = typeIdentityPanel->GetFieldValue(GdtfTypeIdentityField::ModelName);
+               gdtfEditorPanel) {
+      auto value = gdtfEditorPanel->GetIdentityValue(GdtfTypeIdentityField::ModelName);
       panel->table->SetValue(
           wxVariant(wxString::FromUTF8(value.value_or(std::string()).c_str())), row,
           static_cast<unsigned int>(i));
-    } else if (physicalPropertiesPanel && IsGdtfTrussColumn(i)) {
+    } else if (gdtfEditorPanel && IsGdtfTrussColumn(i)) {
       const auto field = i == static_cast<size_t>(ColumnIndex(TrussColumn::Length))
                              ? GdtfPhysicalPropertyField::Length
                          : i == static_cast<size_t>(ColumnIndex(TrussColumn::Width))
@@ -351,7 +352,7 @@ void TrussEditDialog::ApplyChanges() {
                          : i == static_cast<size_t>(ColumnIndex(TrussColumn::Height))
                              ? GdtfPhysicalPropertyField::Height
                              : GdtfPhysicalPropertyField::Weight;
-      auto value = physicalPropertiesPanel->GetFieldValue(field);
+      auto value = gdtfEditorPanel->GetPhysicalPropertyValue(field);
       panel->table->SetValue(
           wxVariant(wxString::FromUTF8(value.value_or(std::string()).c_str())), row,
           static_cast<unsigned int>(i));
@@ -372,8 +373,8 @@ void TrussEditDialog::ApplyChanges() {
       if (!hasTableChanges)
         GetDefaultGuiConfigServices().LegacyConfigManager().PushUndoState(
             "edit truss GDTF metadata");
-      auto value = physicalPropertiesPanel
-                       ? physicalPropertiesPanel->GetFieldValue(
+      auto value = gdtfEditorPanel
+                       ? gdtfEditorPanel->GetPhysicalPropertyValue(
                              GdtfPhysicalPropertyField::CrossSection)
                        : std::optional<std::string>();
       it->second.crossSection = value.value_or(std::string());

--- a/gui/trusseditdialog.cpp
+++ b/gui/trusseditdialog.cpp
@@ -78,6 +78,7 @@ TrussEditDialog::TrussEditDialog(TrussTablePanel *p, int r)
       new wxStaticBoxSizer(wxVERTICAL, this, "MVR instance");
   wxStaticBoxSizer *gdtfSizer =
       new wxStaticBoxSizer(wxVERTICAL, this, "GDTF truss type");
+  wxWindow *mvrParent = mvrSizer->GetStaticBox();
   wxFlexGridSizer *mvrGrid = new wxFlexGridSizer(2, 5, 5);
   mvrGrid->AddGrowableCol(1, 1);
 
@@ -90,12 +91,13 @@ TrussEditDialog::TrussEditDialog(TrussTablePanel *p, int r)
       continue;
     wxVariant value;
     table->GetValue(value, row, static_cast<unsigned int>(i));
-    wxTextCtrl *control = new wxTextCtrl(this, wxID_ANY, value.GetString());
+    wxTextCtrl *control =
+        new wxTextCtrl(mvrParent, wxID_ANY, value.GetString());
     control->Bind(wxEVT_TEXT,
                   [this, i](wxCommandEvent &) { MarkColumnModified(i); });
     ctrls[i] = control;
-    mvrGrid->Add(new wxStaticText(this, wxID_ANY, panel->columnLabels[i]), 0,
-                 wxALIGN_CENTER_VERTICAL);
+    mvrGrid->Add(new wxStaticText(mvrParent, wxID_ANY, panel->columnLabels[i]),
+                 0, wxALIGN_CENTER_VERTICAL);
     mvrGrid->Add(control, 1, wxEXPAND);
   }
 
@@ -175,7 +177,7 @@ TrussEditDialog::TrussEditDialog(TrussTablePanel *p, int r)
   wxStaticBoxSizer *previewSizer =
       new wxStaticBoxSizer(wxVERTICAL, this, "3D preview");
   previewSizer->SetMinSize(wxSize(360, 190));
-  preview = new FixturePreviewPanel(this);
+  preview = new FixturePreviewPanel(previewSizer->GetStaticBox());
   preview->SetMinSize(wxSize(320, 160));
   previewSizer->Add(preview, 1, wxEXPAND | wxALL, 6);
 

--- a/gui/trusseditdialog.cpp
+++ b/gui/trusseditdialog.cpp
@@ -114,7 +114,7 @@ TrussEditDialog::TrussEditDialog(TrussTablePanel *p, int r)
     return std::string(value.GetString().ToUTF8());
   };
 
-  gdtfEditorPanel = new GdtfEditorPanel(this);
+  gdtfEditorPanel = new GdtfEditorPanel(gdtfSizer->GetStaticBox());
   GdtfEditorPanelConfiguration gdtfConfiguration;
   gdtfConfiguration.layout = GdtfEditorPanelLayout::SingleColumn;
   gdtfConfiguration.metadata.title = "GDTF metadata";

--- a/gui/trusseditdialog.h
+++ b/gui/trusseditdialog.h
@@ -24,9 +24,7 @@
 #include <wx/wx.h>
 
 class FixturePreviewPanel;
-class GdtfMetadataPanel;
-class GdtfPhysicalPropertiesPanel;
-class GdtfTypeIdentityPanel;
+class GdtfEditorPanel;
 class TrussTablePanel;
 
 class TrussEditDialog : public wxDialog {
@@ -48,9 +46,7 @@ private:
   TrussTablePanel *panel = nullptr;
   int row = -1;
   std::vector<wxControl *> ctrls;
-  GdtfTypeIdentityPanel *typeIdentityPanel = nullptr;
-  GdtfPhysicalPropertiesPanel *physicalPropertiesPanel = nullptr;
-  GdtfMetadataPanel *metadataPanel = nullptr;
+  GdtfEditorPanel *gdtfEditorPanel = nullptr;
   FixturePreviewPanel *preview = nullptr;
   std::vector<bool> modifiedColumns;
   bool crossSectionModified = false;

--- a/tests/check_gdtf_editor_panel_boundary.sh
+++ b/tests/check_gdtf_editor_panel_boundary.sh
@@ -151,6 +151,14 @@ if ! rg -q "new GdtfEditorPanel\(gdtfSizer->GetStaticBox\(\)\)" "$truss_source";
   echo "Truss Edit must parent its composite to the surrounding static box." >&2
   exit 1
 fi
+if ! rg -q "new wxStaticText\(gdtfGeneralSizer->GetStaticBox\(\)" "$fixture_source"; then
+  echo "Fixture Edit GDTF explanatory text must be parented to the surrounding static box." >&2
+  exit 1
+fi
+if ! rg -q "new wxStaticText\(gdtfSizer->GetStaticBox\(\)" "$truss_source"; then
+  echo "Truss Edit GDTF explanatory text must be parented to the surrounding static box." >&2
+  exit 1
+fi
 if ! rg -q "gdtfConfiguration.modes.title = \"Modes and channels\"" "$fixture_source"; then
   echo "Fixture Edit must keep the composite modes section visible with a host title." >&2
   exit 1

--- a/tests/check_gdtf_editor_panel_boundary.sh
+++ b/tests/check_gdtf_editor_panel_boundary.sh
@@ -32,11 +32,36 @@ for child in GdtfMetadataPanel GdtfTypeIdentityPanel GdtfPhysicalPropertiesPanel
     echo "GdtfEditorPanel must own exactly one ${child} pointer." >&2
     exit 1
   fi
-  if ! rg -q "new ${child}\(this\)" "$panel_source"; then
-    echo "GdtfEditorPanel must create ${child} exactly once with wx parent ownership." >&2
+  if [[ $(rg -c "new ${child}\(" "$panel_source") -ne 1 ]]; then
+    echo "GdtfEditorPanel must instantiate ${child} exactly once." >&2
+    exit 1
+  fi
+  if rg -q "new ${child}\(this\)" "$panel_source"; then
+    echo "GdtfEditorPanel child panels must be parented to their section static boxes, not the composite panel." >&2
     exit 1
   fi
 done
+
+python3 - <<'PY_CHECK'
+from pathlib import Path
+source = Path('gui/gdtf/gdtf_editor_panel.cpp').read_text()
+checks = [
+    ('metadataSection', 'metadataPanel', 'GdtfMetadataPanel', 'metadataSection->GetStaticBox()'),
+    ('typeIdentitySection', 'typeIdentityPanel', 'GdtfTypeIdentityPanel', 'typeIdentitySection->GetStaticBox()'),
+    ('physicalPropertiesSection', 'physicalPropertiesPanel', 'GdtfPhysicalPropertiesPanel', 'physicalPropertiesSection->GetStaticBox()'),
+    ('modesSection', 'modesPanel', 'GdtfModesPanel', 'modesSection->GetStaticBox()'),
+]
+for section, member, child, parent in checks:
+    section_token = f'{section} = new wxStaticBoxSizer'
+    section_index = source.find(section_token)
+    child_index = source.find(f'{member} =', section_index)
+    new_index = source.find(f'new {child}', child_index)
+    parent_index = source.find(parent, new_index)
+    if (section_index < 0 or child_index < 0 or new_index < 0 or
+            parent_index < 0 or section_index > child_index):
+        raise SystemExit(
+            f'{child} must be created after {section} and parented with {parent}.')
+PY_CHECK
 
 for token in GdtfEditorPanelLayout GdtfEditorSectionConfiguration GdtfEditorPanelConfiguration GdtfEditorPanelPresentation metadataAvailable identityFields physicalFields; do
   if ! rg -q "$token" "$panel_header"; then
@@ -107,7 +132,7 @@ for header in "$fixture_header" "$truss_header"; do
   fi
 done
 for source in "$fixture_source" "$truss_source"; do
-  if [[ $(rg -c "new GdtfEditorPanel\(this\)" "$source") -ne 1 ]]; then
+  if [[ $(rg -c "new GdtfEditorPanel\(" "$source") -ne 1 ]]; then
     echo "${source} must instantiate exactly one GdtfEditorPanel with wx parent ownership." >&2
     exit 1
   fi
@@ -118,6 +143,14 @@ for child in GdtfMetadataPanel GdtfTypeIdentityPanel GdtfPhysicalPropertiesPanel
     exit 1
   fi
 done
+if ! rg -q "new GdtfEditorPanel\(gdtfGeneralSizer->GetStaticBox\(\)\)" "$fixture_source"; then
+  echo "Fixture Edit must parent its composite to the surrounding static box." >&2
+  exit 1
+fi
+if ! rg -q "new GdtfEditorPanel\(gdtfSizer->GetStaticBox\(\)\)" "$truss_source"; then
+  echo "Truss Edit must parent its composite to the surrounding static box." >&2
+  exit 1
+fi
 if ! rg -q "gdtfConfiguration.modes.title = \"Modes and channels\"" "$fixture_source"; then
   echo "Fixture Edit must keep the composite modes section visible with a host title." >&2
   exit 1

--- a/tests/check_gdtf_editor_panel_boundary.sh
+++ b/tests/check_gdtf_editor_panel_boundary.sh
@@ -44,7 +44,7 @@ for token in GdtfEditorPanelLayout GdtfEditorSectionConfiguration GdtfEditorPane
     exit 1
   fi
 done
-for api in Configure SetPresentation SetUnavailable SetIdentityChangeCallback SetIdentityActionCallback SetPhysicalPropertyChangeCallback SetModeSelectionCallback GetIdentityValue GetPhysicalPropertyValue GetSelectedMode SetIdentityValue SetPhysicalPropertyValue SetPhysicalPropertyValidation SetModesPresentation SetMetadata SetMetadataUnavailable; do
+for api in Configure SetPresentation SetUnavailable SetIdentityChangeCallback SetIdentityActionCallback SetPhysicalPropertyChangeCallback SetModeSelectionCallback GetIdentityValue GetPhysicalPropertyValue GetSelectedMode SetIdentityValue SetPhysicalPropertyValue SetPhysicalPropertyValidation SetModesPresentation SetModes SetSelectedMode SetChannelCount SetChannels ClearModeDetails SetMetadata SetMetadataUnavailable; do
   if ! rg -q "$api" "$panel_header"; then
     echo "Missing public forwarding API: $api" >&2
     exit 1
@@ -100,8 +100,34 @@ if rg -q "gdtf_editor_panel" "${child_files[@]}"; then
   echo "Reusable child panels must not depend on the composite panel." >&2
   exit 1
 fi
-if rg -q "GdtfEditorPanel" "$fixture_header" "$fixture_source" "$truss_header" "$truss_source"; then
-  echo "Fixture Edit and Truss Edit must not be migrated to GdtfEditorPanel in Checkpoint 06." >&2
+for header in "$fixture_header" "$truss_header"; do
+  if [[ $(rg -c "GdtfEditorPanel \*gdtfEditorPanel|GdtfEditorPanel\* gdtfEditorPanel" "$header") -ne 1 ]]; then
+    echo "${header} must own exactly one GdtfEditorPanel pointer." >&2
+    exit 1
+  fi
+done
+for source in "$fixture_source" "$truss_source"; do
+  if [[ $(rg -c "new GdtfEditorPanel\(this\)" "$source") -ne 1 ]]; then
+    echo "${source} must instantiate exactly one GdtfEditorPanel with wx parent ownership." >&2
+    exit 1
+  fi
+done
+for child in GdtfMetadataPanel GdtfTypeIdentityPanel GdtfPhysicalPropertiesPanel GdtfModesPanel; do
+  if rg -q "${child} \*|${child}\*|new ${child}\(" "$fixture_header" "$fixture_source" "$truss_header" "$truss_source"; then
+    echo "Host dialogs must not own or directly instantiate ${child}." >&2
+    exit 1
+  fi
+done
+if ! rg -q "gdtfConfiguration.modes.title = \"Modes and channels\"" "$fixture_source"; then
+  echo "Fixture Edit must keep the composite modes section visible with a host title." >&2
+  exit 1
+fi
+if ! rg -q "gdtfConfiguration.modes.visible = false" "$truss_source"; then
+  echo "Truss Edit must hide the composite modes section." >&2
+  exit 1
+fi
+if rg -q "gdtf/gdtf_(metadata|type_identity|physical_properties|modes)_panel\.h" "$fixture_source" "$truss_source"; then
+  echo "Host sources must not include obsolete direct child-panel headers." >&2
   exit 1
 fi
 
@@ -110,4 +136,4 @@ if rg -q "Fit\(" "$panel_source"; then
   exit 1
 fi
 
-echo "OK: GDTF editor panel composition boundary checks passed."
+echo "OK: GDTF editor panel Checkpoint 07 composition boundary checks passed."

--- a/tests/check_gdtf_editor_panel_boundary.sh
+++ b/tests/check_gdtf_editor_panel_boundary.sh
@@ -197,6 +197,19 @@ if rg -q "gdtf/gdtf_(metadata|type_identity|physical_properties|modes)_panel\.h"
   exit 1
 fi
 
+if rg -q "Clear\(false\)" "$panel_source"; then
+  echo "Composite layout must detach reusable sizers instead of clearing and deleting them." >&2
+  exit 1
+fi
+if ! rg -q "DetachReusableLayoutSizers" "$panel_header" "$panel_source" || \
+   ! rg -q "rootSizer->Detach\(metadataSection\)" "$panel_source" || \
+   ! rg -q "twoColumnSizer->Detach\(leftColumnSizer\)" "$panel_source" || \
+   ! rg -q "leftColumnSizer->Detach\(metadataSection\)" "$panel_source" || \
+   ! rg -q "rightColumnSizer->Detach\(modesSection\)" "$panel_source"; then
+  echo "Composite layout rebuild must detach all reusable section and column sizers before re-adding them." >&2
+  exit 1
+fi
+
 if rg -q "Fit\(" "$panel_source"; then
   echo "Composite layout must not repeatedly fit parent windows." >&2
   exit 1

--- a/tests/check_gdtf_editor_panel_boundary.sh
+++ b/tests/check_gdtf_editor_panel_boundary.sh
@@ -159,6 +159,31 @@ if ! rg -q "new wxStaticText\(gdtfSizer->GetStaticBox\(\)" "$truss_source"; then
   echo "Truss Edit GDTF explanatory text must be parented to the surrounding static box." >&2
   exit 1
 fi
+for token in \
+  "wxWindow \*fixtureSpecificParent = fixtureSpecificSizer->GetStaticBox\(\)" \
+  "new wxChoice\(fixtureSpecificParent" \
+  "new wxColourPickerCtrl\(fixtureSpecificParent" \
+  "new wxTextCtrl\(fixtureSpecificParent" \
+  "new wxStaticText\(fixtureSpecificParent" \
+  "wxWindow \*symbolParent = symbolSizer->GetStaticBox\(\)" \
+  "new wxStaticText\(symbolParent" \
+  "new wxPanel\(symbolParent" \
+  "new wxStaticBitmap\(imageSizer->GetStaticBox\(\)"; do
+  if ! rg -q "$token" "$fixture_source"; then
+    echo "Fixture Edit static-box contents must use static-box parents: $token" >&2
+    exit 1
+  fi
+done
+for token in \
+  "wxWindow \*mvrParent = mvrSizer->GetStaticBox\(\)" \
+  "new wxTextCtrl\(mvrParent" \
+  "new wxStaticText\(mvrParent" \
+  "new FixturePreviewPanel\(previewSizer->GetStaticBox\(\)"; do
+  if ! rg -q "$token" "$truss_source"; then
+    echo "Truss Edit static-box contents must use static-box parents: $token" >&2
+    exit 1
+  fi
+done
 if ! rg -q "gdtfConfiguration.modes.title = \"Modes and channels\"" "$fixture_source"; then
   echo "Fixture Edit must keep the composite modes section visible with a host title." >&2
   exit 1

--- a/tests/check_gdtf_editor_panel_boundary.sh
+++ b/tests/check_gdtf_editor_panel_boundary.sh
@@ -89,6 +89,17 @@ if ! rg -q "AddSingleColumnSections" "$panel_source" || ! rg -q "AddTwoColumnSec
   echo "Composite must implement deterministic single-column and two-column layouts." >&2
   exit 1
 fi
+if ! rg -Fq "SetSizer(rootSizer)" "$panel_source" || \
+   ! rg -Fq "rootSizer->Add(twoColumnSizer, 1, wxEXPAND)" "$panel_source" || \
+   ! rg -Fq "twoColumnSizer->Add(leftColumnSizer" "$panel_source" || \
+   ! rg -Fq "twoColumnSizer->Add(rightColumnSizer" "$panel_source"; then
+  echo "Composite layout container sizers must have stable parent-sizer ownership after construction." >&2
+  exit 1
+fi
+if rg -q "Detach\(twoColumnSizer\)|Detach\(leftColumnSizer\)|Detach\(rightColumnSizer\)" "$panel_source"; then
+  echo "Composite layout must not detach permanently owned container sizers." >&2
+  exit 1
+fi
 if ! rg -q "AddSection\(leftColumnSizer, metadataSection" "$panel_source" || \
    ! rg -q "AddSection\(leftColumnSizer, typeIdentitySection" "$panel_source" || \
    ! rg -q "AddSection\(rightColumnSizer, physicalPropertiesSection" "$panel_source" || \
@@ -203,10 +214,21 @@ if rg -q "Clear\(false\)" "$panel_source"; then
 fi
 if ! rg -q "DetachReusableLayoutSizers" "$panel_header" "$panel_source" || \
    ! rg -q "rootSizer->Detach\(metadataSection\)" "$panel_source" || \
-   ! rg -q "twoColumnSizer->Detach\(leftColumnSizer\)" "$panel_source" || \
+   ! rg -q "rootSizer->Detach\(modesSection\)" "$panel_source" || \
    ! rg -q "leftColumnSizer->Detach\(metadataSection\)" "$panel_source" || \
+   ! rg -q "leftColumnSizer->Detach\(modesSection\)" "$panel_source" || \
+   ! rg -q "rightColumnSizer->Detach\(metadataSection\)" "$panel_source" || \
    ! rg -q "rightColumnSizer->Detach\(modesSection\)" "$panel_source"; then
-  echo "Composite layout rebuild must detach all reusable section and column sizers before re-adding them." >&2
+  echo "Composite layout rebuild must detach reusable section sizers before re-adding them." >&2
+  exit 1
+fi
+if ! rg -Fq "root->Show(twoColumnSizer, false, true)" "$panel_source" || \
+   ! rg -Fq "root->Show(twoColumnSizer, true, true)" "$panel_source"; then
+  echo "Composite layout must hide the stable two-column container in single-column mode and show it in two-column mode." >&2
+  exit 1
+fi
+if rg -q "delete .*Sizer|delete rootSizer|delete twoColumnSizer|delete leftColumnSizer|delete rightColumnSizer" "$panel_source"; then
+  echo "Composite layout must not manually delete wx-owned sizers." >&2
   exit 1
 fi
 

--- a/tests/check_gdtf_metadata_panel_boundary.sh
+++ b/tests/check_gdtf_metadata_panel_boundary.sh
@@ -26,18 +26,20 @@ if ! rg -q "void SetMetadata\(const GdtfMetadataSummary &summary\)" "$panel_head
   echo "GdtfMetadataPanel must expose the presentation-only SetMetadata/SetUnavailable API." >&2
   exit 1
 fi
-if ! rg -q "GdtfMetadataPanel\*? metadataPanel|GdtfMetadataPanel \*metadataPanel" "$fixture_header" || \
-   ! rg -q "GdtfMetadataPanel \*metadataPanel" "$truss_header"; then
-  echo "Fixture and Truss edit dialogs must own a GdtfMetadataPanel pointer." >&2
+if rg -q "GdtfMetadataPanel\*|GdtfMetadataPanel \*" "$fixture_header" "$truss_header"; then
+  echo "Fixture and Truss edit dialogs must not own GdtfMetadataPanel directly." >&2
+  exit 1
+fi
+if ! rg -q "GdtfEditorPanel \*gdtfEditorPanel|GdtfEditorPanel\* gdtfEditorPanel" "$fixture_header" "$truss_header"; then
+  echo "Fixture and Truss edit dialogs must receive metadata through GdtfEditorPanel." >&2
   exit 1
 fi
 if rg -q "metadataDescriptionCtrl|metadataValueLabels|metadataGrid|metadataLabels" "$fixture_header" "$fixture_source" "$truss_header" "$truss_source"; then
   echo "Fixture and Truss edit dialogs must not keep duplicated metadata controls or label grids." >&2
   exit 1
 fi
-if ! rg -q "new GdtfMetadataPanel\(this\)" "$fixture_source" || \
-   ! rg -q "new GdtfMetadataPanel\(this\)" "$truss_source"; then
-  echo "Both edit dialogs must construct GdtfMetadataPanel." >&2
+if rg -q "new GdtfMetadataPanel\(this\)" "$fixture_source" "$truss_source"; then
+  echo "Host dialogs must not construct GdtfMetadataPanel directly." >&2
   exit 1
 fi
 if [[ $(rg -c "UpdateMetadataSummary\(\);" "$fixture_source") -ne 2 ]]; then

--- a/tests/check_gdtf_reusable_panels_boundary.sh
+++ b/tests/check_gdtf_reusable_panels_boundary.sh
@@ -29,16 +29,12 @@ if rg -q "ConfigManager|GuiConfigServices|FixtureTablePanel|TrussTablePanel|scen
   echo "Reusable GDTF panels must not depend on project, table, viewer, mutation, or editor-session services." >&2
   exit 1
 fi
-if ! rg -q "GdtfPhysicalPropertiesPanel\* physicalPropertiesPanel" gui/fixtureeditdialog.h gui/trusseditdialog.h; then
-  echo "Fixture and Truss edit dialogs must own the reusable physical properties panel." >&2
+if rg -q "GdtfPhysicalPropertiesPanel \*|GdtfPhysicalPropertiesPanel\*|GdtfTypeIdentityPanel \*|GdtfTypeIdentityPanel\*|GdtfModesPanel \*|GdtfModesPanel\*" gui/fixtureeditdialog.h gui/trusseditdialog.h; then
+  echo "Fixture and Truss edit dialogs must access reusable child panels through GdtfEditorPanel." >&2
   exit 1
 fi
-if ! rg -q "GdtfTypeIdentityPanel\* typeIdentityPanel|GdtfTypeIdentityPanel \*typeIdentityPanel" gui/fixtureeditdialog.h gui/trusseditdialog.h; then
-  echo "Fixture and Truss edit dialogs must own the reusable type identity panel." >&2
-  exit 1
-fi
-if ! rg -q "GdtfModesPanel\* modesPanel" gui/fixtureeditdialog.h; then
-  echo "Fixture edit dialog must own the reusable modes panel." >&2
+if ! rg -q "GdtfEditorPanel \*gdtfEditorPanel|GdtfEditorPanel\* gdtfEditorPanel" gui/fixtureeditdialog.h gui/trusseditdialog.h; then
+  echo "Fixture and Truss edit dialogs must own the reusable GdtfEditorPanel composite." >&2
   exit 1
 fi
 if rg -q "modeChoice|chCountCtrl|modelCtrl|channelList|crossSectionCtrl" gui/fixtureeditdialog.h gui/trusseditdialog.h; then


### PR DESCRIPTION
### Motivation
- Move host composition to the reusable presentation-only `GdtfEditorPanel` so Fixture Edit and Truss Edit no longer own the four reusable child panels directly while preserving all existing host apply/undo/preview behavior.  
- Keep `GdtfEditorPanel` strictly presentation-only and avoid moving project/table/mutation/undo/viewer responsibilities into the composite.  
- Replace the Checkpoint 06 static guards with Checkpoint 07 assertions enforcing the new ownership boundary.  
- Update internal docs and release notes to record completion of the controlled host-composition migration and to state Checkpoint 08 is the next step.

### Description
- Replaced direct child-panel members in hosts with a single composite pointer: `FixtureEditDialog` and `TrussEditDialog` now own `GdtfEditorPanel* gdtfEditorPanel` and instantiate it once with normal wx parent ownership.  
- Wired host presentation and callbacks through the composite and translated host logic to use the composite getters/setters so existing semantics (browse, preview, metadata loading, modified-column flags, mode application, shared physical-property mutation, derivative creation, table updates, undo, viewer refresh, hoist/load prompts) are preserved.  
- Added narrow, presentation-only forwarding API on `GdtfEditorPanel` for incremental mode operations: `SetModes`, `SetSelectedMode`, `SetChannelCount`, `SetChannels`, and `ClearModeDetails`, implemented as direct forwards into the internal `GdtfModesPanel` without exposing child pointers or adding project dependencies.  
- Adjusted composite configuration per host: Fixture Edit configures metadata, type identity, physical properties, and modes visible; Truss Edit configures metadata, identity, physical properties and hides modes; section titles and layout chosen to avoid extra `Fit()` calls and layout growth.  
- Updated static guards/tests and docs: `tests/check_gdtf_editor_panel_boundary.sh`, `tests/check_gdtf_reusable_panels_boundary.sh`, `tests/check_gdtf_metadata_panel_boundary.sh` updated to assert the new checkpoint; `docs/internal/gdtf_editor_context_boundaries.md`, `docs/internal/gdtf_editor_architecture_audit.md`, and `docs/release-notes-draft.md` updated to record Checkpoint 07.  
- Files changed (key): `gui/fixtureeditdialog.h/.cpp`, `gui/trusseditdialog.h/.cpp`, `gui/gdtf/gdtf_editor_panel.h/.cpp`, `tests/check_gdtf_editor_panel_boundary.sh`, `tests/check_gdtf_reusable_panels_boundary.sh`, `tests/check_gdtf_metadata_panel_boundary.sh`, `docs/internal/gdtf_editor_context_boundaries.md`, `docs/internal/gdtf_editor_architecture_audit.md`, and `docs/release-notes-draft.md`.

### Testing
- Ran architecture and boundary guards and static checks which all passed: `tests/check_gdtf_editor_panel_boundary.sh`, `tests/check_gdtf_reusable_panels_boundary.sh`, `tests/check_gdtf_metadata_panel_boundary.sh`, `tests/check_gdtf_metadata_summary_boundary.sh`, `tests/check_gdtf_editor_core_boundary.sh`, `tests/check_no_configmanager_get_in_gui.sh`, and `tests/check_perastage_tree_modules.sh` all returned PASS.  
- Ran `git diff --check` and it passed (no whitespace/indexing issues).  
- Attempted CMake configure (`cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`) but full build could not complete in the container because wxWidgets headers/libraries are absent (`Could NOT find wxWidgets: missing: wxWidgets_LIBRARIES wxWidgets_INCLUDE_DIRS`), so no compiled binary-test was performed here.  
- Manual Windows/Visual Studio smoke checklist included in the change (fixture and truss validation steps) for local GUI verification; GUI runtime smoke tests remain required on a host with wxWidgets and the full Perastage build environment.  

Checkpoint 07 is complete: both hosts now own one `GdtfEditorPanel` composite, the composite remains presentation-only, host apply/mutation/preview/undo/viewer responsibilities are unchanged, and Checkpoint 08 (edit-session/apply-adapter migration) remains the next controlled step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4eafe849488324b2117b611983bccc)