### PR TITLE
Improve Edit Fixture mode/channel root labels

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -36,6 +36,7 @@ Perastage 1.5.0 is a substantial update focused on GDTF and truss editing, multi
   - A reusable 3D preview.
   - Support for creating a Perastage-generated GDTF when compatible metadata is edited on a model-only truss.
 - Expanded **Edit Fixture** with a clearer and more structured GDTF inspection interface:
+  - More informative top-level DMX channel labels in the mode/channel browser for faster scanning.
   - DMX modes and channels.
   - Effective channel addresses for matrix fixtures.
   - Logical and channel functions.

--- a/gui/gdtf/gdtf_mode_browser_presenter.cpp
+++ b/gui/gdtf/gdtf_mode_browser_presenter.cpp
@@ -153,6 +153,20 @@ std::string FormatGroupedChannelFunctions(
   return channel.virtualChannel ? "Virtual" : "Not specified";
 }
 
+// Formats a compact channel label for the hierarchical browser root row.
+std::string FormatBrowserChannelRootItem(
+    const gdtf::GdtfDmxChannelNode &channel) {
+  if (channel.virtualChannel)
+    return "Virtual DMX Channel - " + FormatGroupedChannelFunctions(channel);
+
+  const std::string offsets = FormatOffsets(channel.offsets);
+  const std::string functions = FormatGroupedChannelFunctions(channel);
+  std::string label = "Ch " + offsets;
+  if (!functions.empty())
+    label += " - " + functions;
+  return label;
+}
+
 // Returns the summary label for one physical channel byte.
 std::string FormatSummaryFunctionAt(
     const std::vector<std::string> &names, size_t index, int geometryReferenceIndex) {
@@ -181,7 +195,7 @@ BuildGdtfModeBrowserPresentation(const gdtf::GdtfDmxModeNode *mode) {
   for (const auto &channel : mode->channels) {
     GdtfModeBrowserNodePresentation ch;
     ch.id = channel.id;
-    ch.item = channel.virtualChannel ? "Virtual DMX Channel" : "DMX Channel " + FormatOffsets(channel.offsets);
+    ch.item = FormatBrowserChannelRootItem(channel);
     Detail(ch, "raw DMXBreak", RawOrNotSpecified(channel.rawDmxBreak));
     Detail(ch, "raw Offset", RawOrNotSpecified(channel.rawOffset));
     Detail(ch, "parsed offsets", FormatOffsets(channel.offsets));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -335,6 +335,14 @@ target_include_directories(gdtf_mode_channel_browser_test PRIVATE ../core)
 target_link_libraries(gdtf_mode_channel_browser_test PRIVATE tinyxml2::tinyxml2)
 add_test(NAME GdtfModeChannelBrowser COMMAND gdtf_mode_channel_browser_test)
 
+add_executable(gdtf_mode_browser_presenter_test
+               gdtf_mode_browser_presenter_test.cpp
+               ../gui/gdtf/gdtf_mode_browser_presenter.cpp
+               ../core/gdtf/gdtf_mode_channel_browser.cpp)
+target_include_directories(gdtf_mode_browser_presenter_test PRIVATE ../core ../gui)
+target_link_libraries(gdtf_mode_browser_presenter_test PRIVATE tinyxml2::tinyxml2)
+add_test(NAME GdtfModeBrowserPresenter COMMAND gdtf_mode_browser_presenter_test)
+
 add_executable(gdtf_wheel_attribute_inspector_test
                gdtf_wheel_attribute_inspector_test.cpp
                ../core/gdtf/gdtf_color_cie.cpp

--- a/tests/gdtf_mode_browser_presenter_test.cpp
+++ b/tests/gdtf_mode_browser_presenter_test.cpp
@@ -1,0 +1,27 @@
+#include "gdtf/gdtf_mode_browser_presenter.h"
+
+#include <cassert>
+#include <string>
+
+// Verifies top-level mode browser labels include immediate channel contents.
+int main() {
+  const std::string xml = R"(<GDTF><FixtureType Name="Presenter">
+    <AttributeDefinitions><Attributes>
+      <Attribute Name="Pan" Pretty="Pan"/>
+      <Attribute Name="Shutter1" Pretty="Shutter"/>
+    </Attributes></AttributeDefinitions>
+    <DMXModes><DMXMode Name="Mode"><DMXChannels>
+      <DMXChannel Offset="1"><LogicalChannel Attribute="Shutter1"><ChannelFunction Attribute="Shutter1" DMXFrom="0/1"/></LogicalChannel></DMXChannel>
+      <DMXChannel Offset="2,3"><LogicalChannel Attribute="Pan"><ChannelFunction Attribute="Pan" DMXFrom="0/2"/></LogicalChannel></DMXChannel>
+    </DMXChannels></DMXMode></DMXModes>
+  </FixtureType></GDTF>)";
+
+  const auto doc = gdtf::ReadGdtfModeChannelDocument(xml);
+  const auto *mode = doc.FindMode("Mode");
+  const auto rows = BuildGdtfModeBrowserPresentation(mode);
+
+  assert(rows.size() >= 4);
+  assert(rows[0].item == "Ch 1 - Shutter1");
+  assert(rows[3].item == "Ch 2, 3 - Pan, Pan Fine");
+  return 0;
+}


### PR DESCRIPTION
### Motivation
- Top-level items in the Mode and Channel browser show terse DMX names that do not convey what users will find when expanding a root node, making quick scanning harder.
- Provide compact, informative labels at the root level that include channel offsets plus the immediate function summary so users can pick the right channel at a glance.

### Description
- Add `FormatBrowserChannelRootItem(...)` to `gui/gdtf/gdtf_mode_browser_presenter.cpp` to build compact root labels like `Ch 1 - Shutter1` or `Ch 2, 3 - Pan, Pan Fine` and keep a one-line explanatory comment above the new function.
- Use the new helper to populate `ch.item` for top-level DMX channel rows instead of the previous generic text.
- Add a regression test `tests/gdtf_mode_browser_presenter_test.cpp` that validates single-byte and multi-byte channel root labels and register it in `tests/CMakeLists.txt`.
- Update `docs/release-notes-draft.md` to mention the Edit Fixture mode/channel browser label improvement.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded.
- Ran `git diff --check` and it reported no problems.
- Attempted to build and run the new presenter test with CMake but configuration failed due to missing system `wxWidgets` development files in the environment, so the compiled test was not executed.
- Attempted a local compile using `g++` but it failed due to missing `tinyxml2` headers in the environment, so the standalone test run was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58bf01a10c83248b80fcc8d9e36ca8)