### PR TITLE
Preserve fixture type identity when MVR-declared GDTF archive is missing

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -37,6 +37,7 @@ Changes since **v1.4.0**.
 
 ## Fixes
 
+- Fixed MVR imports so fixture types whose declared GDTF archive is missing remain available in the GDTF conflict resolver and can be matched through Download GDTF before falling back to dummy fixtures.
 - Fixed unit-aware table header refreshes so translated fixture, truss, hoist, scene-object, and rigging labels are not overwritten with English after reloads or unit preference changes.
 - Fixed localized unit-label composition on wxWidgets builds that enforce literal translation message IDs.
 - Fixed Windows catalog generation argument quoting so `msgfmt` writes `perastage.mo` to the generated build-tree path during Ninja and Visual Studio builds.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -37,7 +37,7 @@ Changes since **v1.4.0**.
 
 ## Fixes
 
-- Fixed MVR imports so fixture types whose declared GDTF archive is missing remain available in the GDTF conflict resolver and can be matched through Download GDTF before falling back to dummy fixtures.
+- Fixed MVR imports so fixture types whose declared GDTF archive is missing remain available in the GDTF conflict resolver, can be matched through Download GDTF, and report a clear dummy fallback instead of a raw missing-file error when no online match is found.
 - Fixed unit-aware table header refreshes so translated fixture, truss, hoist, scene-object, and rigging labels are not overwritten with English after reloads or unit preference changes.
 - Fixed localized unit-label composition on wxWidgets builds that enforce literal translation message IDs.
 - Fixed Windows catalog generation argument quoting so `msgfmt` writes `perastage.mo` to the generated build-tree path during Ninja and Visual Studio builds.

--- a/mvr/gdtf_import_matching.h
+++ b/mvr/gdtf_import_matching.h
@@ -53,5 +53,14 @@ inline std::string SelectRequestedFixtureName(const std::string &rawFixtureNodeN
   return ExtractFixtureNameFromGdtfSpec(rawGdtfSpec);
 }
 
+// Selects a stable fixture type name when the referenced GDTF file is unavailable.
+inline std::string SelectFallbackFixtureTypeName(const std::string &rawFixtureNodeName,
+                                                 const std::string &rawGdtfSpec) {
+  const std::string specFixtureName = ExtractFixtureNameFromGdtfSpec(rawGdtfSpec);
+  if (!specFixtureName.empty())
+    return specFixtureName;
+  return gdtf_catalog_matcher::TrimFixtureIdentity(rawFixtureNodeName);
+}
+
 } // namespace gdtf_import_matching
 } // namespace mvr

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -2484,6 +2484,11 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
           const GdtfFixtureMetadata &metadata =
               getFixtureMetadata(resolvedGdtfPath);
           fixture.typeName = metadata.fixtureName;
+          if (fixture.typeName.empty()) {
+            fixture.typeName =
+                mvr::gdtf_import_matching::SelectFallbackFixtureTypeName(
+                    rawFixtureNodeName, rawGdtfSpec);
+          }
           if (metadata.hasProperties) {
             if (metadata.weightKg > 0.0f)
               fixture.weightKg = metadata.weightKg;

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -2075,17 +2075,29 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
         PathUtils::PathFromUtf8(resolveGdtfPathCached(normalized)));
   };
 
+  auto resolvedGdtfFileExists = [](const std::string &gdtfPath) {
+    if (gdtfPath.empty())
+      return false;
+    std::error_code ec;
+    return fs::is_regular_file(PathUtils::PathFromUtf8(gdtfPath), ec) && !ec;
+  };
+
   auto getGdtfModesCached =
       [&](const std::string &gdtfPath) -> const std::vector<std::string> & {
     auto cacheIt = gdtfModesCache.find(gdtfPath);
     if (cacheIt != gdtfModesCache.end())
       return cacheIt->second;
+    if (!resolvedGdtfFileExists(gdtfPath))
+      return gdtfModesCache.emplace(gdtfPath, std::vector<std::string>{})
+          .first->second;
     return gdtfModesCache.emplace(gdtfPath, GetGdtfModes(gdtfPath))
         .first->second;
   };
 
   auto getGdtfModeChannelCountCached = [&](const std::string &gdtfPath,
                                            const std::string &modeName) {
+    if (!resolvedGdtfFileExists(gdtfPath))
+      return -1;
     auto &channelCountByMode = gdtfModeChannelCountCache[gdtfPath];
     auto countIt = channelCountByMode.find(modeName);
     if (countIt != channelCountByMode.end())
@@ -2152,7 +2164,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
   const GdtfFixtureMetadata kEmptyFixtureMetadata{};
   auto getFixtureMetadata =
       [&](const std::string &resolvedGdtfPath) -> const GdtfFixtureMetadata & {
-    if (resolvedGdtfPath.empty())
+    if (resolvedGdtfPath.empty() || !resolvedGdtfFileExists(resolvedGdtfPath))
       return kEmptyFixtureMetadata;
 
     auto it = gdtfFixtureMetadataCache.find(resolvedGdtfPath);
@@ -3507,8 +3519,6 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
         reportProgress("Conflict dialog:hide");
         if (!choices.empty()) {
           std::unordered_map<std::string, std::string> selectedPathByType;
-          std::unordered_map<std::string, std::string>
-              downloadFallbackPathByType;
           std::unordered_map<std::string, std::string> selectedModeByType;
           std::vector<GdtfConflict> downloadRequests;
           for (const auto &conflict : gdtfConflicts) {
@@ -3523,7 +3533,6 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
               const std::string fallbackPath =
                   GetDownloadFallbackPath(conflict);
               selectedPathByType[conflict.type] = fallbackPath;
-              downloadFallbackPathByType[conflict.type] = fallbackPath;
             }
           }
 
@@ -3830,6 +3839,18 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                 refreshFooterSummary();
                 refreshBytesSummary();
               };
+              auto fallbackStatusText = [&](const GdtfConflict &request) {
+                if (!request.appPath.empty() &&
+                    resolvedGdtfFileExists(
+                        resolveFixtureGdtfPathForRead(request.appPath)))
+                  return wxString(_("Fallback to App"));
+                if (!request.mvrPath.empty() &&
+                    resolvedGdtfFileExists(
+                        resolveFixtureGdtfPathForRead(request.mvrPath)))
+                  return wxString(_("Fallback to MVR"));
+                return wxString(_("Fallback to dummy"));
+              };
+
               auto updateProgressGauge = [&]() {
                 long long downloaded = 0;
                 long long knownTotal = 0;
@@ -4005,12 +4026,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                                   formatBytes(
                                       rowProgressByType[req.type].totalBytes)
                             : wxString("0 B / ? B");
-                    const bool fallsBackToApp =
-                        downloadFallbackPathByType[req.type] == req.appPath &&
-                        !req.appPath.empty();
-                    updateStatusRow(req.type, "-",
-                                    fallsBackToApp ? _("Fallback to App")
-                                                                   : _("Fallback to MVR"),
+                    updateStatusRow(req.type, "-", fallbackStatusText(req),
                                     progressText, _("No catalog match found"),
                                     DownloadRowState::Fallback);
                     updateProgressGauge();
@@ -4137,12 +4153,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                             ? formatBytes(
                                   rowProgressByType[req.type].totalBytes)
                             : wxString("? B");
-                    const bool fallsBackToApp =
-                        downloadFallbackPathByType[req.type] == req.appPath &&
-                        !req.appPath.empty();
                     updateStatusRow(
-                        req.type, selectedFixtureName,
-                        fallsBackToApp ? _("Fallback to App") : _("Fallback to MVR"),
+                        req.type, selectedFixtureName, fallbackStatusText(req),
                         formatBytes(
                             rowProgressByType[req.type].downloadedBytes) +
                                         " / " + totalText,
@@ -4171,13 +4183,14 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                     _("Selected fixture types for download (catalog load failed: %s)"),
                     wxString::FromUTF8(catalogFailureReason)));
                 for (const GdtfConflict &req : downloadRequests) {
-                  updateStatusRow(req.type, "-", _("Fallback to MVR"), "0 B / ? B",
+                  updateStatusRow(req.type, "-", fallbackStatusText(req),
+                                  "0 B / ? B",
                                   _("Failed to load catalog list"),
                                   DownloadRowState::Fallback);
                 }
                 updateProgressGauge();
                 progressPhaseText->SetLabel(wxString::Format(
-                    _("Catalog load failed. %s. Keeping MVR originals."),
+                    _("Catalog load failed. %s. Keeping available fallbacks."),
                     wxString::FromUTF8(catalogFailureReason)));
               }
               isDownloadInfoFinished = true;
@@ -4234,8 +4247,12 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                   scene.basePath,
                   PathUtils::PathFromUtf8(
                       resolveFixtureGdtfPathForRead(f.gdtfSpec)));
-              std::string parsed = Trim(GetGdtfFixtureName(
-                  resolveFixtureGdtfPathForRead(f.gdtfSpec)));
+              const std::string selectedResolvedGdtfPath =
+                  resolveFixtureGdtfPathForRead(f.gdtfSpec);
+              std::string parsed =
+                  resolvedGdtfFileExists(selectedResolvedGdtfPath)
+                      ? Trim(GetGdtfFixtureName(selectedResolvedGdtfPath))
+                      : std::string{};
             if (!parsed.empty())
               f.typeName = parsed;
             const auto &dictEntry = getDictionaryEntryCached(typeKey);
@@ -4369,7 +4386,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
       }
 
       GdtfFixtureCategory::InferenceResult inferred;
-      if (!resolvedCategoryPath.empty()) {
+      if (!resolvedCategoryPath.empty() &&
+          resolvedGdtfFileExists(resolvedCategoryPath)) {
         auto inferenceCacheIt =
             categoryInferenceByResolvedPath.find(resolvedCategoryPath);
         if (inferenceCacheIt != categoryInferenceByResolvedPath.end()) {
@@ -4380,7 +4398,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                                                   inferred);
         }
       } else {
-        inferred = GdtfFixtureCategory::InferFromGdtf(resolvedCategoryPath);
+        inferred.reason = "GDTF file is missing";
       }
 
       fixture.category =

--- a/tests/mvr_gdtf_import_matching_test.cpp
+++ b/tests/mvr_gdtf_import_matching_test.cpp
@@ -53,6 +53,17 @@ static void VerifyResolvedTypeFallback() {
          "BLED Standard mode 12CH");
 }
 
+
+// Verifies missing GDTF files keep the declared spec identity available as a fixture type.
+static void VerifyMissingGdtfTypeFallbackPrefersSpecBasename() {
+  assert(import_matching::SelectFallbackFixtureTypeName(
+             "Fixture 101", "Fixtures/Super Storm 1500.gdtf") ==
+         "Super Storm 1500");
+  assert(import_matching::SelectFallbackFixtureTypeName(
+             "Aleda K10 B-EYE", "") ==
+         "Aleda K10 B-EYE");
+}
+
 // Verifies name confidence outranks footprint matches.
 static void VerifyExactNameWithoutFootprintBeatsPartialNameWithFootprint() {
   const auto exactTier = catalog::ComputeFixtureNameMatchTier("My Beam 200",
@@ -149,6 +160,7 @@ int main() {
   VerifyDistinctOriginalNamesBeatSharedPlaceholderMetadata();
   VerifySpecBasenameFallback();
   VerifyResolvedTypeFallback();
+  VerifyMissingGdtfTypeFallbackPrefersSpecBasename();
   VerifyExactNameWithoutFootprintBeatsPartialNameWithFootprint();
   VerifyManufacturerMatchBeatsRecencyInsideSameNameAndFootprintTier();
   VerifyStandardModeDigitSignatureBeatsNewerFootprintOnlyMatch();


### PR DESCRIPTION
### Motivation
- MVR files that declare a `GDTFSpec` but reference a missing or unreadable GDTF caused fixtures to be effectively dropped from the conflict/download pipeline instead of remaining available for `Download GDTF` matching.  
- The desired behavior is to keep a stable fixture type identity (derived from the declared GDTF spec or node name) so the download pipeline can attempt an online match before falling back to dummy fixtures.

### Description
- Added `SelectFallbackFixtureTypeName` to `mvr/gdtf_import_matching.h` to derive a stable fallback type name from the declared `GDTFSpec` basename or the fixture node name.  
- Applied that fallback in `mvr/mvrimporter.cpp` when parsed GDTF metadata yields an empty `fixtureName`, preserving a usable `typeName` for the fixture.  
- Added a focused unit check `VerifyMissingGdtfTypeFallbackPrefersSpecBasename` to `tests/mvr_gdtf_import_matching_test.cpp` to cover the missing-GDTF fallback behavior.  
- Updated `docs/release-notes-draft.md` with a short user-facing fix note about MVR imports and missing declared GDTFs.

### Testing
- PASS: `tests/check_perastage_tree_modules.sh` succeeded.  
- PASS: `tests/check_no_configmanager_get_in_gui.sh` succeeded.  
- PASS: Focused unit coverage compiled and ran locally via `g++ -std=c++20 -I mvr tests/mvr_gdtf_import_matching_test.cpp mvr/gdtf_catalog_matcher.cpp -o /tmp/mvr_gdtf_import_matching_test && /tmp/mvr_gdtf_import_matching_test`.  
- WARN: Attempting the full `cmake` build and test target failed to configure in this environment because `wxWidgets` is not available, so the CMake-built test run could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56addf85888324b5157fcc388d5731)