### PR TITLE
Fix Edit Truss dimension units

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -37,7 +37,7 @@ Changes since **v1.4.0**.
 
 ## Fixes
 
-- Fixed Truss Edit physical-property dimensions so length, width, and height are shown and edited in the active UI distance units with visible unit suffixes instead of raw millimeters.
+- Fixed Edit Truss physical-property dimensions so stored millimeter values are converted before display and editing, keeping length, width, and height aligned with the active UI distance units and visible unit suffixes.
 - Fixed MVR imports so fixture types whose declared GDTF archive is missing remain available in the GDTF conflict resolver, can be matched through Download GDTF, and report a clear dummy fallback instead of a raw missing-file error when no online match is found.
 - Fixed unit-aware table header refreshes so translated fixture, truss, hoist, scene-object, and rigging labels are not overwritten with English after reloads or unit preference changes.
 - Fixed localized unit-label composition on wxWidgets builds that enforce literal translation message IDs.

--- a/gui/trusseditdialog.cpp
+++ b/gui/trusseditdialog.cpp
@@ -40,6 +40,8 @@
 #include "viewer3dpanel.h"
 
 #include <algorithm>
+#include <cerrno>
+#include <cstdlib>
 #include <filesystem>
 #include <optional>
 
@@ -86,6 +88,19 @@ Units::WeightUnitSystem ResolveWeightUnitSystem() {
   return Units::ParseWeightUnitSystem(cfg.GetValue("ui_weight_unit_system"));
 }
 
+// Parses a fully consumed double value from editor session storage.
+std::optional<double> ParseSessionDouble(const std::string &rawValue) {
+  if (rawValue.empty())
+    return std::nullopt;
+
+  errno = 0;
+  char *endPtr = nullptr;
+  const double value = std::strtod(rawValue.c_str(), &endPtr);
+  if (endPtr != rawValue.c_str() + rawValue.size() || errno == ERANGE)
+    return std::nullopt;
+  return value;
+}
+
 // Formats a truss dimension from stored millimeters into active display units.
 std::string FormatTrussDimensionForEditor(
     const gdtf::GdtfEditableValues &values, gdtf::GdtfFieldId fieldId,
@@ -95,10 +110,7 @@ std::string FormatTrussDimensionForEditor(
     return fallback;
   if (rawValue->empty())
     return {};
-  if (const auto parsed =
-          Units::ParseDistanceToMillimeters(
-              *rawValue, Units::DistanceUnitSystem::Metric);
-      parsed.has_value())
+  if (const auto parsed = ParseSessionDouble(*rawValue); parsed.has_value())
     return Units::FormatDistanceFromMillimeters(
         *parsed, unitSystem, Units::ValueFormatContext::Table);
   return *rawValue;


### PR DESCRIPTION
### Motivation
- Fix a bug where the Edit Truss dialog displayed stored millimeter session values as raw metric-display numbers (making e.g. a 3000 mm truss appear as “3000 m”) by ensuring session values are interpreted as stored millimeters before formatting for the active UI units.

### Description
- Add `ParseSessionDouble` and switch `FormatTrussDimensionForEditor` in `gui/trusseditdialog.cpp` to parse the stored session numeric value as a fully-consumed double and then call `Units::FormatDistanceFromMillimeters(...)` so lengths/widths/heights are shown in the active UI distance units; also add `<cerrno>` and `<cstdlib>` includes and update `docs/release-notes-draft.md` with the user-visible fix.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both reported `OK`, and verified `git diff --check` produced no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56bc5c504c8324aa3f5f29f4e14774)