### PR TITLE
Refresh 2D and 3D views after table layer edits

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -70,7 +70,7 @@ Perastage 1.5.0 is a substantial update focused on GDTF and truss editing, multi
 
 ## Important fixes
 
-- Fixed Data Views table edits so moving fixtures, trusses, or scene objects between visible and hidden layers rebuilds the relevant viewer resources and immediately refreshes both the 2D and 3D viewports, including layout previews.
+- Fixed Data Views table edits so moving fixtures, trusses, or scene objects between visible and hidden layers rebuilds the relevant viewer resources, invalidates stale 3D visible-set caches, and immediately refreshes both the 2D and 3D viewports, including layout previews.
 - Fixed Windows build and linker issues in the Local Axes viewport integration.
 
 ### MVR, GDTF, and project data

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -70,6 +70,7 @@ Perastage 1.5.0 is a substantial update focused on GDTF and truss editing, multi
 
 ## Important fixes
 
+- Fixed Data Views table edits so moving fixtures, trusses, or scene objects between visible and hidden layers immediately refreshes both the 2D and 3D viewports, including layout previews.
 - Fixed Windows build and linker issues in the Local Axes viewport integration.
 
 ### MVR, GDTF, and project data

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -70,7 +70,7 @@ Perastage 1.5.0 is a substantial update focused on GDTF and truss editing, multi
 
 ## Important fixes
 
-- Fixed Data Views table edits so moving fixtures, trusses, or scene objects between visible and hidden layers immediately refreshes both the 2D and 3D viewports, including layout previews.
+- Fixed Data Views table edits so moving fixtures, trusses, or scene objects between visible and hidden layers rebuilds the relevant viewer resources and immediately refreshes both the 2D and 3D viewports, including layout previews.
 - Fixed Windows build and linker issues in the Local Axes viewport integration.
 
 ### MVR, GDTF, and project data

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -109,6 +109,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/scene_object_primitive_creation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/scene_object_primitive_dialogs.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/scene_object_primitive_editing.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/scene_view_refresh.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ridertextdialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ridertext_autocomplete_provider.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/riggingpanel.cpp

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -39,6 +39,7 @@
 #include "projectutils.h"
 #include "riggingpanel.h"
 #include "selection_origin_token.h"
+#include "scene_view_refresh.h"
 #include "stringutils.h"
 #include "summarypanel.h"
 #include "units/unit_label_utils.h"
@@ -119,17 +120,10 @@ void RefreshViewersForFixtureUpdate(
     FixtureTablePanel::SceneDataUpdateType updateType) {
   const bool requiresFullSceneUpdate =
       FixtureTablePanel::RequiresFullViewerSceneUpdate(updateType);
-  if (Viewer3DPanel::Instance()) {
-    if (requiresFullSceneUpdate) {
-      Viewer3DPanel::Instance()->UpdateScene();
-    }
-    Viewer3DPanel::Instance()->Refresh();
-  } else if (Viewer2DPanel::Instance()) {
-    if (requiresFullSceneUpdate)
-      Viewer2DPanel::Instance()->UpdateScene();
-    else
-      Viewer2DPanel::Instance()->UpdateScene(false);
-  }
+  gui::sceneviewrefresh::RefreshSceneViewsAfterTableEdit(
+      FixtureTablePanel::Instance(),
+      requiresFullSceneUpdate ? gui::sceneviewrefresh::SceneUpdateScope::Full
+                              : gui::sceneviewrefresh::SceneUpdateScope::Light);
 }
 
 // Determines whether a scene update type requires rigging panel refresh.

--- a/gui/fixturetablepanel_update_types.cpp
+++ b/gui/fixturetablepanel_update_types.cpp
@@ -35,8 +35,9 @@ FixtureTablePanel::SceneDataUpdateType UpdateTypeForColumnImpl(int column) {
     return SceneDataUpdateType::kMetadataOnly;
   case Column::FixtureId:
     return SceneDataUpdateType::kFixtureIdOnly;
-  case Column::Type:
   case Column::Layer:
+    return SceneDataUpdateType::kGeneral;
+  case Column::Type:
   case Column::HangPosition:
   case Column::Mode:
   case Column::ModelFile:

--- a/gui/scene_view_refresh.cpp
+++ b/gui/scene_view_refresh.cpp
@@ -1,0 +1,67 @@
+#include "scene_view_refresh.h"
+
+#include "layoutviewerpanel.h"
+#include "viewer2dpanel.h"
+#include "viewer3dpanel.h"
+
+#include <wx/window.h>
+
+namespace gui::sceneviewrefresh {
+namespace {
+
+// Finds the first layout viewer in the provided window subtree.
+LayoutViewerPanel *FindLayoutViewerPanel(wxWindow *root) {
+  if (!root)
+    return nullptr;
+
+  if (auto *layoutViewer = dynamic_cast<LayoutViewerPanel *>(root))
+    return layoutViewer;
+
+  for (wxWindow *child : root->GetChildren()) {
+    if (auto *layoutViewer = FindLayoutViewerPanel(child))
+      return layoutViewer;
+  }
+  return nullptr;
+}
+
+// Refreshes the standalone 2D panel and invalidates symbol caches when needed.
+void RefreshViewer2D(SceneUpdateScope scope) {
+  if (!Viewer2DPanel::Instance())
+    return;
+
+  if (scope == SceneUpdateScope::Full) {
+    Viewer2DPanel::Instance()->InvalidateBottomSymbolCache();
+    Viewer2DPanel::Instance()->UpdateScene();
+  } else {
+    Viewer2DPanel::Instance()->UpdateScene(false);
+  }
+  Viewer2DPanel::Instance()->Refresh();
+}
+
+// Refreshes the standalone 3D panel and rebuilds its scene when needed.
+void RefreshViewer3D(SceneUpdateScope scope) {
+  if (!Viewer3DPanel::Instance())
+    return;
+
+  if (scope == SceneUpdateScope::Full)
+    Viewer3DPanel::Instance()->UpdateScene();
+  Viewer3DPanel::Instance()->Refresh();
+}
+
+// Refreshes layout-viewer rasters that depend on the edited scene content.
+void RefreshLayoutViewer(wxWindow *source) {
+  wxWindow *topLevel = wxGetTopLevelParent(source);
+  if (auto *layoutViewer = FindLayoutViewerPanel(topLevel))
+    layoutViewer->RefreshAfterSceneContentUpdate();
+}
+
+} // namespace
+
+// Refreshes all scene viewers after table edits, including layer visibility transitions.
+void RefreshSceneViewsAfterTableEdit(wxWindow *source, SceneUpdateScope scope) {
+  RefreshViewer2D(scope);
+  RefreshViewer3D(scope);
+  RefreshLayoutViewer(source);
+}
+
+} // namespace gui::sceneviewrefresh

--- a/gui/scene_view_refresh.h
+++ b/gui/scene_view_refresh.h
@@ -1,0 +1,15 @@
+#pragma once
+
+class wxWindow;
+
+namespace gui::sceneviewrefresh {
+
+enum class SceneUpdateScope {
+  Full,
+  Light
+};
+
+// Refreshes the 2D, 3D, and layout previews after scene data changes.
+void RefreshSceneViewsAfterTableEdit(wxWindow *source, SceneUpdateScope scope);
+
+} // namespace gui::sceneviewrefresh

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -33,6 +33,8 @@
 #include "table_column_indices.h"
 #include "scene_view_refresh.h"
 #include "dataview_edit_commit.h"
+#include "viewer2dpanel.h"
+#include "viewer3dpanel.h"
 #include "units/unit_label_utils.h"
 #include "units/units.h"
 #include <wx/aui/aui.h>
@@ -413,10 +415,7 @@ void SceneObjectTablePanel::OnContextMenu(wxDataViewEvent &event) {
         }
         ResyncRows(oldOrder, selectedUuids);
         UpdateSceneData();
-        if (Viewer3DPanel::Instance()) {
-            Viewer3DPanel::Instance()->UpdateScene();
-            Viewer3DPanel::Instance()->Refresh();
-        }
+        RefreshSceneObjectVisuals();
         return;
     }
 
@@ -465,10 +464,7 @@ void SceneObjectTablePanel::OnContextMenu(wxDataViewEvent &event) {
         modelFileEditCommitPending = true;
         UpdateSceneData();
         modelFileEditCommitPending = false;
-        if (Viewer3DPanel::Instance()) {
-            Viewer3DPanel::Instance()->UpdateScene();
-            Viewer3DPanel::Instance()->Refresh();
-        }
+        RefreshSceneObjectVisuals();
         return;
     }
 
@@ -574,10 +570,7 @@ void SceneObjectTablePanel::OnContextMenu(wxDataViewEvent &event) {
     ResyncRows(oldOrder, selectedUuids);
 
     UpdateSceneData();
-    if (Viewer3DPanel::Instance()) {
-        Viewer3DPanel::Instance()->UpdateScene();
-        Viewer3DPanel::Instance()->Refresh();
-    }
+    RefreshSceneObjectVisuals();
 }
 
 void SceneObjectTablePanel::OnLeftDown(wxMouseEvent& evt)
@@ -611,12 +604,7 @@ void SceneObjectTablePanel::OnLeftDClick(wxMouseEvent &evt) {
   const bool edited =
       scene_object_primitives::EditPrimitiveObjectByUuid(this, cfg, uuid);
     if (edited) {
-        if (Viewer3DPanel::Instance()) {
-            Viewer3DPanel::Instance()->UpdateScene();
-            Viewer3DPanel::Instance()->Refresh();
-        } else if (Viewer2DPanel::Instance()) {
-            Viewer2DPanel::Instance()->UpdateScene();
-        }
+        RefreshSceneObjectVisuals();
         ReloadData();
         SelectByUuid({uuid});
         return;
@@ -1058,12 +1046,11 @@ void SceneObjectTablePanel::DeleteSelected(bool pushUndoState) {
 
     if (Viewer3DPanel::Instance()) {
         Viewer3DPanel::Instance()->SetSelectedFixtures(mergedSelection);
-        Viewer3DPanel::Instance()->UpdateScene();
-        Viewer3DPanel::Instance()->Refresh();
-  } else if (Viewer2DPanel::Instance()) {
-        Viewer2DPanel::Instance()->SetSelectedUuids(mergedSelection);
-        Viewer2DPanel::Instance()->UpdateScene();
     }
+    if (Viewer2DPanel::Instance()) {
+        Viewer2DPanel::Instance()->SetSelectedUuids(mergedSelection);
+    }
+    RefreshSceneObjectVisuals();
 
     if (SummaryPanel::Instance())
         SummaryPanel::Instance()->ShowSceneObjectSummary();
@@ -1153,12 +1140,7 @@ void SceneObjectTablePanel::OnItemActivated(wxDataViewEvent &event) {
     if (!edited)
         return;
 
-    if (Viewer3DPanel::Instance()) {
-        Viewer3DPanel::Instance()->UpdateScene();
-        Viewer3DPanel::Instance()->Refresh();
-    } else if (Viewer2DPanel::Instance()) {
-        Viewer2DPanel::Instance()->UpdateScene();
-    }
+    RefreshSceneObjectVisuals();
 
     ReloadData();
     SelectByUuid({uuid});

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -31,10 +31,8 @@
 #include "stringutils.h"
 #include "summarypanel.h"
 #include "table_column_indices.h"
-#include "layoutviewerpanel.h"
+#include "scene_view_refresh.h"
 #include "dataview_edit_commit.h"
-#include "viewer2dpanel.h"
-#include "viewer3dpanel.h"
 #include "units/unit_label_utils.h"
 #include "units/units.h"
 #include <wx/aui/aui.h>
@@ -95,31 +93,10 @@ bool IsNumChar(char c) {
            c == '+';
 }
 
-LayoutViewerPanel *FindLayoutViewerPanel(wxWindow *root) {
-    if (!root)
-        return nullptr;
-
-    if (auto *layoutViewer = dynamic_cast<LayoutViewerPanel *>(root))
-        return layoutViewer;
-
-    for (wxWindow *child : root->GetChildren()) {
-        if (auto *layoutViewer = FindLayoutViewerPanel(child))
-            return layoutViewer;
-    }
-    return nullptr;
-}
-
+// Refreshes all scene previews after scene-object table edits.
 void RefreshSceneObjectVisuals() {
-    if (Viewer2DPanel::Instance()) {
-        Viewer2DPanel::Instance()->InvalidateBottomSymbolCache();
-        Viewer2DPanel::Instance()->UpdateScene();
-        Viewer2DPanel::Instance()->Refresh();
-    }
-
-    wxWindow *topLevel = wxGetTopLevelParent(SceneObjectTablePanel::Instance());
-    if (auto *layoutViewer = FindLayoutViewerPanel(topLevel)) {
-        layoutViewer->RefreshAfterSceneContentUpdate();
-    }
+    gui::sceneviewrefresh::RefreshSceneViewsAfterTableEdit(
+        SceneObjectTablePanel::Instance(), gui::sceneviewrefresh::SceneUpdateScope::Full);
 }
 
 RangeParts SplitRangeParts(const wxString &value) {

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -21,6 +21,7 @@
 #include "colorfulrenderers.h"
 #include "configmanager.h"
 #include "selection_origin_token.h"
+#include "scene_view_refresh.h"
 #include "guiconfigservices.h"
 #include "hang_position_dialog.h"
 #include "consolepanel.h"
@@ -1220,6 +1221,9 @@ void TrussTablePanel::UpdateSceneData(bool logChanges)
 
     if (RiggingPanel::Instance())
         RiggingPanel::Instance()->RefreshData();
+
+    gui::sceneviewrefresh::RefreshSceneViewsAfterTableEdit(
+        this, gui::sceneviewrefresh::SceneUpdateScope::Full);
 }
 
 TrussTablePanel* TrussTablePanel::Instance()

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -86,6 +86,7 @@
 #include <nanovg.h>
 #include <nanovg_gl.h>
 #include <sstream>
+#include <string>
 #include <string_view>
 #include <unordered_map>
 #include <unordered_set>
@@ -115,6 +116,8 @@ struct Viewer3DController::Impl {
       visibleSortedObjects;
   std::unordered_set<std::string> lastHiddenLayers;
   std::unordered_set<std::string> lastHiddenFixtureTypes;
+  size_t sceneLayerMembershipFingerprint = 0;
+  bool hasSceneLayerMembershipFingerprint = false;
   size_t hiddenLayersVersion = 0;
   bool sortedListsDirty = true;
   bool sortedListsLastWas2D = false;
@@ -328,6 +331,31 @@ static uint32_t HashString(std::string_view value) {
     hash *= 16777619u;
   }
   return hash;
+}
+
+// Combines one value into a stable size_t hash accumulator.
+static void CombineHashValue(size_t &seed, size_t value) {
+  seed ^= value + 0x9e3779b97f4a7c15ULL + (seed << 6) + (seed >> 2);
+}
+
+// Computes a stable fingerprint for scene elements whose layer controls visibility.
+static size_t ComputeSceneLayerMembershipFingerprint(const MvrScene &scene) {
+  std::vector<std::string> entries;
+  entries.reserve(scene.fixtures.size() + scene.trusses.size() +
+                  scene.sceneObjects.size());
+  for (const auto &entry : scene.fixtures)
+    entries.push_back("f:" + entry.first + ":" + entry.second.layer + ":" +
+                      entry.second.typeName);
+  for (const auto &entry : scene.trusses)
+    entries.push_back("t:" + entry.first + ":" + entry.second.layer);
+  for (const auto &entry : scene.sceneObjects)
+    entries.push_back("o:" + entry.first + ":" + entry.second.layer);
+  std::sort(entries.begin(), entries.end());
+
+  size_t seed = 0;
+  for (const auto &entry : entries)
+    CombineHashValue(seed, std::hash<std::string>{}(entry));
+  return seed;
 }
 
 // Converts to RGB.
@@ -847,6 +875,20 @@ void Viewer3DController::UpdateFrameStateLightweight() {
     Logger::Instance().Log("visibility dirty reason: hidden fixture types "
                            "changed vs last frame snapshot");
     m_impl->visibilityChangedDirty = true;
+    MarkResourceSyncPending();
+  }
+
+  const size_t layerMembershipFingerprint =
+      ComputeSceneLayerMembershipFingerprint(cfg.GetScene());
+  if (!m_impl->hasSceneLayerMembershipFingerprint ||
+      layerMembershipFingerprint != m_impl->sceneLayerMembershipFingerprint) {
+    Logger::Instance().Log("visibility dirty reason: scene layer membership "
+                           "changed vs last frame snapshot");
+    m_impl->sceneLayerMembershipFingerprint = layerMembershipFingerprint;
+    m_impl->hasSceneLayerMembershipFingerprint = true;
+    m_impl->visibilityChangedDirty = true;
+    ControllerInvalidateVisibleSetLayerCandidateCacheOwnership(
+        m_impl->layerVisibleCandidatesSceneVersion);
     MarkResourceSyncPending();
   }
 }


### PR DESCRIPTION
### Motivation
- Ensure that edits in Data Views (fixtures, trusses, scene objects) that change element visibility (e.g. moving between visible and hidden layers) immediately update all relevant previews so the UI reflects the change.
- Centralize and standardize viewer refresh behavior to avoid divergent per-table refresh logic and reduce duplication.
- Update user-facing release notes to record the visible/hidden layer refresh fix.

### Description
- Added a shared helper `gui::sceneviewrefresh::RefreshSceneViewsAfterTableEdit` in `gui/scene_view_refresh.{h,cpp}` that refreshes the standalone 2D viewer, standalone 3D viewer, and layout preview with a `Full`/`Light` scope.
- Replaced direct per-table viewer update code with calls into the new helper in `gui/fixturetablepanel.cpp`, `gui/sceneobjecttablepanel.cpp`, and `gui/trusstablepanel.cpp` so all viewers refresh consistently when scene data or layer visibility changes.
- Registered `scene_view_refresh.cpp` in `gui/CMakeLists.txt` so the helper is built into the GUI target.
- Updated `docs/release-notes-draft.md` with an entry describing the Data Views layer-visibility refresh fix.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed successfully.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed successfully.
- Attempted a CMake configure (`cmake -S . -B /tmp/perastage-cmake-check -DCMAKE_BUILD_TYPE=Debug`) which could not complete in this environment because the system wxWidgets development libraries are not installed, so full build verification was not possible here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5915f514a083248af54bfb3e3b864b)