### PR TITLE
Preserve Data View multi-selection on double-click edits

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -24,6 +24,7 @@ Perastage 1.5.0 is a substantial update focused on GDTF and truss editing, multi
 - Added a shared **Hang Position editor** for fixtures, trusses, and hoists. Positions can be selected, created, renamed across affected objects, or removed from one dialog.
 - Updated Data Views interactions:
   - Double-clicking with the left mouse button opens cell-specific editing actions.
+  - Multi-row fixture and truss selections are preserved when double-clicking a selected row to batch-edit a cell.
   - Right-clicking opens row-level editors and context actions.
 - Edit Fixture and Edit Truss can now be maximized and use resizable layouts whose proportions are remembered between sessions.
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -24,7 +24,7 @@ Perastage 1.5.0 is a substantial update focused on GDTF and truss editing, multi
 - Added a shared **Hang Position editor** for fixtures, trusses, and hoists. Positions can be selected, created, renamed across affected objects, or removed from one dialog.
 - Updated Data Views interactions:
   - Double-clicking with the left mouse button opens cell-specific editing actions.
-  - Multi-row fixture, truss, hoist, and scene-object selections are reliably preserved when double-clicking a selected row to batch-edit a cell.
+  - Multi-row fixture, truss, hoist, and scene-object selections are reliably preserved when double-clicking a selected row to batch-edit a cell, including plain double-clicks without modifier keys.
   - Right-clicking opens row-level editors and context actions.
 - Edit Fixture and Edit Truss can now be maximized and use resizable layouts whose proportions are remembered between sessions.
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -24,7 +24,7 @@ Perastage 1.5.0 is a substantial update focused on GDTF and truss editing, multi
 - Added a shared **Hang Position editor** for fixtures, trusses, and hoists. Positions can be selected, created, renamed across affected objects, or removed from one dialog.
 - Updated Data Views interactions:
   - Double-clicking with the left mouse button opens cell-specific editing actions.
-  - Multi-row fixture and truss selections are preserved when double-clicking a selected row to batch-edit a cell.
+  - Multi-row fixture, truss, hoist, and scene-object selections are preserved when double-clicking a selected row to batch-edit a cell.
   - Right-clicking opens row-level editors and context actions.
 - Edit Fixture and Edit Truss can now be maximized and use resizable layouts whose proportions are remembered between sessions.
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -24,7 +24,7 @@ Perastage 1.5.0 is a substantial update focused on GDTF and truss editing, multi
 - Added a shared **Hang Position editor** for fixtures, trusses, and hoists. Positions can be selected, created, renamed across affected objects, or removed from one dialog.
 - Updated Data Views interactions:
   - Double-clicking with the left mouse button opens cell-specific editing actions.
-  - Multi-row fixture, truss, hoist, and scene-object selections are preserved when double-clicking a selected row to batch-edit a cell.
+  - Multi-row fixture, truss, hoist, and scene-object selections are reliably preserved when double-clicking a selected row to batch-edit a cell.
   - Right-clicking opens row-level editors and context actions.
 - Edit Fixture and Edit Truss can now be maximized and use resizable layouts whose proportions are remembered between sessions.
 

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -13,6 +13,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/dictionary_selection_controls.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dictionary_export_conflict_dialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dataview_edit_commit.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/dataview_multi_select_click_guard.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/editable_focus_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fixtures/fixture_gdtf_resolution.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tools/fixture_symbol_generation_tool.cpp

--- a/gui/dataview_multi_select_click_guard.cpp
+++ b/gui/dataview_multi_select_click_guard.cpp
@@ -48,6 +48,16 @@ bool DataViewMultiSelectClickGuard::HandleLeftDown(wxMouseEvent &event) {
   if (!ShouldDelayClick(event, item, row))
     return false;
 
+  wxDataViewItemArray selections;
+  table->GetSelections(selections);
+  pendingSelectionRows.clear();
+  pendingSelectionRows.reserve(selections.size());
+  for (const auto &selection : selections) {
+    const int selectedRow = table->ItemToRow(selection);
+    if (selectedRow != wxNOT_FOUND)
+      pendingSelectionRows.push_back(selectedRow);
+  }
+
   pendingItem = item;
   pendingColumn = column;
   pendingRow = row;
@@ -73,9 +83,11 @@ bool DataViewMultiSelectClickGuard::HandleLeftDClick(wxMouseEvent &event) {
   const int editColumnIndex = editColumn ? table->GetColumnPosition(editColumn)
                                         : wxNOT_FOUND;
   wxDataViewItem editItem = item.IsOk() ? item : pendingItem;
+  std::vector<int> editSelectionRows = pendingSelectionRows;
+  RestorePendingSelectionSilently();
   CancelPendingClick();
   if (doubleClickHandler)
-    doubleClickHandler(editItem, editColumnIndex);
+    doubleClickHandler(editItem, editColumnIndex, editSelectionRows);
   return true;
 }
 
@@ -86,6 +98,7 @@ void DataViewMultiSelectClickGuard::CancelPendingClick() {
   pendingItem = wxDataViewItem();
   pendingColumn = nullptr;
   pendingRow = wxNOT_FOUND;
+  pendingSelectionRows.clear();
 }
 
 // Returns true when a delayed single-click action is waiting for resolution.
@@ -120,6 +133,24 @@ bool DataViewMultiSelectClickGuard::ShouldDelayClick(
   return std::any_of(selections.begin(), selections.end(), [&](const auto &sel) {
     return table->ItemToRow(sel) == row;
   });
+}
+
+// Restores the captured multi-selection without notifying selection observers.
+void DataViewMultiSelectClickGuard::RestorePendingSelectionSilently() const {
+  if (!table || pendingSelectionRows.empty())
+    return;
+
+  wxDataViewItemArray currentSelections;
+  table->GetSelections(currentSelections);
+  if (currentSelections.size() == pendingSelectionRows.size())
+    return;
+
+  wxEventBlocker blocker(table, wxEVT_DATAVIEW_SELECTION_CHANGED);
+  table->UnselectAll();
+  for (const int row : pendingSelectionRows) {
+    if (row >= 0 && row < static_cast<int>(table->GetItemCount()))
+      table->SelectRow(static_cast<unsigned int>(row));
+  }
 }
 
 // Returns the platform double-click interval exposed by wxWidgets.

--- a/gui/dataview_multi_select_click_guard.cpp
+++ b/gui/dataview_multi_select_click_guard.cpp
@@ -27,12 +27,35 @@ DataViewMultiSelectClickGuard::DataViewMultiSelectClickGuard(
     : table(table), doubleClickHandler(std::move(doubleClickHandler)),
       pendingTimer(this) {
   Bind(wxEVT_TIMER, &DataViewMultiSelectClickGuard::OnTimer, this);
+  BindMouseEvents();
 }
 
 // Cancels pending work before the guarded table owner is destroyed.
 DataViewMultiSelectClickGuard::~DataViewMultiSelectClickGuard() {
   CancelPendingClick();
   Unbind(wxEVT_TIMER, &DataViewMultiSelectClickGuard::OnTimer, this);
+  UnbindMouseEvents();
+}
+
+// Handles bound left-down events before the native table changes selection.
+void DataViewMultiSelectClickGuard::OnBoundLeftDown(wxMouseEvent &event) {
+  if (HandleLeftDown(event))
+    return;
+  event.Skip();
+}
+
+// Handles bound double-click events before the native table changes selection.
+void DataViewMultiSelectClickGuard::OnBoundLeftDClick(wxMouseEvent &event) {
+  if (HandleLeftDClick(event))
+    return;
+  event.Skip();
+}
+
+// Suppresses left-up while a click is pending so native selection waits too.
+void DataViewMultiSelectClickGuard::OnBoundLeftUp(wxMouseEvent &event) {
+  if (HasPendingClick())
+    return;
+  event.Skip();
 }
 
 // Defers plain clicks on already-selected rows when a multi-selection is active.
@@ -42,7 +65,7 @@ bool DataViewMultiSelectClickGuard::HandleLeftDown(wxMouseEvent &event) {
 
   wxDataViewItem item;
   wxDataViewColumn *column = nullptr;
-  table->HitTest(event.GetPosition(), item, column);
+  table->HitTest(TablePosition(event), item, column);
   const int row = item.IsOk() ? table->ItemToRow(item) : wxNOT_FOUND;
 
   if (HasPendingClick()) {
@@ -68,7 +91,7 @@ bool DataViewMultiSelectClickGuard::HandleLeftDClick(wxMouseEvent &event) {
 
   wxDataViewItem item;
   wxDataViewColumn *column = nullptr;
-  table->HitTest(event.GetPosition(), item, column);
+  table->HitTest(TablePosition(event), item, column);
   const int row = item.IsOk() ? table->ItemToRow(item) : wxNOT_FOUND;
   if (row != pendingRow) {
     CancelPendingClick();
@@ -132,4 +155,55 @@ bool DataViewMultiSelectClickGuard::ShouldDelayClick(
 int DataViewMultiSelectClickGuard::DoubleClickIntervalMs() const {
   const int interval = wxSystemSettings::GetMetric(wxSYS_DCLICK_MSEC);
   return interval > 0 ? interval : 250;
+}
+
+// Converts mouse coordinates from child windows into table client coordinates.
+wxPoint DataViewMultiSelectClickGuard::TablePosition(
+    const wxMouseEvent &event) const {
+  wxWindow *sourceWindow = dynamic_cast<wxWindow *>(event.GetEventObject());
+  if (!table || !sourceWindow || sourceWindow == table)
+    return event.GetPosition();
+  return table->ScreenToClient(sourceWindow->ClientToScreen(event.GetPosition()));
+}
+
+// Binds mouse interception to the table and its native child windows.
+void DataViewMultiSelectClickGuard::BindMouseEvents() {
+  BindMouseEvents(table);
+  if (!table)
+    return;
+  for (wxWindow *child : table->GetChildren())
+    BindMouseEvents(child);
+}
+
+// Unbinds mouse interception from the table and its native child windows.
+void DataViewMultiSelectClickGuard::UnbindMouseEvents() {
+  UnbindMouseEvents(table);
+  if (!table)
+    return;
+  for (wxWindow *child : table->GetChildren())
+    UnbindMouseEvents(child);
+}
+
+// Binds mouse interception to one table window.
+void DataViewMultiSelectClickGuard::BindMouseEvents(wxWindow *window) {
+  if (!window)
+    return;
+  window->Bind(wxEVT_LEFT_DOWN, &DataViewMultiSelectClickGuard::OnBoundLeftDown,
+               this);
+  window->Bind(wxEVT_LEFT_DCLICK,
+               &DataViewMultiSelectClickGuard::OnBoundLeftDClick, this);
+  window->Bind(wxEVT_LEFT_UP, &DataViewMultiSelectClickGuard::OnBoundLeftUp,
+               this);
+}
+
+// Unbinds mouse interception from one table window.
+void DataViewMultiSelectClickGuard::UnbindMouseEvents(wxWindow *window) {
+  if (!window)
+    return;
+  window->Unbind(wxEVT_LEFT_DOWN,
+                 &DataViewMultiSelectClickGuard::OnBoundLeftDown, this);
+  window->Unbind(wxEVT_LEFT_DCLICK,
+                 &DataViewMultiSelectClickGuard::OnBoundLeftDClick, this);
+  window->Unbind(wxEVT_LEFT_UP, &DataViewMultiSelectClickGuard::OnBoundLeftUp,
+                 this);
 }

--- a/gui/dataview_multi_select_click_guard.cpp
+++ b/gui/dataview_multi_select_click_guard.cpp
@@ -27,17 +27,22 @@ DataViewMultiSelectClickGuard::DataViewMultiSelectClickGuard(
     : table(table), doubleClickHandler(std::move(doubleClickHandler)),
       pendingTimer(this) {
   Bind(wxEVT_TIMER, &DataViewMultiSelectClickGuard::OnTimer, this);
+  if (table)
+    table->Bind(wxEVT_DATAVIEW_SELECTION_CHANGED,
+                &DataViewMultiSelectClickGuard::OnSelectionChanged, this);
 }
 
 // Cancels pending work before the guarded table owner is destroyed.
 DataViewMultiSelectClickGuard::~DataViewMultiSelectClickGuard() {
   CancelPendingClick();
   Unbind(wxEVT_TIMER, &DataViewMultiSelectClickGuard::OnTimer, this);
+  if (table)
+    table->Unbind(wxEVT_DATAVIEW_SELECTION_CHANGED,
+                  &DataViewMultiSelectClickGuard::OnSelectionChanged, this);
 }
 
 // Defers plain clicks on already-selected rows when a multi-selection is active.
 bool DataViewMultiSelectClickGuard::HandleLeftDown(wxMouseEvent &event) {
-  CancelPendingClick();
   if (!table)
     return false;
 
@@ -45,18 +50,18 @@ bool DataViewMultiSelectClickGuard::HandleLeftDown(wxMouseEvent &event) {
   wxDataViewColumn *column = nullptr;
   table->HitTest(event.GetPosition(), item, column);
   const int row = item.IsOk() ? table->ItemToRow(item) : wxNOT_FOUND;
+  if (HasPendingClick()) {
+    if (row == pendingRow && !event.ControlDown() && !event.ShiftDown())
+      return true;
+    CancelPendingClick();
+  }
+
   if (!ShouldDelayClick(event, item, row))
     return false;
 
-  wxDataViewItemArray selections;
-  table->GetSelections(selections);
-  pendingSelectionRows.clear();
-  pendingSelectionRows.reserve(selections.size());
-  for (const auto &selection : selections) {
-    const int selectedRow = table->ItemToRow(selection);
-    if (selectedRow != wxNOT_FOUND)
-      pendingSelectionRows.push_back(selectedRow);
-  }
+  pendingSelectionRows = CurrentSelectionRows();
+  if (pendingSelectionRows.size() <= 1 && ContainsRow(lastMultiSelectionRows, row))
+    pendingSelectionRows = lastMultiSelectionRows;
 
   pendingItem = item;
   pendingColumn = column;
@@ -113,6 +118,7 @@ void DataViewMultiSelectClickGuard::OnTimer(wxTimerEvent &WXUNUSED(event)) {
 
   const int row = pendingRow;
   CancelPendingClick();
+  lastMultiSelectionRows.clear();
   table->UnselectAll();
   if (row != wxNOT_FOUND && row < static_cast<int>(table->GetItemCount()))
     table->SelectRow(static_cast<unsigned int>(row));
@@ -125,14 +131,19 @@ bool DataViewMultiSelectClickGuard::ShouldDelayClick(
       event.ShiftDown())
     return false;
 
-  wxDataViewItemArray selections;
-  table->GetSelections(selections);
-  if (selections.size() <= 1)
-    return false;
+  const std::vector<int> currentRows = CurrentSelectionRows();
+  if (currentRows.size() > 1)
+    return ContainsRow(currentRows, row);
 
-  return std::any_of(selections.begin(), selections.end(), [&](const auto &sel) {
-    return table->ItemToRow(sel) == row;
-  });
+  return ContainsRow(lastMultiSelectionRows, row);
+}
+
+// Tracks the most recent multi-row selection before native controls collapse it.
+void DataViewMultiSelectClickGuard::OnSelectionChanged(wxDataViewEvent &event) {
+  const std::vector<int> rows = CurrentSelectionRows();
+  if (rows.size() > 1)
+    lastMultiSelectionRows = rows;
+  event.Skip();
 }
 
 // Restores the captured multi-selection without notifying selection observers.
@@ -151,6 +162,29 @@ void DataViewMultiSelectClickGuard::RestorePendingSelectionSilently() const {
     if (row >= 0 && row < static_cast<int>(table->GetItemCount()))
       table->SelectRow(static_cast<unsigned int>(row));
   }
+}
+
+// Returns the currently selected table row indexes.
+std::vector<int> DataViewMultiSelectClickGuard::CurrentSelectionRows() const {
+  std::vector<int> rows;
+  if (!table)
+    return rows;
+
+  wxDataViewItemArray selections;
+  table->GetSelections(selections);
+  rows.reserve(selections.size());
+  for (const auto &selection : selections) {
+    const int row = table->ItemToRow(selection);
+    if (row != wxNOT_FOUND)
+      rows.push_back(row);
+  }
+  return rows;
+}
+
+// Returns true when the row index exists in the provided row list.
+bool DataViewMultiSelectClickGuard::ContainsRow(const std::vector<int> &rows,
+                                                int row) const {
+  return std::find(rows.begin(), rows.end(), row) != rows.end();
 }
 
 // Returns the platform double-click interval exposed by wxWidgets.

--- a/gui/dataview_multi_select_click_guard.cpp
+++ b/gui/dataview_multi_select_click_guard.cpp
@@ -128,9 +128,13 @@ void DataViewMultiSelectClickGuard::OnTimer(wxTimerEvent &WXUNUSED(event)) {
     return;
 
   const int row = pendingRow;
+  const wxDataViewItem item = pendingItem;
   CancelPendingClick();
+  table->SetFocus();
   table->UnselectAll();
-  if (row != wxNOT_FOUND && row < static_cast<int>(table->GetItemCount()))
+  if (item.IsOk())
+    table->Select(item);
+  else if (row != wxNOT_FOUND && row < static_cast<int>(table->GetItemCount()))
     table->SelectRow(static_cast<unsigned int>(row));
 }
 

--- a/gui/dataview_multi_select_click_guard.cpp
+++ b/gui/dataview_multi_select_click_guard.cpp
@@ -1,0 +1,127 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2026 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "dataview_multi_select_click_guard.h"
+
+#include <algorithm>
+#include <utility>
+#include <wx/settings.h>
+
+// Creates a guard that defers selected-row clicks long enough to detect double-clicks.
+DataViewMultiSelectClickGuard::DataViewMultiSelectClickGuard(
+    wxDataViewListCtrl *table, DoubleClickHandler doubleClickHandler)
+    : table(table), doubleClickHandler(std::move(doubleClickHandler)),
+      pendingTimer(this) {
+  Bind(wxEVT_TIMER, &DataViewMultiSelectClickGuard::OnTimer, this);
+}
+
+// Cancels pending work before the guarded table owner is destroyed.
+DataViewMultiSelectClickGuard::~DataViewMultiSelectClickGuard() {
+  CancelPendingClick();
+  Unbind(wxEVT_TIMER, &DataViewMultiSelectClickGuard::OnTimer, this);
+}
+
+// Defers plain clicks on already-selected rows when a multi-selection is active.
+bool DataViewMultiSelectClickGuard::HandleLeftDown(wxMouseEvent &event) {
+  CancelPendingClick();
+  if (!table)
+    return false;
+
+  wxDataViewItem item;
+  wxDataViewColumn *column = nullptr;
+  table->HitTest(event.GetPosition(), item, column);
+  const int row = item.IsOk() ? table->ItemToRow(item) : wxNOT_FOUND;
+  if (!ShouldDelayClick(event, item, row))
+    return false;
+
+  pendingItem = item;
+  pendingColumn = column;
+  pendingRow = row;
+  pendingTimer.StartOnce(DoubleClickIntervalMs());
+  return true;
+}
+
+// Resolves a pending click as a batch edit when the second click arrives in time.
+bool DataViewMultiSelectClickGuard::HandleLeftDClick(wxMouseEvent &event) {
+  if (!HasPendingClick() || !table)
+    return false;
+
+  wxDataViewItem item;
+  wxDataViewColumn *column = nullptr;
+  table->HitTest(event.GetPosition(), item, column);
+  const int row = item.IsOk() ? table->ItemToRow(item) : wxNOT_FOUND;
+  if (row != pendingRow) {
+    CancelPendingClick();
+    return false;
+  }
+
+  wxDataViewColumn *editColumn = column ? column : pendingColumn;
+  wxDataViewItem editItem = item.IsOk() ? item : pendingItem;
+  CancelPendingClick();
+  if (doubleClickHandler)
+    doubleClickHandler(editItem, editColumn);
+  return true;
+}
+
+// Cancels any delayed single-click action.
+void DataViewMultiSelectClickGuard::CancelPendingClick() {
+  if (pendingTimer.IsRunning())
+    pendingTimer.Stop();
+  pendingItem = wxDataViewItem();
+  pendingColumn = nullptr;
+  pendingRow = wxNOT_FOUND;
+}
+
+// Returns true when a delayed single-click action is waiting for resolution.
+bool DataViewMultiSelectClickGuard::HasPendingClick() const {
+  return pendingRow != wxNOT_FOUND && pendingItem.IsOk();
+}
+
+// Converts an unresolved pending click into normal single-row selection.
+void DataViewMultiSelectClickGuard::OnTimer(wxTimerEvent &WXUNUSED(event)) {
+  if (!table || !HasPendingClick())
+    return;
+
+  const int row = pendingRow;
+  CancelPendingClick();
+  table->UnselectAll();
+  if (row != wxNOT_FOUND && row < static_cast<int>(table->GetItemCount()))
+    table->SelectRow(static_cast<unsigned int>(row));
+}
+
+// Returns true when this click should wait for a possible double-click.
+bool DataViewMultiSelectClickGuard::ShouldDelayClick(
+    const wxMouseEvent &event, const wxDataViewItem &item, int row) const {
+  if (!table || !item.IsOk() || row == wxNOT_FOUND || event.ControlDown() ||
+      event.ShiftDown())
+    return false;
+
+  wxDataViewItemArray selections;
+  table->GetSelections(selections);
+  if (selections.size() <= 1)
+    return false;
+
+  return std::any_of(selections.begin(), selections.end(), [&](const auto &sel) {
+    return table->ItemToRow(sel) == row;
+  });
+}
+
+// Returns the platform double-click interval exposed by wxWidgets.
+int DataViewMultiSelectClickGuard::DoubleClickIntervalMs() const {
+  const int interval = wxSystemSettings::GetMetric(wxSYS_DCLICK_MSEC);
+  return interval > 0 ? interval : 250;
+}

--- a/gui/dataview_multi_select_click_guard.cpp
+++ b/gui/dataview_multi_select_click_guard.cpp
@@ -70,10 +70,12 @@ bool DataViewMultiSelectClickGuard::HandleLeftDClick(wxMouseEvent &event) {
   }
 
   wxDataViewColumn *editColumn = column ? column : pendingColumn;
+  const int editColumnIndex = editColumn ? table->GetColumnPosition(editColumn)
+                                        : wxNOT_FOUND;
   wxDataViewItem editItem = item.IsOk() ? item : pendingItem;
   CancelPendingClick();
   if (doubleClickHandler)
-    doubleClickHandler(editItem, editColumn);
+    doubleClickHandler(editItem, editColumnIndex);
   return true;
 }
 

--- a/gui/dataview_multi_select_click_guard.cpp
+++ b/gui/dataview_multi_select_click_guard.cpp
@@ -27,18 +27,12 @@ DataViewMultiSelectClickGuard::DataViewMultiSelectClickGuard(
     : table(table), doubleClickHandler(std::move(doubleClickHandler)),
       pendingTimer(this) {
   Bind(wxEVT_TIMER, &DataViewMultiSelectClickGuard::OnTimer, this);
-  if (table)
-    table->Bind(wxEVT_DATAVIEW_SELECTION_CHANGED,
-                &DataViewMultiSelectClickGuard::OnSelectionChanged, this);
 }
 
 // Cancels pending work before the guarded table owner is destroyed.
 DataViewMultiSelectClickGuard::~DataViewMultiSelectClickGuard() {
   CancelPendingClick();
   Unbind(wxEVT_TIMER, &DataViewMultiSelectClickGuard::OnTimer, this);
-  if (table)
-    table->Unbind(wxEVT_DATAVIEW_SELECTION_CHANGED,
-                  &DataViewMultiSelectClickGuard::OnSelectionChanged, this);
 }
 
 // Defers plain clicks on already-selected rows when a multi-selection is active.
@@ -50,6 +44,7 @@ bool DataViewMultiSelectClickGuard::HandleLeftDown(wxMouseEvent &event) {
   wxDataViewColumn *column = nullptr;
   table->HitTest(event.GetPosition(), item, column);
   const int row = item.IsOk() ? table->ItemToRow(item) : wxNOT_FOUND;
+
   if (HasPendingClick()) {
     if (row == pendingRow && !event.ControlDown() && !event.ShiftDown())
       return true;
@@ -58,10 +53,6 @@ bool DataViewMultiSelectClickGuard::HandleLeftDown(wxMouseEvent &event) {
 
   if (!ShouldDelayClick(event, item, row))
     return false;
-
-  pendingSelectionRows = CurrentSelectionRows();
-  if (pendingSelectionRows.size() <= 1 && ContainsRow(lastMultiSelectionRows, row))
-    pendingSelectionRows = lastMultiSelectionRows;
 
   pendingItem = item;
   pendingColumn = column;
@@ -88,11 +79,9 @@ bool DataViewMultiSelectClickGuard::HandleLeftDClick(wxMouseEvent &event) {
   const int editColumnIndex = editColumn ? table->GetColumnPosition(editColumn)
                                         : wxNOT_FOUND;
   wxDataViewItem editItem = item.IsOk() ? item : pendingItem;
-  std::vector<int> editSelectionRows = pendingSelectionRows;
-  RestorePendingSelectionSilently();
   CancelPendingClick();
   if (doubleClickHandler)
-    doubleClickHandler(editItem, editColumnIndex, editSelectionRows);
+    doubleClickHandler(editItem, editColumnIndex);
   return true;
 }
 
@@ -103,7 +92,6 @@ void DataViewMultiSelectClickGuard::CancelPendingClick() {
   pendingItem = wxDataViewItem();
   pendingColumn = nullptr;
   pendingRow = wxNOT_FOUND;
-  pendingSelectionRows.clear();
 }
 
 // Returns true when a delayed single-click action is waiting for resolution.
@@ -118,7 +106,6 @@ void DataViewMultiSelectClickGuard::OnTimer(wxTimerEvent &WXUNUSED(event)) {
 
   const int row = pendingRow;
   CancelPendingClick();
-  lastMultiSelectionRows.clear();
   table->UnselectAll();
   if (row != wxNOT_FOUND && row < static_cast<int>(table->GetItemCount()))
     table->SelectRow(static_cast<unsigned int>(row));
@@ -131,60 +118,14 @@ bool DataViewMultiSelectClickGuard::ShouldDelayClick(
       event.ShiftDown())
     return false;
 
-  const std::vector<int> currentRows = CurrentSelectionRows();
-  if (currentRows.size() > 1)
-    return ContainsRow(currentRows, row);
-
-  return ContainsRow(lastMultiSelectionRows, row);
-}
-
-// Tracks the most recent multi-row selection before native controls collapse it.
-void DataViewMultiSelectClickGuard::OnSelectionChanged(wxDataViewEvent &event) {
-  const std::vector<int> rows = CurrentSelectionRows();
-  if (rows.size() > 1)
-    lastMultiSelectionRows = rows;
-  event.Skip();
-}
-
-// Restores the captured multi-selection without notifying selection observers.
-void DataViewMultiSelectClickGuard::RestorePendingSelectionSilently() const {
-  if (!table || pendingSelectionRows.empty())
-    return;
-
-  wxDataViewItemArray currentSelections;
-  table->GetSelections(currentSelections);
-  if (currentSelections.size() == pendingSelectionRows.size())
-    return;
-
-  wxEventBlocker blocker(table, wxEVT_DATAVIEW_SELECTION_CHANGED);
-  table->UnselectAll();
-  for (const int row : pendingSelectionRows) {
-    if (row >= 0 && row < static_cast<int>(table->GetItemCount()))
-      table->SelectRow(static_cast<unsigned int>(row));
-  }
-}
-
-// Returns the currently selected table row indexes.
-std::vector<int> DataViewMultiSelectClickGuard::CurrentSelectionRows() const {
-  std::vector<int> rows;
-  if (!table)
-    return rows;
-
   wxDataViewItemArray selections;
   table->GetSelections(selections);
-  rows.reserve(selections.size());
-  for (const auto &selection : selections) {
-    const int row = table->ItemToRow(selection);
-    if (row != wxNOT_FOUND)
-      rows.push_back(row);
-  }
-  return rows;
-}
+  if (selections.size() <= 1)
+    return false;
 
-// Returns true when the row index exists in the provided row list.
-bool DataViewMultiSelectClickGuard::ContainsRow(const std::vector<int> &rows,
-                                                int row) const {
-  return std::find(rows.begin(), rows.end(), row) != rows.end();
+  return std::any_of(selections.begin(), selections.end(), [&](const auto &sel) {
+    return table->ItemToRow(sel) == row;
+  });
 }
 
 // Returns the platform double-click interval exposed by wxWidgets.

--- a/gui/dataview_multi_select_click_guard.cpp
+++ b/gui/dataview_multi_select_click_guard.cpp
@@ -27,35 +27,12 @@ DataViewMultiSelectClickGuard::DataViewMultiSelectClickGuard(
     : table(table), doubleClickHandler(std::move(doubleClickHandler)),
       pendingTimer(this) {
   Bind(wxEVT_TIMER, &DataViewMultiSelectClickGuard::OnTimer, this);
-  BindMouseEvents();
 }
 
 // Cancels pending work before the guarded table owner is destroyed.
 DataViewMultiSelectClickGuard::~DataViewMultiSelectClickGuard() {
   CancelPendingClick();
   Unbind(wxEVT_TIMER, &DataViewMultiSelectClickGuard::OnTimer, this);
-  UnbindMouseEvents();
-}
-
-// Handles bound left-down events before the native table changes selection.
-void DataViewMultiSelectClickGuard::OnBoundLeftDown(wxMouseEvent &event) {
-  if (HandleLeftDown(event))
-    return;
-  event.Skip();
-}
-
-// Handles bound double-click events before the native table changes selection.
-void DataViewMultiSelectClickGuard::OnBoundLeftDClick(wxMouseEvent &event) {
-  if (HandleLeftDClick(event))
-    return;
-  event.Skip();
-}
-
-// Suppresses left-up while a click is pending so native selection waits too.
-void DataViewMultiSelectClickGuard::OnBoundLeftUp(wxMouseEvent &event) {
-  if (HasPendingClick())
-    return;
-  event.Skip();
 }
 
 // Defers plain clicks on already-selected rows when a multi-selection is active.
@@ -65,7 +42,7 @@ bool DataViewMultiSelectClickGuard::HandleLeftDown(wxMouseEvent &event) {
 
   wxDataViewItem item;
   wxDataViewColumn *column = nullptr;
-  table->HitTest(TablePosition(event), item, column);
+  table->HitTest(event.GetPosition(), item, column);
   const int row = item.IsOk() ? table->ItemToRow(item) : wxNOT_FOUND;
 
   if (HasPendingClick()) {
@@ -91,7 +68,7 @@ bool DataViewMultiSelectClickGuard::HandleLeftDClick(wxMouseEvent &event) {
 
   wxDataViewItem item;
   wxDataViewColumn *column = nullptr;
-  table->HitTest(TablePosition(event), item, column);
+  table->HitTest(event.GetPosition(), item, column);
   const int row = item.IsOk() ? table->ItemToRow(item) : wxNOT_FOUND;
   if (row != pendingRow) {
     CancelPendingClick();
@@ -128,13 +105,9 @@ void DataViewMultiSelectClickGuard::OnTimer(wxTimerEvent &WXUNUSED(event)) {
     return;
 
   const int row = pendingRow;
-  const wxDataViewItem item = pendingItem;
   CancelPendingClick();
-  table->SetFocus();
   table->UnselectAll();
-  if (item.IsOk())
-    table->Select(item);
-  else if (row != wxNOT_FOUND && row < static_cast<int>(table->GetItemCount()))
+  if (row != wxNOT_FOUND && row < static_cast<int>(table->GetItemCount()))
     table->SelectRow(static_cast<unsigned int>(row));
 }
 
@@ -159,55 +132,4 @@ bool DataViewMultiSelectClickGuard::ShouldDelayClick(
 int DataViewMultiSelectClickGuard::DoubleClickIntervalMs() const {
   const int interval = wxSystemSettings::GetMetric(wxSYS_DCLICK_MSEC);
   return interval > 0 ? interval : 250;
-}
-
-// Converts mouse coordinates from child windows into table client coordinates.
-wxPoint DataViewMultiSelectClickGuard::TablePosition(
-    const wxMouseEvent &event) const {
-  wxWindow *sourceWindow = dynamic_cast<wxWindow *>(event.GetEventObject());
-  if (!table || !sourceWindow || sourceWindow == table)
-    return event.GetPosition();
-  return table->ScreenToClient(sourceWindow->ClientToScreen(event.GetPosition()));
-}
-
-// Binds mouse interception to the table and its native child windows.
-void DataViewMultiSelectClickGuard::BindMouseEvents() {
-  BindMouseEvents(table);
-  if (!table)
-    return;
-  for (wxWindow *child : table->GetChildren())
-    BindMouseEvents(child);
-}
-
-// Unbinds mouse interception from the table and its native child windows.
-void DataViewMultiSelectClickGuard::UnbindMouseEvents() {
-  UnbindMouseEvents(table);
-  if (!table)
-    return;
-  for (wxWindow *child : table->GetChildren())
-    UnbindMouseEvents(child);
-}
-
-// Binds mouse interception to one table window.
-void DataViewMultiSelectClickGuard::BindMouseEvents(wxWindow *window) {
-  if (!window)
-    return;
-  window->Bind(wxEVT_LEFT_DOWN, &DataViewMultiSelectClickGuard::OnBoundLeftDown,
-               this);
-  window->Bind(wxEVT_LEFT_DCLICK,
-               &DataViewMultiSelectClickGuard::OnBoundLeftDClick, this);
-  window->Bind(wxEVT_LEFT_UP, &DataViewMultiSelectClickGuard::OnBoundLeftUp,
-               this);
-}
-
-// Unbinds mouse interception from one table window.
-void DataViewMultiSelectClickGuard::UnbindMouseEvents(wxWindow *window) {
-  if (!window)
-    return;
-  window->Unbind(wxEVT_LEFT_DOWN,
-                 &DataViewMultiSelectClickGuard::OnBoundLeftDown, this);
-  window->Unbind(wxEVT_LEFT_DCLICK,
-                 &DataViewMultiSelectClickGuard::OnBoundLeftDClick, this);
-  window->Unbind(wxEVT_LEFT_UP, &DataViewMultiSelectClickGuard::OnBoundLeftUp,
-                 this);
 }

--- a/gui/dataview_multi_select_click_guard.h
+++ b/gui/dataview_multi_select_click_guard.h
@@ -38,9 +38,12 @@ public:
 
 private:
   void OnTimer(wxTimerEvent &event);
+  void OnSelectionChanged(wxDataViewEvent &event);
   bool ShouldDelayClick(const wxMouseEvent &event, const wxDataViewItem &item,
                         int row) const;
   void RestorePendingSelectionSilently() const;
+  std::vector<int> CurrentSelectionRows() const;
+  bool ContainsRow(const std::vector<int> &rows, int row) const;
   int DoubleClickIntervalMs() const;
 
   wxDataViewListCtrl *table = nullptr;
@@ -50,4 +53,5 @@ private:
   wxDataViewColumn *pendingColumn = nullptr;
   int pendingRow = wxNOT_FOUND;
   std::vector<int> pendingSelectionRows;
+  std::vector<int> lastMultiSelectionRows;
 };

--- a/gui/dataview_multi_select_click_guard.h
+++ b/gui/dataview_multi_select_click_guard.h
@@ -18,14 +18,12 @@
 #pragma once
 
 #include <functional>
-#include <vector>
 #include <wx/dataview.h>
 #include <wx/timer.h>
 
 class DataViewMultiSelectClickGuard : public wxEvtHandler {
 public:
-  using DoubleClickHandler =
-      std::function<void(const wxDataViewItem &, int, const std::vector<int> &)>;
+  using DoubleClickHandler = std::function<void(const wxDataViewItem &, int)>;
 
   DataViewMultiSelectClickGuard(wxDataViewListCtrl *table,
                                 DoubleClickHandler doubleClickHandler);
@@ -38,12 +36,8 @@ public:
 
 private:
   void OnTimer(wxTimerEvent &event);
-  void OnSelectionChanged(wxDataViewEvent &event);
   bool ShouldDelayClick(const wxMouseEvent &event, const wxDataViewItem &item,
                         int row) const;
-  void RestorePendingSelectionSilently() const;
-  std::vector<int> CurrentSelectionRows() const;
-  bool ContainsRow(const std::vector<int> &rows, int row) const;
   int DoubleClickIntervalMs() const;
 
   wxDataViewListCtrl *table = nullptr;
@@ -52,6 +46,4 @@ private:
   wxDataViewItem pendingItem;
   wxDataViewColumn *pendingColumn = nullptr;
   int pendingRow = wxNOT_FOUND;
-  std::vector<int> pendingSelectionRows;
-  std::vector<int> lastMultiSelectionRows;
 };

--- a/gui/dataview_multi_select_click_guard.h
+++ b/gui/dataview_multi_select_click_guard.h
@@ -1,0 +1,50 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2026 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <functional>
+#include <wx/dataview.h>
+#include <wx/timer.h>
+
+class DataViewMultiSelectClickGuard : public wxEvtHandler {
+public:
+  using DoubleClickHandler =
+      std::function<void(const wxDataViewItem &, wxDataViewColumn *)>;
+
+  DataViewMultiSelectClickGuard(wxDataViewListCtrl *table,
+                                DoubleClickHandler doubleClickHandler);
+  ~DataViewMultiSelectClickGuard() override;
+
+  bool HandleLeftDown(wxMouseEvent &event);
+  bool HandleLeftDClick(wxMouseEvent &event);
+  void CancelPendingClick();
+  bool HasPendingClick() const;
+
+private:
+  void OnTimer(wxTimerEvent &event);
+  bool ShouldDelayClick(const wxMouseEvent &event, const wxDataViewItem &item,
+                        int row) const;
+  int DoubleClickIntervalMs() const;
+
+  wxDataViewListCtrl *table = nullptr;
+  DoubleClickHandler doubleClickHandler;
+  wxTimer pendingTimer;
+  wxDataViewItem pendingItem;
+  wxDataViewColumn *pendingColumn = nullptr;
+  int pendingRow = wxNOT_FOUND;
+};

--- a/gui/dataview_multi_select_click_guard.h
+++ b/gui/dataview_multi_select_click_guard.h
@@ -36,9 +36,17 @@ public:
 
 private:
   void OnTimer(wxTimerEvent &event);
+  void OnBoundLeftDown(wxMouseEvent &event);
+  void OnBoundLeftDClick(wxMouseEvent &event);
+  void OnBoundLeftUp(wxMouseEvent &event);
   bool ShouldDelayClick(const wxMouseEvent &event, const wxDataViewItem &item,
                         int row) const;
   int DoubleClickIntervalMs() const;
+  wxPoint TablePosition(const wxMouseEvent &event) const;
+  void BindMouseEvents();
+  void UnbindMouseEvents();
+  void BindMouseEvents(wxWindow *window);
+  void UnbindMouseEvents(wxWindow *window);
 
   wxDataViewListCtrl *table = nullptr;
   DoubleClickHandler doubleClickHandler;

--- a/gui/dataview_multi_select_click_guard.h
+++ b/gui/dataview_multi_select_click_guard.h
@@ -36,17 +36,9 @@ public:
 
 private:
   void OnTimer(wxTimerEvent &event);
-  void OnBoundLeftDown(wxMouseEvent &event);
-  void OnBoundLeftDClick(wxMouseEvent &event);
-  void OnBoundLeftUp(wxMouseEvent &event);
   bool ShouldDelayClick(const wxMouseEvent &event, const wxDataViewItem &item,
                         int row) const;
   int DoubleClickIntervalMs() const;
-  wxPoint TablePosition(const wxMouseEvent &event) const;
-  void BindMouseEvents();
-  void UnbindMouseEvents();
-  void BindMouseEvents(wxWindow *window);
-  void UnbindMouseEvents(wxWindow *window);
 
   wxDataViewListCtrl *table = nullptr;
   DoubleClickHandler doubleClickHandler;

--- a/gui/dataview_multi_select_click_guard.h
+++ b/gui/dataview_multi_select_click_guard.h
@@ -18,13 +18,14 @@
 #pragma once
 
 #include <functional>
+#include <vector>
 #include <wx/dataview.h>
 #include <wx/timer.h>
 
 class DataViewMultiSelectClickGuard : public wxEvtHandler {
 public:
   using DoubleClickHandler =
-      std::function<void(const wxDataViewItem &, int)>;
+      std::function<void(const wxDataViewItem &, int, const std::vector<int> &)>;
 
   DataViewMultiSelectClickGuard(wxDataViewListCtrl *table,
                                 DoubleClickHandler doubleClickHandler);
@@ -39,6 +40,7 @@ private:
   void OnTimer(wxTimerEvent &event);
   bool ShouldDelayClick(const wxMouseEvent &event, const wxDataViewItem &item,
                         int row) const;
+  void RestorePendingSelectionSilently() const;
   int DoubleClickIntervalMs() const;
 
   wxDataViewListCtrl *table = nullptr;
@@ -47,4 +49,5 @@ private:
   wxDataViewItem pendingItem;
   wxDataViewColumn *pendingColumn = nullptr;
   int pendingRow = wxNOT_FOUND;
+  std::vector<int> pendingSelectionRows;
 };

--- a/gui/dataview_multi_select_click_guard.h
+++ b/gui/dataview_multi_select_click_guard.h
@@ -24,7 +24,7 @@
 class DataViewMultiSelectClickGuard : public wxEvtHandler {
 public:
   using DoubleClickHandler =
-      std::function<void(const wxDataViewItem &, wxDataViewColumn *)>;
+      std::function<void(const wxDataViewItem &, int)>;
 
   DataViewMultiSelectClickGuard(wxDataViewListCtrl *table,
                                 DoubleClickHandler doubleClickHandler);

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -242,8 +242,9 @@ FixtureTablePanel::FixtureTablePanel(wxWindow *parent,
   table->Bind(wxEVT_DATAVIEW_COLUMN_SORTED, &FixtureTablePanel::OnColumnSorted,
               this);
   multiSelectClickGuard = std::make_unique<DataViewMultiSelectClickGuard>(
-      table, [this](const wxDataViewItem &item, int column) {
-        EditSelectedCell(item, column);
+      table, [this](const wxDataViewItem &item, int column,
+             const std::vector<int> &selectionRows) {
+        EditSelectedCell(item, column, &selectionRows);
       });
 
   InitializeTable();
@@ -497,16 +498,25 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
 }
 
 // Routes table activation through the existing batch cell editor.
-void FixtureTablePanel::EditSelectedCell(const wxDataViewItem &item, int col) {
+void FixtureTablePanel::EditSelectedCell(const wxDataViewItem &item, int col,
+                                 const std::vector<int> *selectionRows) {
   const auto namedColumn = FixtureTableColumns::FromIndex(col);
   if (!item.IsOk() || !namedColumn ||
       static_cast<size_t>(col) >= columnLabels.size())
     return;
 
   wxDataViewItemArray selections;
-  table->GetSelections(selections);
-  if (selections.empty())
-    selections.push_back(item);
+  if (selectionRows) {
+    for (const int row : *selectionRows) {
+      if (row >= 0 && row < static_cast<int>(table->GetItemCount()))
+        selections.push_back(table->RowToItem(static_cast<unsigned int>(row)));
+    }
+  }
+  if (selections.empty()) {
+    table->GetSelections(selections);
+    if (selections.empty())
+      selections.push_back(item);
+  }
 
   std::vector<std::string> selectedUuids;
   for (const auto &itSel : selections) {

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -18,6 +18,7 @@
 #include "fixturetablepanel.h"
 #include "addressdialog.h"
 #include "configmanager.h"
+#include "dataview_multi_select_click_guard.h"
 #include "consolepanel.h"
 #include "fixtureeditdialog.h"
 #include "fixturetable/fixture_table_columns.h"
@@ -225,6 +226,8 @@ FixtureTablePanel::FixtureTablePanel(wxWindow *parent,
   store->SetSelectionColours(selectionBackground, selectionForeground);
   BindTableHoverEvents(table, this, &FixtureTablePanel::OnMouseMove,
                        &FixtureTablePanel::OnMouseLeave);
+  table->Bind(wxEVT_LEFT_DOWN, &FixtureTablePanel::OnLeftDown, this);
+  table->Bind(wxEVT_LEFT_DCLICK, &FixtureTablePanel::OnLeftDClick, this);
   table->CallAfter([this]() {
     BindTableHoverEvents(table, this, &FixtureTablePanel::OnMouseMove,
                          &FixtureTablePanel::OnMouseLeave);
@@ -238,6 +241,10 @@ FixtureTablePanel::FixtureTablePanel(wxWindow *parent,
               &FixtureTablePanel::OnContextMenu, this);
   table->Bind(wxEVT_DATAVIEW_COLUMN_SORTED, &FixtureTablePanel::OnColumnSorted,
               this);
+  multiSelectClickGuard = std::make_unique<DataViewMultiSelectClickGuard>(
+      table, [this](const wxDataViewItem &item, wxDataViewColumn *column) {
+        EditSelectedCell(item, column);
+      });
 
   InitializeTable();
   ReloadData();
@@ -248,6 +255,8 @@ FixtureTablePanel::FixtureTablePanel(wxWindow *parent,
 
 // Releases singleton ownership when the fixture table panel is destroyed.
 FixtureTablePanel::~FixtureTablePanel() {
+  if (multiSelectClickGuard)
+    multiSelectClickGuard->CancelPendingClick();
   if (wxAuiManager *manager = wxAuiManager::GetManager(this))
     manager->DetachPane(this);
   if (HasCapture())
@@ -1490,11 +1499,39 @@ void FixtureTablePanel::OnItemActivated(wxDataViewEvent &event) {
   dlg.ShowModal();
 }
 
+
+// Routes deferred double-clicks through the existing fixture table batch editor.
+void FixtureTablePanel::EditSelectedCell(const wxDataViewItem &item,
+                                         wxDataViewColumn *column) {
+  if (!item.IsOk() || !column)
+    return;
+  wxDataViewEvent event(wxEVT_DATAVIEW_ITEM_ACTIVATED, table->GetId());
+  event.SetEventObject(table);
+  event.SetItem(item);
+  event.SetColumn(table->GetColumnPosition(column));
+  OnContextMenu(event);
+}
+
 // Captures mouse focus for drag-style interactions inside the table.
-void FixtureTablePanel::OnLeftDown(wxMouseEvent &evt) { evt.Skip(); }
+void FixtureTablePanel::OnLeftDown(wxMouseEvent &evt) {
+  if (multiSelectClickGuard && multiSelectClickGuard->HandleLeftDown(evt))
+    return;
+  evt.Skip();
+}
+
+// Opens the existing batch cell editor when a pending multi-select click becomes a double-click.
+void FixtureTablePanel::OnLeftDClick(wxMouseEvent &evt) {
+  if (multiSelectClickGuard && multiSelectClickGuard->HandleLeftDClick(evt))
+    return;
+  evt.Skip();
+}
 
 // Releases mouse capture after table drag-style interactions finish.
-void FixtureTablePanel::OnLeftUp(wxMouseEvent &evt) { evt.Skip(); }
+void FixtureTablePanel::OnLeftUp(wxMouseEvent &evt) {
+  if (multiSelectClickGuard && multiSelectClickGuard->HasPendingClick())
+    return;
+  evt.Skip();
+}
 
 // Resets capture state when the system forces mouse capture loss.
 void FixtureTablePanel::OnCaptureLost(wxMouseCaptureLostEvent &WXUNUSED(evt)) {

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -242,7 +242,7 @@ FixtureTablePanel::FixtureTablePanel(wxWindow *parent,
   table->Bind(wxEVT_DATAVIEW_COLUMN_SORTED, &FixtureTablePanel::OnColumnSorted,
               this);
   multiSelectClickGuard = std::make_unique<DataViewMultiSelectClickGuard>(
-      table, [this](const wxDataViewItem &item, wxDataViewColumn *column) {
+      table, [this](const wxDataViewItem &item, int column) {
         EditSelectedCell(item, column);
       });
 
@@ -493,8 +493,11 @@ void FixtureTablePanel::ReloadData() {
 // Handles context-menu editing actions and only applies scene updates when data
 // actually changes.
 void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
-  wxDataViewItem item = event.GetItem();
-  int col = event.GetColumn();
+  EditSelectedCell(event.GetItem(), event.GetColumn());
+}
+
+// Routes table activation through the existing batch cell editor.
+void FixtureTablePanel::EditSelectedCell(const wxDataViewItem &item, int col) {
   const auto namedColumn = FixtureTableColumns::FromIndex(col);
   if (!item.IsOk() || !namedColumn ||
       static_cast<size_t>(col) >= columnLabels.size())
@@ -1499,19 +1502,6 @@ void FixtureTablePanel::OnItemActivated(wxDataViewEvent &event) {
   dlg.ShowModal();
 }
 
-
-// Routes deferred double-clicks through the existing fixture table batch editor.
-void FixtureTablePanel::EditSelectedCell(const wxDataViewItem &item,
-                                         wxDataViewColumn *column) {
-  if (!item.IsOk() || !column)
-    return;
-  wxDataViewEvent event(wxEVT_DATAVIEW_ITEM_ACTIVATED, table->GetId());
-  event.SetEventObject(table);
-  event.SetItem(item);
-  event.SetColumn(table->GetColumnPosition(column));
-  OnContextMenu(event);
-}
-
 // Captures mouse focus for drag-style interactions inside the table.
 void FixtureTablePanel::OnLeftDown(wxMouseEvent &evt) {
   if (multiSelectClickGuard && multiSelectClickGuard->HandleLeftDown(evt))
@@ -1535,6 +1525,8 @@ void FixtureTablePanel::OnLeftUp(wxMouseEvent &evt) {
 
 // Resets capture state when the system forces mouse capture loss.
 void FixtureTablePanel::OnCaptureLost(wxMouseCaptureLostEvent &WXUNUSED(evt)) {
+  if (multiSelectClickGuard)
+    multiSelectClickGuard->CancelPendingClick();
   dragSelecting = false;
   startRow = wxNOT_FOUND;
 }

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -242,9 +242,8 @@ FixtureTablePanel::FixtureTablePanel(wxWindow *parent,
   table->Bind(wxEVT_DATAVIEW_COLUMN_SORTED, &FixtureTablePanel::OnColumnSorted,
               this);
   multiSelectClickGuard = std::make_unique<DataViewMultiSelectClickGuard>(
-      table, [this](const wxDataViewItem &item, int column,
-             const std::vector<int> &selectionRows) {
-        EditSelectedCell(item, column, &selectionRows);
+      table, [this](const wxDataViewItem &item, int column) {
+        EditSelectedCell(item, column);
       });
 
   InitializeTable();
@@ -498,25 +497,16 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
 }
 
 // Routes table activation through the existing batch cell editor.
-void FixtureTablePanel::EditSelectedCell(const wxDataViewItem &item, int col,
-                                 const std::vector<int> *selectionRows) {
+void FixtureTablePanel::EditSelectedCell(const wxDataViewItem &item, int col) {
   const auto namedColumn = FixtureTableColumns::FromIndex(col);
   if (!item.IsOk() || !namedColumn ||
       static_cast<size_t>(col) >= columnLabels.size())
     return;
 
   wxDataViewItemArray selections;
-  if (selectionRows) {
-    for (const int row : *selectionRows) {
-      if (row >= 0 && row < static_cast<int>(table->GetItemCount()))
-        selections.push_back(table->RowToItem(static_cast<unsigned int>(row)));
-    }
-  }
-  if (selections.empty()) {
-    table->GetSelections(selections);
-    if (selections.empty())
-      selections.push_back(item);
-  }
+  table->GetSelections(selections);
+  if (selections.empty())
+    selections.push_back(item);
 
   std::vector<std::string> selectedUuids;
   for (const auto &itSel : selections) {

--- a/gui/fixturetablepanel.h
+++ b/gui/fixturetablepanel.h
@@ -24,10 +24,12 @@
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <memory>
 #include "colorstore.h"
 #include "positionvalueupdate.h"
 
 class FixtureEditDialog; // forward declaration
+class DataViewMultiSelectClickGuard;
 class IGuiConfigServices;
 
 class FixtureTablePanel : public wxPanel
@@ -101,10 +103,12 @@ private:
     std::vector<std::string> selectionOrderUuids;
     std::unordered_set<std::string> manualCategoryUuidsPending;
     IGuiConfigServices *guiConfigServices = nullptr;
+    std::unique_ptr<DataViewMultiSelectClickGuard> multiSelectClickGuard;
 
     void InitializeTable(); // Set up columns
     void OnContextMenu(wxDataViewEvent& event);
     void OnItemActivated(wxDataViewEvent& event);
+    void EditSelectedCell(const wxDataViewItem& item, wxDataViewColumn* column);
     void OnColumnSorted(wxDataViewEvent& event);
     void RebuildRowCachesFromRowKeys();
     std::string UuidForItem(const wxDataViewItem& item) const;
@@ -113,6 +117,7 @@ private:
                     const std::vector<std::string>& selectedUuids,
                     const std::vector<wxString>* oldPaths = nullptr);
     void OnLeftDown(wxMouseEvent& evt);
+    void OnLeftDClick(wxMouseEvent& evt);
     void OnLeftUp(wxMouseEvent& evt);
     void OnMouseMove(wxMouseEvent& evt);
     void OnMouseLeave(wxMouseEvent& evt);

--- a/gui/fixturetablepanel.h
+++ b/gui/fixturetablepanel.h
@@ -108,7 +108,8 @@ private:
     void InitializeTable(); // Set up columns
     void OnContextMenu(wxDataViewEvent& event);
     void OnItemActivated(wxDataViewEvent& event);
-    void EditSelectedCell(const wxDataViewItem& item, int column);
+    void EditSelectedCell(const wxDataViewItem& item, int column,
+                          const std::vector<int>* selectionRows = nullptr);
     void OnColumnSorted(wxDataViewEvent& event);
     void RebuildRowCachesFromRowKeys();
     std::string UuidForItem(const wxDataViewItem& item) const;

--- a/gui/fixturetablepanel.h
+++ b/gui/fixturetablepanel.h
@@ -108,7 +108,7 @@ private:
     void InitializeTable(); // Set up columns
     void OnContextMenu(wxDataViewEvent& event);
     void OnItemActivated(wxDataViewEvent& event);
-    void EditSelectedCell(const wxDataViewItem& item, wxDataViewColumn* column);
+    void EditSelectedCell(const wxDataViewItem& item, int column);
     void OnColumnSorted(wxDataViewEvent& event);
     void RebuildRowCachesFromRowKeys();
     std::string UuidForItem(const wxDataViewItem& item) const;

--- a/gui/fixturetablepanel.h
+++ b/gui/fixturetablepanel.h
@@ -108,8 +108,7 @@ private:
     void InitializeTable(); // Set up columns
     void OnContextMenu(wxDataViewEvent& event);
     void OnItemActivated(wxDataViewEvent& event);
-    void EditSelectedCell(const wxDataViewItem& item, int column,
-                          const std::vector<int>* selectionRows = nullptr);
+    void EditSelectedCell(const wxDataViewItem& item, int column);
     void OnColumnSorted(wxDataViewEvent& event);
     void RebuildRowCachesFromRowKeys();
     std::string UuidForItem(const wxDataViewItem& item) const;

--- a/gui/hoisttablepanel.cpp
+++ b/gui/hoisttablepanel.cpp
@@ -22,6 +22,7 @@
 #include "columnutils.h"
 #include "configmanager.h"
 #include "dataview_edit_commit.h"
+#include "dataview_multi_select_click_guard.h"
 #include "dummyprofilelibrary.h"
 #include "editable_focus_utils.h"
 #include "guiconfigservices.h"
@@ -421,6 +422,7 @@ HoistTablePanel::HoistTablePanel(wxWindow *parent, IGuiConfigServices *services)
   const wxColour selectionForeground(0, 0, 0);
   store->SetSelectionColours(selectionBackground, selectionForeground);
   table->Bind(wxEVT_LEFT_DOWN, &HoistTablePanel::OnLeftDown, this);
+  table->Bind(wxEVT_LEFT_DCLICK, &HoistTablePanel::OnLeftDClick, this);
   table->Bind(wxEVT_LEFT_UP, &HoistTablePanel::OnLeftUp, this);
   BindTableHoverEvents(table, this, &HoistTablePanel::OnMouseMove,
                        &HoistTablePanel::OnMouseLeave);
@@ -435,6 +437,10 @@ HoistTablePanel::HoistTablePanel(wxWindow *parent, IGuiConfigServices *services)
               this);
   table->Bind(wxEVT_DATAVIEW_COLUMN_SORTED, &HoistTablePanel::OnColumnSorted,
               this);
+  multiSelectClickGuard = std::make_unique<DataViewMultiSelectClickGuard>(
+      table, [this](const wxDataViewItem &item, int column) {
+        EditSelectedCell(item, column);
+      });
 
   Bind(wxEVT_MOUSE_CAPTURE_LOST, &HoistTablePanel::OnCaptureLost, this);
 
@@ -448,6 +454,8 @@ HoistTablePanel::HoistTablePanel(wxWindow *parent, IGuiConfigServices *services)
 // Releases table resources and detaches the hoist pane from AUI layout
 // management.
 HoistTablePanel::~HoistTablePanel() {
+  if (multiSelectClickGuard)
+    multiSelectClickGuard->CancelPendingClick();
   if (wxAuiManager *manager = wxAuiManager::GetManager(this))
     manager->DetachPane(this);
   if (s_instance == this)
@@ -658,9 +666,13 @@ void HoistTablePanel::ReloadData() {
     RiggingPanel::Instance()->RefreshData();
 }
 
+// Handles context-menu edits and forwards them to the shared batch editor.
 void HoistTablePanel::OnContextMenu(wxDataViewEvent &event) {
-  wxDataViewItem item = event.GetItem();
-  int col = event.GetColumn();
+  EditSelectedCell(event.GetItem(), event.GetColumn());
+}
+
+// Routes table activation through the existing batch cell editor.
+void HoistTablePanel::EditSelectedCell(const wxDataViewItem &item, int col) {
   const auto namedColumn = TableColumnIndices::FromIndex<HoistColumn>(col);
   if (!item.IsOk() || !namedColumn ||
       static_cast<size_t>(col) >= columnLabels.size())
@@ -961,7 +973,11 @@ void HoistTablePanel::OnContextMenu(wxDataViewEvent &event) {
   }
 }
 
+// Starts immediate or deferred left-click selection handling for the table.
 void HoistTablePanel::OnLeftDown(wxMouseEvent &evt) {
+  if (multiSelectClickGuard && multiSelectClickGuard->HandleLeftDown(evt))
+    return;
+
   wxDataViewItem item;
   wxDataViewColumn *col;
   table->HitTest(evt.GetPosition(), item, col);
@@ -975,7 +991,17 @@ void HoistTablePanel::OnLeftDown(wxMouseEvent &evt) {
   evt.Skip();
 }
 
+// Opens the existing batch cell editor when a pending multi-select click becomes a double-click.
+void HoistTablePanel::OnLeftDClick(wxMouseEvent &evt) {
+  if (multiSelectClickGuard && multiSelectClickGuard->HandleLeftDClick(evt))
+    return;
+  evt.Skip();
+}
+
+// Releases mouse capture after table drag-style interactions finish.
 void HoistTablePanel::OnLeftUp(wxMouseEvent &evt) {
+  if (multiSelectClickGuard && multiSelectClickGuard->HasPendingClick())
+    return;
   if (dragSelecting) {
     dragSelecting = false;
     ReleaseMouse();
@@ -983,7 +1009,10 @@ void HoistTablePanel::OnLeftUp(wxMouseEvent &evt) {
   evt.Skip();
 }
 
+// Resets capture state when the system forces mouse capture loss.
 void HoistTablePanel::OnCaptureLost(wxMouseCaptureLostEvent &WXUNUSED(evt)) {
+  if (multiSelectClickGuard)
+    multiSelectClickGuard->CancelPendingClick();
   dragSelecting = false;
 }
 

--- a/gui/hoisttablepanel.cpp
+++ b/gui/hoisttablepanel.cpp
@@ -438,8 +438,9 @@ HoistTablePanel::HoistTablePanel(wxWindow *parent, IGuiConfigServices *services)
   table->Bind(wxEVT_DATAVIEW_COLUMN_SORTED, &HoistTablePanel::OnColumnSorted,
               this);
   multiSelectClickGuard = std::make_unique<DataViewMultiSelectClickGuard>(
-      table, [this](const wxDataViewItem &item, int column) {
-        EditSelectedCell(item, column);
+      table, [this](const wxDataViewItem &item, int column,
+             const std::vector<int> &selectionRows) {
+        EditSelectedCell(item, column, &selectionRows);
       });
 
   Bind(wxEVT_MOUSE_CAPTURE_LOST, &HoistTablePanel::OnCaptureLost, this);
@@ -672,7 +673,8 @@ void HoistTablePanel::OnContextMenu(wxDataViewEvent &event) {
 }
 
 // Routes table activation through the existing batch cell editor.
-void HoistTablePanel::EditSelectedCell(const wxDataViewItem &item, int col) {
+void HoistTablePanel::EditSelectedCell(const wxDataViewItem &item, int col,
+                                 const std::vector<int> *selectionRows) {
   const auto namedColumn = TableColumnIndices::FromIndex<HoistColumn>(col);
   if (!item.IsOk() || !namedColumn ||
       static_cast<size_t>(col) >= columnLabels.size())
@@ -687,9 +689,17 @@ void HoistTablePanel::EditSelectedCell(const wxDataViewItem &item, int col) {
   wxWindowUpdateLocker locker(table);
 
   wxDataViewItemArray selections;
-  table->GetSelections(selections);
-  if (selections.empty())
-    selections.push_back(item);
+  if (selectionRows) {
+    for (const int row : *selectionRows) {
+      if (row >= 0 && row < static_cast<int>(table->GetItemCount()))
+        selections.push_back(table->RowToItem(static_cast<unsigned int>(row)));
+    }
+  }
+  if (selections.empty()) {
+    table->GetSelections(selections);
+    if (selections.empty())
+      selections.push_back(item);
+  }
 
   std::vector<std::string> selectedUuids;
   for (const auto &it : selections) {

--- a/gui/hoisttablepanel.cpp
+++ b/gui/hoisttablepanel.cpp
@@ -438,9 +438,8 @@ HoistTablePanel::HoistTablePanel(wxWindow *parent, IGuiConfigServices *services)
   table->Bind(wxEVT_DATAVIEW_COLUMN_SORTED, &HoistTablePanel::OnColumnSorted,
               this);
   multiSelectClickGuard = std::make_unique<DataViewMultiSelectClickGuard>(
-      table, [this](const wxDataViewItem &item, int column,
-             const std::vector<int> &selectionRows) {
-        EditSelectedCell(item, column, &selectionRows);
+      table, [this](const wxDataViewItem &item, int column) {
+        EditSelectedCell(item, column);
       });
 
   Bind(wxEVT_MOUSE_CAPTURE_LOST, &HoistTablePanel::OnCaptureLost, this);
@@ -673,8 +672,7 @@ void HoistTablePanel::OnContextMenu(wxDataViewEvent &event) {
 }
 
 // Routes table activation through the existing batch cell editor.
-void HoistTablePanel::EditSelectedCell(const wxDataViewItem &item, int col,
-                                 const std::vector<int> *selectionRows) {
+void HoistTablePanel::EditSelectedCell(const wxDataViewItem &item, int col) {
   const auto namedColumn = TableColumnIndices::FromIndex<HoistColumn>(col);
   if (!item.IsOk() || !namedColumn ||
       static_cast<size_t>(col) >= columnLabels.size())
@@ -689,17 +687,9 @@ void HoistTablePanel::EditSelectedCell(const wxDataViewItem &item, int col,
   wxWindowUpdateLocker locker(table);
 
   wxDataViewItemArray selections;
-  if (selectionRows) {
-    for (const int row : *selectionRows) {
-      if (row >= 0 && row < static_cast<int>(table->GetItemCount()))
-        selections.push_back(table->RowToItem(static_cast<unsigned int>(row)));
-    }
-  }
-  if (selections.empty()) {
-    table->GetSelections(selections);
-    if (selections.empty())
-      selections.push_back(item);
-  }
+  table->GetSelections(selections);
+  if (selections.empty())
+    selections.push_back(item);
 
   std::vector<std::string> selectedUuids;
   for (const auto &it : selections) {

--- a/gui/hoisttablepanel.h
+++ b/gui/hoisttablepanel.h
@@ -19,6 +19,7 @@
 
 #include <wx/dataview.h>
 #include <wx/wx.h>
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -27,6 +28,7 @@
 #include "hoist_load_limit_utils.h"
 #include "positionvalueupdate.h"
 
+class DataViewMultiSelectClickGuard;
 class IGuiConfigServices;
 
 class HoistTablePanel : public wxPanel {
@@ -66,10 +68,12 @@ private:
   bool dragSelecting = false;
   int startRow = -1;
   IGuiConfigServices *guiConfigServices = nullptr;
+  std::unique_ptr<DataViewMultiSelectClickGuard> multiSelectClickGuard;
 
   void InitializeTable();
   void OnSelectionChanged(wxDataViewEvent &evt);
   void OnContextMenu(wxDataViewEvent &event);
+  void EditSelectedCell(const wxDataViewItem &item, int column);
   void OnColumnSorted(wxDataViewEvent &event);
   void RebuildRowCachesFromRowKeys();
   std::string UuidForItem(const wxDataViewItem &item) const;
@@ -78,6 +82,7 @@ private:
   void ResyncRows(const std::vector<std::string> &oldOrder,
                   const std::vector<std::string> &selectedUuids);
   void OnLeftDown(wxMouseEvent &evt);
+  void OnLeftDClick(wxMouseEvent &evt);
   void OnLeftUp(wxMouseEvent &evt);
   void OnMouseMove(wxMouseEvent &evt);
   void OnMouseLeave(wxMouseEvent &evt);

--- a/gui/hoisttablepanel.h
+++ b/gui/hoisttablepanel.h
@@ -73,8 +73,7 @@ private:
   void InitializeTable();
   void OnSelectionChanged(wxDataViewEvent &evt);
   void OnContextMenu(wxDataViewEvent &event);
-  void EditSelectedCell(const wxDataViewItem &item, int column,
-                        const std::vector<int> *selectionRows = nullptr);
+  void EditSelectedCell(const wxDataViewItem &item, int column);
   void OnColumnSorted(wxDataViewEvent &event);
   void RebuildRowCachesFromRowKeys();
   std::string UuidForItem(const wxDataViewItem &item) const;

--- a/gui/hoisttablepanel.h
+++ b/gui/hoisttablepanel.h
@@ -73,7 +73,8 @@ private:
   void InitializeTable();
   void OnSelectionChanged(wxDataViewEvent &evt);
   void OnContextMenu(wxDataViewEvent &event);
-  void EditSelectedCell(const wxDataViewItem &item, int column);
+  void EditSelectedCell(const wxDataViewItem &item, int column,
+                        const std::vector<int> *selectionRows = nullptr);
   void OnColumnSorted(wxDataViewEvent &event);
   void RebuildRowCachesFromRowKeys();
   std::string UuidForItem(const wxDataViewItem &item) const;

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -239,9 +239,8 @@ SceneObjectTablePanel::SceneObjectTablePanel(wxWindow *parent,
     table->Bind(wxEVT_DATAVIEW_ITEM_ACTIVATED,
                 &SceneObjectTablePanel::OnContextMenu, this);
   multiSelectClickGuard = std::make_unique<DataViewMultiSelectClickGuard>(
-      table, [this](const wxDataViewItem &item, int column,
-             const std::vector<int> &selectionRows) {
-        EditSelectedCell(item, column, &selectionRows);
+      table, [this](const wxDataViewItem &item, int column) {
+        EditSelectedCell(item, column);
       });
 
     Bind(wxEVT_MOUSE_CAPTURE_LOST, &SceneObjectTablePanel::OnCaptureLost, this);
@@ -396,8 +395,7 @@ void SceneObjectTablePanel::OnContextMenu(wxDataViewEvent &event) {
 }
 
 // Routes table activation through the existing batch cell editor.
-void SceneObjectTablePanel::EditSelectedCell(const wxDataViewItem &item, int col,
-                                 const std::vector<int> *selectionRows) {
+void SceneObjectTablePanel::EditSelectedCell(const wxDataViewItem &item, int col) {
   const auto namedColumn =
       TableColumnIndices::FromIndex<SceneObjectColumn>(col);
   if (!item.IsOk() || !namedColumn ||
@@ -411,19 +409,9 @@ void SceneObjectTablePanel::EditSelectedCell(const wxDataViewItem &item, int col
     wxWindowUpdateLocker locker(table);
 
     wxDataViewItemArray selections;
-    if (selectionRows) {
-        for (const int selectedRow : *selectionRows) {
-            if (selectedRow >= 0 &&
-                selectedRow < static_cast<int>(table->GetItemCount()))
-                selections.push_back(
-                    table->RowToItem(static_cast<unsigned int>(selectedRow)));
-        }
-    }
-    if (selections.empty()) {
-        table->GetSelections(selections);
-        if (selections.empty())
-            selections.push_back(item);
-    }
+    table->GetSelections(selections);
+    if (selections.empty())
+        selections.push_back(item);
 
     // Preserve selection and current row order before edits
     std::vector<std::string> selectedUuids;

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -239,8 +239,9 @@ SceneObjectTablePanel::SceneObjectTablePanel(wxWindow *parent,
     table->Bind(wxEVT_DATAVIEW_ITEM_ACTIVATED,
                 &SceneObjectTablePanel::OnContextMenu, this);
   multiSelectClickGuard = std::make_unique<DataViewMultiSelectClickGuard>(
-      table, [this](const wxDataViewItem &item, int column) {
-        EditSelectedCell(item, column);
+      table, [this](const wxDataViewItem &item, int column,
+             const std::vector<int> &selectionRows) {
+        EditSelectedCell(item, column, &selectionRows);
       });
 
     Bind(wxEVT_MOUSE_CAPTURE_LOST, &SceneObjectTablePanel::OnCaptureLost, this);
@@ -395,7 +396,8 @@ void SceneObjectTablePanel::OnContextMenu(wxDataViewEvent &event) {
 }
 
 // Routes table activation through the existing batch cell editor.
-void SceneObjectTablePanel::EditSelectedCell(const wxDataViewItem &item, int col) {
+void SceneObjectTablePanel::EditSelectedCell(const wxDataViewItem &item, int col,
+                                 const std::vector<int> *selectionRows) {
   const auto namedColumn =
       TableColumnIndices::FromIndex<SceneObjectColumn>(col);
   if (!item.IsOk() || !namedColumn ||
@@ -409,9 +411,19 @@ void SceneObjectTablePanel::EditSelectedCell(const wxDataViewItem &item, int col
     wxWindowUpdateLocker locker(table);
 
     wxDataViewItemArray selections;
-    table->GetSelections(selections);
-    if (selections.empty())
-        selections.push_back(item);
+    if (selectionRows) {
+        for (const int selectedRow : *selectionRows) {
+            if (selectedRow >= 0 &&
+                selectedRow < static_cast<int>(table->GetItemCount()))
+                selections.push_back(
+                    table->RowToItem(static_cast<unsigned int>(selectedRow)));
+        }
+    }
+    if (selections.empty()) {
+        table->GetSelections(selections);
+        if (selections.empty())
+            selections.push_back(item);
+    }
 
     // Preserve selection and current row order before edits
     std::vector<std::string> selectedUuids;

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -20,6 +20,7 @@
 #include "columnutils.h"
 #include "colorfulrenderers.h"
 #include "configmanager.h"
+#include "dataview_multi_select_click_guard.h"
 #include "selection_origin_token.h"
 #include "guiconfigservices.h"
 #include "layerpanel.h"
@@ -225,6 +226,7 @@ SceneObjectTablePanel::SceneObjectTablePanel(wxWindow *parent,
   const wxColour selectionForeground(0, 0, 0);
   store->SetSelectionColours(selectionBackground, selectionForeground);
     table->Bind(wxEVT_LEFT_DOWN, &SceneObjectTablePanel::OnLeftDown, this);
+    table->Bind(wxEVT_LEFT_DCLICK, &SceneObjectTablePanel::OnLeftDClick, this);
     table->Bind(wxEVT_LEFT_UP, &SceneObjectTablePanel::OnLeftUp, this);
     table->Bind(wxEVT_MOTION, &SceneObjectTablePanel::OnMouseMove, this);
     table->Bind(wxEVT_DATAVIEW_SELECTION_CHANGED,
@@ -236,6 +238,10 @@ SceneObjectTablePanel::SceneObjectTablePanel(wxWindow *parent,
                 &SceneObjectTablePanel::OnColumnSorted, this);
     table->Bind(wxEVT_DATAVIEW_ITEM_ACTIVATED,
                 &SceneObjectTablePanel::OnContextMenu, this);
+  multiSelectClickGuard = std::make_unique<DataViewMultiSelectClickGuard>(
+      table, [this](const wxDataViewItem &item, int column) {
+        EditSelectedCell(item, column);
+      });
 
     Bind(wxEVT_MOUSE_CAPTURE_LOST, &SceneObjectTablePanel::OnCaptureLost, this);
 
@@ -249,6 +255,8 @@ SceneObjectTablePanel::SceneObjectTablePanel(wxWindow *parent,
 // Releases table resources and detaches the scene-object pane from AUI layout
 // management.
 SceneObjectTablePanel::~SceneObjectTablePanel() {
+    if (multiSelectClickGuard)
+        multiSelectClickGuard->CancelPendingClick();
     if (wxAuiManager *manager = wxAuiManager::GetManager(this))
         manager->DetachPane(this);
     store = nullptr;
@@ -383,8 +391,11 @@ void SceneObjectTablePanel::ReloadData() {
 // Handles context-menu edits and updates scene/rendering only when an actual
 // table value changes.
 void SceneObjectTablePanel::OnContextMenu(wxDataViewEvent &event) {
-    wxDataViewItem item = event.GetItem();
-    int col = event.GetColumn();
+  EditSelectedCell(event.GetItem(), event.GetColumn());
+}
+
+// Routes table activation through the existing batch cell editor.
+void SceneObjectTablePanel::EditSelectedCell(const wxDataViewItem &item, int col) {
   const auto namedColumn =
       TableColumnIndices::FromIndex<SceneObjectColumn>(col);
   if (!item.IsOk() || !namedColumn ||
@@ -603,8 +614,12 @@ void SceneObjectTablePanel::OnContextMenu(wxDataViewEvent &event) {
     }
 }
 
+// Starts immediate or deferred left-click selection handling for the table.
 void SceneObjectTablePanel::OnLeftDown(wxMouseEvent& evt)
 {
+    if (multiSelectClickGuard && multiSelectClickGuard->HandleLeftDown(evt))
+        return;
+
     wxDataViewItem item;
     wxDataViewColumn* col;
     table->HitTest(evt.GetPosition(), item, col);
@@ -619,7 +634,11 @@ void SceneObjectTablePanel::OnLeftDown(wxMouseEvent& evt)
     evt.Skip();
 }
 
+// Opens the primitive editor or deferred batch editor for double-clicks.
 void SceneObjectTablePanel::OnLeftDClick(wxMouseEvent &evt) {
+    if (multiSelectClickGuard && multiSelectClickGuard->HandleLeftDClick(evt))
+        return;
+
     wxDataViewItem item;
     wxDataViewColumn* col;
     table->HitTest(evt.GetPosition(), item, col);
@@ -648,7 +667,10 @@ void SceneObjectTablePanel::OnLeftDClick(wxMouseEvent &evt) {
     evt.Skip();
 }
 
+// Releases mouse capture after table drag-style interactions finish.
 void SceneObjectTablePanel::OnLeftUp(wxMouseEvent &evt) {
+  if (multiSelectClickGuard && multiSelectClickGuard->HasPendingClick())
+    return;
   if (dragSelecting) {
         dragSelecting = false;
         ReleaseMouse();
@@ -656,8 +678,11 @@ void SceneObjectTablePanel::OnLeftUp(wxMouseEvent &evt) {
     evt.Skip();
 }
 
+// Resets capture state when the system forces mouse capture loss.
 void SceneObjectTablePanel::OnCaptureLost(
     wxMouseCaptureLostEvent &WXUNUSED(evt)) {
+    if (multiSelectClickGuard)
+        multiSelectClickGuard->CancelPendingClick();
     dragSelecting = false;
 }
 

--- a/gui/sceneobjecttablepanel.h
+++ b/gui/sceneobjecttablepanel.h
@@ -73,8 +73,7 @@ private:
     void InitializeTable();
     void OnSelectionChanged(wxDataViewEvent& evt);
     void OnContextMenu(wxDataViewEvent& event);
-    void EditSelectedCell(const wxDataViewItem& item, int column,
-                          const std::vector<int>* selectionRows = nullptr);
+    void EditSelectedCell(const wxDataViewItem& item, int column);
     void OnColumnSorted(wxDataViewEvent& event);
     void RebuildRowCachesFromRowKeys();
     std::string UuidForItem(const wxDataViewItem& item) const;

--- a/gui/sceneobjecttablepanel.h
+++ b/gui/sceneobjecttablepanel.h
@@ -20,12 +20,14 @@
 #include <wx/wx.h>
 #include <wx/dataview.h>
 #include <wx/time.h>
+#include <memory>
 #include <vector>
 #include <string>
 #include <unordered_map>
 #include "colorstore.h"
 #include "positionvalueupdate.h"
 
+class DataViewMultiSelectClickGuard;
 class IGuiConfigServices;
 
 class SceneObjectTablePanel : public wxPanel
@@ -67,9 +69,11 @@ private:
     bool modelFileEditCommitPending = false;
     int startRow = -1;
     IGuiConfigServices *guiConfigServices = nullptr;
+    std::unique_ptr<DataViewMultiSelectClickGuard> multiSelectClickGuard;
     void InitializeTable();
     void OnSelectionChanged(wxDataViewEvent& evt);
     void OnContextMenu(wxDataViewEvent& event);
+    void EditSelectedCell(const wxDataViewItem& item, int column);
     void OnColumnSorted(wxDataViewEvent& event);
     void RebuildRowCachesFromRowKeys();
     std::string UuidForItem(const wxDataViewItem& item) const;

--- a/gui/sceneobjecttablepanel.h
+++ b/gui/sceneobjecttablepanel.h
@@ -73,7 +73,8 @@ private:
     void InitializeTable();
     void OnSelectionChanged(wxDataViewEvent& evt);
     void OnContextMenu(wxDataViewEvent& event);
-    void EditSelectedCell(const wxDataViewItem& item, int column);
+    void EditSelectedCell(const wxDataViewItem& item, int column,
+                          const std::vector<int>* selectionRows = nullptr);
     void OnColumnSorted(wxDataViewEvent& event);
     void RebuildRowCachesFromRowKeys();
     std::string UuidForItem(const wxDataViewItem& item) const;

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -263,7 +263,7 @@ TrussTablePanel::TrussTablePanel(wxWindow* parent, IGuiConfigServices* services)
   table->Bind(wxEVT_DATAVIEW_COLUMN_SORTED, &TrussTablePanel::OnColumnSorted,
               this);
   multiSelectClickGuard = std::make_unique<DataViewMultiSelectClickGuard>(
-      table, [this](const wxDataViewItem &item, wxDataViewColumn *column) {
+      table, [this](const wxDataViewItem &item, int column) {
         EditSelectedCell(item, column);
       });
 
@@ -480,8 +480,11 @@ void TrussTablePanel::ReloadData()
 // Handles context-menu editing workflows and avoids expensive refreshes when no
 // row values change.
 void TrussTablePanel::OnContextMenu(wxDataViewEvent &event) {
-    wxDataViewItem item = event.GetItem();
-    int col = event.GetColumn();
+  EditSelectedCell(event.GetItem(), event.GetColumn());
+}
+
+// Routes table activation through the existing batch cell editor.
+void TrussTablePanel::EditSelectedCell(const wxDataViewItem &item, int col) {
   const auto namedColumn = TableColumnIndices::FromIndex<TrussColumn>(col);
   if (!item.IsOk() || !namedColumn ||
       static_cast<size_t>(col) >= columnLabels.size())
@@ -815,6 +818,8 @@ void TrussTablePanel::OnLeftUp(wxMouseEvent &evt) {
 }
 
 void TrussTablePanel::OnCaptureLost(wxMouseCaptureLostEvent &WXUNUSED(evt)) {
+    if (multiSelectClickGuard)
+        multiSelectClickGuard->CancelPendingClick();
     dragSelecting = false;
 }
 
@@ -940,19 +945,6 @@ void TrussTablePanel::ApplyPositionValueUpdates(
         table->SetValue(wxVariant(wxString::FromUTF8(update.posZ)), row,
                         ColumnIndex(TrussColumn::PositionZ));
     }
-}
-
-
-// Routes deferred double-clicks through the existing truss table batch editor.
-void TrussTablePanel::EditSelectedCell(const wxDataViewItem &item,
-                                       wxDataViewColumn *column) {
-  if (!item.IsOk() || !column)
-    return;
-  wxDataViewEvent event(wxEVT_DATAVIEW_ITEM_ACTIVATED, table->GetId());
-  event.SetEventObject(table);
-  event.SetItem(item);
-  event.SetColumn(table->GetColumnPosition(column));
-  OnContextMenu(event);
 }
 
 // Opens the truss edit dialog for the activated table row.

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -263,8 +263,9 @@ TrussTablePanel::TrussTablePanel(wxWindow* parent, IGuiConfigServices* services)
   table->Bind(wxEVT_DATAVIEW_COLUMN_SORTED, &TrussTablePanel::OnColumnSorted,
               this);
   multiSelectClickGuard = std::make_unique<DataViewMultiSelectClickGuard>(
-      table, [this](const wxDataViewItem &item, int column) {
-        EditSelectedCell(item, column);
+      table, [this](const wxDataViewItem &item, int column,
+             const std::vector<int> &selectionRows) {
+        EditSelectedCell(item, column, &selectionRows);
       });
 
     Bind(wxEVT_MOUSE_CAPTURE_LOST, &TrussTablePanel::OnCaptureLost, this);
@@ -484,7 +485,8 @@ void TrussTablePanel::OnContextMenu(wxDataViewEvent &event) {
 }
 
 // Routes table activation through the existing batch cell editor.
-void TrussTablePanel::EditSelectedCell(const wxDataViewItem &item, int col) {
+void TrussTablePanel::EditSelectedCell(const wxDataViewItem &item, int col,
+                                 const std::vector<int> *selectionRows) {
   const auto namedColumn = TableColumnIndices::FromIndex<TrussColumn>(col);
   if (!item.IsOk() || !namedColumn ||
       static_cast<size_t>(col) >= columnLabels.size())
@@ -497,9 +499,19 @@ void TrussTablePanel::EditSelectedCell(const wxDataViewItem &item, int col) {
     wxWindowUpdateLocker locker(table);
 
     wxDataViewItemArray selections;
-    table->GetSelections(selections);
-    if (selections.empty())
-        selections.push_back(item);
+    if (selectionRows) {
+        for (const int selectedRow : *selectionRows) {
+            if (selectedRow >= 0 &&
+                selectedRow < static_cast<int>(table->GetItemCount()))
+                selections.push_back(
+                    table->RowToItem(static_cast<unsigned int>(selectedRow)));
+        }
+    }
+    if (selections.empty()) {
+        table->GetSelections(selections);
+        if (selections.empty())
+            selections.push_back(item);
+    }
 
     std::vector<std::string> selectedUuids;
   for (const auto &it : selections) {

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -20,6 +20,7 @@
 #include "columnutils.h"
 #include "colorfulrenderers.h"
 #include "configmanager.h"
+#include "dataview_multi_select_click_guard.h"
 #include "selection_origin_token.h"
 #include "guiconfigservices.h"
 #include "hang_position_dialog.h"
@@ -249,6 +250,7 @@ TrussTablePanel::TrussTablePanel(wxWindow* parent, IGuiConfigServices* services)
   const wxColour selectionForeground(0, 0, 0);
   store->SetSelectionColours(selectionBackground, selectionForeground);
   table->Bind(wxEVT_LEFT_DOWN, &TrussTablePanel::OnLeftDown, this);
+  table->Bind(wxEVT_LEFT_DCLICK, &TrussTablePanel::OnLeftDClick, this);
     table->Bind(wxEVT_LEFT_UP, &TrussTablePanel::OnLeftUp, this);
     table->Bind(wxEVT_MOTION, &TrussTablePanel::OnMouseMove, this);
     table->Bind(wxEVT_DATAVIEW_SELECTION_CHANGED,
@@ -260,6 +262,10 @@ TrussTablePanel::TrussTablePanel(wxWindow* parent, IGuiConfigServices* services)
               &TrussTablePanel::OnItemActivated, this);
   table->Bind(wxEVT_DATAVIEW_COLUMN_SORTED, &TrussTablePanel::OnColumnSorted,
               this);
+  multiSelectClickGuard = std::make_unique<DataViewMultiSelectClickGuard>(
+      table, [this](const wxDataViewItem &item, wxDataViewColumn *column) {
+        EditSelectedCell(item, column);
+      });
 
     Bind(wxEVT_MOUSE_CAPTURE_LOST, &TrussTablePanel::OnCaptureLost, this);
 
@@ -270,14 +276,17 @@ TrussTablePanel::TrussTablePanel(wxWindow* parent, IGuiConfigServices* services)
     SetSizer(sizer);
 }
 
-// Releases table resources and detaches the truss pane from AUI layout management.
+// Releases table resources, detaches the pane, and cancels delayed table actions.
 TrussTablePanel::~TrussTablePanel()
 {
+    if (multiSelectClickGuard)
+        multiSelectClickGuard->CancelPendingClick();
     if (wxAuiManager *manager = wxAuiManager::GetManager(this))
         manager->DetachPane(this);
     store = nullptr;
 }
 
+// Configures truss table columns and unit-aware header labels.
 void TrussTablePanel::InitializeTable()
 {
     const auto distanceUnit = ResolveDistanceUnitSystem();
@@ -766,8 +775,12 @@ void TrussTablePanel::OnContextMenu(wxDataViewEvent &event) {
     }
 }
 
+// Starts immediate or deferred left-click selection handling for the table.
 void TrussTablePanel::OnLeftDown(wxMouseEvent& evt)
 {
+    if (multiSelectClickGuard && multiSelectClickGuard->HandleLeftDown(evt))
+        return;
+
     wxDataViewItem item;
     wxDataViewColumn* col;
     table->HitTest(evt.GetPosition(), item, col);
@@ -782,7 +795,18 @@ void TrussTablePanel::OnLeftDown(wxMouseEvent& evt)
     evt.Skip();
 }
 
+// Opens the existing batch cell editor when a pending multi-select click becomes a double-click.
+void TrussTablePanel::OnLeftDClick(wxMouseEvent& evt)
+{
+    if (multiSelectClickGuard && multiSelectClickGuard->HandleLeftDClick(evt))
+        return;
+    evt.Skip();
+}
+
+// Releases mouse capture after table drag-style interactions finish.
 void TrussTablePanel::OnLeftUp(wxMouseEvent &evt) {
+  if (multiSelectClickGuard && multiSelectClickGuard->HasPendingClick())
+    return;
   if (dragSelecting) {
         dragSelecting = false;
         ReleaseMouse();
@@ -916,6 +940,19 @@ void TrussTablePanel::ApplyPositionValueUpdates(
         table->SetValue(wxVariant(wxString::FromUTF8(update.posZ)), row,
                         ColumnIndex(TrussColumn::PositionZ));
     }
+}
+
+
+// Routes deferred double-clicks through the existing truss table batch editor.
+void TrussTablePanel::EditSelectedCell(const wxDataViewItem &item,
+                                       wxDataViewColumn *column) {
+  if (!item.IsOk() || !column)
+    return;
+  wxDataViewEvent event(wxEVT_DATAVIEW_ITEM_ACTIVATED, table->GetId());
+  event.SetEventObject(table);
+  event.SetItem(item);
+  event.SetColumn(table->GetColumnPosition(column));
+  OnContextMenu(event);
 }
 
 // Opens the truss edit dialog for the activated table row.

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -263,9 +263,8 @@ TrussTablePanel::TrussTablePanel(wxWindow* parent, IGuiConfigServices* services)
   table->Bind(wxEVT_DATAVIEW_COLUMN_SORTED, &TrussTablePanel::OnColumnSorted,
               this);
   multiSelectClickGuard = std::make_unique<DataViewMultiSelectClickGuard>(
-      table, [this](const wxDataViewItem &item, int column,
-             const std::vector<int> &selectionRows) {
-        EditSelectedCell(item, column, &selectionRows);
+      table, [this](const wxDataViewItem &item, int column) {
+        EditSelectedCell(item, column);
       });
 
     Bind(wxEVT_MOUSE_CAPTURE_LOST, &TrussTablePanel::OnCaptureLost, this);
@@ -485,8 +484,7 @@ void TrussTablePanel::OnContextMenu(wxDataViewEvent &event) {
 }
 
 // Routes table activation through the existing batch cell editor.
-void TrussTablePanel::EditSelectedCell(const wxDataViewItem &item, int col,
-                                 const std::vector<int> *selectionRows) {
+void TrussTablePanel::EditSelectedCell(const wxDataViewItem &item, int col) {
   const auto namedColumn = TableColumnIndices::FromIndex<TrussColumn>(col);
   if (!item.IsOk() || !namedColumn ||
       static_cast<size_t>(col) >= columnLabels.size())
@@ -499,19 +497,9 @@ void TrussTablePanel::EditSelectedCell(const wxDataViewItem &item, int col,
     wxWindowUpdateLocker locker(table);
 
     wxDataViewItemArray selections;
-    if (selectionRows) {
-        for (const int selectedRow : *selectionRows) {
-            if (selectedRow >= 0 &&
-                selectedRow < static_cast<int>(table->GetItemCount()))
-                selections.push_back(
-                    table->RowToItem(static_cast<unsigned int>(selectedRow)));
-        }
-    }
-    if (selections.empty()) {
-        table->GetSelections(selections);
-        if (selections.empty())
-            selections.push_back(item);
-    }
+    table->GetSelections(selections);
+    if (selections.empty())
+        selections.push_back(item);
 
     std::vector<std::string> selectedUuids;
   for (const auto &it : selections) {

--- a/gui/trusstablepanel.h
+++ b/gui/trusstablepanel.h
@@ -88,8 +88,7 @@ private:
     void OnMouseMove(wxMouseEvent& evt);
     void OnCaptureLost(wxMouseCaptureLostEvent& evt);
     void OnItemActivated(wxDataViewEvent& event);
-    void EditSelectedCell(const wxDataViewItem& item, int column,
-                          const std::vector<int>* selectionRows = nullptr);
+    void EditSelectedCell(const wxDataViewItem& item, int column);
     void UpdateSelectionHighlight();
 
     friend class TrussEditDialog;

--- a/gui/trusstablepanel.h
+++ b/gui/trusstablepanel.h
@@ -88,7 +88,7 @@ private:
     void OnMouseMove(wxMouseEvent& evt);
     void OnCaptureLost(wxMouseCaptureLostEvent& evt);
     void OnItemActivated(wxDataViewEvent& event);
-    void EditSelectedCell(const wxDataViewItem& item, wxDataViewColumn* column);
+    void EditSelectedCell(const wxDataViewItem& item, int column);
     void UpdateSelectionHighlight();
 
     friend class TrussEditDialog;

--- a/gui/trusstablepanel.h
+++ b/gui/trusstablepanel.h
@@ -23,9 +23,11 @@
 #include <vector>
 #include <string>
 #include <unordered_map>
+#include <memory>
 #include "colorstore.h"
 #include "positionvalueupdate.h"
 
+class DataViewMultiSelectClickGuard;
 class IGuiConfigServices;
 class TrussEditDialog;
 
@@ -69,6 +71,7 @@ private:
     bool dragSelecting = false;
     int startRow = -1;
     IGuiConfigServices *guiConfigServices = nullptr;
+    std::unique_ptr<DataViewMultiSelectClickGuard> multiSelectClickGuard;
     void InitializeTable(); // Set up columns
     void OnSelectionChanged(wxDataViewEvent& evt);
     void OnContextMenu(wxDataViewEvent& event);
@@ -80,10 +83,12 @@ private:
     void ResyncRows(const std::vector<std::string>& oldOrder,
                     const std::vector<std::string>& selectedUuids);
     void OnLeftDown(wxMouseEvent& evt);
+    void OnLeftDClick(wxMouseEvent& evt);
     void OnLeftUp(wxMouseEvent& evt);
     void OnMouseMove(wxMouseEvent& evt);
     void OnCaptureLost(wxMouseCaptureLostEvent& evt);
     void OnItemActivated(wxDataViewEvent& event);
+    void EditSelectedCell(const wxDataViewItem& item, wxDataViewColumn* column);
     void UpdateSelectionHighlight();
 
     friend class TrussEditDialog;

--- a/gui/trusstablepanel.h
+++ b/gui/trusstablepanel.h
@@ -88,7 +88,8 @@ private:
     void OnMouseMove(wxMouseEvent& evt);
     void OnCaptureLost(wxMouseCaptureLostEvent& evt);
     void OnItemActivated(wxDataViewEvent& event);
-    void EditSelectedCell(const wxDataViewItem& item, int column);
+    void EditSelectedCell(const wxDataViewItem& item, int column,
+                          const std::vector<int>* selectionRows = nullptr);
     void UpdateSelectionHighlight();
 
     friend class TrussEditDialog;


### PR DESCRIPTION
### Motivation
- Prevent accidental collapse of a multi-row selection when the user intends to double-click to batch-edit a column, while preserving the existing per-row double-click edit behavior. 
- Provide a modular, reusable guard to apply the short delay only where needed and avoid emitting temporary selection state to the rest of the app. 

### Description
- Added a reusable helper `DataViewMultiSelectClickGuard` (`gui/dataview_multi_select_click_guard.h/.cpp`) that defers a plain left-click on a row that is already part of a multi-selection for the platform double-click interval exposed by wxWidgets and resolves either to a normal single-row selection or invokes a provided double-click handler. 
- Integrated the guard into the Fixture and Truss Data View panels by adding a `std::unique_ptr<DataViewMultiSelectClickGuard> multiSelectClickGuard` member and wiring `wxEVT_LEFT_DOWN` / `wxEVT_LEFT_DCLICK` handlers to consult the guard; deferred double-clicks are routed back into the existing batch edit path via a small `EditSelectedCell` bridge to `OnContextMenu`/activation handlers so no selection deselect/restore is performed. 
- Kept all other interactions immediate (unselected-row clicks, Ctrl/Shift-click, drag-selection, right-click/context menus, empty-space clicks) and cancelled pending timers safely on guard destruction and panel teardown. 
- Updated build sources (`gui/CMakeLists.txt`) and the release notes (`docs/release-notes-draft.md`) to mention preserved multi-row batch-edit behavior; added concise one-line comments above modified functions where appropriate to comply with code-style guidance. 

Files changed: `gui/dataview_multi_select_click_guard.h`, `gui/dataview_multi_select_click_guard.cpp`, `gui/fixturetablepanel.h`, `gui/fixturetablepanel.cpp`, `gui/trusstablepanel.h`, `gui/trusstablepanel.cpp`, `gui/CMakeLists.txt`, `docs/release-notes-draft.md`. 

### Testing
- Ran `./tests/check_perastage_tree_modules.sh` which passed. 
- Ran `./tests/check_no_configmanager_get_in_gui.sh` which passed. 
- Ran `git diff --cached --check` style checks which passed. 
- Attempted `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build -j2` but configuration failed because wxWidgets development headers/libraries are not available in the environment, so no full build was produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58c0dad8688324a25961f33c125306)