### PR TITLE
Fix Windows GDTF/truss path identity, importer/exporter deduplication, and Viewer2D pick diagnostics

### DIFF
--- a/core/configmanager.cpp
+++ b/core/configmanager.cpp
@@ -645,6 +645,8 @@ bool ConfigManager::LoadProject(const std::string &path,
     SetHiddenFixtureTypes(
         DeserializeStringSet(GetValue(kHiddenFixtureTypesConfigKey)));
     restoreUserPreferences();
+    LogSelectionIntegrityAfterSceneReload(projectSession.GetScene(),
+                                           selectionState);
     ClearHistory();
     selectionState.Clear();
     projectSession.ResetDirty();

--- a/core/configservices.cpp
+++ b/core/configservices.cpp
@@ -27,6 +27,37 @@ class wxZipStreamLink;
 namespace {
 namespace fs = std::filesystem;
 
+// Appends missing selected UUIDs for one scene entity type to the integrity report.
+template <typename MapT>
+void AppendSelectionIntegrityIssue(std::vector<SelectionIntegrityIssue> &issues,
+                                   const std::string &entityType,
+                                   const std::vector<std::string> &selected,
+                                   const MapT &entities,
+                                   std::size_t sampleLimit) {
+  SelectionIntegrityIssue issue;
+  issue.entityType = entityType;
+  for (const std::string &uuid : selected) {
+    if (entities.find(uuid) != entities.end())
+      continue;
+    ++issue.missingCount;
+    if (issue.sampleUuids.size() < sampleLimit)
+      issue.sampleUuids.push_back(uuid);
+  }
+  if (issue.missingCount > 0)
+    issues.push_back(std::move(issue));
+}
+
+// Joins a bounded list of UUIDs for concise diagnostics.
+std::string JoinUuidSample(const std::vector<std::string> &uuids) {
+  std::ostringstream out;
+  for (std::size_t i = 0; i < uuids.size(); ++i) {
+    if (i > 0)
+      out << ",";
+    out << uuids[i];
+  }
+  return out.str();
+}
+
 std::string Utf8StringFromPath(const fs::path &path) {
   const auto utf8 = path.u8string();
   return std::string(utf8.begin(), utf8.end());
@@ -519,6 +550,41 @@ bool UserPreferencesStore::LoadUserConfig() {
 
 bool UserPreferencesStore::SaveUserConfig() const {
   return SaveToFile(GetUserConfigFile());
+}
+
+
+// Finds selected UUIDs that no longer exist in the loaded scene containers.
+std::vector<SelectionIntegrityIssue> FindStaleSelectionUuids(
+    const MvrScene &scene, const SelectionState &selection,
+    std::size_t sampleLimit) {
+  std::vector<SelectionIntegrityIssue> issues;
+  AppendSelectionIntegrityIssue(issues, "fixtures", selection.GetSelectedFixtures(),
+                                scene.fixtures, sampleLimit);
+  AppendSelectionIntegrityIssue(issues, "trusses", selection.GetSelectedTrusses(),
+                                scene.trusses, sampleLimit);
+  AppendSelectionIntegrityIssue(issues, "supports", selection.GetSelectedSupports(),
+                                scene.supports, sampleLimit);
+  AppendSelectionIntegrityIssue(issues, "sceneObjects",
+                                selection.GetSelectedSceneObjects(),
+                                scene.sceneObjects, sampleLimit);
+  return issues;
+}
+
+// Logs a bounded post-reload warning when persisted selections reference missing UUIDs.
+void LogSelectionIntegrityAfterSceneReload(const MvrScene &scene,
+                                           const SelectionState &selection) {
+  const auto issues = FindStaleSelectionUuids(scene, selection);
+  if (issues.empty())
+    return;
+
+  std::ostringstream msg;
+  msg << "Selection integrity after scene reload: stale selected UUIDs found; "
+      << "action=preserved";
+  for (const auto &issue : issues) {
+    msg << " " << issue.entityType << " missing=" << issue.missingCount
+        << " sample=[" << JoinUuidSample(issue.sampleUuids) << "]";
+  }
+  Logger::Instance().Log(Logger::Level::Warn, msg.str());
 }
 
 const std::vector<std::string> &SelectionState::GetSelectedFixtures() const {

--- a/core/configservices.h
+++ b/core/configservices.h
@@ -79,6 +79,18 @@ private:
   std::vector<std::string> selectedSceneObjects;
 };
 
+struct SelectionIntegrityIssue {
+  std::string entityType;
+  std::size_t missingCount = 0;
+  std::vector<std::string> sampleUuids;
+};
+
+std::vector<SelectionIntegrityIssue> FindStaleSelectionUuids(
+    const MvrScene &scene, const SelectionState &selection,
+    std::size_t sampleLimit = 3);
+void LogSelectionIntegrityAfterSceneReload(const MvrScene &scene,
+                                           const SelectionState &selection);
+
 class LayerVisibilityState;
 
 class HistoryManager {

--- a/core/filesystem_path_utils.cpp
+++ b/core/filesystem_path_utils.cpp
@@ -1,6 +1,9 @@
 #include "filesystem_path_utils.h"
 
+#include <algorithm>
+#include <cwctype>
 #include <stdexcept>
+#include <system_error>
 
 #ifdef _WIN32
 #ifndef NOMINMAX
@@ -10,6 +13,39 @@
 #endif
 
 namespace PathUtils {
+
+
+// Resolves a path for identity-key generation without throwing on filesystem errors.
+static std::filesystem::path ResolveIdentityPath(const std::filesystem::path &path) {
+  if (path.empty())
+    return {};
+
+  std::error_code ec;
+  std::filesystem::path resolved = std::filesystem::weakly_canonical(path, ec);
+  if (ec) {
+    ec.clear();
+    resolved = std::filesystem::absolute(path, ec);
+  }
+  if (ec)
+    resolved = path;
+  return resolved.lexically_normal();
+}
+
+// Normalizes platform path spelling for cache identity while preserving UTF-8 validity.
+static std::string NormalizeIdentityText(std::filesystem::path path) {
+  path.make_preferred();
+  std::string text = PathToUtf8(path.lexically_normal());
+  std::replace(text.begin(), text.end(), '\\', '/');
+#ifdef _WIN32
+  std::wstring wide = path.lexically_normal().wstring();
+  std::replace(wide.begin(), wide.end(), L'\\', L'/');
+  std::transform(wide.begin(), wide.end(), wide.begin(),
+                 [](wchar_t c) { return static_cast<wchar_t>(std::towlower(c)); });
+  return PathToUtf8(std::filesystem::path(wide));
+#else
+  return text;
+#endif
+}
 
 // Creates a filesystem path from UTF-8 text using the native platform encoding.
 std::filesystem::path PathFromUtf8(const std::string &text) {
@@ -61,6 +97,27 @@ std::string PathToUtf8(const std::filesystem::path &path) {
 #else
   return path.string();
 #endif
+}
+
+
+// Builds an internal filesystem identity key for cache and deduplication lookups.
+std::string BuildFilesystemIdentityKey(const std::filesystem::path &path) {
+  return NormalizeIdentityText(ResolveIdentityPath(path));
+}
+
+// Builds an internal filesystem identity key from UTF-8 path text.
+std::string BuildFilesystemIdentityKey(const std::string &utf8Path) {
+  return BuildFilesystemIdentityKey(PathFromUtf8(utf8Path));
+}
+
+// Builds an internal identity key after resolving a relative path against a base path.
+std::string BuildFilesystemIdentityKey(const std::filesystem::path &path,
+                                       const std::filesystem::path &basePath) {
+  if (path.empty())
+    return {};
+  if (path.is_relative() && !basePath.empty())
+    return BuildFilesystemIdentityKey(basePath / path);
+  return BuildFilesystemIdentityKey(path);
 }
 
 } // namespace PathUtils

--- a/core/filesystem_path_utils.h
+++ b/core/filesystem_path_utils.h
@@ -7,5 +7,9 @@ namespace PathUtils {
 
 std::filesystem::path PathFromUtf8(const std::string &text);
 std::string PathToUtf8(const std::filesystem::path &path);
+std::string BuildFilesystemIdentityKey(const std::filesystem::path &path);
+std::string BuildFilesystemIdentityKey(const std::string &utf8Path);
+std::string BuildFilesystemIdentityKey(const std::filesystem::path &path,
+                                       const std::filesystem::path &basePath);
 
 } // namespace PathUtils

--- a/core/trussloader.cpp
+++ b/core/trussloader.cpp
@@ -29,6 +29,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstdint>
 #include <filesystem>
 #include <functional>
 #include <fstream>
@@ -179,25 +180,33 @@ static bool ExtractArchive(const fs::path &archivePath, const fs::path &destinat
 }
 
 
+// Computes a deterministic FNV-1a hash for extraction cache directory names.
+static std::string StableHashString(const std::string &text) {
+  uint64_t hash = 14695981039346656037ull;
+  for (unsigned char c : text) {
+    hash ^= c;
+    hash *= 1099511628211ull;
+  }
+  std::ostringstream out;
+  out << std::hex << hash;
+  return out.str();
+}
+
 // Builds a stable extraction cache path for a GDTF archive.
 static fs::path BuildGdtfExtractionCacheDir(const fs::path &gdtfPath) {
-  std::error_code ec;
-  fs::path normalized = fs::weakly_canonical(gdtfPath, ec);
-  if (ec)
-    normalized = fs::absolute(gdtfPath, ec);
-  if (ec)
-    normalized = gdtfPath;
-
-  std::string key = normalized.generic_string();
+  std::string key = PathUtils::BuildFilesystemIdentityKey(gdtfPath);
   std::error_code timeEc;
   const auto writeTime = fs::last_write_time(gdtfPath, timeEc);
   if (!timeEc)
     key += "#" +
            std::to_string(static_cast<long long>(writeTime.time_since_epoch().count()));
+  std::error_code sizeEc;
+  const auto size = fs::file_size(gdtfPath, sizeEc);
+  if (!sizeEc)
+    key += "#" + std::to_string(static_cast<unsigned long long>(size));
 
-  const std::size_t hashValue = std::hash<std::string>{}(key);
   fs::path cacheRoot = fs::temp_directory_path() / "perastage-truss-gdtf-cache";
-  return cacheRoot / std::to_string(hashValue);
+  return cacheRoot / StableHashString(key);
 }
 
 // Finds the first candidate path that exists below the provided base directory.
@@ -225,6 +234,11 @@ static void LogTrussDefinitionLoadResult(const fs::path &path, const std::string
 }
 
 } // namespace
+
+// Returns the extraction cache directory used for a GDTF archive in tests.
+fs::path BuildGdtfExtractionCacheDirForTesting(const fs::path &gdtfPath) {
+  return BuildGdtfExtractionCacheDir(gdtfPath);
+}
 
 // Returns the file dialog wildcard matching the supported truss loader inputs.
 std::string GetTrussDefinitionFileDialogWildcard() {

--- a/core/trussloader.h
+++ b/core/trussloader.h
@@ -17,6 +17,7 @@
  */
 #pragma once
 
+#include <filesystem>
 #include <string>
 
 #include "truss.h"
@@ -26,3 +27,5 @@ bool IsSupportedTrussDefinitionExtension(const std::string &path);
 bool LoadTrussGdtf(const std::string &gdtfPath, Truss &outTruss);
 bool LoadTrussArchive(const std::string &archivePath, Truss &outTruss);
 bool LoadTrussDefinition(const std::string &path, Truss &outTruss);
+std::filesystem::path BuildGdtfExtractionCacheDirForTesting(
+    const std::filesystem::path &gdtfPath);

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -41,6 +41,7 @@ Changes since **v1.4.0**.
 
 ## Fixes
 
+- Fixed Windows GDTF and truss resource identity so differently cased paths to the same file share extraction, import, and export cache entries while preserving user-visible file spelling, and clarified Viewer2D cursor hit-test diagnostics separately from stale-selection integrity warnings.
 - Fixed Edit Truss so converting a model-only MVR truss from a shared `.3ds` geometry into a Perastage-generated GDTF updates every truss that still used that same source geometry, while preserving each truss instance placement and load state.
 - Fixed Ctrl-left rectangle selection so the Cross-table Actions toggle makes it select across all object tables without also requiring Shift.
 - Fixed Windows builds for the Cross-table Actions viewport toggle by using include paths that resolve from GUI and viewport source directories.

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -2490,7 +2490,17 @@ bool MvrExporter::ExportToFile(const std::string &filePath,
       src = PathUtils::PathFromUtf8(scene.basePath) / src;
     std::error_code ec;
     fs::path weak = fs::weakly_canonical(src, ec);
-    return ec ? fs::absolute(src).generic_string() : weak.generic_string();
+    if (!ec)
+      return PathUtils::PathToUtf8(weak);
+    ec.clear();
+    fs::path absolute = fs::absolute(src, ec);
+    return PathUtils::PathToUtf8(ec ? src.lexically_normal()
+                                    : absolute.lexically_normal());
+  };
+
+  auto buildSourceIdentityKey = [&](const std::string &sourcePath) {
+    return PathUtils::BuildFilesystemIdentityKey(
+        PathUtils::PathFromUtf8(sourcePath));
   };
 
   auto findSceneResourceByFileName =
@@ -2558,14 +2568,15 @@ bool MvrExporter::ExportToFile(const std::string &filePath,
     std::string normalizedSource = resolveExistingResourceSourcePath(rawSource);
     if (normalizedSource.empty())
       normalizedSource = normalizeSourcePath(rawSource);
-    auto srcIt = sourceToArchivePath.find(normalizedSource);
+    const std::string sourceIdentityKey = buildSourceIdentityKey(normalizedSource);
+    auto srcIt = sourceToArchivePath.find(sourceIdentityKey);
     if (allowReuseBySource && srcIt != sourceToArchivePath.end())
       return srcIt->second;
 
     std::string archivePath =
         EnsureUniqueArchivePath(preferredArchivePath, reservedArchivePaths);
     if (allowReuseBySource)
-      sourceToArchivePath[normalizedSource] = archivePath;
+      sourceToArchivePath[sourceIdentityKey] = archivePath;
     resourceEntries.push_back({fs::path(normalizedSource), archivePath});
     return archivePath;
   };
@@ -3192,7 +3203,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath,
     std::string fixtureGdtfArchivePath;
     if (needsPhysicalPatch) {
       std::ostringstream patchKey;
-      patchKey << normalizeSourcePath(fixtureSourceGdtf) << '|'
+      patchKey << buildSourceIdentityKey(normalizeSourcePath(fixtureSourceGdtf))
+               << '|'
                << (fixtureOverrides.hasWeightKg ? fixtureOverrides.weightKg
                                                 : -1.0f)
                << '|'

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -2084,15 +2084,23 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
     return fs::is_regular_file(PathUtils::PathFromUtf8(gdtfPath), ec) && !ec;
   };
 
+  auto buildResolvedGdtfIdentityKey = [&](const std::string &gdtfPath) {
+    if (gdtfPath.empty())
+      return std::string{};
+    return PathUtils::BuildFilesystemIdentityKey(
+        PathUtils::PathFromUtf8(gdtfPath));
+  };
+
   auto getGdtfModesCached =
       [&](const std::string &gdtfPath) -> const std::vector<std::string> & {
-    auto cacheIt = gdtfModesCache.find(gdtfPath);
+    const std::string cacheKey = buildResolvedGdtfIdentityKey(gdtfPath);
+    auto cacheIt = gdtfModesCache.find(cacheKey);
     if (cacheIt != gdtfModesCache.end())
       return cacheIt->second;
     if (!resolvedGdtfFileExists(gdtfPath))
-      return gdtfModesCache.emplace(gdtfPath, std::vector<std::string>{})
+      return gdtfModesCache.emplace(cacheKey, std::vector<std::string>{})
           .first->second;
-    return gdtfModesCache.emplace(gdtfPath, GetGdtfModes(gdtfPath))
+    return gdtfModesCache.emplace(cacheKey, GetGdtfModes(gdtfPath))
         .first->second;
   };
 
@@ -2100,7 +2108,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                                            const std::string &modeName) {
     if (!resolvedGdtfFileExists(gdtfPath))
       return -1;
-    auto &channelCountByMode = gdtfModeChannelCountCache[gdtfPath];
+    const std::string cacheKey = buildResolvedGdtfIdentityKey(gdtfPath);
+    auto &channelCountByMode = gdtfModeChannelCountCache[cacheKey];
     auto countIt = channelCountByMode.find(modeName);
     if (countIt != channelCountByMode.end())
       return countIt->second;
@@ -2169,7 +2178,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
     if (resolvedGdtfPath.empty() || !resolvedGdtfFileExists(resolvedGdtfPath))
       return kEmptyFixtureMetadata;
 
-    auto it = gdtfFixtureMetadataCache.find(resolvedGdtfPath);
+    const std::string cacheKey = buildResolvedGdtfIdentityKey(resolvedGdtfPath);
+    auto it = gdtfFixtureMetadataCache.find(cacheKey);
     if (it != gdtfFixtureMetadataCache.end())
       return it->second;
 
@@ -2178,7 +2188,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
     metadata.hasProperties =
         GetGdtfProperties(resolvedGdtfPath, metadata.weightKg, metadata.powerW);
     return gdtfFixtureMetadataCache
-        .emplace(resolvedGdtfPath, std::move(metadata))
+        .emplace(cacheKey, std::move(metadata))
         .first->second;
   };
 
@@ -2188,14 +2198,14 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
     if (resolvedGdtfPath.empty())
       return false;
 
-    auto it = trussDefinitionCache.find(resolvedGdtfPath);
+    const std::string cacheKey = buildResolvedGdtfIdentityKey(resolvedGdtfPath);
+    auto it = trussDefinitionCache.find(cacheKey);
     if (it == trussDefinitionCache.end()) {
       Truss loaded;
       if (LoadTrussDefinition(resolvedGdtfPath, loaded))
-        it = trussDefinitionCache.emplace(resolvedGdtfPath, std::move(loaded))
-                 .first;
+        it = trussDefinitionCache.emplace(cacheKey, std::move(loaded)).first;
       else
-        it = trussDefinitionCache.emplace(resolvedGdtfPath, std::nullopt).first;
+        it = trussDefinitionCache.emplace(cacheKey, std::nullopt).first;
     }
 
     if (!it->second.has_value())
@@ -2824,7 +2834,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                     : PathUtils::PathFromUtf8(scene.basePath) /
                           PathUtils::PathFromUtf8(typeIt->second);
             Truss sidecar;
-            if (LoadTrussDefinition(ToString(auxPath.u8string()), sidecar)) {
+            if (loadTrussDefinitionCached(PathUtils::PathToUtf8(auxPath), sidecar)) {
               if (truss.manufacturer.empty())
                 truss.manufacturer = sidecar.manufacturer;
               if (truss.model.empty())

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1576,6 +1576,31 @@ target_include_directories(project_session_test PRIVATE ../core ../models ../thi
 target_link_libraries(project_session_test PRIVATE ${wxWidgets_LIBRARIES})
 add_test(NAME ProjectSession COMMAND project_session_test)
 
+
+add_executable(filesystem_identity_test
+               filesystem_identity_test.cpp
+               ../core/filesystem_path_utils.cpp
+               ../core/trussloader.cpp
+               ../core/truss_gdtf_builder.cpp
+               ../core/logger.cpp
+               ../core/apppaths.cpp
+               ../core/diagnostics/DiagnosticPaths.cpp)
+target_include_directories(filesystem_identity_test PRIVATE ../core ../models ../third_party)
+target_link_libraries(filesystem_identity_test PRIVATE ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
+add_test(NAME FilesystemIdentity COMMAND filesystem_identity_test)
+
+add_executable(selection_integrity_test
+               selection_integrity_test.cpp
+               ../core/configservices.cpp
+               ../models/mvrscene.cpp
+               ../models/fixture.cpp
+               ../models/truss.cpp
+               ../models/sceneobject.cpp
+               ../models/layer.cpp)
+target_include_directories(selection_integrity_test PRIVATE ../core ../models ../third_party)
+target_link_libraries(selection_integrity_test PRIVATE ${wxWidgets_LIBRARIES})
+add_test(NAME SelectionIntegrity COMMAND selection_integrity_test)
+
 add_executable(selection_state_test
                selection_state_test.cpp
                ../core/configservices.cpp)

--- a/tests/filesystem_identity_test.cpp
+++ b/tests/filesystem_identity_test.cpp
@@ -1,0 +1,45 @@
+#include "filesystem_path_utils.h"
+#include "trussloader.h"
+
+#include <cassert>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+namespace fs = std::filesystem;
+
+// Writes a small temporary file used by path identity regression checks.
+static fs::path WriteTempFile(const fs::path &path) {
+  fs::create_directories(path.parent_path());
+  std::ofstream out(path, std::ios::binary);
+  out << "identity";
+  return path;
+}
+
+// Runs filesystem identity checks for spaces and UTF-8 path spelling.
+int main() {
+  const fs::path root = fs::temp_directory_path() / "perastage_identity_test_å";
+  fs::remove_all(root);
+  const fs::path path = WriteTempFile(root / "Folder With Spaces" / "Sample File.gdtf");
+
+  const std::string key = PathUtils::BuildFilesystemIdentityKey(path);
+  assert(!key.empty());
+  assert(key.find('\\') == std::string::npos);
+
+  const std::string relativeKey = PathUtils::BuildFilesystemIdentityKey(
+      fs::path("Folder With Spaces") / "Sample File.gdtf", root);
+  assert(key == relativeKey);
+
+#ifdef _WIN32
+  fs::path upper = path.parent_path() / "SAMPLE FILE.gdtf";
+  assert(PathUtils::BuildFilesystemIdentityKey(upper) == key);
+  assert(BuildGdtfExtractionCacheDirForTesting(upper) ==
+         BuildGdtfExtractionCacheDirForTesting(path));
+#else
+  assert(BuildGdtfExtractionCacheDirForTesting(path) ==
+         BuildGdtfExtractionCacheDirForTesting(path));
+#endif
+
+  fs::remove_all(root);
+  return 0;
+}

--- a/tests/selection_integrity_test.cpp
+++ b/tests/selection_integrity_test.cpp
@@ -1,0 +1,28 @@
+#include "configservices.h"
+
+#include <cassert>
+
+// Verifies stale selection UUID detection is bounded and type-specific.
+int main() {
+  MvrScene scene;
+  Fixture fixture;
+  fixture.uuid = "fixture-ok";
+  scene.fixtures[fixture.uuid] = fixture;
+  Truss truss;
+  truss.uuid = "truss-ok";
+  scene.trusses[truss.uuid] = truss;
+
+  SelectionState selection;
+  selection.SetSelectedFixtures({"fixture-ok", "fixture-missing-a", "fixture-missing-b"});
+  selection.SetSelectedTrusses({"truss-ok"});
+  selection.SetSelectedSupports({"support-missing"});
+
+  const auto issues = FindStaleSelectionUuids(scene, selection, 1);
+  assert(issues.size() == 2);
+  assert(issues[0].entityType == "fixtures");
+  assert(issues[0].missingCount == 2);
+  assert(issues[0].sampleUuids.size() == 1);
+  assert(issues[1].entityType == "supports");
+  assert(issues[1].missingCount == 1);
+  return 0;
+}

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -2527,11 +2527,12 @@ void Viewer2DPanel::StorePickCache(PickQueryKind queryKind,
     case PickQueryKind::None:
       break;
     }
+    // This diagnostic only reports cursor hit-testing after a scene refresh.
     Logger::Instance().Log(
         Logger::Level::Debug,
-        "Viewer2DPanel: first pick after scene update; updateSceneRequested=true reload=" +
+        "Viewer2DPanel: first cursor hit-test after scene update; reloadRequested=" +
             std::string(m_lastUpdateSceneReloadRequested ? "true" : "false") +
-            " query='" + queryName + "' found=" +
+            " query='" + queryName + "' objectUnderCursor=" +
             std::string(found ? "true" : "false") + " sceneGeneration=" +
             std::to_string(m_pickCacheSceneGeneration) + ".");
     m_logFirstPickAfterSceneUpdate = false;


### PR DESCRIPTION
### Motivation
- Windows can report the same physical GDTF/truss file with different path spellings/casing which produced distinct cache keys and duplicated parsing and archive entries. 
- The Viewer2D debug line for the first pick after a scene update was worded in a way that could be mistaken for persistent-selection UUID recovery. 
- The project needs a small, shared identity primitive so truss extraction, importer caches, and exporter deduplication all use the same platform-aware identity without changing visible path spelling.

### Description
- Added a shared filesystem identity API `PathUtils::BuildFilesystemIdentityKey(...)` that resolves with `weakly_canonical()`, falls back safely, normalizes separators, and on Windows produces a case-insensitive identity while preserving presentation paths (`core/filesystem_path_utils.*`).
- Reworked GDTF extraction cache directory naming to use the new identity key plus file `last_write_time` and file size, and to use a deterministic FNV-1a hex hash instead of `std::hash` (`core/trussloader.*`).
- Updated MVR importer caches (GDTF modes, mode channel counts, fixture metadata, truss-definition cache) to use the filesystem identity key as lookup keys, and routed sidecar/auxiliary truss loads through the same `loadTrussDefinitionCached` path so a single physical file is parsed once per import operation (`mvr/mvrimporter.cpp`).
- Updated MVR exporter resource deduplication and physical-patch keys to use the same filesystem identity key for source-path reuse while preserving normalized source paths for actual archive entries (`mvr/mvrexporter.cpp`).
- Clarified the Viewer2D first-pick diagnostic to explicitly state it is a cursor hit-test and to expose `objectUnderCursor` and `reloadRequested` fields at debug level, and added a code comment clarifying the intent so misses are not mistaken for UUID recovery (`viewer2d/viewer2dpanel.cpp`).
- Added a separate, low-noise post-reload selection-integrity diagnostic that checks selected UUID lists against loaded scene containers and emits a single structured warning when stale selections are found (`core/configservices.*`, `core/configmanager.cpp`).
- Added focused regression tests and test registration for path identity/extraction-cache identity and selection-integrity detection, and updated `docs/release-notes-draft.md` to reflect the fix (`tests/filesystem_identity_test.cpp`, `tests/selection_integrity_test.cpp`, `tests/CMakeLists.txt`, `docs/release-notes-draft.md`).

### Testing
- Ran repository checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both completed `OK` in this environment. 
- Performed code hygiene checks with `git diff --check` and a local compile smoke-check `g++ -std=c++20 -Icore -c core/filesystem_path_utils.cpp -o /tmp/fs.o`, which succeeded. 
- Attempted to configure and build the CTest target tree with `cmake -S tests -B build-tests`, but the container lacks wxWidgets development files so CMake could not configure the test project (environment limitation), therefore the newly added unit executables were registered but not executed here. 
- All changes are confined to path-identity, caching, deduplication, viewer diagnostics, and focused tests, and the change preserves user-visible path spelling and existing metadata precedence.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a576d5159a48324bbabb084c0ff294a)