### PR TITLE
Add maximize/restore to Edit dialogs and fix GDTF wheel-slot highlighting

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -12,6 +12,7 @@ Changes since **v1.4.0**.
 
 ## Improvements
 
+- Added maximize and restore support to the Edit Fixture and Edit Truss dialogs for more flexible editing on large screens.
 - Added visual GDTF wheel previews in Fixture Edit, including static gobo/graphic-wheel thumbnails and approximate color/filter swatches for wheel slots.
 - Refined Fixture Edit DMX inspection with structured wrapping detail panels that update values in place while dragging the slider, per-channel slider value memory during the edit session, a cleaner wheel-slot preview summary, no duplicate mode-browser detail pane, and resolution-matched slider ranges, so exact DMX values, selected mode-browser details, percentages, and active function or set ranges stay readable and aligned with the selected channel.
 
@@ -30,6 +31,7 @@ Changes since **v1.4.0**.
 
 ## Fixes
 
+- Fixed Wheel slots selection emphasis so highlighting no longer changes thumbnail or swatch colors.
 - Fixed GDTF wheel color swatches so CIE xyY luminance values authored on the common 0-100 scale are normalized before sRGB preview conversion, avoiding washed-out or incorrectly white wheel colors.
 - Fixed GDTF wheel PNG previews so failed decodes are reported separately from placeholders, standard `wheels/<MediaFileName>.png` resources are preferred, cached extracted GDTF resource folders from restored MVR/project data are used as a safe read-only fallback, transparent gobo artwork is composed over a visible checkerboard background, clicking a wheel-slot row shows a larger slot preview or diagnostic directly, and repeated image-handler initialization no longer triggers wxWidgets debug assertions.
 

--- a/gui/fixtureeditdialog.cpp
+++ b/gui/fixtureeditdialog.cpp
@@ -449,7 +449,7 @@ std::filesystem::path FixtureEditDialog::GetActiveResolvedGdtfPath() const {
 // Builds the fixture editing dialog and arranges fixture, GDTF, and preview panels.
 FixtureEditDialog::FixtureEditDialog(FixtureTablePanel *p, int r)
     : wxDialog(p, wxID_ANY, "Edit Fixture", wxDefaultPosition,
-               wxDefaultSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER),
+               wxDefaultSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER | wxMAXIMIZE_BOX),
       panel(p), row(r) {
   BuildEditSession();
   wxBoxSizer *topSizer = new wxBoxSizer(wxVERTICAL);

--- a/gui/gdtf/gdtf_wheel_inspector_panel.cpp
+++ b/gui/gdtf/gdtf_wheel_inspector_panel.cpp
@@ -13,6 +13,7 @@
 #include <wx/sizer.h>
 #include <wx/statbmp.h>
 #include <wx/stattext.h>
+#include <wx/font.h>
 
 namespace {
 constexpr int kSlotThumbnailSize = 48;
@@ -82,23 +83,14 @@ void GdtfWheelInspectorPanel::SetPresentation(
                 previewDetailControls,
                 MergeDetailRows(presentation.previewRows, presentation.previewStatus));
 
-  slotList->DeleteAllItems();
-  slotImages->RemoveAll();
-  long selectedIndex = -1;
+  highlightedSlotIndex = -1;
   for (size_t i = 0; i < currentSlots.size(); ++i) {
-    const auto &slot = currentSlots[i];
-    wxBitmap image = slot.hasThumbnail ? slot.thumbnail
-                     : slot.hasSwatch && slot.mediaResource.empty()
-                         ? CreateSwatchBitmap(slot.swatch, wxSize(kSlotThumbnailSize, kSlotThumbnailSize))
-                         : CreatePlaceholderBitmap(wxSize(kSlotThumbnailSize, kSlotThumbnailSize));
-    const int imageIndex = slotImages->Add(image);
-    const long row = slotList->InsertItem(static_cast<long>(i), wxString::FromUTF8(slot.label), imageIndex);
-    if (slot.selected)
-      selectedIndex = row;
+    if (currentSlots[i].selected) {
+      highlightedSlotIndex = static_cast<long>(i);
+      break;
+    }
   }
-  if (selectedIndex >= 0)
-    slotList->SetItemState(selectedIndex, wxLIST_STATE_SELECTED | wxLIST_STATE_FOCUSED,
-                           wxLIST_STATE_SELECTED | wxLIST_STATE_FOCUSED);
+  RefreshSlotList();
 }
 
 // Clears the wheel inspector to an unavailable read-only state.
@@ -113,6 +105,7 @@ void GdtfWheelInspectorPanel::ClearPresentation() {
   slotList->DeleteAllItems();
   slotImages->RemoveAll();
   currentSlots.clear();
+  highlightedSlotIndex = -1;
 }
 
 // Applies a clicked wheel-slot preview without changing the resolved DMX mapping.
@@ -131,11 +124,43 @@ void GdtfWheelInspectorPanel::ApplySlotPreview(const GdtfWheelInspectorSlotPrese
                 MergeDetailRows(slot.detailRows, slot.previewStatus));
 }
 
+// Rebuilds the slot gallery while keeping selection emphasis on text only.
+void GdtfWheelInspectorPanel::RefreshSlotList() {
+  slotList->DeleteAllItems();
+  slotImages->RemoveAll();
+  const wxFont normalFont = slotList->GetFont();
+  wxFont highlightedFont = normalFont;
+  highlightedFont.SetWeight(wxFONTWEIGHT_BOLD);
+  for (size_t i = 0; i < currentSlots.size(); ++i) {
+    const auto &slot = currentSlots[i];
+    wxBitmap image = slot.hasThumbnail ? slot.thumbnail
+                     : slot.hasSwatch && slot.mediaResource.empty()
+                         ? CreateSwatchBitmap(slot.swatch, wxSize(kSlotThumbnailSize, kSlotThumbnailSize))
+                         : CreatePlaceholderBitmap(wxSize(kSlotThumbnailSize, kSlotThumbnailSize));
+    const int imageIndex = slotImages->Add(image);
+    const long row = slotList->InsertItem(static_cast<long>(i), wxString::FromUTF8(slot.label), imageIndex);
+    slotList->SetItemFont(row, row == highlightedSlotIndex ? highlightedFont : normalFont);
+  }
+}
+
+// Updates the selected slot emphasis without applying native row highlight colors.
+void GdtfWheelInspectorPanel::UpdateSlotHighlight(long row) {
+  highlightedSlotIndex = row;
+  const wxFont normalFont = slotList->GetFont();
+  wxFont highlightedFont = normalFont;
+  highlightedFont.SetWeight(wxFONTWEIGHT_BOLD);
+  for (long i = 0; i < static_cast<long>(currentSlots.size()); ++i) {
+    slotList->SetItemFont(i, i == highlightedSlotIndex ? highlightedFont : normalFont);
+    slotList->SetItemState(i, 0, wxLIST_STATE_SELECTED | wxLIST_STATE_FOCUSED);
+  }
+}
+
 // Updates the preview pane when the user selects a wheel slot row.
 void GdtfWheelInspectorPanel::OnSlotSelected(wxListEvent &event) {
   const long row = event.GetIndex();
   if (row < 0 || static_cast<size_t>(row) >= currentSlots.size())
     return;
+  UpdateSlotHighlight(row);
   ApplySlotPreview(currentSlots[static_cast<size_t>(row)]);
 }
 

--- a/gui/gdtf/gdtf_wheel_inspector_panel.h
+++ b/gui/gdtf/gdtf_wheel_inspector_panel.h
@@ -72,6 +72,8 @@ public:
 
 private:
   void ApplySlotPreview(const GdtfWheelInspectorSlotPresentation &slot);
+  void RefreshSlotList();
+  void UpdateSlotHighlight(long row);
   void OnSlotSelected(wxListEvent &event);
   wxBitmap CreateSwatchBitmap(const wxColour &colour, const wxSize &size) const;
   wxBitmap CreatePlaceholderBitmap(const wxSize &size) const;
@@ -105,4 +107,5 @@ private:
   std::vector<GdtfWheelInspectorDetailControls> activeDetailControls;
   std::vector<GdtfWheelInspectorDetailControls> previewDetailControls;
   std::vector<GdtfWheelInspectorSlotPresentation> currentSlots;
+  long highlightedSlotIndex = -1;
 };

--- a/gui/trusseditdialog.cpp
+++ b/gui/trusseditdialog.cpp
@@ -101,7 +101,7 @@ void TrussEditDialog::BuildEditSession() {
 // Builds the truss editing dialog with MVR and GDTF fields.
 TrussEditDialog::TrussEditDialog(TrussTablePanel *p, int r)
     : wxDialog(p, wxID_ANY, "Edit Truss", wxDefaultPosition, wxDefaultSize,
-               wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER),
+               wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER | wxMAXIMIZE_BOX),
       panel(p), row(r) {
   BuildEditSession();
   wxBoxSizer *topSizer = new wxBoxSizer(wxVERTICAL);


### PR DESCRIPTION
### Motivation
- Provide maximize/restore controls for the Edit Fixture and Edit Truss dialogs so users can expand editors on large screens and improve usability.
- Fix the Wheel slots gallery highlight so selecting a slot does not change the thumbnail or color swatch rendering, preserving accurate visual previews.
- Keep docs in sync by adding release-note entries for both the dialog control improvement and the wheel-slot highlight fix.
- The `FixtureEditDialog` file is large (>1200 LOC) so this change is intentionally minimal and does not attempt a large extraction in this PR; a follow-up should extract GDTF visual-resource and editor-layout responsibilities into smaller, owned modules.

### Description
- Enabled maximize/restore on the dialogs by adding `wxMAXIMIZE_BOX` to the dialog style in `gui/fixtureeditdialog.cpp` and `gui/trusseditdialog.cpp` (one-line style changes using `wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER | wxMAXIMIZE_BOX`).
- Reworked wheel-slot emphasis in `gui/gdtf/gdtf_wheel_inspector_panel.{h,cpp}` to avoid native row-selection coloring by adding a `highlightedSlotIndex` member, `RefreshSlotList()` and `UpdateSlotHighlight()` helpers, and applying a bold font to the selected slot label while keeping thumbnails and swatches unmodified.
- Added `#include <wx/font.h>` to support font-weight updates in the wheel inspector implementation.
- Updated `docs/release-notes-draft.md` with entries for the maximize/restore support and the wheel-slot highlight fix.

### Testing
- PASS: `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh` both succeeded.
- PASS: `git diff --check` reported no whitespace or diff issues.
- WARN: `cmake --build build -j2` could not be executed because `/workspace/Perastage/build` does not exist in this environment.
- WARN: `cmake --preset wsl-x64-debug` could not configure here because the environment lacks a wxWidgets development installation, so a full build/test was not performed in this sandbox.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5416f586bc8324ab82613738652496)