### PR TITLE
Move Mode channels summary into Fixture instance pane

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -20,7 +20,7 @@ Changes since **v1.4.0**.
 - Made Truss Edit open more compactly and gave the official Fixture SVG symbol region the same vertical priority as the generated Top, Front, and Side symbol previews.
 - Improved Truss Edit spacing and composition so type and metadata stay in the second column while the 3D preview sits above physical properties in the third column.
 - Improved Fixture Edit visual resources by combining 3D preview and fixture image into one Preview tab, adding an official GDTF SVG symbol preview above Perastage-generated symbols when available, and increasing GDTF column spacing for readability.
-- Moved Fixture Edit's Mode channels summary into the Fixture instance pane, giving GDTF metadata more room to display longer text.
+- Moved Fixture Edit's Mode channels summary into the Fixture instance pane and let GDTF metadata use the freed overview-column height for longer text.
 - Refined Fixture Edit and Truss Edit GDTF editor layouts with compact instance panes, resizable splitters, flatter GDTF sections, larger metadata and preview areas, Fixture visual-resource tabs, and persisted layout preferences while preserving existing apply behavior.
 
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -20,6 +20,7 @@ Changes since **v1.4.0**.
 - Made Truss Edit open more compactly and gave the official Fixture SVG symbol region the same vertical priority as the generated Top, Front, and Side symbol previews.
 - Improved Truss Edit spacing and composition so type and metadata stay in the second column while the 3D preview sits above physical properties in the third column.
 - Improved Fixture Edit visual resources by combining 3D preview and fixture image into one Preview tab, adding an official GDTF SVG symbol preview above Perastage-generated symbols when available, and increasing GDTF column spacing for readability.
+- Moved Fixture Edit's Mode channels summary into the Fixture instance pane, giving GDTF metadata more room to display longer text.
 - Refined Fixture Edit and Truss Edit GDTF editor layouts with compact instance panes, resizable splitters, flatter GDTF sections, larger metadata and preview areas, Fixture visual-resource tabs, and persisted layout preferences while preserving existing apply behavior.
 
 

--- a/gui/fixtureeditdialog.cpp
+++ b/gui/fixtureeditdialog.cpp
@@ -24,6 +24,7 @@
 #include "fixturetablepanel.h"
 #include "fixtures/fixture_gdtf_resolution.h"
 #include "gdtf/gdtf_color_cie.h"
+#include "gdtf/gdtf_channel_summary_panel.h"
 #include "gdtf/gdtf_editor_panel.h"
 #include "gdtf/gdtf_wheel_inspector_panel.h"
 #include "gdtf/gdtf_mode_browser_presenter.h"
@@ -69,6 +70,7 @@
 #include <wx/scrolwin.h>
 #include <wx/settings.h>
 #include <wx/splitter.h>
+#include <wx/statbox.h>
 #include <wx/wfstream.h>
 #include <wx/statline.h>
 #include <wx/zipstrm.h>
@@ -444,6 +446,7 @@ std::filesystem::path FixtureEditDialog::GetActiveResolvedGdtfPath() const {
   return {};
 }
 
+// Builds the fixture editing dialog and arranges fixture, GDTF, and preview panels.
 FixtureEditDialog::FixtureEditDialog(FixtureTablePanel *p, int r)
     : wxDialog(p, wxID_ANY, "Edit Fixture", wxDefaultPosition,
                wxDefaultSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER),
@@ -576,11 +579,11 @@ FixtureEditDialog::FixtureEditDialog(FixtureTablePanel *p, int r)
       {GdtfEditorPane::Overview, GdtfEditorSection::TypeIdentity, 0},
       {GdtfEditorPane::Overview, GdtfEditorSection::Metadata, 0},
       {GdtfEditorPane::Overview, GdtfEditorSection::PhysicalProperties, 0},
-      {GdtfEditorPane::Overview, GdtfEditorSection::ChannelSummary, 1},
       {GdtfEditorPane::Workspace, GdtfEditorSection::Modes, 1}};
   gdtfConfiguration.metadata.title = "GDTF metadata";
   gdtfConfiguration.typeIdentity.title = "Fixture type";
   gdtfConfiguration.physicalProperties.title = "Physical properties";
+  gdtfConfiguration.channelSummary.visible = false;
   gdtfConfiguration.channelSummary.title = "Mode channels";
   gdtfConfiguration.modes.title = "Modes and channels";
   gdtfEditorPanel->Configure(gdtfConfiguration);
@@ -662,7 +665,14 @@ FixtureEditDialog::FixtureEditDialog(FixtureTablePanel *p, int r)
       gdtfWheelInspectorPanel->SetPresentation(BuildWheelInspectorVisualPresentation(presentation));
   });
 
-  fixtureSpecificSizer->Add(fixtureGrid, 1, wxEXPAND | wxALL, gui::gdtf_layout::SectionPadding(this));
+  fixtureSpecificSizer->Add(fixtureGrid, 0, wxEXPAND | wxALL, gui::gdtf_layout::SectionPadding(this));
+  auto *modeChannelsSizer = new wxStaticBoxSizer(wxVERTICAL, fixtureScroll,
+                                                 "Mode channels");
+  fixtureChannelSummaryPanel = new GdtfChannelSummaryPanel(fixtureScroll);
+  modeChannelsSizer->Add(fixtureChannelSummaryPanel, 1, wxEXPAND | wxALL,
+                         gui::gdtf_layout::SectionPadding(this));
+  fixtureSpecificSizer->Add(modeChannelsSizer, 1, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM,
+                            gui::gdtf_layout::SectionPadding(this));
   fixtureScroll->SetMinSize(wxSize(gui::gdtf_layout::MinimumContextPaneWidth(this), -1));
 
   gdtfHostSizer->Add(gdtfEditorPanel, 1, wxEXPAND | wxALL, gui::gdtf_layout::SectionPadding(this));
@@ -1092,6 +1102,8 @@ void FixtureEditDialog::UpdateChannels(bool markChannelCountDirty) {
       gdtfEditorPanel->ClearModeDetails();
       gdtfEditorPanel->SetInspectionData(nullptr, nullptr);
     }
+    if (fixtureChannelSummaryPanel)
+      fixtureChannelSummaryPanel->ClearChannels();
     return;
   }
   if (cachedModeChannelSource != gdtfPath)
@@ -1099,9 +1111,12 @@ void FixtureEditDialog::UpdateChannels(bool markChannelCountDirty) {
   const std::string modeName(mode.ToUTF8());
   const auto *modeNode = cachedModeChannelDocument.FindMode(modeName);
   if (gdtfEditorPanel) {
+    const auto channelSummary = BuildGdtfModeChannelSummaryPresentation(modeNode);
     gdtfEditorPanel->SetInspectionData(modeNode, &cachedWheelCatalog);
     gdtfEditorPanel->SetModeBrowserNodes(BuildGdtfModeBrowserPresentation(modeNode));
-    gdtfEditorPanel->SetChannels(BuildGdtfModeChannelSummaryPresentation(modeNode));
+    gdtfEditorPanel->SetChannels(channelSummary);
+    if (fixtureChannelSummaryPanel)
+      fixtureChannelSummaryPanel->SetChannels(channelSummary);
   }
   const int chCount = modeNode ? modeNode->calculatedFootprint
                                : GetGdtfModeChannelCount(PathUtils::PathToUtf8(gdtfPath), modeName);

--- a/gui/fixtureeditdialog.cpp
+++ b/gui/fixtureeditdialog.cpp
@@ -577,7 +577,7 @@ FixtureEditDialog::FixtureEditDialog(FixtureTablePanel *p, int r)
   gdtfConfiguration.twoPaneInitialRatio = 0.45;
   gdtfConfiguration.twoPaneOrder = {
       {GdtfEditorPane::Overview, GdtfEditorSection::TypeIdentity, 0},
-      {GdtfEditorPane::Overview, GdtfEditorSection::Metadata, 0},
+      {GdtfEditorPane::Overview, GdtfEditorSection::Metadata, 1},
       {GdtfEditorPane::Overview, GdtfEditorSection::PhysicalProperties, 0},
       {GdtfEditorPane::Workspace, GdtfEditorSection::Modes, 1}};
   gdtfConfiguration.metadata.title = "GDTF metadata";

--- a/gui/fixtureeditdialog.h
+++ b/gui/fixtureeditdialog.h
@@ -38,6 +38,7 @@ class wxStaticBitmap;
 class wxPanel;
 class wxNotebook;
 class wxSplitterWindow;
+class GdtfChannelSummaryPanel;
 class GdtfEditorPanel;
 namespace gdtf { class GdtfEditSession; }
 
@@ -74,6 +75,7 @@ private:
     FixtureTablePanel* panel;
     int row;
     std::vector<wxControl*> ctrls;
+    GdtfChannelSummaryPanel* fixtureChannelSummaryPanel = nullptr;
     GdtfEditorPanel* gdtfEditorPanel = nullptr;
     GdtfWheelInspectorPanel* gdtfWheelInspectorPanel = nullptr;
     std::unique_ptr<gdtf::GdtfEditSession> gdtfEditSession;


### PR DESCRIPTION
### Motivation
- Free space in the GDTF metadata area of the `Edit Fixture` dialog by moving the quick Mode channels summary into the compact `Fixture instance` pane so longer metadata text can be shown without truncation.
- Keep the existing channel presentation and synchronization behavior while avoiding duplicate visible summaries in the GDTF overview column for this dialog.

### Description
- Added a `GdtfChannelSummaryPanel* fixtureChannelSummaryPanel` member to `FixtureEditDialog` and included `gdtf_channel_summary_panel.h` to host the moved channel summary.
- Hidden the reusable GDTF editor overview `ChannelSummary` for this dialog by setting `gdtfConfiguration.channelSummary.visible = false` and removed it from the dialog two-pane placement.
- Inserted a `wxStaticBoxSizer` titled "Mode channels" under the `Fixture instance` scroll area and placed the new `GdtfChannelSummaryPanel` there, adjusted sizing so the fixture form stays compact while the new box expands.
- Kept data flow unchanged by computing `channelSummary = BuildGdtfModeChannelSummaryPresentation(...)` in `UpdateChannels` and forwarding it to both `gdtfEditorPanel` and the new `fixtureChannelSummaryPanel`, and clearing the panel when no GDTF path or mode is available.
- Added a one-line English comment above the `FixtureEditDialog` constructor to satisfy the C++ function-comment policy and updated `docs/release-notes-draft.md` with the new layout improvement entry.

### Testing
- Ran `tests/check_perastage_tree_modules.sh`, which passed successfully.
- Ran `tests/check_no_configmanager_get_in_gui.sh`, which passed successfully.
- Ran `tests/check_gdtf_editor_checkpoint08e1_layout.sh`, which failed because the check expects the visual-resource notebook to have exactly `Preview` and `Symbols` tabs while the dialog also contains the existing `GDTF wheels` tab (preexisting behavior), so the layout check needs adjustment if the wheels tab is intended to remain visible.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a53ddbe87e48324b4cddf54210dfbf4)