### PR TITLE
Add Scene Object → Truss conversion tool

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -62,6 +62,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/rigging_extra_weight_settings.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/riderimporter.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/scene_grouping.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/scene_object_truss_converter.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/scenedatamanager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/simplecrypt.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/symbol_cache_manifest.cpp

--- a/core/scene_object_truss_converter.cpp
+++ b/core/scene_object_truss_converter.cpp
@@ -1,0 +1,91 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2026 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+#include "scene_object_truss_converter.h"
+
+#include "groupobject.h"
+#include "mvrscene.h"
+#include "sceneobject.h"
+#include "truss.h"
+
+#include <algorithm>
+
+namespace {
+
+// Returns the model identity used to group scene objects for conversion.
+std::string SceneObjectModelKey(const SceneObject &object) {
+  return object.GetPrimaryModel();
+}
+
+// Builds a truss from a scene object while preserving MVR placement metadata.
+Truss BuildTrussFromSceneObject(const SceneObject &object,
+                                const std::string &modelFile) {
+  Truss truss;
+  truss.uuid = object.uuid;
+  truss.name = object.name;
+  truss.symbolFile = modelFile;
+  truss.modelFile = modelFile;
+  truss.layer = object.layer;
+  truss.transform = object.transform;
+  truss.localTransform = object.localTransform;
+  truss.hasLocalTransform = object.hasLocalTransform;
+  truss.parentGroupUuid = object.parentGroupUuid;
+  truss.sourceRepresentation = Truss::GeometryRepresentation::Geometry3D;
+  if (!object.geometries.empty()) {
+    truss.sourceSymbolUuid = object.geometries.front().sourceSymbolUuid;
+    truss.sourceSymdefUuid = object.geometries.front().sourceSymdefUuid;
+    truss.sourceGeometryMatrix = object.geometries.front().localTransform;
+  }
+  return truss;
+}
+
+// Repoints existing group child references from SceneObject to Truss.
+void RepointGroupChildrenToTrusses(MvrScene &scene,
+                                   const std::vector<std::string> &uuids) {
+  for (auto &[groupUuid, group] : scene.groupObjects) {
+    (void)groupUuid;
+    for (GroupObjectChildRef &child : group.children) {
+      if (child.type == MvrNodeType::SceneObject &&
+          std::find(uuids.begin(), uuids.end(), child.uuid) != uuids.end()) {
+        child.type = MvrNodeType::Truss;
+      }
+    }
+  }
+}
+
+} // namespace
+
+// Converts all scene objects sharing the selected object's model into trusses.
+SceneObjectToTrussConversionResult ConvertSceneObjectsWithSameModelToTrusses(
+    MvrScene &scene, const std::string &sourceSceneObjectUuid) {
+  SceneObjectToTrussConversionResult result;
+  const auto sourceIt = scene.sceneObjects.find(sourceSceneObjectUuid);
+  if (sourceIt == scene.sceneObjects.end())
+    return result;
+
+  result.modelFile = SceneObjectModelKey(sourceIt->second);
+  if (result.modelFile.empty())
+    return result;
+
+  std::vector<SceneObject> objectsToConvert;
+  for (const auto &[uuid, object] : scene.sceneObjects) {
+    if (SceneObjectModelKey(object) == result.modelFile)
+      objectsToConvert.push_back(object);
+  }
+
+  result.convertedUuids.reserve(objectsToConvert.size());
+  for (const SceneObject &object : objectsToConvert) {
+    scene.trusses[object.uuid] = BuildTrussFromSceneObject(object, result.modelFile);
+    scene.sceneObjects.erase(object.uuid);
+    result.convertedUuids.push_back(object.uuid);
+  }
+
+  RepointGroupChildrenToTrusses(scene, result.convertedUuids);
+  return result;
+}

--- a/core/scene_object_truss_converter.h
+++ b/core/scene_object_truss_converter.h
@@ -1,0 +1,24 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2026 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+class MvrScene;
+
+struct SceneObjectToTrussConversionResult {
+  std::string modelFile;
+  std::vector<std::string> convertedUuids;
+};
+
+SceneObjectToTrussConversionResult ConvertSceneObjectsWithSameModelToTrusses(
+    MvrScene &scene, const std::string &sourceSceneObjectUuid);

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -44,6 +44,7 @@ Changes since **v1.4.0**.
 - Fixed Edit Truss so converting a model-only MVR truss from a shared `.3ds` geometry into a Perastage-generated GDTF updates every truss that still used that same source geometry, while preserving each truss instance placement and load state.
 - Fixed Ctrl-left rectangle selection so the Cross-table Actions toggle makes it select across all object tables without also requiring Shift.
 - Fixed Windows builds for the Cross-table Actions viewport toggle by using include paths that resolve from GUI and viewport source directories.
+- Fixed the Scene Object to Truss conversion command so it refreshes the existing scene-object table member correctly on Windows builds.
 - Hardened layer editing and MVR persistence so layer names are treated as validated UTF-8, legacy Windows-1252 layer-name corruption can be recovered without losing objects, layer edits target stable UUIDs, and exported scene XML is re-parsed before archive writing.
 
 - Fixed GDTF editor numeric text parsing so fixture power, fixture weight, and truss dimensions compile with the macOS 15 / Xcode 16.4 toolchain while preserving locale-independent validation.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -12,6 +12,7 @@ Changes since **v1.4.0**.
 - Added an Edit Truss dialog from double-clicking the Trusses table, including MVR instance fields, GDTF metadata, a reusable 3D preview arranged above the GDTF truss type fields, and automatic Perastage GDTF creation when type metadata is edited on a model-only truss.
 - Added MVR-xchange remote file requests with a larger selectable advertised-MVR list, Console-styled transfer log, corrected station-name alignment, and the standard import choice to open as a new project or merge into the current project.
 - Added the first MVR-xchange TCP Mode publisher so Perastage can manually publish the current scene as an MVR revision for compatible clients.
+- Added a Scene Object to Truss conversion tool in the Tools menu and 2D/3D scene-object context menus, converting all scene objects that share the selected model file into trusses while updating tables, viewports, and rigging calculations.
 
 ## Improvements
 

--- a/docs/user/features.md
+++ b/docs/user/features.md
@@ -113,6 +113,7 @@ Additional safeguards include:
   confirmed element, or undoing before any confirmation, cancels continuous
   placement.
 - Add Truss supports quantity, real-world insertion-point coordinates in the active distance units, automatic linear placement from the selected truss bounding-box length, and optional default grouping into one bridge.
+- **Tools → Convert Scene Objects to Truss** converts the selected scene object and every other scene object that uses the same model file into truss objects. The same command is available by right-clicking a scene object in the 2D or 3D viewer.
 - Multi-row editing helpers include fills, ranges, interpolation, and relative expressions.
 - **Group** and **Ungroup** in the Edit menu create and remove MVR-compatible GroupObject hierarchy from the active cross-table selection across fixtures, trusses, hoists, and scene objects while preserving world placement and hang-position assignments; after grouping, clicking a member selects the full group across related tables, and the selection highlights and moves/rotates the full group, including nested groups, while hovering a grouped member uses a more yellow primary highlight and a paler related-green highlight on the other group members in the 3D view and related tables using the same row style as table selection.
 - CSV export is available through file/export workflows.

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -398,6 +398,7 @@ EVT_MENU(ID_Tools_ExportSceneObject, MainWindow::OnExportSceneObject)
 EVT_MENU(ID_Tools_AutoPatch, MainWindow::OnAutoPatch)
 EVT_MENU(ID_Tools_AutoColor, MainWindow::OnAutoColor)
 EVT_MENU(ID_Tools_ConvertToHoist, MainWindow::OnConvertToHoist)
+EVT_MENU(ID_Tools_ConvertSceneObjectsToTruss, MainWindow::OnConvertSceneObjectsToTruss)
 EVT_MENU(ID_Tools_GenerateFixtureSymbols, MainWindow::OnGenerateFixtureSymbols)
 EVT_MENU(ID_Tools_AssignSelectedFixtureCategory,
          MainWindow::OnAssignSelectedFixtureCategory)

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -170,6 +170,7 @@ private:
   void OnAutoPatch(wxCommandEvent &event);         // Auto patch fixtures
   void OnAutoColor(wxCommandEvent &event);         // Auto assign colors
   void OnConvertToHoist(wxCommandEvent &event);    // Convert fixtures to hoists
+  void OnConvertSceneObjectsToTruss(wxCommandEvent &event); // Convert scene objects to trusses
   void OnGenerateFixtureSymbols(wxCommandEvent &event); // Generate fixture symbols
   void OnAssignSelectedFixtureCategory(wxCommandEvent &event); // Debug category assignment
   void OnPrintViewer2D(wxCommandEvent &event); // Print 2D view to PDF

--- a/gui/mainwindow/ids/tools_ids.h
+++ b/gui/mainwindow/ids/tools_ids.h
@@ -14,7 +14,8 @@ constexpr int ID_Tools_ExportSceneObject = ID_Tools_ExportTruss + 1;
 constexpr int ID_Tools_AutoPatch = ID_Tools_ExportSceneObject + 1;
 constexpr int ID_Tools_AutoColor = ID_Tools_AutoPatch + 1;
 constexpr int ID_Tools_ConvertToHoist = ID_Tools_AutoColor + 1;
-constexpr int ID_Tools_GenerateFixtureSymbols = ID_Tools_ConvertToHoist + 1;
+constexpr int ID_Tools_ConvertSceneObjectsToTruss = ID_Tools_ConvertToHoist + 1;
+constexpr int ID_Tools_GenerateFixtureSymbols = ID_Tools_ConvertSceneObjectsToTruss + 1;
 constexpr int ID_Tools_AssignSelectedFixtureCategory =
     ID_Tools_GenerateFixtureSymbols + 1;
 constexpr int ID_Tools_OpenUserLibraryFolder =

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -908,8 +908,8 @@ void MainWindow::OnConvertSceneObjectsToTruss(wxCommandEvent &WXUNUSED(event)) {
   cfg.SetSelectedSceneObjects({});
   cfg.SetSelectedTrusses(result.convertedUuids);
 
-  if (sceneObjectPanel)
-    sceneObjectPanel->ReloadData();
+  if (sceneObjPanel)
+    sceneObjPanel->ReloadData();
   if (trussPanel)
     trussPanel->ReloadData();
   if (viewportPanel) {

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -87,6 +87,7 @@
 #include "rigging_extra_weight_settings.h"
 #include "riggingpanel.h"
 #include "scene_grouping.h"
+#include "scene_object_truss_converter.h"
 #include "scene_object_primitive_creation.h"
 #include "scene_object_primitive_dialogs.h"
 #include "sceneobjecttablepanel.h"
@@ -881,6 +882,51 @@ void MainWindow::OnConvertToHoist(wxCommandEvent &WXUNUSED(event)) {
   wxMessageBox(
       wxString::Format("Converted %zu fixture(s) to hoists.", newIds.size()),
       "Convert to Hoist", wxOK | wxICON_INFORMATION);
+}
+
+
+// Converts selected scene objects sharing the same model file into trusses.
+void MainWindow::OnConvertSceneObjectsToTruss(wxCommandEvent &WXUNUSED(event)) {
+  ConfigManager &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
+  const auto selected = cfg.GetSelectedSceneObjects();
+  if (selected.empty()) {
+    wxMessageBox("Please select a scene object to convert first.",
+                 "Convert Scene Objects to Truss", wxOK | wxICON_INFORMATION);
+    return;
+  }
+
+  cfg.PushUndoState("convert scene objects to trusses");
+  auto &scene = cfg.GetScene();
+  const SceneObjectToTrussConversionResult result =
+      ConvertSceneObjectsWithSameModelToTrusses(scene, selected.front());
+  if (result.convertedUuids.empty()) {
+    wxMessageBox("No scene objects with a valid model file were converted.",
+                 "Convert Scene Objects to Truss", wxOK | wxICON_INFORMATION);
+    return;
+  }
+
+  cfg.SetSelectedSceneObjects({});
+  cfg.SetSelectedTrusses(result.convertedUuids);
+
+  if (sceneObjectPanel)
+    sceneObjectPanel->ReloadData();
+  if (trussPanel)
+    trussPanel->ReloadData();
+  if (viewportPanel) {
+    viewportPanel->UpdateScene();
+    viewportPanel->Refresh();
+  }
+  if (viewport2DPanel) {
+    viewport2DPanel->UpdateScene();
+    viewport2DPanel->Refresh();
+  }
+  RefreshSummary();
+  RefreshRigging();
+
+  wxMessageBox(wxString::Format("Converted %zu scene object(s) with model '%s' to truss.",
+                                result.convertedUuids.size(),
+                                wxString::FromUTF8(result.modelFile).c_str()),
+               "Convert Scene Objects to Truss", wxOK | wxICON_INFORMATION);
 }
 
 // Runs the fixture symbol generation tool when the feature is enabled.

--- a/gui/mainwindow_menu_builders.cpp
+++ b/gui/mainwindow_menu_builders.cpp
@@ -98,6 +98,8 @@ wxMenu *BuildToolsMenu() {
   toolsMenu->Append(ID_Tools_AutoPatch, _("Auto patch"));
   toolsMenu->Append(ID_Tools_AutoColor, _("Auto color"));
   toolsMenu->Append(ID_Tools_ConvertToHoist, _("Convert to Hoist"));
+  toolsMenu->Append(ID_Tools_ConvertSceneObjectsToTruss,
+                    _("Convert Scene Objects to Truss"));
   if (ui::IsFeatureEnabled(ui::FeatureFlag::GenerateFixtureSymbols)) {
     toolsMenu->Append(ID_Tools_GenerateFixtureSymbols,
                       _("Generate Fixture Symbols..."));

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -42,6 +42,7 @@
 
 #include "viewer2dpanel.h"
 #include "mainwindow.h"
+#include "../gui/mainwindow/ids/tools_ids.h"
 #include "editable_focus_utils.h"
 #include "configmanager.h"
 #include "continuous_placement_scene.h"
@@ -3375,11 +3376,6 @@ void Viewer2DPanel::OnRightUp(wxMouseEvent &event) {
     return;
   }
 
-  if (!(FixtureTablePanel::Instance() && FixtureTablePanel::Instance()->IsActivePage())) {
-    event.Skip();
-    return;
-  }
-
   const RenderSize renderSize = ResolveRenderSize(this);
   const int w = renderSize.width;
   const int h = renderSize.height;
@@ -3395,6 +3391,27 @@ void Viewer2DPanel::OnRightUp(wxMouseEvent &event) {
   wxPoint pos;
   std::string hitUuid;
   const wxPoint pickPos = ToFramebufferPoint(this, event.GetPosition());
+  std::string sceneObjectUuid;
+  if (m_controller.GetSceneObjectLabelAt(pickPos.x, pickPos.y, w, h, label,
+                                         pos, &sceneObjectUuid)) {
+    wxMenu menu;
+    constexpr int kConvertSceneObjectToTrussId = wxID_HIGHEST + 1300;
+    menu.Append(kConvertSceneObjectToTrussId, "Convert to Truss");
+    const int selectedId = GetPopupMenuSelectionFromUser(menu, event.GetPosition());
+    if (selectedId == kConvertSceneObjectToTrussId) {
+      ConfigManager::Get().SetSelectedSceneObjects({sceneObjectUuid});
+      wxCommandEvent command(wxEVT_MENU, ID_Tools_ConvertSceneObjectsToTruss);
+      if (MainWindow::Instance())
+        MainWindow::Instance()->ProcessWindowEvent(command);
+    }
+    return;
+  }
+
+  if (!(FixtureTablePanel::Instance() && FixtureTablePanel::Instance()->IsActivePage())) {
+    event.Skip();
+    return;
+  }
+
   if (m_controller.GetFixtureLabelAt(pickPos.x, pickPos.y, w, h, label,
                                      pos, &hitUuid, true)) {
     event.Skip();

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -41,6 +41,7 @@
 
 #include "viewer3dpanel.h"
 #include "mainwindow.h"
+#include "../gui/mainwindow/ids/tools_ids.h"
 #include "editable_focus_utils.h"
 #include "consolepanel.h"
 #include "fixturetablepanel.h"
@@ -2002,6 +2003,12 @@ void Viewer3DPanel::OnRightUp(wxMouseEvent& event)
     std::set<std::string> positionNames;
     bool hasNoPosition = false;
     bool showSelectionSubmenus = false;
+    std::string hitSceneObjectUuid;
+    if (TryBindGlContextForInteraction("OnRightUp")) {
+        const wxPoint pickPos = ToFramebufferPoint(this, event.GetPosition());
+        QueryHoverUuid(m_controller, HoverTargetTable::SceneObjects, pickPos.x,
+                       pickPos.y, w, h, hitSceneObjectUuid);
+    }
     if (fixturePageActive && !scene.fixtures.empty() &&
         TryBindGlContextForInteraction("OnRightUp")) {
         std::string hitUuid;
@@ -2038,6 +2045,7 @@ void Viewer3DPanel::OnRightUp(wxMouseEvent& event)
     constexpr int kRenderStyleByLayerId = wxID_HIGHEST + 1206;
     constexpr int kRenderStyleByUniverseId = wxID_HIGHEST + 1207;
     constexpr int kExportImagePngId = wxID_HIGHEST + 1208;
+    constexpr int kConvertSceneObjectToTrussId = wxID_HIGHEST + 1209;
 
     typeSubmenu->Append(kSelectTypeAllId, "All fixtures");
     std::vector<std::string> orderedTypes;
@@ -2094,6 +2102,10 @@ void Viewer3DPanel::OnRightUp(wxMouseEvent& event)
             break;
     }
 
+    if (!hitSceneObjectUuid.empty()) {
+        rootMenu.Append(kConvertSceneObjectToTrussId, "Convert to Truss");
+        rootMenu.AppendSeparator();
+    }
     if (showSelectionSubmenus) {
         rootMenu.AppendSubMenu(typeSubmenu.release(), "Select by fixture type");
         rootMenu.AppendSubMenu(positionSubmenu.release(), "Select by position");
@@ -2106,6 +2118,14 @@ void Viewer3DPanel::OnRightUp(wxMouseEvent& event)
     const int selectedId = GetPopupMenuSelectionFromUser(rootMenu, event.GetPosition());
     if (selectedId == wxID_NONE)
         return;
+
+    if (selectedId == kConvertSceneObjectToTrussId) {
+        ConfigManager::Get().SetSelectedSceneObjects({hitSceneObjectUuid});
+        wxCommandEvent command(wxEVT_MENU, ID_Tools_ConvertSceneObjectsToTruss);
+        if (MainWindow::Instance())
+            MainWindow::Instance()->ProcessWindowEvent(command);
+        return;
+    }
 
     auto applyRenderStyleSelection = [this](Viewer3DRenderStyle style) {
         ConfigManager::Get().SetValue("viewer3d_render_style", ToConfigValue(style));


### PR DESCRIPTION
### Motivation
- Some imports place trusses as generic Scene Objects in MVRs instead of proper `Truss` entries, so add a tool to migrate those Scene Objects into canonical trusses and keep the project consistent. 
- The conversion must update MVR scene state, table views, 2D/3D viewports, group references, and downstream rigging/weight calculations just like adding/removing trusses normally. 

### Description
- Added a core conversion helper `ConvertSceneObjectsWithSameModelToTrusses` in `core/scene_object_truss_converter.{h,cpp}` that finds all `SceneObject`s sharing the selected object's primary model and migrates them to `Truss` entries while preserving UUID, name, transforms, layer, parent-group metadata, and repointing `GroupObject` children. 
- Exposed a UI command `ID_Tools_ConvertSceneObjectsToTruss` and added `Tools → Convert Scene Objects to Truss` in `gui/mainwindow_menu_builders.cpp`, with the handler `MainWindow::OnConvertSceneObjectsToTruss` implemented in `gui/mainwindow_menu.cpp` and declared in `gui/mainwindow.h`. 
- Added context-menu entry in the 3D and 2D viewports so right-clicking a Scene Object shows “Convert to Truss” and invokes the same tool via `wxCommandEvent` (changes in `viewer3d/viewer3dpanel.cpp` and `viewer2d/viewer2dpanel.cpp`). 
- Wired project refresh and selection updates: after conversion the code clears selected scene objects, selects the new trusses, reloads `SceneObject` and `Truss` tables, refreshes 2D/3D viewports, and calls `RefreshSummary()`/`RefreshRigging()`. 
- Added the new source to the core build (`core/CMakeLists.txt`) and updated user-facing docs: `docs/release-notes-draft.md` and `docs/user/features.md`. 

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed. 
- Ran `git diff --check` (no whitespace/format errors) and commit was created. 
- Attempted project configure/build with `cmake --preset wsl-x64-debug && cmake --build --preset wsl-debug-build` but configure failed in this environment because `wxWidgets` is not available; local builds should be verified by CI or a dev machine with dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57606837cc8324967a45a04f58c838)