### PR TITLE
Propagate generated truss GDTF to matching source-only trusses

### DIFF
--- a/core/gdtf/editor/project_truss_gdtf_apply_adapter.cpp
+++ b/core/gdtf/editor/project_truss_gdtf_apply_adapter.cpp
@@ -2,6 +2,8 @@
 
 #include "filesystem_path_utils.h"
 
+#include <algorithm>
+#include <cctype>
 #include <cmath>
 #include <set>
 #include <system_error>
@@ -17,6 +19,55 @@ ProjectTrussGdtfApplyResult Fail(std::string message) {
   result.common.validationErrors.push_back(message);
   result.common.diagnostics.push_back(std::move(message));
   return result;
+}
+
+// Trims ASCII whitespace from a resource reference.
+std::string TrimResourceReference(std::string value) {
+  auto isSpace = [](unsigned char ch) { return std::isspace(ch) != 0; };
+  value.erase(value.begin(),
+              std::find_if(value.begin(), value.end(), [&](char ch) {
+                return !isSpace(static_cast<unsigned char>(ch));
+              }));
+  value.erase(std::find_if(value.rbegin(), value.rend(), [&](char ch) {
+                return !isSpace(static_cast<unsigned char>(ch));
+              }).base(),
+              value.end());
+  return value;
+}
+
+// Builds a comparison key for scene resource references.
+std::string NormalizeResourceReferenceKey(std::string value) {
+  value = TrimResourceReference(std::move(value));
+  std::replace(value.begin(), value.end(), '\\', '/');
+  std::transform(value.begin(), value.end(), value.begin(), [](unsigned char ch) {
+    return static_cast<char>(std::tolower(ch));
+  });
+  return value;
+}
+
+// Checks whether a truss still uses the same source-only geometry.
+bool MatchesSourceOnlyTrussGeometry(const Truss &truss,
+                                    const std::string &sourceSymbolKey) {
+  return !sourceSymbolKey.empty() && TrimResourceReference(truss.gdtfSpec).empty() &&
+         NormalizeResourceReferenceKey(truss.symbolFile) == sourceSymbolKey;
+}
+
+// Copies generated type metadata while preserving instance data.
+Truss BuildGeneratedTypeUpdate(const Truss &instance, const Truss &generatedType) {
+  Truss updated = instance;
+  updated.manufacturer = generatedType.manufacturer;
+  updated.model = generatedType.model;
+  updated.lengthMm = generatedType.lengthMm;
+  updated.widthMm = generatedType.widthMm;
+  updated.heightMm = generatedType.heightMm;
+  updated.weightKg = generatedType.weightKg;
+  updated.crossSection = generatedType.crossSection;
+  updated.gdtfSpec = generatedType.gdtfSpec;
+  updated.modelFile = generatedType.modelFile;
+  updated.perastageAuxGdtfArchivePath = generatedType.perastageAuxGdtfArchivePath;
+  updated.gdtfMode = generatedType.gdtfMode.empty() ? instance.gdtfMode
+                                                    : generatedType.gdtfMode;
+  return updated;
 }
 
 // Checks whether a changed-field set contains a field.
@@ -93,7 +144,13 @@ ProjectTrussGdtfApplyResult ProjectTrussGdtfApplyAdapter::Apply(
   if (!HasOnlySupportedFields(request))
     return Fail("Truss apply request contains unsupported changed fields.");
 
-  Truss prepared = it->second;
+  const Truss original = it->second;
+  const std::string originalSymbolKey =
+      TrimResourceReference(original.gdtfSpec).empty()
+          ? NormalizeResourceReferenceKey(original.symbolFile)
+          : std::string();
+
+  Truss prepared = original;
   prepared.manufacturer = request.values.manufacturer.value_or(prepared.manufacturer);
   prepared.model = request.values.modelName.value_or(prepared.model);
   prepared.lengthMm = request.values.trussLengthMm.value_or(prepared.lengthMm);
@@ -156,12 +213,25 @@ ProjectTrussGdtfApplyResult ProjectTrussGdtfApplyAdapter::Apply(
 
   result.resultingTruss = prepared;
   result.resultingProjectReference = prepared.gdtfSpec;
+  if (input.trusses) {
+    for (const auto &[uuid, truss] : *input.trusses) {
+      if (uuid == request.stableHostId) {
+        result.resultingTrusses.emplace_back(uuid, prepared);
+      } else if (MatchesSourceOnlyTrussGeometry(truss, originalSymbolKey)) {
+        result.resultingTrusses.emplace_back(
+            uuid, BuildGeneratedTypeUpdate(truss, prepared));
+      }
+    }
+  }
   result.canonicalFileName = canonical;
   result.generationOccurred = true;
   result.existingOwnedFileUpdated = existedBefore;
   result.newFileCreated = !existedBefore;
   result.externalFileCreatedOrModified = true;
-  result.affectedTrussUuids.push_back(request.stableHostId);
+  for (const auto &[uuid, truss] : result.resultingTrusses)
+    result.affectedTrussUuids.push_back(uuid);
+  if (result.affectedTrussUuids.empty())
+    result.affectedTrussUuids.push_back(request.stableHostId);
   result.tableResynchronizationRequired = true;
   result.previewRefreshRequired = true;
   result.common.changedGdtfFields = request.changedDocumentFields;

--- a/core/gdtf/editor/project_truss_gdtf_apply_adapter.h
+++ b/core/gdtf/editor/project_truss_gdtf_apply_adapter.h
@@ -7,6 +7,7 @@
 #include <functional>
 #include <unordered_map>
 #include <optional>
+#include <utility>
 #include <string>
 #include <vector>
 
@@ -27,6 +28,7 @@ struct ProjectTrussGdtfApplyInput {
 struct ProjectTrussGdtfApplyResult {
   GdtfApplyResult common;
   std::optional<Truss> resultingTruss;
+  std::vector<std::pair<std::string, Truss>> resultingTrusses;
   std::string resultingProjectReference;
   std::string canonicalFileName;
   std::vector<std::string> affectedTrussUuids;

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -40,6 +40,7 @@ Changes since **v1.4.0**.
 
 ## Fixes
 
+- Fixed Edit Truss so converting a model-only MVR truss from a shared `.3ds` geometry into a Perastage-generated GDTF updates every truss that still used that same source geometry, while preserving each truss instance placement and load state.
 - Fixed Ctrl-left rectangle selection so the Cross-table Actions toggle makes it select across all object tables without also requiring Shift.
 - Fixed Windows builds for the Cross-table Actions viewport toggle by using include paths that resolve from GUI and viewport source directories.
 - Hardened layer editing and MVR persistence so layer names are treated as validated UTF-8, legacy Windows-1252 layer-name corruption can be recovered without losing objects, layer edits target stable UUIDs, and exported scene XML is re-parsed before archive writing.

--- a/gui/trusseditdialog.cpp
+++ b/gui/trusseditdialog.cpp
@@ -687,8 +687,13 @@ bool TrussEditDialog::ApplyChanges() {
     GetDefaultGuiConfigServices().LegacyConfigManager().PushUndoState(
         "edit truss");
 
-  if (trussApplyResult.resultingTruss && row >= 0 &&
-      static_cast<size_t>(row) < panel->rowUuids.size()) {
+  if (!trussApplyResult.resultingTrusses.empty()) {
+    auto &scene =
+        GetDefaultGuiConfigServices().LegacyConfigManager().GetScene();
+    for (const auto &[uuid, truss] : trussApplyResult.resultingTrusses)
+      scene.trusses[uuid] = truss;
+  } else if (trussApplyResult.resultingTruss && row >= 0 &&
+             static_cast<size_t>(row) < panel->rowUuids.size()) {
     auto &scene =
         GetDefaultGuiConfigServices().LegacyConfigManager().GetScene();
     scene.trusses[panel->rowUuids[static_cast<size_t>(row)]] =

--- a/tests/project_truss_gdtf_apply_adapter_test.cpp
+++ b/tests/project_truss_gdtf_apply_adapter_test.cpp
@@ -50,10 +50,24 @@ gdtf::ProjectTrussGdtfApplyServices MakeServices(bool failGeneration = false,
 // Exercises validation, no-op, generation, failure, paths, and stable UUID behavior.
 int main() {
   const auto root = std::filesystem::temp_directory_path() / "perastage-truss-adapter-ü";
-  std::filesystem::create_directories(root);
+  std::filesystem::create_directories(root / "models");
+  std::ofstream(root / "models" / "shared.3ds").put('s');
+  std::ofstream(root / "models" / "other.3ds").put('o');
   std::unordered_map<std::string, Truss> trusses;
-  trusses.emplace("other", MakeTruss("other"));
-  trusses.emplace("target", MakeTruss("target"));
+  Truss other = MakeTruss("other");
+  other.symbolFile = "models/other.3ds";
+  trusses.emplace("other", other);
+  Truss target = MakeTruss("target");
+  target.symbolFile = "models/shared.3ds";
+  trusses.emplace("target", target);
+  Truss shared = MakeTruss("shared");
+  shared.symbolFile = "models\\shared.3ds";
+  shared.transform.o[0] = 42.0f;
+  trusses.emplace("shared", shared);
+  Truss alreadyGdtf = MakeTruss("already-gdtf");
+  alreadyGdtf.symbolFile = "models/shared.3ds";
+  alreadyGdtf.gdtfSpec = "existing.gdtf";
+  trusses.emplace("already-gdtf", alreadyGdtf);
 
   gdtf::GdtfApplyRequest request;
   request.contextKind = gdtf::GdtfEditorContextKind::ProjectTruss;
@@ -76,6 +90,20 @@ int main() {
   assert(result.resultingTruss);
   assert(result.resultingTruss->model == "ModelB");
   assert(result.resultingTruss->gdtfSpec.find("ModelB@Perastage.gdtf") != std::string::npos);
+  assert(result.resultingTrusses.size() == 2);
+  bool sawTarget = false;
+  bool sawShared = false;
+  for (const auto &[uuid, truss] : result.resultingTrusses) {
+    if (uuid == "target")
+      sawTarget = truss.model == "ModelB" && !truss.gdtfSpec.empty();
+    if (uuid == "shared")
+      sawShared = truss.model == "ModelB" && !truss.gdtfSpec.empty() &&
+                  truss.transform.o[0] == 42.0f;
+    assert(uuid != "already-gdtf");
+    assert(uuid != "other");
+  }
+  assert(sawTarget);
+  assert(sawShared);
   assert(trusses["target"].model == "Model");
 
   request.values.weightKg = -1.0f;


### PR DESCRIPTION
### Motivation
- When a model-only MVR truss that referenced a `.3ds` file is converted to a Perastage-generated GDTF, the project should treat all other trusses that still reference that same `.3ds` as the same type and receive the same generated GDTF metadata. 

### Description
- Add stable resource-key normalization and matching helpers (`TrimResourceReference`, `NormalizeResourceReferenceKey`, `MatchesSourceOnlyTrussGeometry`) and a `BuildGeneratedTypeUpdate` helper to copy generated type metadata while preserving instance placement and load fields in `core/gdtf/editor/project_truss_gdtf_apply_adapter.cpp`.
- Extend the adapter result with a `resultingTrusses` list (`std::vector<std::pair<std::string, Truss>>`) and populate it with the edited truss plus any matching source-only trusses, and make `affectedTrussUuids` reflect all updated instances in `core/gdtf/editor/project_truss_gdtf_apply_adapter.h/.cpp`.
- Apply the multi-truss update from the UI by committing every `resultingTrusses` entry into the scene instead of only replacing the edited row in `gui/trusseditdialog.cpp`.
- Add and adapt tests in `tests/project_truss_gdtf_apply_adapter_test.cpp` to cover propagation from a shared `models/shared.3ds` resource and to exclude trusses that already have a GDTF, and update `docs/release-notes-draft.md` with the user-visible fix.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed successfully.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed successfully.
- Ran `tests/check_gdtf_editor_checkpoint08c_truss_apply_adapter.sh` and it passed successfully.
- Compiled and executed the adapter unit test with `g++` and the test binary succeeded (`tests/project_truss_gdtf_apply_adapter_test.cpp` exercised propagation and validation checks).
- Attempted a full CMake configure/build with `cmake --preset wsl-x64-debug` but configuration failed in this container because `wxWidgets` is not installed (`wxWidgets_LIBRARIES` / `wxWidgets_INCLUDE_DIRS` missing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a575a480b9c83249af04542f6013fc4)