### PR TITLE
Add shared Hang Position editor for fixtures, trusses and hoists

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -14,6 +14,7 @@ Changes since **v1.4.0**.
 
 ## Improvements
 
+- Added a shared Hang Position editor for fixtures, trusses, and hoists so users can select existing positions, add missing ones, rename positions across all affected table rows, or remove positions from one dialog.
 - Expanded desktop Spanish localization coverage for remaining table headers, layer and summary controls, rigging weight headers, GDTF search, Create from Text, MVR import, GDTF download queue, primitive object, console help, print, and save-confirmation dialogs, and unit-aware labels so unit changes preserve translated UI text.
 - Expanded Spanish localization coverage for core creation and selection dialogs, About dialog text, GDTF Share login labels, and related startup translation checks while keeping imported names and user-entered data unchanged.
 - Expanded Preferences localization coverage for Rider Import, Units, Updates, MVR export, and 3D Viewer settings while preserving stable configuration values and selection-index based behavior.

--- a/docs/user/features.md
+++ b/docs/user/features.md
@@ -98,6 +98,7 @@ Additional safeguards include:
 ### Data tables
 
 - Dedicated tables for fixtures, trusses, hoists, and objects.
+- Fixture, truss, and hoist Hang Position cells use the shared Hang Position dialog, which lists existing MVR positions and can add, rename, or delete positions across affected rigging items when confirmed.
 - Add Fixture, Add Truss, and Add Object offer a continuous placement mode that
   disables the fixed quantity field and attaches one new element at a time to
   the pointer in the visible 2D or 3D viewer. Left-click confirms each element

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -50,6 +50,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtf/gdtf_physical_properties_panel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtf/gdtf_type_identity_panel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtfsearchdialog.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/hang_position_dialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/highlight_status_bar.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/hoist_load_limit_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/hoist_load_recalculation_prompt.cpp

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -31,6 +31,7 @@
 #include "gdtfloader.h"
 #include "guiconfigservices.h"
 #include "hoist_load_recalculation_prompt.h"
+#include "hang_position_dialog.h"
 #include "layerpanel.h"
 #include "mainwindow.h"
 #include "matrixutils.h"
@@ -950,6 +951,24 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
     const auto updateType = UpdateTypeForColumn(col);
     UpdateSceneData(true, updateType);
     RefreshViewersForFixtureUpdate(updateType);
+    return;
+  }
+
+  if (*namedColumn == FixtureTableColumns::Column::HangPosition) {
+    std::vector<unsigned int> selectedRows;
+    for (const auto &it : selections) {
+      const int row = table->ItemToRow(it);
+      if (row != wxNOT_FOUND)
+        selectedRows.push_back(static_cast<unsigned int>(row));
+    }
+
+    HangPositionDialogResult result;
+    if (!ShowHangPositionDialog(this, current.GetString(), &result))
+      return;
+    ApplySharedHangPositionChanges(result, true, selectedRows, false, {}, false,
+                                    {});
+    ResyncRows(oldOrder, selectedUuids);
+    RefreshViewersForFixtureUpdate(SceneDataUpdateType::kMetadataOnly);
     return;
   }
 

--- a/gui/hang_position_dialog.cpp
+++ b/gui/hang_position_dialog.cpp
@@ -1,0 +1,341 @@
+#include "hang_position_dialog.h"
+
+#include "fixturetable/fixture_table_columns.h"
+#include "fixturetablepanel.h"
+#include "hoisttablepanel.h"
+#include "table_column_indices.h"
+#include "trusstablepanel.h"
+
+#include <wx/button.h>
+#include <wx/dataview.h>
+#include <wx/dialog.h>
+#include <wx/listbox.h>
+#include <wx/msgdlg.h>
+#include <wx/stattext.h>
+#include <wx/sizer.h>
+#include <wx/textdlg.h>
+
+#include <algorithm>
+#include <set>
+
+namespace {
+
+// Returns the model column that stores fixture hang position values.
+constexpr int FixtureHangPositionColumn() {
+  return FixtureTableColumns::ToIndex(FixtureTableColumns::Column::HangPosition);
+}
+
+// Returns the model column that stores truss hang position values.
+constexpr int TrussHangPositionColumn() {
+  return TableColumnIndices::ToIndex(TrussTableColumns::Column::HangPosition);
+}
+
+// Returns the model column that stores hoist hang position values.
+constexpr int HoistHangPositionColumn() {
+  return TableColumnIndices::ToIndex(HoistTableColumns::Column::HangPosition);
+}
+
+// Normalizes a hang position entered by the user.
+wxString NormalizeHangPosition(const wxString &value) {
+  wxString normalized = value;
+  return normalized.Trim(true).Trim(false);
+}
+
+// Adds non-empty hang positions from a table column to the shared set.
+void CollectFromTable(wxDataViewListCtrl *table, int column,
+                      std::set<wxString> *positions) {
+  if (!table || !positions)
+    return;
+
+  const unsigned int count = table->GetItemCount();
+  for (unsigned int row = 0; row < count; ++row) {
+    wxVariant value;
+    table->GetValue(value, row, column);
+    wxString position = NormalizeHangPosition(value.GetString());
+    if (!position.empty())
+      positions->insert(position);
+  }
+}
+
+// Collects hang positions currently visible in all open rigging tables.
+std::vector<wxString> CollectSharedHangPositions() {
+  std::set<wxString> positions;
+  if (auto *panel = FixtureTablePanel::Instance())
+    CollectFromTable(panel->GetTableCtrl(), FixtureHangPositionColumn(),
+                     &positions);
+  if (auto *panel = TrussTablePanel::Instance())
+    CollectFromTable(panel->GetTableCtrl(), TrussHangPositionColumn(),
+                     &positions);
+  if (auto *panel = HoistTablePanel::Instance())
+    CollectFromTable(panel->GetTableCtrl(), HoistHangPositionColumn(),
+                     &positions);
+  return {positions.begin(), positions.end()};
+}
+
+// Sets the list box contents and preserves the requested selection when possible.
+void PopulateList(wxListBox *list, const std::vector<wxString> &positions,
+                  const wxString &selection) {
+  list->Clear();
+  for (const wxString &position : positions)
+    list->Append(position);
+  const int selectedIndex = list->FindString(selection, true);
+  if (selectedIndex != wxNOT_FOUND)
+    list->SetSelection(selectedIndex);
+  else if (!positions.empty())
+    list->SetSelection(0);
+}
+
+// Replaces table values using accepted rename and delete operations.
+bool ApplyDictionaryChanges(wxDataViewListCtrl *table, int column,
+                            const HangPositionDialogResult &result) {
+  if (!table)
+    return false;
+
+  bool changed = false;
+  const unsigned int count = table->GetItemCount();
+  for (unsigned int row = 0; row < count; ++row) {
+    wxVariant current;
+    table->GetValue(current, row, column);
+    const wxString oldValue = NormalizeHangPosition(current.GetString());
+    wxString newValue = oldValue;
+
+    auto renameIt = result.renamedPositions.find(oldValue);
+    if (renameIt != result.renamedPositions.end())
+      newValue = renameIt->second;
+    if (result.deletedPositions.find(oldValue) != result.deletedPositions.end())
+      newValue.clear();
+
+    if (newValue != oldValue) {
+      table->SetValue(wxVariant(newValue), row, column);
+      changed = true;
+    }
+  }
+  return changed;
+}
+
+// Sets selected rows in a table to the selected hang position.
+bool ApplySelectedRows(wxDataViewListCtrl *table, int column,
+                       const std::vector<unsigned int> &rows,
+                       const wxString &selectedName) {
+  if (!table)
+    return false;
+
+  bool changed = false;
+  const unsigned int count = table->GetItemCount();
+  for (unsigned int row : rows) {
+    if (row >= count)
+      continue;
+    wxVariant current;
+    table->GetValue(current, row, column);
+    if (NormalizeHangPosition(current.GetString()) != selectedName) {
+      table->SetValue(wxVariant(selectedName), row, column);
+      changed = true;
+    }
+  }
+  return changed;
+}
+
+class HangPositionDialog : public wxDialog {
+public:
+  HangPositionDialog(wxWindow *parent, const wxString &currentName);
+  HangPositionDialogResult Result() const;
+
+private:
+  void OnAdd(wxCommandEvent &event);
+  void OnRename(wxCommandEvent &event);
+  void OnDelete(wxCommandEvent &event);
+
+  wxListBox *positionList = nullptr;
+  std::vector<wxString> positions;
+  std::map<wxString, wxString> renamedPositions;
+  std::set<wxString> deletedPositions;
+};
+
+// Builds the shared hang position editor dialog.
+HangPositionDialog::HangPositionDialog(wxWindow *parent,
+                                       const wxString &currentName)
+    : wxDialog(parent, wxID_ANY, _("Hang Position"), wxDefaultPosition,
+               wxSize(420, 360), wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER),
+      positions(CollectSharedHangPositions()) {
+  const wxString normalizedCurrent = NormalizeHangPosition(currentName);
+  if (!normalizedCurrent.empty() &&
+      std::find(positions.begin(), positions.end(), normalizedCurrent) ==
+          positions.end())
+    positions.push_back(normalizedCurrent);
+  std::sort(positions.begin(), positions.end());
+
+  auto *mainSizer = new wxBoxSizer(wxVERTICAL);
+  mainSizer->Add(new wxStaticText(this, wxID_ANY,
+                                  _("Select or manage a shared hang position:")),
+                 0, wxALL, 8);
+
+  positionList = new wxListBox(this, wxID_ANY);
+  PopulateList(positionList, positions, normalizedCurrent);
+  mainSizer->Add(positionList, 1, wxEXPAND | wxLEFT | wxRIGHT, 8);
+
+  auto *buttonSizer = new wxBoxSizer(wxHORIZONTAL);
+  auto *addButton = new wxButton(this, wxID_ADD, _("Add"));
+  auto *renameButton = new wxButton(this, wxID_ANY, _("Rename"));
+  auto *deleteButton = new wxButton(this, wxID_DELETE, _("Delete"));
+  buttonSizer->Add(addButton, 0, wxRIGHT, 6);
+  buttonSizer->Add(renameButton, 0, wxRIGHT, 6);
+  buttonSizer->Add(deleteButton, 0);
+  mainSizer->Add(buttonSizer, 0, wxALL, 8);
+
+  mainSizer->Add(CreateSeparatedButtonSizer(wxOK | wxCANCEL), 0,
+                 wxEXPAND | wxALL, 8);
+  SetSizerAndFit(mainSizer);
+
+  addButton->Bind(wxEVT_BUTTON, &HangPositionDialog::OnAdd, this);
+  renameButton->Bind(wxEVT_BUTTON, &HangPositionDialog::OnRename, this);
+  deleteButton->Bind(wxEVT_BUTTON, &HangPositionDialog::OnDelete, this);
+}
+
+// Returns the dialog result after the user accepts the changes.
+HangPositionDialogResult HangPositionDialog::Result() const {
+  HangPositionDialogResult result;
+  const int selection = positionList->GetSelection();
+  if (selection != wxNOT_FOUND)
+    result.selectedName = positionList->GetString(selection);
+  result.renamedPositions = renamedPositions;
+  result.deletedPositions = deletedPositions;
+  return result;
+}
+
+// Adds a new hang position to the shared list.
+void HangPositionDialog::OnAdd(wxCommandEvent &event) {
+  wxTextEntryDialog dialog(this, _("Enter hang position name:"),
+                           _("Add Hang Position"));
+  if (dialog.ShowModal() != wxID_OK)
+    return;
+
+  const wxString value = NormalizeHangPosition(dialog.GetValue());
+  if (value.empty())
+    return;
+  if (std::find(positions.begin(), positions.end(), value) == positions.end()) {
+    positions.push_back(value);
+    std::sort(positions.begin(), positions.end());
+  }
+  deletedPositions.erase(value);
+  PopulateList(positionList, positions, value);
+}
+
+// Renames the currently selected hang position in the shared list.
+void HangPositionDialog::OnRename(wxCommandEvent &event) {
+  const int selection = positionList->GetSelection();
+  if (selection == wxNOT_FOUND)
+    return;
+
+  const wxString oldValue = positionList->GetString(selection);
+  wxTextEntryDialog dialog(this, _("Enter hang position name:"),
+                           _("Rename Hang Position"), oldValue);
+  if (dialog.ShowModal() != wxID_OK)
+    return;
+
+  const wxString newValue = NormalizeHangPosition(dialog.GetValue());
+  if (newValue.empty() || newValue == oldValue)
+    return;
+
+  positions.erase(std::remove(positions.begin(), positions.end(), oldValue),
+                  positions.end());
+  if (std::find(positions.begin(), positions.end(), newValue) == positions.end())
+    positions.push_back(newValue);
+  std::sort(positions.begin(), positions.end());
+
+  for (auto &rename : renamedPositions) {
+    if (rename.second == oldValue)
+      rename.second = newValue;
+  }
+  renamedPositions[oldValue] = newValue;
+  deletedPositions.erase(oldValue);
+  deletedPositions.erase(newValue);
+  PopulateList(positionList, positions, newValue);
+}
+
+// Deletes the currently selected hang position from the shared list.
+void HangPositionDialog::OnDelete(wxCommandEvent &event) {
+  const int selection = positionList->GetSelection();
+  if (selection == wxNOT_FOUND)
+    return;
+
+  const wxString oldValue = positionList->GetString(selection);
+  if (wxMessageBox(_("Delete this hang position from all affected items?"),
+                   _("Delete Hang Position"),
+                   wxYES_NO | wxNO_DEFAULT | wxICON_QUESTION, this) != wxYES)
+    return;
+
+  positions.erase(std::remove(positions.begin(), positions.end(), oldValue),
+                  positions.end());
+  renamedPositions.erase(oldValue);
+  for (auto it = renamedPositions.begin(); it != renamedPositions.end();) {
+    if (it->second == oldValue) {
+      deletedPositions.insert(it->first);
+      it = renamedPositions.erase(it);
+    } else {
+      ++it;
+    }
+  }
+  deletedPositions.insert(oldValue);
+  PopulateList(positionList, positions, wxString());
+}
+
+} // namespace
+
+// Shows the shared hang position editor and returns accepted changes.
+bool ShowHangPositionDialog(wxWindow *parent, const wxString &currentName,
+                            HangPositionDialogResult *result) {
+  HangPositionDialog dialog(parent, currentName);
+  if (dialog.ShowModal() != wxID_OK)
+    return false;
+  if (result)
+    *result = dialog.Result();
+  return true;
+}
+
+// Applies accepted hang position changes to all open rigging tables.
+void ApplySharedHangPositionChanges(
+    const HangPositionDialogResult &result, bool updateFixtures,
+    const std::vector<unsigned int> &fixtureRows, bool updateTrusses,
+    const std::vector<unsigned int> &trussRows, bool updateHoists,
+    const std::vector<unsigned int> &hoistRows) {
+  bool fixtureChanged = false;
+  bool trussChanged = false;
+  bool hoistChanged = false;
+
+  if (auto *panel = FixtureTablePanel::Instance()) {
+    auto *table = panel->GetTableCtrl();
+    fixtureChanged =
+        ApplyDictionaryChanges(table, FixtureHangPositionColumn(), result);
+    if (updateFixtures)
+      fixtureChanged = ApplySelectedRows(table, FixtureHangPositionColumn(),
+                                         fixtureRows, result.selectedName) ||
+                       fixtureChanged;
+    if (fixtureChanged)
+      panel->UpdateSceneData(true,
+                             FixtureTablePanel::SceneDataUpdateType::kMetadataOnly);
+  }
+
+  if (auto *panel = TrussTablePanel::Instance()) {
+    auto *table = panel->GetTableCtrl();
+    trussChanged = ApplyDictionaryChanges(table, TrussHangPositionColumn(),
+                                          result);
+    if (updateTrusses)
+      trussChanged = ApplySelectedRows(table, TrussHangPositionColumn(), trussRows,
+                                       result.selectedName) ||
+                     trussChanged;
+    if (trussChanged)
+      panel->UpdateSceneData();
+  }
+
+  if (auto *panel = HoistTablePanel::Instance()) {
+    auto *table = panel->GetTableCtrl();
+    hoistChanged = ApplyDictionaryChanges(table, HoistHangPositionColumn(),
+                                          result);
+    if (updateHoists)
+      hoistChanged = ApplySelectedRows(table, HoistHangPositionColumn(), hoistRows,
+                                       result.selectedName) ||
+                     hoistChanged;
+    if (hoistChanged)
+      panel->UpdateSceneData();
+  }
+}

--- a/gui/hang_position_dialog.h
+++ b/gui/hang_position_dialog.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <wx/string.h>
+#include <wx/window.h>
+
+#include <map>
+#include <set>
+#include <vector>
+
+struct HangPositionDialogResult {
+  wxString selectedName;
+  std::map<wxString, wxString> renamedPositions;
+  std::set<wxString> deletedPositions;
+};
+
+bool ShowHangPositionDialog(wxWindow *parent, const wxString &currentName,
+                            HangPositionDialogResult *result);
+void ApplySharedHangPositionChanges(
+    const HangPositionDialogResult &result, bool updateFixtures,
+    const std::vector<unsigned int> &fixtureRows, bool updateTrusses,
+    const std::vector<unsigned int> &trussRows, bool updateHoists,
+    const std::vector<unsigned int> &hoistRows);

--- a/gui/hoisttablepanel.cpp
+++ b/gui/hoisttablepanel.cpp
@@ -25,6 +25,7 @@
 #include "dummyprofilelibrary.h"
 #include "editable_focus_utils.h"
 #include "guiconfigservices.h"
+#include "hang_position_dialog.h"
 #include "hoist_load_recalculation_prompt.h"
 #include "hoist_weight_distribution.h"
 #include "layerpanel.h"
@@ -829,6 +830,21 @@ void HoistTablePanel::OnContextMenu(wxDataViewEvent &event) {
   wxString value;
   if (*namedColumn == HoistColumn::Load) {
     value = current.GetString().Trim(true).Trim(false);
+  } else if (*namedColumn == HoistColumn::HangPosition) {
+    std::vector<unsigned int> selectedRows;
+    for (const auto &it : selections) {
+      const int row = table->ItemToRow(it);
+      if (row != wxNOT_FOUND)
+        selectedRows.push_back(static_cast<unsigned int>(row));
+    }
+
+    HangPositionDialogResult result;
+    if (!ShowHangPositionDialog(this, current.GetString(), &result))
+      return;
+    ApplySharedHangPositionChanges(result, false, {}, false, {}, true,
+                                    selectedRows);
+    ResyncRows(oldOrder, selectedUuids);
+    return;
   } else {
     wxTextEntryDialog dlg(this, _("Edit value:"), columnLabels[col],
                           current.GetString());

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -22,6 +22,7 @@
 #include "configmanager.h"
 #include "selection_origin_token.h"
 #include "guiconfigservices.h"
+#include "hang_position_dialog.h"
 #include "consolepanel.h"
 #include "hoist_load_recalculation_prompt.h"
 #include "layerpanel.h"
@@ -633,6 +634,23 @@ void TrussTablePanel::OnContextMenu(wxDataViewEvent &event) {
         }
         return;
     }
+
+  if (*namedColumn == TrussColumn::HangPosition) {
+    std::vector<unsigned int> selectedRows;
+    for (const auto &it : selections) {
+      const int row = table->ItemToRow(it);
+      if (row != wxNOT_FOUND)
+        selectedRows.push_back(static_cast<unsigned int>(row));
+    }
+
+    HangPositionDialogResult result;
+    if (!ShowHangPositionDialog(this, current.GetString(), &result))
+      return;
+    ApplySharedHangPositionChanges(result, false, {}, true, selectedRows, false,
+                                    {});
+    ResyncRows(oldOrder, selectedUuids);
+    return;
+  }
 
   wxTextEntryDialog dlg(this, _("Edit value:"), columnLabels[col],
                         current.GetString());


### PR DESCRIPTION
### Motivation
- The existing Hang Pos popup was a minimal single-text-entry dialog and did not expose the shared set of MVR hang positions or management actions across fixtures, trusses, and hoists.
- Users need a single, reusable editor to pick existing positions, add missing ones, rename positions globally, and remove positions and then apply those changes to all affected rows on OK.

### Description
- Added a new reusable dialog implemented in `gui/hang_position_dialog.{h,cpp}` that collects visible hang positions from fixture, truss, and hoist tables and provides a list with Add/Rename/Delete controls and an OK/Cancel result structure (`HangPositionDialogResult`).
- Implemented `ApplySharedHangPositionChanges(...)` to apply accepted renames/deletes and to set the selected position on the invoking table's selected rows for fixtures, trusses, and hoists.
- Wired the dialog into the three tables by replacing the simple `wxTextEntryDialog` flow for the Hang Position column in `gui/fixturetablepanel.cpp`, `gui/trusstablepanel.cpp`, and `gui/hoisttablepanel.cpp` so the shared editor is shown and its results applied instead of the old text popup.
- Registered `hang_position_dialog.cpp` in `gui/CMakeLists.txt` and updated user-facing docs and release notes in `docs/user/features.md` and `docs/release-notes-draft.md` to document the new behavior.

### Testing
- Ran `git diff --check` which passed with no whitespace or patch issues.
- Ran `tests/check_perastage_tree_modules.sh` which passed and confirmed module-tree rules.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed and confirmed no forbidden ConfigManager::Get() usage in `gui/`.
- Attempted a local CMake build via `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug` which failed in this environment because system wxWidgets development files are not installed (build-time dependency), not due to source errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57423687c88324917b2da8363be0f4)