### PR TITLE
Normalize GDTF source fingerprint timestamps (portable nanoseconds)

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -103,6 +103,8 @@ Changes since **v1.4.0**.
 
 ## Internal changes
 
+- Normalized GDTF source cache fingerprints to use portable filesystem timestamp values across supported C++ standard libraries.
+
 - Hardened gettext catalog generation, runtime copying, CMake helper argument validation, and installer/package validation so Spanish localization catalogs are generated and staged reliably across Linux, Windows, macOS, and Arch builds.
 
 - Tightened localization maintenance checks so POT generation scans root-level C/C++ sources, dynamic labels use extraction markers, catalog checks validate synchronization and accelerators, and audit exceptions require durable reasons instead of line-number debt entries.

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -27,6 +27,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/exportobjectdialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/exporttrussdialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fixtureeditdialog.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gdtf_source_fingerprint.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fixture_gdtf_apply_services.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fixturepatchdialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fixturepreviewpanel.cpp

--- a/gui/fixtureeditdialog.cpp
+++ b/gui/fixtureeditdialog.cpp
@@ -31,6 +31,7 @@
 #include "gdtf_archive_reader.h"
 #include "gdtf/gdtf_editor_layout_preferences.h"
 #include "gdtf/gdtf_editor_visual_metrics.h"
+#include "gdtf_source_fingerprint.h"
 #include "gdtf/gdtf_session_panel_binding.h"
 #include "gdtf_mutation_audit.h"
 #include "gdtf_metadata_summary.h"
@@ -123,22 +124,6 @@ bool IsExistingRegularFile(const std::filesystem::path &path) {
 // Converts a wx path string to a filesystem path for operational I/O.
 std::filesystem::path PathFromWxString(const wxString &path) {
   return PathUtils::PathFromUtf8(std::string(path.ToUTF8()));
-}
-
-// Builds a stable source fingerprint for cached GDTF preview resources.
-std::string BuildGdtfSourceFingerprint(const std::filesystem::path &path) {
-  if (path.empty())
-    return {};
-  std::error_code canonicalError;
-  const auto canonical = std::filesystem::weakly_canonical(path, canonicalError);
-  std::error_code sizeError;
-  const auto size = std::filesystem::file_size(path, sizeError);
-  std::error_code timeError;
-  const auto timestamp = std::filesystem::last_write_time(path, timeError).time_since_epoch().count();
-  std::ostringstream out;
-  out << PathUtils::PathToUtf8(canonicalError ? path : canonical) << "|"
-      << (sizeError ? 0 : size) << "|" << (timeError ? 0 : timestamp);
-  return out.str();
 }
 
 // Parses a floating-point value while preserving the previous value on failure.
@@ -1130,7 +1115,7 @@ GdtfWheelInspectorPresentation FixtureEditDialog::BuildWheelInspectorVisualPrese
     const GdtfWheelInspectorPresentation &presentation) {
   GdtfWheelInspectorPresentation enriched = presentation;
   const std::filesystem::path gdtfPath = GetActiveResolvedGdtfPath();
-  const std::string sourceId = BuildGdtfSourceFingerprint(gdtfPath);
+  const std::string sourceId = gui::BuildGdtfSourceFingerprint(gdtfPath);
   std::vector<std::filesystem::path> resourceRoots;
   const std::string extractedRoot = GetCachedGdtfExtractionDirectory(PathUtils::PathToUtf8(gdtfPath));
   if (!extractedRoot.empty())

--- a/gui/gdtf_source_fingerprint.cpp
+++ b/gui/gdtf_source_fingerprint.cpp
@@ -1,0 +1,34 @@
+#include "gdtf_source_fingerprint.h"
+
+#include "filesystem_path_utils.h"
+
+#include <chrono>
+#include <cstdint>
+#include <sstream>
+
+namespace gui {
+
+// Builds a stable source fingerprint for cached GDTF preview resources.
+std::string BuildGdtfSourceFingerprint(const std::filesystem::path &path) {
+  if (path.empty())
+    return {};
+  std::error_code canonicalError;
+  const auto canonical = std::filesystem::weakly_canonical(path, canonicalError);
+  std::error_code sizeError;
+  const auto size = std::filesystem::file_size(path, sizeError);
+  const std::uintmax_t normalizedSize = sizeError ? std::uintmax_t{0} : size;
+  std::error_code timeError;
+  const auto writeTime = std::filesystem::last_write_time(path, timeError);
+  std::int64_t timestampNs = 0;
+  if (!timeError) {
+    timestampNs = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                      writeTime.time_since_epoch())
+                      .count();
+  }
+  std::ostringstream out;
+  out << PathUtils::PathToUtf8(canonicalError ? path : canonical) << "|"
+      << normalizedSize << "|" << timestampNs;
+  return out.str();
+}
+
+} // namespace gui

--- a/gui/gdtf_source_fingerprint.h
+++ b/gui/gdtf_source_fingerprint.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+
+namespace gui {
+
+std::string BuildGdtfSourceFingerprint(const std::filesystem::path &path);
+
+} // namespace gui

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -296,6 +296,13 @@ target_link_libraries(gdtf_canonicalizer_test PRIVATE ${wxWidgets_LIBRARIES} tin
 add_test(NAME GdtfCanonicalizerExportRules COMMAND gdtf_canonicalizer_test)
 
 
+add_executable(gdtf_source_fingerprint_test
+               gdtf_source_fingerprint_test.cpp
+               ../gui/gdtf_source_fingerprint.cpp
+               ../core/filesystem_path_utils.cpp)
+target_include_directories(gdtf_source_fingerprint_test PRIVATE ../gui ../core)
+add_test(NAME GdtfSourceFingerprint COMMAND gdtf_source_fingerprint_test)
+
 add_executable(gdtf_metadata_summary_test
                gdtf_metadata_summary_test.cpp
                ../core/gdtf_archive_reader.cpp

--- a/tests/gdtf_source_fingerprint_test.cpp
+++ b/tests/gdtf_source_fingerprint_test.cpp
@@ -1,0 +1,71 @@
+#include "gdtf_source_fingerprint.h"
+
+#include <cassert>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+// Splits a fingerprint into its delimiter-separated fields.
+std::vector<std::string> SplitFingerprint(const std::string &fingerprint) {
+  std::vector<std::string> parts;
+  std::size_t start = 0;
+  while (start <= fingerprint.size()) {
+    const std::size_t next = fingerprint.find('|', start);
+    if (next == std::string::npos) {
+      parts.push_back(fingerprint.substr(start));
+      break;
+    }
+    parts.push_back(fingerprint.substr(start, next - start));
+    start = next + 1;
+  }
+  return parts;
+}
+
+// Writes test content to a temporary file.
+void WriteFile(const fs::path &path, const std::string &content) {
+  std::ofstream out(path, std::ios::binary | std::ios::trunc);
+  out << content;
+}
+
+// Verifies GDTF source fingerprints use path, size, and normalized timestamp fields.
+int main() {
+  const fs::path dir = fs::temp_directory_path() / "perastage_gdtf_source_fingerprint_test_dir";
+  if (fs::exists(dir) && !fs::is_directory(dir))
+    fs::remove(dir);
+  fs::remove_all(dir);
+  fs::create_directories(dir);
+  const fs::path file = dir / "fixture.gdtf";
+  WriteFile(file, "first");
+
+  const std::string initial = gui::BuildGdtfSourceFingerprint(file);
+  assert(!initial.empty());
+  const auto initialParts = SplitFingerprint(initial);
+  assert(initialParts.size() == 3);
+  assert(!initialParts[0].empty());
+  assert(initialParts[1] == "5");
+  assert(!initialParts[2].empty());
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(2));
+  WriteFile(file, "second content");
+  const std::string updated = gui::BuildGdtfSourceFingerprint(file);
+  assert(updated != initial);
+  const auto updatedParts = SplitFingerprint(updated);
+  assert(updatedParts.size() == 3);
+  assert(updatedParts[1] == "14");
+
+  const fs::path missing = dir / "missing.gdtf";
+  const std::string missingFingerprint = gui::BuildGdtfSourceFingerprint(missing);
+  const auto missingParts = SplitFingerprint(missingFingerprint);
+  assert(missingParts.size() == 3);
+  assert(missingParts[1] == "0");
+  assert(missingParts[2] == "0");
+
+  fs::remove(file);
+  fs::remove_all(dir);
+  return 0;
+}


### PR DESCRIPTION
### Motivation
- Fix a macOS/libc++ compilation error caused by streaming an implementation-defined filesystem timestamp type into `std::ostringstream`, which can be an unstreamable wide integer on Xcode 26.5. 
- Keep the existing GDTF preview cache fingerprint format `<path>|<size>|<timestamp>` while making the timestamp representation portable and streamable across libc++, libstdc++, and MSVC.

### Description
- Extracted fingerprint logic into a focused helper `gui::BuildGdtfSourceFingerprint` in `gui/gdtf_source_fingerprint.{h,cpp}` and added a one-line comment describing the function. 
- Normalized file size to `std::uintmax_t` and modification time to nanoseconds via `std::chrono::duration_cast<std::chrono::nanoseconds>(writeTime.time_since_epoch()).count()` stored in `std::int64_t` before stream insertion so only standard streamable types are used. 
- Replaced the local fingerprint implementation call in `gui/fixtureeditdialog.cpp` with `gui::BuildGdtfSourceFingerprint(...)` and registered the new source file in `gui/CMakeLists.txt`. 
- Added a focused unit test `tests/gdtf_source_fingerprint_test.cpp` and wired it into `tests/CMakeLists.txt`. 
- Added explicit includes (`<chrono>`, `<cstdint>`) and updated `docs/release-notes-draft.md` with an internal-changes entry describing the portability fix.

### Testing
- Built and ran the focused unit test by compiling and executing the test with GCC and Clang using: `g++ -std=c++20 -Igui -Icore tests/gdtf_source_fingerprint_test.cpp gui/gdtf_source_fingerprint.cpp core/filesystem_path_utils.cpp -o /tmp/gdtf_source_fingerprint_test && /tmp/gdtf_source_fingerprint_test` and `clang++ -std=c++20 -Igui -Icore tests/gdtf_source_fingerprint_test.cpp gui/gdtf_source_fingerprint.cpp core/filesystem_path_utils.cpp -o /tmp/gdtf_source_fingerprint_test_clang && /tmp/gdtf_source_fingerprint_test_clang`, both of which executed successfully. 
- Ran repository structural checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, which succeeded in this environment. 
- Attempting a full CMake configure/build in the container failed due to missing wxWidgets development files (`Could NOT find wxWidgets`), so a full project build was not performed here and macOS/Xcode 26.5 could not be executed locally. 

No platform-specific workarounds, compiler flags, or global streaming overloads were added; the change is standard C++20 and portable across standard libraries.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54e8e5f0f083249aef542248643c10)