### PR TITLE
Harden Layers: UTF‑8 validation, UUID‑backed mutations, atomic history, and MVR preflight

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -49,6 +49,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/layouts/LayoutImageResourceRegistry.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/layouts/LayoutTemplateSerializer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/layoutviewpresets.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/layer_service.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/logger.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/markdown.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/magnet_snap.cpp
@@ -73,6 +74,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/trussloader.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ui_render_size.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ui_unit_utils.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/utf8_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/units/unit_label_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/units/units.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/uuidutils.cpp

--- a/core/configmanager.cpp
+++ b/core/configmanager.cpp
@@ -690,7 +690,8 @@ bool ConfigManager::SaveUserConfig() const {
 
 void ConfigManager::PushUndoState(const std::string &description) {
   historyManager.PushUndoState(projectSession.GetScene(), selectionState,
-                               description, GetValue(kLayoutsConfigKey));
+                               description, GetValue(kLayoutsConfigKey),
+                               &layerVisibilityState);
   projectSession.Touch();
 }
 
@@ -702,7 +703,7 @@ std::string ConfigManager::Undo() {
   std::optional<std::string> layoutsCollection;
   std::string action =
       historyManager.Undo(projectSession.GetScene(), selectionState,
-                          &layoutsCollection);
+                          &layoutsCollection, &layerVisibilityState);
   if (!action.empty() || layoutsCollection.has_value()) {
     if (layoutsCollection.has_value())
       SetValue(kLayoutsConfigKey, *layoutsCollection);
@@ -718,7 +719,7 @@ std::string ConfigManager::Redo() {
   std::optional<std::string> layoutsCollection;
   std::string action =
       historyManager.Redo(projectSession.GetScene(), selectionState,
-                          &layoutsCollection);
+                          &layoutsCollection, &layerVisibilityState);
   if (!action.empty() || layoutsCollection.has_value()) {
     if (layoutsCollection.has_value())
       SetValue(kLayoutsConfigKey, *layoutsCollection);

--- a/core/configservices.cpp
+++ b/core/configservices.cpp
@@ -564,14 +564,17 @@ void SelectionState::Clear() {
 void HistoryManager::PushUndoState(
     const MvrScene &scene, const SelectionState &selection,
     const std::string &description,
-    const std::optional<std::string> &layoutsCollection) {
+    const std::optional<std::string> &layoutsCollection,
+    const LayerVisibilityState *layerState) {
   Snapshot snap{scene,
                 selection.GetSelectedFixtures(),
                 selection.GetSelectedTrusses(),
                 selection.GetSelectedSupports(),
                 selection.GetSelectedSceneObjects(),
                 description,
-                layoutsCollection};
+                layoutsCollection,
+                layerState ? layerState->GetHiddenLayers() : std::unordered_set<std::string>{},
+                layerState ? layerState->GetCurrentLayer() : std::string{}};
   undoStack.push_back(std::move(snap));
   if (undoStack.size() > maxHistory)
     undoStack.erase(undoStack.begin());
@@ -584,7 +587,8 @@ bool HistoryManager::CanRedo() const { return !redoStack.empty(); }
 
 std::string HistoryManager::Undo(
     MvrScene &scene, SelectionState &selection,
-    std::optional<std::string> *layoutsCollection) {
+    std::optional<std::string> *layoutsCollection,
+    LayerVisibilityState *layerState) {
   if (undoStack.empty())
     return {};
   const Snapshot snap = undoStack.back();
@@ -594,7 +598,9 @@ std::string HistoryManager::Undo(
                        selection.GetSelectedSupports(),
                        selection.GetSelectedSceneObjects(),
                        snap.description,
-                       snap.layoutsCollection});
+                       snap.layoutsCollection,
+                       layerState ? layerState->GetHiddenLayers() : std::unordered_set<std::string>{},
+                       layerState ? layerState->GetCurrentLayer() : std::string{}});
   scene = snap.scene;
   if (layoutsCollection)
     *layoutsCollection = snap.layoutsCollection;
@@ -602,13 +608,19 @@ std::string HistoryManager::Undo(
   selection.SetSelectedTrusses(snap.selTrusses);
   selection.SetSelectedSupports(snap.selSupports);
   selection.SetSelectedSceneObjects(snap.selSceneObjects);
+  if (layerState) {
+    layerState->SetHiddenLayers(snap.hiddenLayers);
+    if (!snap.currentLayer.empty())
+      layerState->SetCurrentLayer(snap.currentLayer);
+  }
   undoStack.pop_back();
   return snap.description;
 }
 
 std::string HistoryManager::Redo(
     MvrScene &scene, SelectionState &selection,
-    std::optional<std::string> *layoutsCollection) {
+    std::optional<std::string> *layoutsCollection,
+    LayerVisibilityState *layerState) {
   if (redoStack.empty())
     return {};
   const Snapshot snap = redoStack.back();
@@ -618,7 +630,9 @@ std::string HistoryManager::Redo(
                        selection.GetSelectedSupports(),
                        selection.GetSelectedSceneObjects(),
                        snap.description,
-                       snap.layoutsCollection});
+                       snap.layoutsCollection,
+                       layerState ? layerState->GetHiddenLayers() : std::unordered_set<std::string>{},
+                       layerState ? layerState->GetCurrentLayer() : std::string{}});
   scene = snap.scene;
   if (layoutsCollection)
     *layoutsCollection = snap.layoutsCollection;
@@ -626,6 +640,11 @@ std::string HistoryManager::Redo(
   selection.SetSelectedTrusses(snap.selTrusses);
   selection.SetSelectedSupports(snap.selSupports);
   selection.SetSelectedSceneObjects(snap.selSceneObjects);
+  if (layerState) {
+    layerState->SetHiddenLayers(snap.hiddenLayers);
+    if (!snap.currentLayer.empty())
+      layerState->SetCurrentLayer(snap.currentLayer);
+  }
   redoStack.pop_back();
   return snap.description;
 }
@@ -652,21 +671,12 @@ bool LayerVisibilityState::IsLayerVisible(const std::string &layer) const {
 void LayerVisibilityState::SetLayerColor(MvrScene &scene, const std::string &layer,
                                          const std::string &color) {
   std::string name = layer.empty() ? DEFAULT_LAYER_NAME : layer;
-  std::string layerUuid;
   for (auto &[uuid, l] : scene.layers) {
+    (void)uuid;
     if (l.name == name) {
-      layerUuid = uuid;
-      break;
+      l.color = color;
+      return;
     }
-  }
-  if (layerUuid.empty()) {
-    Layer l;
-    l.name = name;
-    l.color = color;
-    l.uuid = "layer_" + std::to_string(scene.layers.size() + 1);
-    scene.layers[l.uuid] = l;
-  } else {
-    scene.layers[layerUuid].color = color;
   }
 }
 
@@ -698,6 +708,8 @@ LayerVisibilityState::GetLayerNames(const MvrScene &scene) const {
     collect(s.layer);
   for (const auto &[u, o] : scene.sceneObjects)
     collect(o.layer);
+  for (const auto &[u, g] : scene.groupObjects)
+    collect(g.layer);
   names.insert(DEFAULT_LAYER_NAME);
   return {names.begin(), names.end()};
 }

--- a/core/configservices.h
+++ b/core/configservices.h
@@ -79,6 +79,8 @@ private:
   std::vector<std::string> selectedSceneObjects;
 };
 
+class LayerVisibilityState;
+
 class HistoryManager {
 public:
   struct Snapshot {
@@ -89,18 +91,23 @@ public:
     std::vector<std::string> selSceneObjects;
     std::string description;
     std::optional<std::string> layoutsCollection;
+    std::unordered_set<std::string> hiddenLayers;
+    std::string currentLayer;
   };
 
   void PushUndoState(const MvrScene &scene, const SelectionState &selection,
                      const std::string &description = "",
                      const std::optional<std::string> &layoutsCollection =
-                         std::nullopt);
+                         std::nullopt,
+                     const LayerVisibilityState *layerState = nullptr);
   bool CanUndo() const;
   bool CanRedo() const;
   std::string Undo(MvrScene &scene, SelectionState &selection,
-                   std::optional<std::string> *layoutsCollection = nullptr);
+                   std::optional<std::string> *layoutsCollection = nullptr,
+                   LayerVisibilityState *layerState = nullptr);
   std::string Redo(MvrScene &scene, SelectionState &selection,
-                   std::optional<std::string> *layoutsCollection = nullptr);
+                   std::optional<std::string> *layoutsCollection = nullptr,
+                   LayerVisibilityState *layerState = nullptr);
   void ClearHistory();
 
 private:

--- a/core/layer_service.cpp
+++ b/core/layer_service.cpp
@@ -1,0 +1,380 @@
+#include "layer_service.h"
+
+#include "utf8_utils.h"
+#include "uuidutils.h"
+
+#include <algorithm>
+#include <cctype>
+#include <iostream>
+#include <map>
+#include <optional>
+#include <set>
+#include <unordered_map>
+
+namespace layerdomain {
+namespace {
+
+// Reports a layer-domain action in a concise structured form.
+void LogLayerAction(const char *action, const LayerResult &result) {
+  std::cerr << "layer action=" << action << " status=" << static_cast<int>(result.status)
+            << " uuid=" << result.layerUuid << " name="
+            << EscapeTextForDiagnostics(result.layerName) << " message="
+            << result.message << '\n';
+}
+
+// Returns true when the color is a canonical #RRGGBB value.
+bool IsCanonicalColor(const std::string &color) {
+  if (color.empty())
+    return true;
+  if (color.size() != 7 || color[0] != '#')
+    return false;
+  return std::all_of(color.begin() + 1, color.end(), [](unsigned char c) {
+    return std::isxdigit(c) != 0 && !std::islower(c);
+  });
+}
+
+// Trims ASCII and common Unicode whitespace without changing interior text.
+std::string TrimLayerName(const std::string &name) {
+  auto isSpace = [](unsigned char c) { return std::isspace(c) != 0; };
+  size_t first = 0;
+  size_t last = name.size();
+  while (first < last && isSpace(static_cast<unsigned char>(name[first])))
+    ++first;
+  while (last > first && isSpace(static_cast<unsigned char>(name[last - 1])))
+    --last;
+  return name.substr(first, last - first);
+}
+
+// Validates and normalizes a layer name for editable scene storage.
+LayerResult NormalizeLayerName(const std::string &name, std::string &out) {
+  if (!IsValidUtf8(name))
+    return {LayerStatus::InvalidUtf8, "Layer name is not valid UTF-8"};
+  out = TrimLayerName(name);
+  if (out.empty())
+    return {LayerStatus::ValidationFailure, "Layer name is empty"};
+  if (out == DEFAULT_LAYER_NAME)
+    return {LayerStatus::ValidationFailure, "Default layer is reserved"};
+  if (out.size() > kMaxLayerNameBytes)
+    return {LayerStatus::ValidationFailure, "Layer name is too long"};
+  for (unsigned char c : out) {
+    if (c < 0x20 || c == 0x7F)
+      return {LayerStatus::ValidationFailure,
+              "Layer name contains a control character"};
+  }
+  return {};
+}
+
+// Returns the layer name for an existing UUID.
+std::optional<std::string> FindLayerName(const MvrScene &scene,
+                                         const std::string &uuid) {
+  const auto it = scene.layers.find(uuid);
+  if (it == scene.layers.end())
+    return std::nullopt;
+  return it->second.name;
+}
+
+// Generates a canonical UUID that does not collide with existing layers.
+std::optional<std::string> GenerateLayerUuid(const MvrScene &scene) {
+  for (int i = 0; i < 32; ++i) {
+    const std::string uuid = CanonicalizeUuid(GenerateUuid());
+    if (!uuid.empty() && scene.layers.find(uuid) == scene.layers.end())
+      return uuid;
+  }
+  return std::nullopt;
+}
+
+// Renames all object layer references that belong to one unique layer name.
+void RenameObjectLayers(MvrScene &scene, const std::string &oldName,
+                        const std::string &newName) {
+  auto rename = [&](auto &container) {
+    for (auto &[uuid, object] : container) {
+      (void)uuid;
+      if (object.layer == oldName)
+        object.layer = newName;
+    }
+  };
+  rename(scene.fixtures);
+  rename(scene.trusses);
+  rename(scene.supports);
+  rename(scene.sceneObjects);
+  rename(scene.groupObjects);
+}
+
+// Deletes all objects assigned to the given layer name and cleans selections.
+void DeleteLayerContents(ConfigManager &config, const std::string &name) {
+  MvrScene &scene = config.GetScene();
+  auto eraseLayer = [&](auto &container) {
+    for (auto it = container.begin(); it != container.end();) {
+      if (it->second.layer == name)
+        it = container.erase(it);
+      else
+        ++it;
+    }
+  };
+  eraseLayer(scene.fixtures);
+  eraseLayer(scene.trusses);
+  eraseLayer(scene.supports);
+  eraseLayer(scene.sceneObjects);
+  eraseLayer(scene.groupObjects);
+
+  auto keepFixtures = config.GetSelectedFixtures();
+  keepFixtures.erase(std::remove_if(keepFixtures.begin(), keepFixtures.end(),
+                                    [&](const std::string &uuid) {
+                                      return scene.fixtures.count(uuid) == 0;
+                                    }),
+                     keepFixtures.end());
+  config.SetSelectedFixtures(keepFixtures);
+  auto keepTrusses = config.GetSelectedTrusses();
+  keepTrusses.erase(std::remove_if(keepTrusses.begin(), keepTrusses.end(),
+                                   [&](const std::string &uuid) {
+                                     return scene.trusses.count(uuid) == 0;
+                                   }),
+                    keepTrusses.end());
+  config.SetSelectedTrusses(keepTrusses);
+  auto keepSupports = config.GetSelectedSupports();
+  keepSupports.erase(std::remove_if(keepSupports.begin(), keepSupports.end(),
+                                    [&](const std::string &uuid) {
+                                      return scene.supports.count(uuid) == 0;
+                                    }),
+                     keepSupports.end());
+  config.SetSelectedSupports(keepSupports);
+  auto keepObjects = config.GetSelectedSceneObjects();
+  keepObjects.erase(std::remove_if(keepObjects.begin(), keepObjects.end(),
+                                   [&](const std::string &uuid) {
+                                     return scene.sceneObjects.count(uuid) == 0;
+                                   }),
+                    keepObjects.end());
+  config.SetSelectedSceneObjects(keepObjects);
+}
+
+} // namespace
+
+// Returns every canonical layer, including names inferred from all object types.
+std::vector<LayerEntry> EnumerateLayers(const MvrScene &scene) {
+  std::map<std::string, LayerEntry> byName;
+  byName[DEFAULT_LAYER_NAME] = {"layer_default", DEFAULT_LAYER_NAME, {}};
+  for (const auto &[uuid, layer] : scene.layers)
+    byName[layer.name] = {uuid, layer.name, layer.color};
+  auto collect = [&](const std::string &name) {
+    if (!name.empty() && byName.find(name) == byName.end())
+      byName[name] = {{}, name, {}};
+  };
+  for (const auto &[uuid, object] : scene.fixtures) { (void)uuid; collect(object.layer); }
+  for (const auto &[uuid, object] : scene.trusses) { (void)uuid; collect(object.layer); }
+  for (const auto &[uuid, object] : scene.supports) { (void)uuid; collect(object.layer); }
+  for (const auto &[uuid, object] : scene.sceneObjects) { (void)uuid; collect(object.layer); }
+  for (const auto &[uuid, object] : scene.groupObjects) { (void)uuid; collect(object.layer); }
+  std::vector<LayerEntry> out;
+  for (const auto &[name, entry] : byName)
+    out.push_back(entry);
+  return out;
+}
+
+// Creates a validated layer through the undoable domain pipeline.
+LayerResult CreateLayer(ConfigManager &config, const std::string &name) {
+  std::string normalized;
+  LayerResult result = NormalizeLayerName(name, normalized);
+  if (result.status != LayerStatus::Success) { LogLayerAction("create", result); return result; }
+  MvrScene &scene = config.GetScene();
+  for (const auto &[uuid, layer] : scene.layers) {
+    (void)uuid;
+    if (layer.name == normalized)
+      return {LayerStatus::DuplicateName, "Layer name already exists"};
+  }
+  const auto uuid = GenerateLayerUuid(scene);
+  if (!uuid)
+    return {LayerStatus::InvalidUuid, "Could not generate a unique layer UUID"};
+  config.PushUndoState("add layer");
+  scene.layers[*uuid] = Layer{*uuid, normalized, {}, {}};
+  config.SetCurrentLayer(normalized);
+  result = {LayerStatus::Success, {}, *uuid, normalized, {}};
+  result.changes.layerStructureChanged = true;
+  result.changes.currentLayerChanged = true;
+  LogLayerAction("create", result);
+  return result;
+}
+
+// Renames one existing layer by UUID and updates object references atomically.
+LayerResult RenameLayer(ConfigManager &config, const std::string &uuid,
+                        const std::string &newName) {
+  MvrScene &scene = config.GetScene();
+  const auto oldName = FindLayerName(scene, uuid);
+  if (!oldName)
+    return {LayerStatus::NotFound, "Layer UUID was not found", uuid};
+  if (*oldName == DEFAULT_LAYER_NAME)
+    return {LayerStatus::ValidationFailure, "Default layer cannot be renamed", uuid};
+  std::string normalized;
+  LayerResult result = NormalizeLayerName(newName, normalized);
+  if (result.status != LayerStatus::Success)
+    return result;
+  if (normalized == *oldName)
+    return {LayerStatus::NoChange, {}, uuid, normalized};
+  for (const auto &[otherUuid, layer] : scene.layers) {
+    if (otherUuid != uuid && layer.name == normalized)
+      return {LayerStatus::DuplicateName, "Layer name already exists", uuid,
+              normalized};
+  }
+  const MvrScene before = scene;
+  config.PushUndoState("rename layer");
+  scene.layers[uuid].name = normalized;
+  RenameObjectLayers(scene, *oldName, normalized);
+  auto hidden = config.GetHiddenLayers();
+  if (hidden.erase(*oldName))
+    hidden.insert(normalized);
+  config.SetHiddenLayers(hidden);
+  if (config.GetCurrentLayer() == *oldName)
+    config.SetCurrentLayer(normalized);
+  result = ValidateSceneLayers(scene);
+  if (result.status != LayerStatus::Success) {
+    scene = before;
+    return result;
+  }
+  result = {LayerStatus::Success, {}, uuid, normalized, {}};
+  result.changes.layerStructureChanged = true;
+  result.changes.sceneContentChanged = true;
+  LogLayerAction("rename", result);
+  return result;
+}
+
+// Deletes one existing layer by UUID together with its assigned objects.
+LayerResult DeleteLayer(ConfigManager &config, const std::string &uuid) {
+  MvrScene &scene = config.GetScene();
+  const auto name = FindLayerName(scene, uuid);
+  if (!name)
+    return {LayerStatus::NotFound, "Layer UUID was not found", uuid};
+  if (*name == DEFAULT_LAYER_NAME)
+    return {LayerStatus::ValidationFailure, "Default layer cannot be deleted", uuid};
+  config.PushUndoState("delete layer");
+  DeleteLayerContents(config, *name);
+  scene.layers.erase(uuid);
+  auto hidden = config.GetHiddenLayers();
+  hidden.erase(*name);
+  config.SetHiddenLayers(hidden);
+  if (config.GetCurrentLayer() == *name)
+    config.SetCurrentLayer(DEFAULT_LAYER_NAME);
+  LayerResult result{LayerStatus::Success, {}, uuid, *name, {}};
+  result.changes.layerStructureChanged = true;
+  result.changes.sceneContentChanged = true;
+  result.changes.selectionChanged = true;
+  LogLayerAction("delete", result);
+  return result;
+}
+
+// Changes an existing layer color by UUID without implicit layer creation.
+LayerResult SetLayerColor(ConfigManager &config, const std::string &uuid,
+                          const std::string &color) {
+  if (!IsCanonicalColor(color))
+    return {LayerStatus::InvalidColor, "Layer color must be #RRGGBB", uuid};
+  MvrScene &scene = config.GetScene();
+  const auto it = scene.layers.find(uuid);
+  if (it == scene.layers.end())
+    return {LayerStatus::NotFound, "Layer UUID was not found", uuid};
+  if (it->second.color == color)
+    return {LayerStatus::NoChange, {}, uuid, it->second.name};
+  config.PushUndoState("change layer color");
+  it->second.color = color;
+  LayerResult result{LayerStatus::Success, {}, uuid, it->second.name, {}};
+  result.changes.layerAppearanceChanged = true;
+  LogLayerAction("color", result);
+  return result;
+}
+
+// Changes layer visibility by UUID using the current name-backed compatibility state.
+LayerResult SetLayerVisibility(ConfigManager &config, const std::string &uuid,
+                               bool visible) {
+  const auto name = FindLayerName(config.GetScene(), uuid);
+  if (!name)
+    return {LayerStatus::NotFound, "Layer UUID was not found", uuid};
+  auto hidden = config.GetHiddenLayers();
+  const bool wasVisible = hidden.count(*name) == 0;
+  if (wasVisible == visible)
+    return {LayerStatus::NoChange, {}, uuid, *name};
+  config.PushUndoState("change layer visibility");
+  if (visible)
+    hidden.erase(*name);
+  else
+    hidden.insert(*name);
+  config.SetHiddenLayers(hidden);
+  LayerResult result{LayerStatus::Success, {}, uuid, *name, {}};
+  result.changes.layerVisibilityChanged = true;
+  return result;
+}
+
+// Sets the current layer by UUID using centralized name compatibility mapping.
+LayerResult SetCurrentLayer(ConfigManager &config, const std::string &uuid) {
+  const auto name = FindLayerName(config.GetScene(), uuid);
+  if (!name)
+    return {LayerStatus::NotFound, "Layer UUID was not found", uuid};
+  if (config.GetCurrentLayer() == *name)
+    return {LayerStatus::NoChange, {}, uuid, *name};
+  config.SetCurrentLayer(*name);
+  LayerResult result{LayerStatus::Success, {}, uuid, *name, {}};
+  result.changes.currentLayerChanged = true;
+  return result;
+}
+
+// Validates layer UUIDs, names, colors, and duplicate canonical names.
+LayerResult ValidateSceneLayers(const MvrScene &scene) {
+  std::set<std::string> names;
+  std::set<std::string> uuids;
+  for (const auto &[uuid, layer] : scene.layers) {
+    if (CanonicalizeUuid(uuid).empty() && uuid != "layer_default")
+      return {LayerStatus::InvalidUuid, "Layer UUID is malformed", uuid,
+              layer.name};
+    if (!uuids.insert(uuid).second)
+      return {LayerStatus::InvalidUuid, "Layer UUID is duplicated", uuid,
+              layer.name};
+    if (!IsValidUtf8(layer.name))
+      return {LayerStatus::InvalidUtf8, "Layer name is not valid UTF-8", uuid};
+    if (!IsCanonicalColor(layer.color))
+      return {LayerStatus::InvalidColor, "Layer color is invalid", uuid,
+              layer.name};
+    if (!names.insert(TrimLayerName(layer.name)).second)
+      return {LayerStatus::DuplicateName, "Layer name is duplicated", uuid,
+              layer.name};
+  }
+  return {};
+}
+
+// Repairs known legacy Windows-1252 layer-name corruption without merging layers.
+LayerResult ReconcileLegacyLayers(MvrScene &scene) {
+  bool repaired = false;
+  std::set<std::string> names;
+  for (auto &[uuid, layer] : scene.layers) {
+    if (!IsValidUtf8(layer.name)) {
+      const auto repairedName = RepairWindows1252AsUtf8(layer.name);
+      if (!repairedName)
+        return {LayerStatus::InvalidUtf8, "Layer name cannot be repaired", uuid};
+      layer.name = *repairedName;
+      repaired = true;
+    }
+    std::string unique = layer.name;
+    for (int suffix = 2; names.count(unique) > 0; ++suffix)
+      unique = layer.name + " (Recovered " + std::to_string(suffix) + ")";
+    if (unique != layer.name) {
+      RenameObjectLayers(scene, layer.name, unique);
+      layer.name = unique;
+      repaired = true;
+    }
+    names.insert(layer.name);
+  }
+  return {repaired ? LayerStatus::Success : LayerStatus::NoChange,
+          repaired ? "Legacy layer data repaired" : "No legacy repairs needed"};
+}
+
+// Converts a layer status to a user-facing English diagnostic.
+std::string StatusMessage(LayerStatus status) {
+  switch (status) {
+  case LayerStatus::Success: return "Layer operation succeeded.";
+  case LayerStatus::NoChange: return "Layer operation made no changes.";
+  case LayerStatus::ValidationFailure: return "Layer data is not valid.";
+  case LayerStatus::NotFound: return "Layer was not found.";
+  case LayerStatus::DuplicateName: return "Layer name already exists.";
+  case LayerStatus::InvalidUtf8: return "Layer text is not valid UTF-8.";
+  case LayerStatus::InvalidUuid: return "Layer UUID is not valid.";
+  case LayerStatus::InvalidColor: return "Layer color is not valid.";
+  }
+  return "Layer operation failed.";
+}
+
+} // namespace layerdomain

--- a/core/layer_service.cpp
+++ b/core/layer_service.cpp
@@ -1,5 +1,6 @@
 #include "layer_service.h"
 
+#include "configmanager.h"
 #include "utf8_utils.h"
 #include "uuidutils.h"
 

--- a/core/layer_service.h
+++ b/core/layer_service.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "configservices.h"
+
+#include <string>
+#include <vector>
+
+namespace layerdomain {
+
+constexpr size_t kMaxLayerNameBytes = 256;
+
+struct LayerEntry {
+  std::string uuid;
+  std::string name;
+  std::string color;
+};
+
+enum class LayerStatus {
+  Success,
+  NoChange,
+  ValidationFailure,
+  NotFound,
+  DuplicateName,
+  InvalidUtf8,
+  InvalidUuid,
+  InvalidColor
+};
+
+struct LayerChangeSet {
+  bool layerStructureChanged = false;
+  bool layerAppearanceChanged = false;
+  bool layerVisibilityChanged = false;
+  bool currentLayerChanged = false;
+  bool sceneContentChanged = false;
+  bool selectionChanged = false;
+};
+
+struct LayerResult {
+  LayerStatus status = LayerStatus::Success;
+  std::string message;
+  std::string layerUuid;
+  std::string layerName;
+  LayerChangeSet changes;
+};
+
+std::vector<LayerEntry> EnumerateLayers(const MvrScene &scene);
+LayerResult CreateLayer(ConfigManager &config, const std::string &name);
+LayerResult RenameLayer(ConfigManager &config, const std::string &uuid,
+                        const std::string &newName);
+LayerResult DeleteLayer(ConfigManager &config, const std::string &uuid);
+LayerResult SetLayerColor(ConfigManager &config, const std::string &uuid,
+                          const std::string &color);
+LayerResult SetLayerVisibility(ConfigManager &config, const std::string &uuid,
+                               bool visible);
+LayerResult SetCurrentLayer(ConfigManager &config, const std::string &uuid);
+LayerResult ValidateSceneLayers(const MvrScene &scene);
+LayerResult ReconcileLegacyLayers(MvrScene &scene);
+std::string StatusMessage(LayerStatus status);
+
+} // namespace layerdomain

--- a/core/layer_service.h
+++ b/core/layer_service.h
@@ -2,8 +2,11 @@
 
 #include "configservices.h"
 
+#include <cstddef>
 #include <string>
 #include <vector>
+
+class ConfigManager;
 
 namespace layerdomain {
 

--- a/core/utf8_utils.cpp
+++ b/core/utf8_utils.cpp
@@ -1,0 +1,129 @@
+#include "utf8_utils.h"
+
+#include <array>
+#include <iomanip>
+#include <sstream>
+
+namespace {
+
+// Appends one Unicode code point as UTF-8.
+void AppendCodePoint(std::string &out, uint32_t cp) {
+  if (cp <= 0x7F) {
+    out.push_back(static_cast<char>(cp));
+  } else if (cp <= 0x7FF) {
+    out.push_back(static_cast<char>(0xC0 | (cp >> 6)));
+    out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+  } else if (cp <= 0xFFFF) {
+    out.push_back(static_cast<char>(0xE0 | (cp >> 12)));
+    out.push_back(static_cast<char>(0x80 | ((cp >> 6) & 0x3F)));
+    out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+  } else {
+    out.push_back(static_cast<char>(0xF0 | (cp >> 18)));
+    out.push_back(static_cast<char>(0x80 | ((cp >> 12) & 0x3F)));
+    out.push_back(static_cast<char>(0x80 | ((cp >> 6) & 0x3F)));
+    out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+  }
+}
+
+// Returns the Unicode scalar value for one Windows-1252 byte.
+std::optional<uint32_t> Windows1252CodePoint(unsigned char byte) {
+  static constexpr std::array<uint16_t, 32> kTable = {
+      0x20AC, 0,      0x201A, 0x0192, 0x201E, 0x2026, 0x2020, 0x2021,
+      0x02C6, 0x2030, 0x0160, 0x2039, 0x0152, 0,      0x017D, 0,
+      0,      0x2018, 0x2019, 0x201C, 0x201D, 0x2022, 0x2013, 0x2014,
+      0x02DC, 0x2122, 0x0161, 0x203A, 0x0153, 0,      0x017E, 0x0178};
+  if (byte < 0x80)
+    return byte;
+  if (byte >= 0xA0)
+    return byte;
+  const uint16_t cp = kTable[byte - 0x80];
+  if (cp == 0)
+    return std::nullopt;
+  return cp;
+}
+
+} // namespace
+
+// Validates that text is well-formed UTF-8 and reports the first bad byte.
+Utf8ValidationResult ValidateUtf8(std::string_view text) {
+  for (size_t i = 0; i < text.size();) {
+    const unsigned char c = static_cast<unsigned char>(text[i]);
+    size_t needed = 0;
+    uint32_t cp = 0;
+    if (c <= 0x7F) {
+      ++i;
+      continue;
+    } else if (c >= 0xC2 && c <= 0xDF) {
+      needed = 1;
+      cp = c & 0x1F;
+    } else if (c >= 0xE0 && c <= 0xEF) {
+      needed = 2;
+      cp = c & 0x0F;
+    } else if (c >= 0xF0 && c <= 0xF4) {
+      needed = 3;
+      cp = c & 0x07;
+    } else {
+      return {false, i};
+    }
+    if (i + needed >= text.size())
+      return {false, i};
+    for (size_t j = 1; j <= needed; ++j) {
+      const unsigned char cc = static_cast<unsigned char>(text[i + j]);
+      if ((cc & 0xC0) != 0x80)
+        return {false, i + j};
+      cp = (cp << 6) | (cc & 0x3F);
+    }
+    if ((needed == 2 && cp < 0x800) || (needed == 3 && cp < 0x10000) ||
+        cp > 0x10FFFF || (cp >= 0xD800 && cp <= 0xDFFF))
+      return {false, i};
+    i += needed + 1;
+  }
+  return {true, 0};
+}
+
+// Returns true when text is well-formed UTF-8.
+bool IsValidUtf8(std::string_view text) { return ValidateUtf8(text).valid; }
+
+// Repairs invalid Windows-1252 bytes while leaving valid UTF-8 sequences intact.
+std::optional<std::string> RepairWindows1252AsUtf8(std::string_view text) {
+  if (IsValidUtf8(text))
+    return std::string(text);
+  std::string out;
+  out.reserve(text.size());
+  for (size_t i = 0; i < text.size();) {
+    const auto valid = ValidateUtf8(text.substr(i));
+    if (valid.valid) {
+      out.append(text.substr(i));
+      break;
+    }
+    if (valid.errorOffset > 0) {
+      out.append(text.substr(i, valid.errorOffset));
+      i += valid.errorOffset;
+      continue;
+    }
+    const unsigned char byte = static_cast<unsigned char>(text[i++]);
+    const auto cp = Windows1252CodePoint(byte);
+    if (!cp)
+      return std::nullopt;
+    AppendCodePoint(out, *cp);
+  }
+  return IsValidUtf8(out) ? std::optional<std::string>(out) : std::nullopt;
+}
+
+// Escapes bytes for concise diagnostics without exposing full raw content.
+std::string EscapeTextForDiagnostics(std::string_view text) {
+  std::ostringstream out;
+  size_t count = 0;
+  for (unsigned char c : text) {
+    if (count++ >= 64) {
+      out << "...";
+      break;
+    }
+    if (c >= 0x20 && c <= 0x7E && c != '\\')
+      out << static_cast<char>(c);
+    else
+      out << "\\x" << std::uppercase << std::hex << std::setw(2)
+          << std::setfill('0') << static_cast<int>(c) << std::dec;
+  }
+  return out.str();
+}

--- a/core/utf8_utils.cpp
+++ b/core/utf8_utils.cpp
@@ -1,6 +1,7 @@
 #include "utf8_utils.h"
 
 #include <array>
+#include <cstdint>
 #include <iomanip>
 #include <sstream>
 

--- a/core/utf8_utils.h
+++ b/core/utf8_utils.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <string_view>
+
+struct Utf8ValidationResult {
+  bool valid = true;
+  size_t errorOffset = 0;
+};
+
+Utf8ValidationResult ValidateUtf8(std::string_view text);
+bool IsValidUtf8(std::string_view text);
+std::optional<std::string> RepairWindows1252AsUtf8(std::string_view text);
+std::string EscapeTextForDiagnostics(std::string_view text);

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -37,6 +37,8 @@ Changes since **v1.4.0**.
 
 ## Fixes
 
+- Hardened layer editing and MVR persistence so layer names are treated as validated UTF-8, legacy Windows-1252 layer-name corruption can be recovered without losing objects, layer edits target stable UUIDs, and exported scene XML is re-parsed before archive writing.
+
 - Fixed GDTF editor numeric text parsing so fixture power, fixture weight, and truss dimensions compile with the macOS 15 / Xcode 16.4 toolchain while preserving locale-independent validation.
 - Fixed Edit Truss physical-property dimensions so stored millimeter values are converted before display and editing, keeping length, width, and height aligned with the active UI distance units and visible unit suffixes.
 - Fixed MVR imports so fixture types whose declared GDTF archive is missing remain available in the GDTF conflict resolver, can be matched through Download GDTF, and report a clear dummy fallback instead of a raw missing-file error when no online match is found.

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/consolepanel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/console_command_parser.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ui_feature_flags.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/wx_text_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dictionaryeditdialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dictionary_selection_controls.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dictionary_export_conflict_dialog.cpp

--- a/gui/layerpanel.cpp
+++ b/gui/layerpanel.cpp
@@ -178,11 +178,11 @@ void LayerPanel::ReloadLayers() {
     const bool vis = hidden.find(entry.name) == hidden.end();
     wxVector<wxVariant> cols;
     cols.push_back(wxVariant(vis));
-    cols.push_back(wxVariant(Utf8ToWx(entry.name)));
+    cols.push_back(wxVariant(wxtext::FromUtf8(entry.name)));
     wxBitmap bmp(16, 16);
     wxColour c;
     if (!entry.color.empty())
-      c.Set(Utf8ToWx(entry.color));
+      c.Set(wxtext::FromUtf8(entry.color));
     else
       c.Set(128, 128, 128);
     wxMemoryDC dc(bmp);
@@ -260,17 +260,17 @@ void LayerPanel::OnContext(wxDataViewEvent &evt) {
     const std::string name = layerIt->second.name;
     wxColourData data;
     if (!layerIt->second.color.empty())
-        data.SetColour(wxColour(Utf8ToWx(layerIt->second.color)));
+        data.SetColour(wxColour(wxtext::FromUtf8(layerIt->second.color)));
     wxColourDialog dlg(this, &data);
     if (dlg.ShowModal() != wxID_OK)
         return;
     wxColour col = dlg.GetColourData().GetColour();
-  std::string hex = WxToUtf8(
+  std::string hex = wxtext::ToUtf8(
       wxString::Format("#%02X%02X%02X", col.Red(), col.Green(), col.Blue()));
     auto result = layerdomain::SetLayerColor(*configManager, uuid, hex);
     if (result.status != layerdomain::LayerStatus::Success &&
         result.status != layerdomain::LayerStatus::NoChange) {
-        wxMessageBox(Utf8ToWx(result.message.empty() ? layerdomain::StatusMessage(result.status) : result.message),
+        wxMessageBox(wxtext::FromUtf8(result.message.empty() ? layerdomain::StatusMessage(result.status) : result.message),
                      _("Layer Color"), wxOK | wxICON_ERROR, this);
         return;
     }
@@ -298,10 +298,10 @@ void LayerPanel::OnAddLayer(wxCommandEvent &) {
     wxTextEntryDialog dlg(this, _("Enter new layer name:"), _("Add Layer"));
     if (dlg.ShowModal() != wxID_OK)
         return;
-    auto result = layerdomain::CreateLayer(*configManager, WxToUtf8(dlg.GetValue()));
+    auto result = layerdomain::CreateLayer(*configManager, wxtext::ToUtf8(dlg.GetValue()));
     if (result.status != layerdomain::LayerStatus::Success &&
         result.status != layerdomain::LayerStatus::NoChange) {
-        wxMessageBox(Utf8ToWx(result.message.empty() ? layerdomain::StatusMessage(result.status) : result.message),
+        wxMessageBox(wxtext::FromUtf8(result.message.empty() ? layerdomain::StatusMessage(result.status) : result.message),
                      _("Add Layer"), wxOK | wxICON_ERROR, this);
         return;
     }
@@ -357,7 +357,7 @@ void LayerPanel::OnDeleteLayer(wxCommandEvent&)
     }
     auto result = layerdomain::DeleteLayer(*configManager, uuid);
     if (result.status != layerdomain::LayerStatus::Success) {
-        wxMessageBox(Utf8ToWx(result.message.empty() ? layerdomain::StatusMessage(result.status) : result.message),
+        wxMessageBox(wxtext::FromUtf8(result.message.empty() ? layerdomain::StatusMessage(result.status) : result.message),
                      _("Delete Layer"), wxOK | wxICON_ERROR, this);
         return;
     }
@@ -398,14 +398,14 @@ void LayerPanel::OnRenameLayer(wxDataViewEvent &evt) {
         return;
     }
 
-    wxTextEntryDialog dlg(this, _("Enter new layer name:"), _("Rename Layer"), Utf8ToWx(oldName));
+    wxTextEntryDialog dlg(this, _("Enter new layer name:"), _("Rename Layer"), wxtext::FromUtf8(oldName));
     if (dlg.ShowModal() != wxID_OK)
         return;
-    auto result = layerdomain::RenameLayer(*configManager, uuid, WxToUtf8(dlg.GetValue()));
+    auto result = layerdomain::RenameLayer(*configManager, uuid, wxtext::ToUtf8(dlg.GetValue()));
     if (result.status == layerdomain::LayerStatus::NoChange)
         return;
     if (result.status != layerdomain::LayerStatus::Success) {
-        wxMessageBox(Utf8ToWx(result.message.empty() ? layerdomain::StatusMessage(result.status) : result.message),
+        wxMessageBox(wxtext::FromUtf8(result.message.empty() ? layerdomain::StatusMessage(result.status) : result.message),
                      _("Rename Layer"), wxOK | wxICON_ERROR, this);
         return;
     }

--- a/gui/layerpanel.cpp
+++ b/gui/layerpanel.cpp
@@ -18,6 +18,9 @@
 #include "layerpanel.h"
 #include "configmanager.h"
 #include "guiconfigservices.h"
+#include "hoisttablepanel.h"
+#include "layer_service.h"
+#include "wx_text_utils.h"
 #include "fixturetablepanel.h"
 #include "sceneobjecttablepanel.h"
 #include "table_column_indices.h"
@@ -25,7 +28,6 @@
 #include "viewer2dpanel.h"
 #include "viewer3dpanel.h"
 #include <set>
-#include <chrono>
 #include <algorithm>
 #include <functional>
 #include <wx/dcmemory.h>
@@ -163,69 +165,58 @@ void LayerPanel::SetInstance(LayerPanel *p) { s_instance = p; }
 void LayerPanel::ReloadLayers() {
   if (!list)
     return;
-    list->DeleteAllItems();
+  list->DeleteAllItems();
+  rowLayerUuids.clear();
 
-    std::set<std::string> names;
-    auto& scene = (*configManager).GetScene();
-    for (const auto& [uuid, layer] : scene.layers)
-        names.insert(layer.name);
+  auto &scene = (*configManager).GetScene();
+  auto hidden = (*configManager).GetHiddenLayers();
+  std::string current = (*configManager).GetCurrentLayer();
+  int idx = 0;
+  int sel = -1;
 
-    auto collect = [&](const std::string& ln) {
-        if (!ln.empty())
-            names.insert(ln);
-    };
-  for (const auto &[u, f] : scene.fixtures)
-    collect(f.layer);
-  for (const auto &[u, t] : scene.trusses)
-    collect(t.layer);
-  for (const auto &[u, o] : scene.sceneObjects)
-    collect(o.layer);
-    names.insert(DEFAULT_LAYER_NAME);
+  auto addRow = [&](const layerdomain::LayerEntry &entry) {
+    const bool vis = hidden.find(entry.name) == hidden.end();
+    wxVector<wxVariant> cols;
+    cols.push_back(wxVariant(vis));
+    cols.push_back(wxVariant(Utf8ToWx(entry.name)));
+    wxBitmap bmp(16, 16);
+    wxColour c;
+    if (!entry.color.empty())
+      c.Set(Utf8ToWx(entry.color));
+    else
+      c.Set(128, 128, 128);
+    wxMemoryDC dc(bmp);
+    dc.SetBrush(wxBrush(c));
+    dc.SetPen(*wxBLACK_PEN);
+    dc.DrawRectangle(0, 0, 16, 16);
+    dc.SelectObject(wxNullBitmap);
+    wxDataViewIconText icon("", bmp);
+    cols.push_back(wxVariant(icon));
+    list->AppendItem(cols);
+    rowLayerUuids.push_back(entry.uuid);
+    if (entry.name == current)
+      sel = idx;
+    ++idx;
+  };
 
-    auto hidden = (*configManager).GetHiddenLayers();
-    std::string current = (*configManager).GetCurrentLayer();
-    int idx = 0;
-    int sel = -1;
+  for (const auto &entry : layerdomain::EnumerateLayers(scene))
+    addRow(entry);
 
-    auto addRow = [&](const std::string& n){
-        bool vis = hidden.find(n) == hidden.end();
-        wxVector<wxVariant> cols;
-        cols.push_back(wxVariant(vis));
-        cols.push_back(wxVariant(wxString::FromUTF8(n)));
-        wxBitmap bmp(16,16);
-        wxColour c;
-        auto opt = (*configManager).GetLayerColor(n);
-        if (opt)
-            c.Set(wxString::FromUTF8(opt->c_str()));
-        else
-            c.Set(128,128,128);
-        wxMemoryDC dc(bmp);
-        dc.SetBrush(wxBrush(c));
-        dc.SetPen(*wxBLACK_PEN);
-        dc.DrawRectangle(0,0,16,16);
-        dc.SelectObject(wxNullBitmap);
-        wxDataViewIconText icon("", bmp);
-        cols.push_back(wxVariant(icon));
-        list->AppendItem(cols);
-        if (n == current)
-            sel = idx;
-        ++idx;
-    };
+  if (sel < 0 && list->GetItemCount() > 0)
+    sel = 0;
+  if (sel >= 0) {
+    list->SelectRow(sel);
+    const std::string uuid = LayerUuidForRow(sel);
+    if (!uuid.empty())
+      layerdomain::SetCurrentLayer(*configManager, uuid);
+  }
+}
 
-    if (names.find(DEFAULT_LAYER_NAME) != names.end()) {
-        addRow(DEFAULT_LAYER_NAME);
-        names.erase(DEFAULT_LAYER_NAME);
-    }
-    for (const auto& n : names)
-        addRow(n);
-
-    if (sel < 0 && list->GetItemCount() > 0)
-        sel = 0;
-    if (sel >= 0) {
-        list->SelectRow(sel);
-    wxString wname = list->GetTextValue(sel, ColumnIndex(LayerColumn::Layer));
-        (*configManager).SetCurrentLayer(wname.ToStdString());
-    }
+// Returns the stable layer UUID bound to a visible row.
+std::string LayerPanel::LayerUuidForRow(int row) const {
+  if (row < 0 || row >= static_cast<int>(rowLayerUuids.size()))
+    return {};
+  return rowLayerUuids[static_cast<size_t>(row)];
 }
 
 // Applies visibility checkbox changes to the hidden-layer set.
@@ -234,18 +225,15 @@ void LayerPanel::OnCheck(wxDataViewEvent &evt) {
   if (idx == wxNOT_FOUND || idx < 0 ||
       idx >= static_cast<int>(list->GetItemCount()))
         return;
-  wxString wname = list->GetTextValue(idx, ColumnIndex(LayerColumn::Layer));
-    std::string name = wname.ToStdString();
+  const std::string uuid = LayerUuidForRow(idx);
+    if (uuid.empty())
+        return;
     wxVariant v;
   list->GetValue(v, idx, ColumnIndex(LayerColumn::Visible));
     bool checked = v.GetBool();
-    auto hidden = (*configManager).GetHiddenLayers();
-    if (checked)
-        hidden.erase(name);
-    else
-        hidden.insert(name);
-    (*configManager).SetHiddenLayers(hidden);
-    RefreshVisibleViewers();
+    auto result = layerdomain::SetLayerVisibility(*configManager, uuid, checked);
+    if (result.status == layerdomain::LayerStatus::Success)
+        RefreshVisibleViewers();
 }
 
 // Updates the current layer when the selected row changes.
@@ -253,8 +241,9 @@ void LayerPanel::OnSelect(wxDataViewEvent &evt) {
     unsigned int idx = list->ItemToRow(evt.GetItem());
     if (idx == wxNOT_FOUND)
         return;
-  wxString wname = list->GetTextValue(idx, ColumnIndex(LayerColumn::Layer));
-    (*configManager).SetCurrentLayer(wname.ToStdString());
+  const std::string uuid = LayerUuidForRow(static_cast<int>(idx));
+    if (!uuid.empty())
+        layerdomain::SetCurrentLayer(*configManager, uuid);
 }
 
 // Opens the layer color picker for the context-menu row.
@@ -262,20 +251,29 @@ void LayerPanel::OnContext(wxDataViewEvent &evt) {
     unsigned int idx = list->ItemToRow(evt.GetItem());
     if (idx == wxNOT_FOUND)
         return;
-  wxString wname = list->GetTextValue(idx, ColumnIndex(LayerColumn::Layer));
-    std::string name = wname.ToStdString();
+  const std::string uuid = LayerUuidForRow(static_cast<int>(idx));
+    if (uuid.empty())
+        return;
+    const auto layerIt = (*configManager).GetScene().layers.find(uuid);
+    if (layerIt == (*configManager).GetScene().layers.end())
+        return;
+    const std::string name = layerIt->second.name;
     wxColourData data;
-    if (auto c = (*configManager).GetLayerColor(name))
-        data.SetColour(wxColour(wxString::FromUTF8(c->c_str())));
+    if (!layerIt->second.color.empty())
+        data.SetColour(wxColour(Utf8ToWx(layerIt->second.color)));
     wxColourDialog dlg(this, &data);
     if (dlg.ShowModal() != wxID_OK)
         return;
     wxColour col = dlg.GetColourData().GetColour();
-  std::string hex =
-      wxString::Format("#%02X%02X%02X", col.Red(), col.Green(), col.Blue())
-          .ToStdString();
-    (*configManager).PushUndoState("change layer color");
-    (*configManager).SetLayerColor(name, hex);
+  std::string hex = WxToUtf8(
+      wxString::Format("#%02X%02X%02X", col.Red(), col.Green(), col.Blue()));
+    auto result = layerdomain::SetLayerColor(*configManager, uuid, hex);
+    if (result.status != layerdomain::LayerStatus::Success &&
+        result.status != layerdomain::LayerStatus::NoChange) {
+        wxMessageBox(Utf8ToWx(result.message.empty() ? layerdomain::StatusMessage(result.status) : result.message),
+                     _("Layer Color"), wxOK | wxICON_ERROR, this);
+        return;
+    }
     wxBitmap bmp(16,16);
     wxMemoryDC dc(bmp);
     dc.SetBrush(wxBrush(col));
@@ -300,26 +298,13 @@ void LayerPanel::OnAddLayer(wxCommandEvent &) {
     wxTextEntryDialog dlg(this, _("Enter new layer name:"), _("Add Layer"));
     if (dlg.ShowModal() != wxID_OK)
         return;
-    std::string name = dlg.GetValue().ToStdString();
-    if (name.empty() || name == DEFAULT_LAYER_NAME)
+    auto result = layerdomain::CreateLayer(*configManager, WxToUtf8(dlg.GetValue()));
+    if (result.status != layerdomain::LayerStatus::Success &&
+        result.status != layerdomain::LayerStatus::NoChange) {
+        wxMessageBox(Utf8ToWx(result.message.empty() ? layerdomain::StatusMessage(result.status) : result.message),
+                     _("Add Layer"), wxOK | wxICON_ERROR, this);
         return;
-
-    ConfigManager& cfg = (*configManager);
-    auto& scene = cfg.GetScene();
-    for (const auto& [uuid, layer] : scene.layers)
-        if (layer.name == name)
-        {
-            wxMessageBox(_("Layer already exists."), _("Add Layer"), wxOK | wxICON_ERROR, this);
-            return;
-        }
-
-    cfg.PushUndoState("add layer");
-    Layer layer;
-    auto baseId = std::chrono::steady_clock::now().time_since_epoch().count();
-    layer.uuid = wxString::Format("layer_%lld", static_cast<long long>(baseId)).ToStdString();
-    layer.name = name;
-    scene.layers[layer.uuid] = layer;
-    cfg.SetCurrentLayer(name);
+    }
     ReloadLayers();
 }
 
@@ -331,40 +316,32 @@ void LayerPanel::OnDeleteLayer(wxCommandEvent&)
     int sel = list->GetSelectedRow();
     if (sel == wxNOT_FOUND)
         return;
-    wxString wname =
-        list->GetTextValue(sel, ColumnIndex(LayerColumn::Layer));
-    std::string name = wname.ToStdString();
+    const std::string uuid = LayerUuidForRow(sel);
+    auto &scene = (*configManager).GetScene();
+    auto layerIt = scene.layers.find(uuid);
+    if (uuid.empty() || layerIt == scene.layers.end()) {
+        wxMessageBox(_("Layer no longer exists."), _("Delete Layer"), wxOK | wxICON_ERROR, this);
+        return;
+    }
+    const std::string name = layerIt->second.name;
     if (name == DEFAULT_LAYER_NAME)
     {
         wxMessageBox(_("Cannot delete default layer."), _("Delete Layer"), wxOK | wxICON_ERROR, this);
         return;
     }
 
-    ConfigManager& cfg = (*configManager);
-    auto& scene = cfg.GetScene();
-    std::string layerUuid;
-    for (const auto& [uuid, layer] : scene.layers)
-        if (layer.name == name)
-        {
-            layerUuid = uuid;
-            break;
-        }
-
     bool empty = true;
-    for (const auto& [u, f] : scene.fixtures)
-        if (f.layer == name) { empty = false; break; }
-    if (empty)
-        for (const auto& [u, t] : scene.trusses)
-            if (t.layer == name) { empty = false; break; }
-    if (empty)
-        for (const auto& [u, o] : scene.sceneObjects)
-            if (o.layer == name) { empty = false; break; }
-    if (empty)
-        for (const auto& [u, s] : scene.supports)
-            if (s.layer == name) { empty = false; break; }
-    if (empty)
-        for (const auto& [u, g] : scene.groupObjects)
-            if (g.layer == name) { empty = false; break; }
+    auto contains = [&](const auto &container) {
+        for (const auto &[u, obj] : container) {
+            (void)u;
+            if (obj.layer == name)
+                return true;
+        }
+        return false;
+    };
+    empty = !(contains(scene.fixtures) || contains(scene.trusses) ||
+              contains(scene.sceneObjects) || contains(scene.supports) ||
+              contains(scene.groupObjects));
 
     if (!empty)
     {
@@ -374,72 +351,16 @@ void LayerPanel::OnDeleteLayer(wxCommandEvent&)
             return;
     }
 
-    cfg.PushUndoState("delete layer");
-
-    for (auto it = scene.fixtures.begin(); it != scene.fixtures.end();) {
-        if (it->second.layer == name)
-            it = scene.fixtures.erase(it);
-        else
-            ++it;
+    if (scene.layers.find(uuid) == scene.layers.end()) {
+        wxMessageBox(_("Layer no longer exists."), _("Delete Layer"), wxOK | wxICON_ERROR, this);
+        return;
     }
-    for (auto it = scene.trusses.begin(); it != scene.trusses.end();) {
-        if (it->second.layer == name)
-            it = scene.trusses.erase(it);
-        else
-            ++it;
+    auto result = layerdomain::DeleteLayer(*configManager, uuid);
+    if (result.status != layerdomain::LayerStatus::Success) {
+        wxMessageBox(Utf8ToWx(result.message.empty() ? layerdomain::StatusMessage(result.status) : result.message),
+                     _("Delete Layer"), wxOK | wxICON_ERROR, this);
+        return;
     }
-    for (auto it = scene.sceneObjects.begin(); it != scene.sceneObjects.end();) {
-        if (it->second.layer == name)
-            it = scene.sceneObjects.erase(it);
-        else
-            ++it;
-    }
-    for (auto it = scene.supports.begin(); it != scene.supports.end();) {
-        if (it->second.layer == name)
-            it = scene.supports.erase(it);
-        else
-            ++it;
-    }
-    for (auto it = scene.groupObjects.begin(); it != scene.groupObjects.end();) {
-        if (it->second.layer == name)
-            it = scene.groupObjects.erase(it);
-        else
-            ++it;
-    }
-
-    if (!layerUuid.empty())
-        scene.layers.erase(layerUuid);
-
-    auto hidden = cfg.GetHiddenLayers();
-    hidden.erase(name);
-    cfg.SetHiddenLayers(hidden);
-    if (cfg.GetCurrentLayer() == name)
-        cfg.SetCurrentLayer(DEFAULT_LAYER_NAME);
-
-    auto selFix = cfg.GetSelectedFixtures();
-    selFix.erase(std::remove_if(selFix.begin(), selFix.end(),
-                              [&](const std::string &u) {
-                                return scene.fixtures.find(u) ==
-                                       scene.fixtures.end();
-                              }),
-               selFix.end());
-    cfg.SetSelectedFixtures(selFix);
-    auto selTr = cfg.GetSelectedTrusses();
-    selTr.erase(std::remove_if(selTr.begin(), selTr.end(),
-                             [&](const std::string &u) {
-                               return scene.trusses.find(u) ==
-                                      scene.trusses.end();
-                             }),
-              selTr.end());
-    cfg.SetSelectedTrusses(selTr);
-    auto selObj = cfg.GetSelectedSceneObjects();
-    selObj.erase(std::remove_if(selObj.begin(), selObj.end(),
-                              [&](const std::string &u) {
-                                return scene.sceneObjects.find(u) ==
-                                       scene.sceneObjects.end();
-                              }),
-               selObj.end());
-    cfg.SetSelectedSceneObjects(selObj);
 
     ReloadLayers();
     if (FixtureTablePanel::Instance())
@@ -448,10 +369,9 @@ void LayerPanel::OnDeleteLayer(wxCommandEvent&)
         TrussTablePanel::Instance()->ReloadData();
     if (SceneObjectTablePanel::Instance())
         SceneObjectTablePanel::Instance()->ReloadData();
-    if (Viewer3DPanel::Instance()) {
-        Viewer3DPanel::Instance()->UpdateScene();
-        Viewer3DPanel::Instance()->Refresh();
-    }
+    if (HoistTablePanel::Instance())
+        HoistTablePanel::Instance()->ReloadData();
+    RefreshVisibleViewers();
 }
 
 // Renames the activated layer when the layer-name column is activated.
@@ -466,61 +386,29 @@ void LayerPanel::OnRenameLayer(wxDataViewEvent &evt) {
     if (idx == wxNOT_FOUND)
         return;
 
-  wxString oldW = list->GetTextValue(idx, ColumnIndex(LayerColumn::Layer));
-    std::string oldName = oldW.ToStdString();
-  if (oldName == DEFAULT_LAYER_NAME) {
-    wxMessageBox(_("Cannot rename default layer."), _("Rename Layer"),
-                 wxOK | wxICON_ERROR, this);
+    const std::string uuid = LayerUuidForRow(static_cast<int>(idx));
+    auto &scene = (*configManager).GetScene();
+    auto layerIt = scene.layers.find(uuid);
+    if (uuid.empty() || layerIt == scene.layers.end())
+        return;
+    const std::string oldName = layerIt->second.name;
+    if (oldName == DEFAULT_LAYER_NAME) {
+        wxMessageBox(_("Cannot rename default layer."), _("Rename Layer"),
+                     wxOK | wxICON_ERROR, this);
         return;
     }
 
-    wxTextEntryDialog dlg(this, _("Enter new layer name:"), _("Rename Layer"), oldW);
+    wxTextEntryDialog dlg(this, _("Enter new layer name:"), _("Rename Layer"), Utf8ToWx(oldName));
     if (dlg.ShowModal() != wxID_OK)
         return;
-    std::string newName = dlg.GetValue().ToStdString();
-    if (newName.empty() || newName == DEFAULT_LAYER_NAME || newName == oldName)
+    auto result = layerdomain::RenameLayer(*configManager, uuid, WxToUtf8(dlg.GetValue()));
+    if (result.status == layerdomain::LayerStatus::NoChange)
         return;
-
-    ConfigManager& cfg = (*configManager);
-    auto& scene = cfg.GetScene();
-
-    // check duplicate
-    for (const auto& [u, layer] : scene.layers)
-        if (layer.name == newName)
-        {
-            wxMessageBox(_("Layer already exists."), _("Rename Layer"), wxOK | wxICON_ERROR, this);
-            return;
-        }
-
-    std::string layerUuid;
-    for (const auto& [uuid, layer] : scene.layers)
-        if (layer.name == oldName)
-        {
-            layerUuid = uuid;
-            break;
-        }
-
-    cfg.PushUndoState("rename layer");
-
-    if (!layerUuid.empty())
-        scene.layers[layerUuid].name = newName;
-    auto rename = [&](auto& container){
-        for (auto& [u, obj] : container)
-            if (obj.layer == oldName)
-                obj.layer = newName;
-    };
-    rename(scene.fixtures);
-    rename(scene.trusses);
-    rename(scene.sceneObjects);
-    rename(scene.supports);
-    rename(scene.groupObjects);
-
-    auto hidden = cfg.GetHiddenLayers();
-    if (hidden.erase(oldName))
-        hidden.insert(newName);
-    cfg.SetHiddenLayers(hidden);
-    if (cfg.GetCurrentLayer() == oldName)
-        cfg.SetCurrentLayer(newName);
+    if (result.status != layerdomain::LayerStatus::Success) {
+        wxMessageBox(Utf8ToWx(result.message.empty() ? layerdomain::StatusMessage(result.status) : result.message),
+                     _("Rename Layer"), wxOK | wxICON_ERROR, this);
+        return;
+    }
 
     ReloadLayers();
     if (FixtureTablePanel::Instance())
@@ -529,8 +417,7 @@ void LayerPanel::OnRenameLayer(wxDataViewEvent &evt) {
         TrussTablePanel::Instance()->ReloadData();
     if (SceneObjectTablePanel::Instance())
         SceneObjectTablePanel::Instance()->ReloadData();
-    if (Viewer3DPanel::Instance()) {
-        Viewer3DPanel::Instance()->UpdateScene();
-        Viewer3DPanel::Instance()->Refresh();
-    }
+    if (HoistTablePanel::Instance())
+        HoistTablePanel::Instance()->ReloadData();
+    RefreshVisibleViewers();
 }

--- a/gui/layerpanel.h
+++ b/gui/layerpanel.h
@@ -20,6 +20,8 @@
 #include <wx/wx.h>
 #include <wx/dataview.h>
 #include <wx/colordlg.h>
+#include <string>
+#include <vector>
 
 class ConfigManager;
 
@@ -39,7 +41,9 @@ private:
     void OnAddLayer(wxCommandEvent& evt);
     void OnDeleteLayer(wxCommandEvent& evt);
     void OnRenameLayer(wxDataViewEvent& evt);
+    std::string LayerUuidForRow(int row) const;
     wxDataViewListCtrl* list = nullptr;
+    std::vector<std::string> rowLayerUuids;
     static LayerPanel* s_instance;
     ConfigManager* configManager = nullptr;
 };

--- a/gui/wx_text_utils.cpp
+++ b/gui/wx_text_utils.cpp
@@ -1,0 +1,16 @@
+#include "wx_text_utils.h"
+
+#include "utf8_utils.h"
+
+// Converts wxWidgets text to the application UTF-8 string contract.
+std::string WxToUtf8(const wxString &text) {
+  const wxScopedCharBuffer buffer = text.ToUTF8();
+  return buffer ? std::string(buffer.data(), buffer.length()) : std::string();
+}
+
+// Converts validated UTF-8 application text into wxWidgets text.
+wxString Utf8ToWx(std::string_view text) {
+  if (!IsValidUtf8(text))
+    return wxString();
+  return wxString::FromUTF8(text.data(), text.size());
+}

--- a/gui/wx_text_utils.cpp
+++ b/gui/wx_text_utils.cpp
@@ -2,15 +2,19 @@
 
 #include "utf8_utils.h"
 
+namespace wxtext {
+
 // Converts wxWidgets text to the application UTF-8 string contract.
-std::string WxToUtf8(const wxString &text) {
+std::string ToUtf8(const wxString &text) {
   const wxScopedCharBuffer buffer = text.ToUTF8();
   return buffer ? std::string(buffer.data(), buffer.length()) : std::string();
 }
 
 // Converts validated UTF-8 application text into wxWidgets text.
-wxString Utf8ToWx(std::string_view text) {
+wxString FromUtf8(std::string_view text) {
   if (!IsValidUtf8(text))
     return wxString();
   return wxString::FromUTF8(text.data(), text.size());
 }
+
+} // namespace wxtext

--- a/gui/wx_text_utils.h
+++ b/gui/wx_text_utils.h
@@ -4,5 +4,9 @@
 #include <string_view>
 #include <wx/string.h>
 
-std::string WxToUtf8(const wxString &text);
-wxString Utf8ToWx(std::string_view text);
+namespace wxtext {
+
+std::string ToUtf8(const wxString &text);
+wxString FromUtf8(std::string_view text);
+
+} // namespace wxtext

--- a/gui/wx_text_utils.h
+++ b/gui/wx_text_utils.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <wx/string.h>
+
+std::string WxToUtf8(const wxString &text);
+wxString Utf8ToWx(std::string_view text);

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -26,6 +26,8 @@
 #include "gdtfdictionary.h"
 #include "gdtfloader.h"
 #include "logger.h"
+#include "layer_service.h"
+#include "utf8_utils.h"
 #include "matrixutils.h"
 #include "mvr_preferences.h"
 #include "primitive_model_resources.h"
@@ -4193,6 +4195,15 @@ bool MvrExporter::ExportToFile(const std::string &filePath,
     ++plannedArchiveEntries[entry.archivePath];
   }
 
+  const auto layerValidation = layerdomain::ValidateSceneLayers(scene);
+  if (layerValidation.status != layerdomain::LayerStatus::Success) {
+    zip.Close();
+    return failExport("ValidateLayers", "GeneralSceneDescription.xml", {},
+                      layerValidation.message.empty()
+                          ? layerdomain::StatusMessage(layerValidation.status)
+                          : layerValidation.message);
+  }
+
   if (!ValidateMvr16Export(doc, gdtfArchiveByObjectUuid, plannedArchiveEntries,
                            &m_exportWarnings)) {
     zip.Close();
@@ -4203,6 +4214,17 @@ bool MvrExporter::ExportToFile(const std::string &filePath,
   tinyxml2::XMLPrinter printer;
   doc.Print(&printer);
   std::string xmlData = printer.CStr();
+  if (!IsValidUtf8(xmlData)) {
+    zip.Close();
+    return failExport("ValidateXmlUtf8", "GeneralSceneDescription.xml", {},
+                      "serialized XML is not valid UTF-8");
+  }
+  tinyxml2::XMLDocument strictParse;
+  if (strictParse.Parse(xmlData.c_str(), xmlData.size()) != tinyxml2::XML_SUCCESS) {
+    zip.Close();
+    return failExport("ValidateXmlParse", "GeneralSceneDescription.xml", {},
+                      "serialized XML failed strict parse");
+  }
 
   std::unordered_set<std::string> writtenArchiveEntries;
   {

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -3403,7 +3403,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
     if (!IsValidUtf8(layerStr)) {
       const auto repairedLayerName = RepairWindows1252AsUtf8(layerStr);
       if (repairedLayerName) {
-        LogMessage(Logger::Level::Warning,
+        LogMessage(Logger::Level::Warn,
                    "Repaired legacy Windows-1252 layer name bytes at Layer uuid=" +
                        std::string(layer->Attribute("uuid") ? layer->Attribute("uuid") : "") +
                        " offset=" + std::to_string(ValidateUtf8(layerStr).errorOffset));
@@ -3451,7 +3451,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
 
   const auto reconcileResult = layerdomain::ReconcileLegacyLayers(scene);
   if (reconcileResult.status == layerdomain::LayerStatus::Success) {
-    LogMessage(Logger::Level::Warning,
+    LogMessage(Logger::Level::Warn,
                "Reconciled legacy layer metadata: " + reconcileResult.message);
   }
 

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -33,6 +33,8 @@
 #include "gdtf_fixture_category.h"
 #include "gdtf_import_matching.h"
 #include "gdtfloader.h"
+#include "layer_service.h"
+#include "utf8_utils.h"
 #include "groupobject.h"
 #include "matrixutils.h"
 #include "primitive_model_resources.h"
@@ -3398,6 +3400,22 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
        layer; layer = layer->NextSiblingElement("Layer")) {
     const char *layerName = layer->Attribute("name");
     std::string layerStr = layerName ? layerName : "";
+    if (!IsValidUtf8(layerStr)) {
+      const auto repairedLayerName = RepairWindows1252AsUtf8(layerStr);
+      if (repairedLayerName) {
+        LogMessage(Logger::Level::Warning,
+                   "Repaired legacy Windows-1252 layer name bytes at Layer uuid=" +
+                       std::string(layer->Attribute("uuid") ? layer->Attribute("uuid") : "") +
+                       " offset=" + std::to_string(ValidateUtf8(layerStr).errorOffset));
+        layerStr = *repairedLayerName;
+      } else {
+        LogMessage(Logger::Level::Error,
+                   "Rejected invalid UTF-8 layer name at Layer uuid=" +
+                       std::string(layer->Attribute("uuid") ? layer->Attribute("uuid") : "") +
+                       " offset=" + std::to_string(ValidateUtf8(layerStr).errorOffset));
+        layerStr.clear();
+      }
+    }
     bool isDefaultLayer = layerStr.empty();
 
     tinyxml2::XMLElement *childList = layer->FirstChildElement("ChildList");
@@ -3429,6 +3447,12 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
       }
       scene.layers[l.uuid] = l;
     }
+  }
+
+  const auto reconcileResult = layerdomain::ReconcileLegacyLayers(scene);
+  if (reconcileResult.status == layerdomain::LayerStatus::Success) {
+    LogMessage(Logger::Level::Warning,
+               "Reconciled legacy layer metadata: " + reconcileResult.message);
   }
 
   if (preservedGroupObjectCount > 0) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1712,3 +1712,13 @@ if(WIN32)
     target_link_libraries(mvr_xchange_protocol_test PRIVATE iphlpapi ws2_32)
 endif()
 add_test(NAME MvrXchangeProtocol COMMAND mvr_xchange_protocol_test)
+
+add_executable(layer_service_utf8_test layer_service_utf8_test.cpp
+               ../core/layer_service.cpp
+               ../core/configservices.cpp
+               ../core/utf8_utils.cpp
+               ../core/uuidutils.cpp
+               ../models/layer.cpp)
+target_include_directories(layer_service_utf8_test PRIVATE ../core ../models)
+target_link_libraries(layer_service_utf8_test PRIVATE ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
+add_test(NAME LayerServiceUtf8 COMMAND layer_service_utf8_test)

--- a/tests/layer_service_utf8_test.cpp
+++ b/tests/layer_service_utf8_test.cpp
@@ -1,0 +1,65 @@
+#include "layer_service.h"
+#include "utf8_utils.h"
+
+#include <cassert>
+#include <string>
+
+namespace {
+
+// Builds a minimal scene with one layer and one support assigned to it.
+MvrScene MakeSceneWithSupportLayer(const std::string &uuid,
+                                   const std::string &name) {
+  MvrScene scene;
+  Layer layer;
+  layer.uuid = uuid;
+  layer.name = name;
+  scene.layers[uuid] = layer;
+  Support support;
+  support.uuid = "support-1";
+  support.layer = name;
+  scene.supports[support.uuid] = support;
+  return scene;
+}
+
+} // namespace
+
+// Verifies UTF-8 validation and controlled Windows-1252 repair.
+int main() {
+  assert(IsValidUtf8("Iluminación"));
+  assert(IsValidUtf8("Vídeo"));
+  assert(IsValidUtf8("Música"));
+  assert(IsValidUtf8("照明"));
+
+  const std::string invalid = std::string("rig Iluminaci") + char(0xF3) + "n";
+  assert(!IsValidUtf8(invalid));
+  const auto repaired = RepairWindows1252AsUtf8(invalid);
+  assert(repaired.has_value());
+  assert(*repaired == "rig Iluminación");
+  assert(RepairWindows1252AsUtf8("rig Iluminación").value() ==
+         "rig Iluminación");
+
+  MvrScene scene = MakeSceneWithSupportLayer(
+      "f806f881-7e6d-538f-bc17-e2a08ec678f1", invalid);
+  Layer valid;
+  valid.uuid = "1e4e210c-6fe9-579c-a6f5-e4ba379b368e";
+  valid.name = "rig Iluminación";
+  scene.layers[valid.uuid] = valid;
+
+  const auto reconcile = layerdomain::ReconcileLegacyLayers(scene);
+  assert(reconcile.status == layerdomain::LayerStatus::Success);
+  assert(layerdomain::ValidateSceneLayers(scene).status ==
+         layerdomain::LayerStatus::Success);
+  assert(scene.layers.at("f806f881-7e6d-538f-bc17-e2a08ec678f1").name ==
+         "rig Iluminación");
+  assert(scene.layers.at("1e4e210c-6fe9-579c-a6f5-e4ba379b368e").name ==
+         "rig Iluminación (Recovered 2)");
+
+  const auto entries = layerdomain::EnumerateLayers(scene);
+  bool foundSupportLayer = false;
+  for (const auto &entry : entries) {
+    if (entry.name == "rig Iluminación")
+      foundSupportLayer = true;
+  }
+  assert(foundSupportLayer);
+  return 0;
+}

--- a/tests/layer_visibility_state_test.cpp
+++ b/tests/layer_visibility_state_test.cpp
@@ -10,8 +10,12 @@ int main() {
   assert(!layers.IsLayerVisible("Layer A"));
   assert(layers.IsLayerVisible("Layer B"));
 
-  layers.SetLayerColor(scene, "Layer A", "#ff0000");
-  assert(layers.GetLayerColor(scene, "Layer A").value() == "#ff0000");
+  Layer layer;
+  layer.uuid = "11111111-1111-1111-1111-111111111111";
+  layer.name = "Layer A";
+  scene.layers[layer.uuid] = layer;
+  layers.SetLayerColor(scene, "Layer A", "#FF0000");
+  assert(layers.GetLayerColor(scene, "Layer A").value() == "#FF0000");
 
   layers.SetCurrentLayer("Layer B");
   assert(layers.GetCurrentLayer() == "Layer B");


### PR DESCRIPTION
### Motivation
- Existing layer workflows used locale-dependent wxString conversions and display names as primary keys, which produced malformed UTF-8 bytes, undeletable rows, and non-deterministic mutations when projects contained legacy corrupted bytes (e.g. Windows-1252 0xF3).
- The change centralizes validation and mutation logic to ensure all persisted/domain text is strict UTF-8, layer edits are selected by stable UUIDs, and layer mutations are atomic and undoable.
- Export/import and project-save needed stricter preflight and deterministic recovery so no saved archive contains XML that a strict UTF-8 parser rejects or silently loses object data.

### Description
- Added a small UTF-8 utility module (`core/utf8_utils.{h,cpp}`) and a wxWidgets adapter (`gui/wx_text_utils.{h,cpp}`) providing validation, narrow Windows-1252 repair, and safe wx <-> UTF-8 boundaries; removed ad-hoc `ToStdString()` uses in the Layers GUI.
- Introduced a GUI-independent layer domain service (`core/layer_service.{h,cpp}`) that enumerates canonical layers, performs UUID-targeted `Create/Rename/Delete/Color/Visibility/SetCurrent` operations, returns typed results and change flags, validates invariants, and reconciles legacy corrupted layer names deterministically.
- Updated the Layers UI (`gui/layerpanel.{h,cpp}`) to bind visible rows to stable layer UUIDs, call `layerdomain` service APIs (instead of resolving by displayed name), use explicit UTF-8 adapters for text, and refresh dependent tables/viewers after mutations; removed unsafe ad-hoc ID generation.
- Extended undo/redo snapshots (`core/configservices.*`, `core/configmanager.cpp`) to include hidden-layer and current-layer state so Undo/Redo restores complete layer-related user-visible state, and hardened MVR import/export (`mvr/mvrimporter.cpp`, `mvr/mvrexporter.cpp`) to pre-validate/repair layers and to strict-parse serialized `GeneralSceneDescription.xml` as UTF-8 before committing the archive.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed to verify module boundaries and scope rules.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed to verify no forbidden ConfigManager usage in GUI code.
- Ran `git diff --check` (whitespace/patch checks) and it passed with no problems.
- Added a focused regression/unit test `tests/layer_service_utf8_test.cpp` (synthesizes the `rig Iluminaci\xF3n` case, verifies repair to `rig Iluminación`, duplicate recovery suffix, UTF-8 round-trips, and support-layer enumeration) and wired it into `tests/CMakeLists.txt`, but a local build of that test failed to configure in this container because wxWidgets development libraries are not available here; the test is present and expected to build and pass in CI or developer machines with wxWidgets installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5737fc890483248ca59c54f699d558)