### PR TITLE
Stabilize GDTF editor apply transactions (Checkpoint 08D)

### DIFF
--- a/core/gdtf/editor/project_fixture_gdtf_apply_adapter.cpp
+++ b/core/gdtf/editor/project_fixture_gdtf_apply_adapter.cpp
@@ -114,8 +114,7 @@ ProjectFixtureGdtfApplyResult ProjectFixtureGdtfApplyAdapter::Apply(
       (request.sourcePath.empty() || !std::filesystem::is_regular_file(request.sourcePath, ec)))
     return Fail("Resolved GDTF source path is not an existing regular file.");
 
-  auto preparedFixtures = *input.fixtures;
-  auto preparedTargetIt = preparedFixtures.find(request.stableHostId);
+  std::unordered_map<std::string, Fixture> preparedUpdates;
 
   ProjectFixtureGdtfApplyResult result;
   result.common.success = true;
@@ -140,7 +139,7 @@ ProjectFixtureGdtfApplyResult ProjectFixtureGdtfApplyAdapter::Apply(
       if (!services_.createDerivative)
         return Fail("Derivative creation service is not available.");
       std::string diagnostic;
-      if (!services_.createDerivative(request.sourcePath, writablePath, diagnostic))
+      if (!services_.createDerivative(request.sourcePath, resultingType, resultingMode, writablePath, diagnostic))
         return Fail(diagnostic.empty() ? "Could not create a writable GDTF derivative." : diagnostic);
       result.common.derivativeCreated = writablePath != request.sourcePath;
       result.externalFileCreatedOrModified = true;
@@ -166,32 +165,36 @@ ProjectFixtureGdtfApplyResult ProjectFixtureGdtfApplyAdapter::Apply(
     result.common.changedGdtfFields = request.changedDocumentFields;
   }
 
-  preparedTargetIt->second.typeName = resultingType;
-  preparedTargetIt->second.gdtfMode = resultingMode;
-  preparedTargetIt->second.gdtfSpec = result.resultingSourceReference;
+  Fixture preparedTarget = original;
+  preparedTarget.typeName = resultingType;
+  preparedTarget.gdtfMode = resultingMode;
+  preparedTarget.gdtfSpec = result.resultingSourceReference;
   result.contextSelectionChanged = typeChanged || sourceChanged || modeChanged || result.common.derivativeCreated;
 
   if (documentChanged) {
-    for (auto &[uuid, fixture] : preparedFixtures) {
+    for (const auto &[uuid, fixture] : *input.fixtures) {
       if (!MatchesResultingFamily(fixture, original.gdtfSpec,
                                   result.resultingSourceReference,
                                   resultingType) &&
           uuid != request.stableHostId)
         continue;
-      if (std::fabs(fixture.weightKg - resultingWeight) > 0.001f) {
+      Fixture updated = fixture;
+      if (std::fabs(updated.weightKg - resultingWeight) > 0.001f) {
         result.weightChangedFixtureUuids.insert(uuid);
-        result.changedWeightPositionNames.insert(EffectivePositionName(fixture));
+        result.changedWeightPositionNames.insert(EffectivePositionName(updated));
       }
-      fixture.typeName = resultingType;
-      fixture.gdtfSpec = result.resultingSourceReference;
-      fixture.weightKg = resultingWeight;
-      fixture.powerConsumptionW = resultingPower;
-      fixture.physicalPropertiesSource = FixturePhysicalPropertiesSource::Gdtf;
-      fixture.physicalPropertiesDirty = false;
+      updated.typeName = resultingType;
+      updated.gdtfSpec = result.resultingSourceReference;
+      updated.weightKg = resultingWeight;
+      updated.powerConsumptionW = resultingPower;
+      updated.physicalPropertiesSource = FixturePhysicalPropertiesSource::Gdtf;
+      updated.physicalPropertiesDirty = false;
+      preparedUpdates.emplace(uuid, std::move(updated));
       result.affectedFixtureUuids.insert(uuid);
     }
     result.physicalPropagationOccurred = !result.affectedFixtureUuids.empty();
   } else if (result.contextSelectionChanged) {
+    preparedUpdates.emplace(request.stableHostId, std::move(preparedTarget));
     result.affectedFixtureUuids.insert(request.stableHostId);
   }
 
@@ -200,7 +203,7 @@ ProjectFixtureGdtfApplyResult ProjectFixtureGdtfApplyAdapter::Apply(
   result.common.viewerRefreshRequired = changed;
   result.common.hoistLoadRecalculationRequired = !result.changedWeightPositionNames.empty();
   result.common.projectDirtyStateMustBeUpdated = changed;
-  *input.fixtures = std::move(preparedFixtures);
+  result.updatedFixtures = std::move(preparedUpdates);
   return result;
 }
 

--- a/core/gdtf/editor/project_fixture_gdtf_apply_adapter.h
+++ b/core/gdtf/editor/project_fixture_gdtf_apply_adapter.h
@@ -16,12 +16,12 @@ struct ProjectFixtureGdtfApplyServices {
   std::function<bool(const std::filesystem::path &, const std::string &)> modeExists;
   std::function<int(const std::filesystem::path &, const std::string &)> channelCount;
   std::function<bool(const std::filesystem::path &, float, float, std::string &)> writePhysicalProperties;
-  std::function<bool(const std::filesystem::path &, std::filesystem::path &, std::string &)> createDerivative;
+  std::function<bool(const std::filesystem::path &, const std::string &, const std::string &, std::filesystem::path &, std::string &)> createDerivative;
 };
 
 struct ProjectFixtureGdtfApplyInput {
   GdtfApplyRequest request;
-  std::unordered_map<std::string, Fixture> *fixtures = nullptr;
+  const std::unordered_map<std::string, Fixture> *fixtures = nullptr;
 };
 
 struct ProjectFixtureGdtfApplyResult {
@@ -29,6 +29,7 @@ struct ProjectFixtureGdtfApplyResult {
   std::set<std::string> affectedFixtureUuids;
   std::set<std::string> weightChangedFixtureUuids;
   std::set<std::string> changedWeightPositionNames;
+  std::unordered_map<std::string, Fixture> updatedFixtures;
   std::string resultingType;
   std::string resultingMode;
   std::string resultingSourceReference;

--- a/docs/gdtf_mutation_policy.md
+++ b/docs/gdtf_mutation_policy.md
@@ -141,3 +141,7 @@ After a successful physical write, the adapter propagates Weight and PowerConsum
 ## Checkpoint 08 apply adapters
 
 Checkpoint 08 is complete: Fixture Edit now routes session-backed type, source, mode, Weight, and PowerConsumption changes through the non-GUI ProjectFixtureGdtfApplyAdapter, and Project Truss GDTF type edits route through ProjectTrussGdtfApplyAdapter. Truss generation is controlled by dirty GDTF type fields; geometry-only and MVR-only edits remain non-generating. Operational resource paths are resolved separately from portable project references. Adapter failures do not commit project, table, or session state, while UI messages, preview refresh, and viewer refresh remain host-owned. StartupRouter and direct .gdtf opening remain Checkpoint 09 work.
+
+## Checkpoint 08D Apply transaction policy
+
+Adapters validate requests, perform required external file preparation, and return prepared project mutations. Hosts create one project undo checkpoint only after adapter success and before committing the prepared mutation to the project model. Existing verified Perastage derivatives may be overwritten; ordinary library, external, or extracted sources must create a derivative before physical mutation. UTF-8 path boundaries must use `PathUtils::PathToUtf8(...)` and `PathUtils::PathFromUtf8(...)`. External file changes cannot be undone by project undo and must be reported separately from project commits.

--- a/docs/internal/gdtf_editor_architecture_audit.md
+++ b/docs/internal/gdtf_editor_architecture_audit.md
@@ -246,3 +246,7 @@ The adapter enforces write policy before project mutation: read-only document ed
 ## Checkpoint 08C audit update
 
 The prior Checkpoint 08B merge was incomplete because FixtureEditDialog still performed the legacy fixture GDTF apply flow directly and the guard could pass by finding the adapter token in its own implementation file. The guard now inspects FixtureEditDialog itself for adapter construction, BuildApplyRequest(), result success handling, and absence of migrated legacy operations. Checkpoint 08C adds ProjectTrussGdtfApplyAdapter for controlled non-GUI truss generation and leaves StartupRouter/direct .gdtf opening to Checkpoint 09.
+
+## Checkpoint 08D stabilization audit
+
+Checkpoint 08D stabilizes the runtime transaction order for Fixture and Truss Edit. Tables are no longer used as pre-commit transaction buffers before adapter success, Fixture adapter results carry prepared fixture mutations instead of committing the live collection, and hosts reconcile row caches and sessions to the actual resulting GDTF source. Checkpoint 08 is therefore stabilized; Checkpoint 08E is the next UI-only refinement, while startup routing remains after stabilization and UI review.

--- a/docs/internal/gdtf_editor_checkpoint08d_regression_matrix.md
+++ b/docs/internal/gdtf_editor_checkpoint08d_regression_matrix.md
@@ -1,0 +1,54 @@
+# GDTF Editor Checkpoint 08D Regression Matrix
+
+Checkpoint 08D verifies transaction stability after Fixture and Truss hosts adopted the reusable GDTF editor panels and apply adapters.
+
+## Fixture sources
+
+| Source | Expected result |
+| --- | --- |
+| MVR-extracted GDTF | Physical edits create a Perastage derivative; the extracted source is not overwritten. |
+| User Fixture library source | Physical edits create or reuse a stable Perastage derivative and preserve dictionary type context. |
+| Existing Perastage derivative | Physical edits update the owned derivative instead of creating a derivative-of-derivative. |
+| Missing source | Apply fails with one concise validation message and no project/table/cache mutation. |
+| Unicode path | Metadata, modes, channels, mutation, and derivative references use UTF-8-safe path conversion. |
+
+## Fixture edits
+
+| Edit | Expected result |
+| --- | --- |
+| No-op | No undo entry, file write, table refresh, viewer rebuild, or dirty-state change. |
+| Mode only | One project undo checkpoint, no derivative, committed mode reference, clean session baseline. |
+| Source/type only | One project undo checkpoint and table/cache/session rebind to the resulting source. |
+| Weight only | One project undo checkpoint; propagated fixtures in the same source/type family update. |
+| Power only | One project undo checkpoint; original source is unchanged when a derivative is required. |
+| Weight + Power | One project undo checkpoint and one physical write target. |
+| Mixed project fields | Adapter preparation succeeds before table/project commit; all changes commit together. |
+| Derivative failure | Dialog remains open; table, project, row cache, session, visual color, and dirty state remain unchanged. |
+| Physical write failure | No project commit; only safe newly-created incomplete outputs may be cleaned up. |
+| Reopen and second Apply | The editor reopens on the resulting derivative; no-op second Apply creates no derivative or undo. |
+| Undo | Project Fixture values and references return to the previous project state; external files are outside undo. |
+
+## Truss sources
+
+| Source | Expected result |
+| --- | --- |
+| Geometry-only | Generation occurs only when a GDTF-owned value changes. |
+| External/extracted GDTF | Generated project-controlled output is committed without resolving references against the process cwd. |
+| Existing generated Perastage GDTF | Owned generated output may be updated; project references remain stable. |
+| Missing resource | Required resource failure stops Apply before project/table/cache mutation. |
+| Unicode resource path | Resource resolution and generated references preserve UTF-8 paths. |
+
+## Truss edits
+
+| Edit | Expected result |
+| --- | --- |
+| No-op | No generation, undo entry, table refresh, viewer rebuild, or dirty-state change. |
+| MVR-only | One undo checkpoint through table synchronization; no GDTF generation. |
+| Manufacturer/Model | One generation and one undo checkpoint. |
+| Dimensions | One generation and one undo checkpoint. |
+| Weight | One generation and one undo checkpoint. |
+| Cross Section only | One generation and one explicit undo checkpoint even when no table column changes. |
+| Mixed Apply | Adapter preparation succeeds before table/project commit; exactly one undo checkpoint. |
+| Generation failure | Dialog remains open; table, project, session, and caches remain unchanged. |
+| Reopen and second Apply | Metadata and preview use the generated result; no-op second Apply does not regenerate. |
+| Undo | Project truss type values and generated references restore to the previous project state. |

--- a/docs/internal/gdtf_editor_context_boundaries.md
+++ b/docs/internal/gdtf_editor_context_boundaries.md
@@ -207,3 +207,7 @@ Checkpoint 08B also corrects host-side rejected input tracking so Fixture Edit a
 ## Checkpoint 08 completion
 
 Fixture Edit now invokes the non-GUI fixture apply adapter at the host integration boundary instead of performing physical GDTF mutation directly. Project Truss Apply uses a non-GUI adapter that consumes GdtfApplyRequest, returns a typed result containing GdtfApplyResult, and keeps generation policy outside TrussEditDialog. Dirty GDTF type fields are the only trigger for truss generation; no-op, Cancel, geometry-only open, and MVR-only edits do not generate archives.
+
+## Checkpoint 08D transaction boundary
+
+Fixture and Truss apply adapters prepare validated project mutations and perform required external GDTF file operations, but hosts own the project commit, table refresh, GUI messages, viewer refresh, and session rebaseline. A successful Apply establishes one project undo checkpoint after external file preparation and before project model mutation; external GDTF file writes are explicitly outside project undo.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -58,6 +58,7 @@ Changes since **v1.4.0**.
 - Improved Windows crash dumps so native access violations are captured from the original exception context before best-effort text stack reporting.
 
 ## Internal changes
+- Stabilized GDTF editor Apply transactions for Fixture and Truss editing so project changes are committed only after adapter success, with clearer undo ordering, derivative reconciliation, and UTF-8 path handling.
 
 - Improved the internal GDTF editor architecture by moving Project Fixture apply decisions toward a non-GUI adapter, adding structured apply results, preserving per-field validation errors, and making derived Channel Count dirty tracking reversible while leaving Truss apply migration for the next checkpoint.
 
@@ -147,6 +148,7 @@ sudo pacman -U Perastage-1.4.0-arch-x86_64.pkg.tar.zst
 If you encounter any problems installing or running Perastage, please open an issue on GitHub or contact the developer. Including a diagnostic report (available from the Help menu) makes it much easier to investigate problems.
 
 ## Internal changes
+- Stabilized GDTF editor Apply transactions for Fixture and Truss editing so project changes are committed only after adapter success, with clearer undo ordering, derivative reconciliation, and UTF-8 path handling.
 
 - Improved the internal GDTF editor architecture by moving Project Fixture apply decisions toward a non-GUI adapter, adding structured apply results, preserving per-field validation errors, and making derived Channel Count dirty tracking reversible while leaving Truss apply migration for the next checkpoint.
 
@@ -164,5 +166,6 @@ If you encounter any problems installing or running Perastage, please open an is
 - Fixed Windows build compatibility for Layout 2D preview diagnostics.
 
 ## Internal changes
+- Stabilized GDTF editor Apply transactions for Fixture and Truss editing so project changes are committed only after adapter success, with clearer undo ordering, derivative reconciliation, and UTF-8 path handling.
 
 - Completed Checkpoint 08 GDTF editor apply architecture by routing Fixture and Truss GDTF type edits through non-GUI apply adapters, preserving no-op and MVR-only behavior, and preventing failed generation or mutation from committing project state, and preserving Windows build compatibility for the new adapter host calls and project collection types.

--- a/gui/fixture_gdtf_apply_services.cpp
+++ b/gui/fixture_gdtf_apply_services.cpp
@@ -3,6 +3,7 @@
 #include "gdtf_mutation_audit.h"
 #include "gdtfdictionary.h"
 #include "gdtfloader.h"
+#include "filesystem_path_utils.h"
 
 #include <algorithm>
 
@@ -13,24 +14,30 @@ gdtf::ProjectFixtureGdtfApplyServices MakeFixtureGdtfApplyServices() {
   gdtf::ProjectFixtureGdtfApplyServices services;
   services.modeExists = [](const std::filesystem::path &path,
                            const std::string &mode) {
-    const auto modes = GetGdtfModes(path.string());
+    const auto modes = GetGdtfModes(PathUtils::PathToUtf8(path));
     return std::find(modes.begin(), modes.end(), mode) != modes.end();
   };
   services.channelCount = [](const std::filesystem::path &path,
                              const std::string &mode) {
-    return GetGdtfModeChannelCount(path.string(), mode);
+    return GetGdtfModeChannelCount(PathUtils::PathToUtf8(path), mode);
   };
   services.writePhysicalProperties = [](const std::filesystem::path &path,
                                         float weightKg, float powerW,
                                         std::string &) {
-    return SetGdtfProperties(path.string(), weightKg, powerW,
+    return SetGdtfProperties(PathUtils::PathToUtf8(path), weightKg, powerW,
                              GdtfMutationAudit::BuildPerastageModifiedBy());
   };
   services.createDerivative = [](const std::filesystem::path &source,
+                                 const std::string &fixtureType,
+                                 const std::string &,
                                  std::filesystem::path &out,
                                  std::string &diagnostic) {
+    if (fixtureType.empty()) {
+      diagnostic = "Fixture type context is required to create a derivative.";
+      return false;
+    }
     auto derivative = GdtfDictionary::CreateOrUpdatePerastageLibraryDerivative(
-        {}, source.string());
+        fixtureType, PathUtils::PathToUtf8(source));
     if (!derivative || derivative->path.empty()) {
       diagnostic = "Could not create a writable GDTF derivative.";
       return false;

--- a/gui/fixtureeditdialog.cpp
+++ b/gui/fixtureeditdialog.cpp
@@ -265,12 +265,13 @@ void FixtureEditDialog::BuildEditSession() {
   input.fixture = fixture;
   input.resolvedGdtfPath = resolvedPath;
   input.editorSourceFileReference =
-      !resolvedPath.empty() ? resolvedPath.string() : fixture.gdtfSpec;
+      !resolvedPath.empty() ? PathUtils::PathToUtf8(resolvedPath) : fixture.gdtfSpec;
   if (IsExistingRegularFile(input.resolvedGdtfPath))
     input.document = gdtf::LoadGdtfDocument(input.resolvedGdtfPath);
-  input.sourceKind = IsUserFixtureLibraryPath(input.resolvedGdtfPath.string())
-                         ? gdtf::GdtfSourceKind::PerastageFixtureLibraryFile
-                         : gdtf::GdtfSourceKind::Unknown;
+  input.sourceKind =
+      IsUserFixtureLibraryPath(PathUtils::PathToUtf8(input.resolvedGdtfPath))
+          ? gdtf::GdtfSourceKind::PerastageFixtureLibraryFile
+          : gdtf::GdtfSourceKind::Unknown;
   input.writePolicy = gdtf::GdtfWritePolicy::CreateDerivativeBeforeMutation;
   gdtfEditSession = std::make_unique<gdtf::GdtfEditSession>(
       gdtf::BuildProjectFixtureGdtfEditSession(input));
@@ -441,7 +442,7 @@ FixtureEditDialog::FixtureEditDialog(FixtureTablePanel *p, int r)
           {GdtfTypeIdentityField::SourceFileReference, "Model file",
            gui::gdtf_binding::ValueText(
                sessionValues, gdtf::GdtfFieldId::SourceFileReference,
-               initialGdtfPath.string()),
+               PathUtils::PathToUtf8(initialGdtfPath)),
            true,
            gdtfEditSession &&
                gui::gdtf_binding::IsEditable(
@@ -469,7 +470,7 @@ FixtureEditDialog::FixtureEditDialog(FixtureTablePanel *p, int r)
            "kg"},
       },
       {initialGdtfPath.empty() ? std::vector<std::string>()
-                               : GetGdtfModes(initialGdtfPath.string()),
+                               : GetGdtfModes(PathUtils::PathToUtf8(initialGdtfPath)),
        gui::gdtf_binding::ValueText(
            sessionValues, gdtf::GdtfFieldId::ModeName,
            std::string(modeValue.GetString().ToUTF8())),
@@ -685,11 +686,11 @@ void FixtureEditDialog::OnBrowse(wxCommandEvent &) {
       gdtf::ProjectFixtureGdtfContextInput input;
       input.fixture = it->second;
       input.resolvedGdtfPath = pendingSelectedGdtfPath;
-      input.editorSourceFileReference = input.resolvedGdtfPath.string();
+      input.editorSourceFileReference = PathUtils::PathToUtf8(input.resolvedGdtfPath);
       if (IsExistingRegularFile(input.resolvedGdtfPath))
         input.document = gdtf::LoadGdtfDocument(input.resolvedGdtfPath);
       input.sourceKind =
-          IsUserFixtureLibraryPath(input.resolvedGdtfPath.string())
+          IsUserFixtureLibraryPath(PathUtils::PathToUtf8(input.resolvedGdtfPath))
               ? gdtf::GdtfSourceKind::PerastageFixtureLibraryFile
               : gdtf::GdtfSourceKind::Unknown;
       input.writePolicy = gdtf::GdtfWritePolicy::CreateDerivativeBeforeMutation;
@@ -833,7 +834,7 @@ void FixtureEditDialog::OnSymbolPreviewPaint(wxPaintEvent &evt) {
 }
 
 void FixtureEditDialog::UpdateVisualizers() {
-  const std::string path = GetActiveResolvedGdtfPath().string();
+  const std::string path = PathUtils::PathToUtf8(GetActiveResolvedGdtfPath());
   const std::array<SymbolViewKind, 3> views = {
       SymbolViewKind::Bottom, SymbolViewKind::Front, SymbolViewKind::Left};
   for (size_t i = 0; i < views.size(); ++i) {
@@ -867,7 +868,7 @@ void FixtureEditDialog::UpdateVisualizers() {
 }
 
 void FixtureEditDialog::UpdateMetadataSummary() {
-  const std::string path = GetActiveResolvedGdtfPath().string();
+  const std::string path = PathUtils::PathToUtf8(GetActiveResolvedGdtfPath());
   GdtfMetadataSummary metadata;
   if (LoadGdtfMetadataSummary(path, metadata)) {
     if (gdtfEditorPanel)
@@ -917,6 +918,7 @@ void FixtureEditDialog::OnOk(wxCommandEvent &) {
 
 void FixtureEditDialog::OnCancel(wxCommandEvent &) { EndModal(wxID_CANCEL); }
 
+// Applies fixture edits only after GDTF adapter preparation succeeds.
 bool FixtureEditDialog::ApplyChanges() {
   if (!panel)
     return true;
@@ -936,6 +938,40 @@ bool FixtureEditDialog::ApplyChanges() {
                                           [](bool modified) { return modified; });
   if (!hasUserChanges)
     return true;
+
+  std::unordered_set<std::string> changedWeightPositions;
+  gdtf::ProjectFixtureGdtfApplyResult fixtureApplyResult;
+  if (gdtfEditSession) {
+    auto request = gdtfEditSession->BuildApplyRequest();
+    const bool hasAdapterChanges = !request.changedDocumentFields.empty() ||
+                                   !request.changedContextFields.empty();
+    if (hasAdapterChanges) {
+      gdtf::ProjectFixtureGdtfApplyAdapter adapter(
+          gui::MakeFixtureGdtfApplyServices());
+      const auto &scene =
+          GetDefaultGuiConfigServices().LegacyConfigManager().GetScene();
+      gdtf::ProjectFixtureGdtfApplyInput applyInput;
+      applyInput.request = request;
+      applyInput.fixtures = &scene.fixtures;
+      fixtureApplyResult = adapter.Apply(applyInput);
+      if (!fixtureApplyResult.common.success) {
+        const std::string message = fixtureApplyResult.common.diagnostics.empty()
+                                        ? "Could not apply fixture GDTF changes."
+                                        : fixtureApplyResult.common.diagnostics.front();
+        wxMessageBox(wxString::FromUTF8(message), "GDTF update",
+                     wxOK | wxICON_WARNING, this);
+        return false;
+      }
+      gdtfPath = fixtureApplyResult.common.resultingGdtfPath.empty()
+                     ? gdtfPath
+                     : fixtureApplyResult.common.resultingGdtfPath;
+      pendingSelectedGdtfPath = gdtfPath;
+      for (const auto &position : fixtureApplyResult.changedWeightPositionNames)
+        changedWeightPositions.insert(position);
+      originalPowerW = fixtureApplyResult.resultingPowerConsumptionW;
+      originalWeightKg = fixtureApplyResult.resultingWeightKg;
+    }
+  }
 
   for (size_t i = 0; i < ctrls.size(); ++i) {
     if (i >= modifiedColumns.size() || !modifiedColumns[i])
@@ -1041,38 +1077,6 @@ bool FixtureEditDialog::ApplyChanges() {
     }
   }
 
-  std::unordered_set<std::string> changedWeightPositions;
-  gdtf::ProjectFixtureGdtfApplyResult fixtureApplyResult;
-  if (gdtfEditSession) {
-    auto request = gdtfEditSession->BuildApplyRequest();
-    const bool hasAdapterChanges = !request.changedDocumentFields.empty() ||
-                                   !request.changedContextFields.empty();
-    if (hasAdapterChanges) {
-      gdtf::ProjectFixtureGdtfApplyAdapter adapter(
-          gui::MakeFixtureGdtfApplyServices());
-      gdtf::ProjectFixtureGdtfApplyInput applyInput;
-      applyInput.request = request;
-      applyInput.fixtures =
-          &GetDefaultGuiConfigServices().LegacyConfigManager().GetScene().fixtures;
-      fixtureApplyResult = adapter.Apply(applyInput);
-      if (!fixtureApplyResult.common.success) {
-        const std::string message = fixtureApplyResult.common.diagnostics.empty()
-                                        ? "Could not apply fixture GDTF changes."
-                                        : fixtureApplyResult.common.diagnostics.front();
-        wxMessageBox(wxString::FromUTF8(message), "GDTF update",
-                     wxOK | wxICON_WARNING, this);
-        return false;
-      }
-      gdtfPath = fixtureApplyResult.common.resultingGdtfPath.empty()
-                     ? gdtfPath
-                     : fixtureApplyResult.common.resultingGdtfPath;
-      pendingSelectedGdtfPath = gdtfPath;
-      for (const auto &position : fixtureApplyResult.changedWeightPositionNames)
-        changedWeightPositions.insert(position);
-      originalPowerW = fixtureApplyResult.resultingPowerConsumptionW;
-      originalWeightKg = fixtureApplyResult.resultingWeightKg;
-    }
-  }
   if (fixtureColorChanged) {
     wxDataViewItemArray colorSource;
     colorSource.Add(table->RowToItem(row));
@@ -1091,6 +1095,12 @@ bool FixtureEditDialog::ApplyChanges() {
         FixtureTablePanel::UpdateTypeForColumn(static_cast<int>(i)));
   }
   panel->UpdateSceneData(true, updateType);
+  if (!fixtureApplyResult.updatedFixtures.empty()) {
+    auto &fixtures =
+        GetDefaultGuiConfigServices().LegacyConfigManager().GetScene().fixtures;
+    for (const auto &[uuid, fixture] : fixtureApplyResult.updatedFixtures)
+      fixtures[uuid] = fixture;
+  }
   HoistLoadRecalculationPrompt::PromptAndApply(
       GetDefaultGuiConfigServices().LegacyConfigManager(), panel,
       changedWeightPositions);

--- a/gui/trusseditdialog.cpp
+++ b/gui/trusseditdialog.cpp
@@ -456,6 +456,30 @@ bool TrussEditDialog::ApplyChanges() {
     gdtfColumnChanged =
         gdtfColumnChanged || (modifiedColumns[i] && IsGdtfTrussColumn(i));
 
+  if (gdtfColumnChanged && gdtfEditSession) {
+    auto request = gdtfEditSession->BuildApplyRequest();
+    if (!request.changedDocumentFields.empty() || !request.changedContextFields.empty()) {
+      const auto &scene =
+          GetDefaultGuiConfigServices().LegacyConfigManager().GetScene();
+      gdtf::ProjectTrussGdtfApplyAdapter adapter(gui::MakeTrussGdtfApplyServices());
+      gdtf::ProjectTrussGdtfApplyInput applyInput;
+      applyInput.request = request;
+      applyInput.trusses = &scene.trusses;
+      applyInput.projectResourceBasePath = PathUtils::PathFromUtf8(scene.basePath);
+      applyInput.outputRoot =
+          PathUtils::PathFromUtf8(ProjectUtils::GetWritableLibraryPath("trusses"));
+      trussApplyResult = adapter.Apply(applyInput);
+      if (!trussApplyResult.common.success) {
+        const std::string message = trussApplyResult.common.diagnostics.empty()
+                                        ? "Could not apply truss GDTF changes."
+                                        : trussApplyResult.common.diagnostics.front();
+        wxMessageBox(wxString::FromUTF8(message), "Truss GDTF",
+                     wxOK | wxICON_WARNING, this);
+        return false;
+      }
+    }
+  }
+
   for (size_t i = 0; i < ctrls.size(); ++i) {
     if (!modifiedColumns[i])
       continue;
@@ -490,31 +514,12 @@ bool TrussEditDialog::ApplyChanges() {
     }
   }
 
-  if (gdtfColumnChanged && gdtfEditSession) {
-    auto request = gdtfEditSession->BuildApplyRequest();
-    if (!request.changedDocumentFields.empty() || !request.changedContextFields.empty()) {
-      const auto &scene =
-          GetDefaultGuiConfigServices().LegacyConfigManager().GetScene();
-      gdtf::ProjectTrussGdtfApplyAdapter adapter(gui::MakeTrussGdtfApplyServices());
-      gdtf::ProjectTrussGdtfApplyInput applyInput;
-      applyInput.request = request;
-      applyInput.trusses = &scene.trusses;
-      applyInput.projectResourceBasePath = PathUtils::PathFromUtf8(scene.basePath);
-      applyInput.outputRoot =
-          PathUtils::PathFromUtf8(ProjectUtils::GetWritableLibraryPath("trusses"));
-      trussApplyResult = adapter.Apply(applyInput);
-      if (!trussApplyResult.common.success) {
-        const std::string message = trussApplyResult.common.diagnostics.empty()
-                                        ? "Could not apply truss GDTF changes."
-                                        : trussApplyResult.common.diagnostics.front();
-        wxMessageBox(wxString::FromUTF8(message), "Truss GDTF",
-                     wxOK | wxICON_WARNING, this);
-        return false;
-      }
-    }
-  }
 
   panel->UpdateSceneData(true);
+
+  if (trussApplyResult.resultingTruss && !hasTableChanges)
+    GetDefaultGuiConfigServices().LegacyConfigManager().PushUndoState(
+        "edit truss");
 
   if (trussApplyResult.resultingTruss && row >= 0 &&
       static_cast<size_t>(row) < panel->rowUuids.size()) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -305,6 +305,7 @@ add_executable(project_truss_gdtf_apply_adapter_test
 target_include_directories(project_truss_gdtf_apply_adapter_test PRIVATE .. ../core ../models)
 add_test(NAME ProjectTrussGdtfApplyAdapter COMMAND project_truss_gdtf_apply_adapter_test)
 add_test(NAME GdtfEditorCheckpoint08CTrussApplyAdapter COMMAND ${CMAKE_SOURCE_DIR}/tests/check_gdtf_editor_checkpoint08c_truss_apply_adapter.sh)
+add_test(NAME GdtfEditorCheckpoint08DStabilization COMMAND ${CMAKE_SOURCE_DIR}/tests/check_gdtf_editor_checkpoint08d_stabilization.sh)
 
 add_executable(gdtf_editor_context_test
                gdtf_editor_context_test.cpp

--- a/tests/check_gdtf_editor_checkpoint08d_stabilization.sh
+++ b/tests/check_gdtf_editor_checkpoint08d_stabilization.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 - <<'PY'
+from pathlib import Path
+import re
+
+def body(path, name):
+    text = Path(path).read_text()
+    m = re.search(r'(?:bool|[\w:]+)\s+' + re.escape(name) + r'\([^)]*\)\s*\{', text)
+    assert m, f'{name} not found in {path}'
+    i = m.end(); depth = 1
+    while i < len(text) and depth:
+        if text[i] == '{': depth += 1
+        elif text[i] == '}': depth -= 1
+        i += 1
+    return text[m.end():i-1]
+
+adapter_h = Path('core/gdtf/editor/project_fixture_gdtf_apply_adapter.h').read_text()
+assert 'const std::unordered_map<std::string, Fixture> *fixtures' in adapter_h
+assert 'updatedFixtures' in adapter_h
+adapter_cpp = Path('core/gdtf/editor/project_fixture_gdtf_apply_adapter.cpp').read_text()
+assert '*input.fixtures =' not in adapter_cpp
+assert 'result.updatedFixtures' in adapter_cpp
+assert 'fixtureType' in Path('gui/fixture_gdtf_apply_services.cpp').read_text()
+assert 'CreateOrUpdatePerastageLibraryDerivative(\n        fixtureType' in Path('gui/fixture_gdtf_apply_services.cpp').read_text()
+assert '.string()' not in Path('gui/fixture_gdtf_apply_services.cpp').read_text()
+
+for path, name in [('gui/fixtureeditdialog.cpp','FixtureEditDialog::ApplyChanges'),('gui/trusseditdialog.cpp','TrussEditDialog::ApplyChanges')]:
+    b = body(path, name)
+    apply_pos = b.find('.Apply(')
+    set_pos = b.find('SetValue(')
+    assert apply_pos >= 0, f'{path} must invoke adapter before committing table state'
+    assert set_pos < 0 or apply_pos < set_pos, f'{path} writes table before adapter success'
+    if 'fixture' in path:
+        cache_pos = b.find('gdtfPaths')
+        assert cache_pos < 0 or apply_pos < cache_pos, 'Fixture path cache is updated before adapter success'
+        assert 'updatedFixtures' in b and 'UpdateSceneData(true' in b
+    else:
+        assert 'PushUndoState(\n        "edit truss")' in b
+
+for path in ['core/gdtf/editor/project_fixture_gdtf_apply_adapter.cpp','core/gdtf/editor/project_truss_gdtf_apply_adapter.cpp']:
+    text = Path(path).read_text()
+    forbidden = ['wx', 'ConfigManager', 'DataView', 'Viewer2D', 'Viewer3D', 'wxMessageBox']
+    assert not any(token in text for token in forbidden), f'{path} must remain non-GUI'
+
+code_text = '\n'.join(Path(p).read_text(errors='ignore') for p in Path('.').rglob('*') if p.is_file() and p.suffix in {'.cpp','.h','.hpp','.cc'})
+assert 'StartupRouter' not in code_text
+print('OK: GDTF editor Checkpoint 08D stabilization checks passed.')
+PY
+bash tests/check_gdtf_editor_checkpoint08a_binding.sh >/dev/null
+bash tests/check_gdtf_editor_checkpoint08b_fixture_apply_adapter.sh >/dev/null
+bash tests/check_gdtf_editor_checkpoint08c_truss_apply_adapter.sh >/dev/null

--- a/tests/project_fixture_gdtf_apply_adapter_test.cpp
+++ b/tests/project_fixture_gdtf_apply_adapter_test.cpp
@@ -32,8 +32,11 @@ gdtf::ProjectFixtureGdtfApplyServices MakeServices(bool failDerivative = false,
     return mode == "Mode B" ? 12 : 8;
   };
   services.createDerivative = [failDerivative](const std::filesystem::path &source,
+                                               const std::string &fixtureType,
+                                               const std::string &,
                                                std::filesystem::path &out,
                                                std::string &diagnostic) {
+    assert(!fixtureType.empty());
     if (failDerivative) {
       diagnostic = "Derivative failed.";
       return false;
@@ -90,7 +93,9 @@ int main() {
   request.values.modeName = "Mode B";
   result = adapter.Apply({request, &fixtures});
   assert(result.common.success);
-  assert(fixtures["a"].gdtfMode == "Mode B");
+  assert(fixtures["a"].gdtfMode == "Mode A");
+  assert(result.updatedFixtures.at("a").gdtfMode == "Mode B");
+  fixtures["a"] = result.updatedFixtures.at("a");
   assert(fixtures["b"].gdtfMode == "Mode A");
   assert(result.derivedChannelCount == 12);
 
@@ -106,8 +111,11 @@ int main() {
   request.values.weightKg = 12.0f;
   result = adapter.Apply({request, &fixtures});
   assert(result.common.success);
-  assert(std::fabs(fixtures["a"].weightKg - 12.0f) < 0.001f);
-  assert(std::fabs(fixtures["b"].weightKg - 12.0f) < 0.001f);
+  assert(std::fabs(fixtures["a"].weightKg - 10.0f) < 0.001f);
+  assert(std::fabs(result.updatedFixtures.at("a").weightKg - 12.0f) < 0.001f);
+  assert(std::fabs(result.updatedFixtures.at("b").weightKg - 12.0f) < 0.001f);
+  for (const auto &[uuid, fixture] : result.updatedFixtures)
+    fixtures[uuid] = fixture;
   assert(result.changedWeightPositionNames.count("Front") == 1);
   assert(result.changedWeightPositionNames.count("Back") == 1);
 
@@ -120,7 +128,8 @@ int main() {
   result = adapter.Apply({request, &fixtures});
   assert(result.common.success);
   assert(result.common.derivativeCreated);
-  assert(fixtures["a"].gdtfSpec.find("derived.gdtf") != std::string::npos);
+  assert(fixtures["a"].gdtfSpec.find("derived.gdtf") == std::string::npos);
+  assert(result.updatedFixtures.at("a").gdtfSpec.find("derived.gdtf") != std::string::npos);
 
   request.stableHostId = "missing";
   result = adapter.Apply({request, &fixtures});


### PR DESCRIPTION
### Motivation
- Fix incorrect runtime ordering where Fixture/Truss UI wrote table/state before adapter success, which left the visible table/row caches mutated on adapter or file failures.
- Make adapters prepare mutation results instead of committing live project collections so hosts can create a single undo snapshot and then commit prepared changes atomically.
- Preserve derivative dictionary context and fix UTF‑8 path handling so derivative creation and all editor/service boundaries use stable UTF‑8 conversions.
- Add static guards and regression artifacts to prevent regressions and to document the expected transactional behavior for future UI work (08E).

### Description
- ProjectFixtureGdtfApplyAdapter: changed contract and behavior so input fixture map is `const`, derivative creation service receives fixture type/mode context, and the adapter returns a focused `updatedFixtures` map plus result flags instead of mutating the live collection.
- Fixture host flow: refactored `FixtureEditDialog::ApplyChanges()` to invoke the adapter before applying any `table->SetValue(...)` or updating `panel->gdtfPaths`, collect host-only drafts, and commit `updatedFixtures` into the project only after `UpdateSceneData(...)`/undo checkpoint and successful adapter result.
- Truss host flow: refactored `TrussEditDialog::ApplyChanges()` so generation runs before committing table cells and added an explicit undo path for GDTF-only / CrossSection-only generation results.
- UTF‑8 and derivative fixes: replaced native `path.string()` usages in the editor/service bridge with `PathUtils::PathToUtf8(...)` / `PathUtils::PathFromUtf8(...)`, and changed `CreateOrUpdatePerastageLibraryDerivative(...)` calls to pass a non-empty fixture type context.
- Tests, guards and docs: added `tests/check_gdtf_editor_checkpoint08d_stabilization.sh`, updated `tests/CMakeLists.txt`, extended `tests/project_fixture_gdtf_apply_adapter_test.cpp`, and added `docs/internal/gdtf_editor_checkpoint08d_regression_matrix.md` plus architecture/mutation-policy/release-note updates describing the 08D transaction model.

### Testing
- Ran the expanded adapter unit tests and static guards: `project_fixture_gdtf_apply_adapter_test` (compiled and executed) — PASS, and `project_truss_gdtf_apply_adapter_test` — PASS.
- Ran the new checkpoint guard and existing adapter/host guards: `tests/check_gdtf_editor_checkpoint08d_stabilization.sh`, `check_gdtf_editor_checkpoint08a_binding.sh`, `check_gdtf_editor_checkpoint08b_fixture_apply_adapter.sh`, and `check_gdtf_editor_checkpoint08c_truss_apply_adapter.sh` — all PASS.
- Ran repository static guards: `tests/check_perastage_tree_modules.sh`, `tests/check_no_configmanager_get_in_gui.sh`, and `git diff --check` — PASS.
- Limitation: full CMake configure/build (GUI targets) could not complete in this environment because wxWidgets was not found (`Could NOT find wxWidgets`), so GUI integration and a full build were not performed here; deterministic non-GUI tests and the static guards above were executed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a504601d43883248eb395e2db424046)