### PR TITLE
Preserve multi-selection for Data Views bulk cell edits

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -24,6 +24,7 @@ Perastage 1.5.0 is a substantial update focused on GDTF and truss editing, multi
 - Added a shared **Hang Position editor** for fixtures, trusses, and hoists. Positions can be selected, created, renamed across affected objects, or removed from one dialog.
 - Updated Data Views interactions:
   - Double-clicking with the left mouse button opens cell-specific editing actions.
+  - Double-clicking a cell inside an existing multi-selection now keeps that selection and applies the existing bulk-edit behavior to all selected rows without requiring Shift.
   - Right-clicking opens row-level editors and context actions.
 - Edit Fixture and Edit Truss can now be maximized and use resizable layouts whose proportions are remembered between sessions.
 

--- a/docs/user/views.md
+++ b/docs/user/views.md
@@ -36,5 +36,6 @@ You can export layout-oriented output as PDF for sharing or printing.
 Best practice is to combine visual review with table review:
 
 - Validate elements in Fixtures, Trusses, Hoists, and Objects tables.
+- Double-click a cell inside an existing multi-selection to edit that column for all selected elements. A single click on one selected row still reduces the selection to that row after the normal system double-click interval when no second click follows.
 - Cross-check selected elements in 2D and 3D.
 - Confirm updates before saving or exporting MVR.

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -13,6 +13,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/dictionary_selection_controls.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dictionary_export_conflict_dialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dataview_edit_commit.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/dataview_deferred_selection_guard.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/editable_focus_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fixtures/fixture_gdtf_resolution.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tools/fixture_symbol_generation_tool.cpp

--- a/gui/dataview_deferred_selection_guard.cpp
+++ b/gui/dataview_deferred_selection_guard.cpp
@@ -1,0 +1,263 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "dataview_deferred_selection_guard.h"
+
+#include <algorithm>
+#include <utility>
+#include <wx/event.h>
+#include <wx/settings.h>
+#include <wx/wupdlock.h>
+
+namespace gui {
+
+// Creates a guard and binds mouse hooks to the table item area.
+DataViewDeferredSelectionGuard::DataViewDeferredSelectionGuard(
+    wxWindow *owner, wxDataViewCtrl *table, ItemKeyProvider itemKeyProvider,
+    ItemFinder itemFinder, SelectionSyncCallback selectionSyncCallback,
+    HighlightCallback highlightCallback)
+    : owner(owner), table(table), itemKeyProvider(std::move(itemKeyProvider)),
+      itemFinder(std::move(itemFinder)),
+      selectionSyncCallback(std::move(selectionSyncCallback)),
+      highlightCallback(std::move(highlightCallback)), timer(owner) {
+  if (owner)
+    owner->Bind(wxEVT_TIMER, &DataViewDeferredSelectionGuard::OnTimer, this,
+                timer.GetId());
+  BindMouseEvents();
+}
+
+// Unbinds callbacks and stops pending deferred selection work.
+DataViewDeferredSelectionGuard::~DataViewDeferredSelectionGuard() {
+  Cancel();
+  UnbindMouseEvents();
+  if (owner)
+    owner->Unbind(wxEVT_TIMER, &DataViewDeferredSelectionGuard::OnTimer, this,
+                  timer.GetId());
+}
+
+// Clears any pending deferred click without synchronizing a selection.
+void DataViewDeferredSelectionGuard::Cancel() {
+  if (timer.IsRunning())
+    timer.Stop();
+  pending = false;
+  clickedKey.clear();
+  clickedModelColumn = wxNOT_FOUND;
+  snapshotKeys.clear();
+}
+
+// Restores a transient native collapse and reports whether propagation was handled.
+bool DataViewDeferredSelectionGuard::HandleSelectionChanged() {
+  if (!pending || restoringSelection)
+    return false;
+
+  const std::vector<ItemKey> keys = CurrentSelectionKeys();
+  if (keys.size() == 1 && keys.front() == clickedKey) {
+    RestoreSnapshotSelection();
+    timer.StartOnce(DoubleClickIntervalMs());
+    return true;
+  }
+
+  if (keys != snapshotKeys)
+    Cancel();
+  return false;
+}
+
+// Cancels deferred single-selection commit when activation matches the pending cell.
+void DataViewDeferredSelectionGuard::NotifyItemActivated(
+    const wxDataViewItem &item, int modelColumn) {
+  if (!pending)
+    return;
+
+  if (itemKeyProvider(item) == clickedKey && modelColumn == clickedModelColumn)
+    Cancel();
+  else
+    Cancel();
+}
+
+// Cancels pending work when rows are reloaded, sorted, deleted, or cleared.
+void DataViewDeferredSelectionGuard::NotifyContentChanged() { Cancel(); }
+
+// Cancels pending work before drag range selection changes the table selection.
+void DataViewDeferredSelectionGuard::NotifyDragStarted() { Cancel(); }
+
+// Cancels pending work before right-click/context actions proceed.
+void DataViewDeferredSelectionGuard::NotifyContextActionStarted() { Cancel(); }
+
+// Binds low-level mouse hooks on the data-view main window when available.
+void DataViewDeferredSelectionGuard::BindMouseEvents() {
+  if (!table)
+    return;
+  mainWindow = table->GetMainWindow();
+  wxWindow *target = mainWindow ? mainWindow : table;
+  target->Bind(wxEVT_LEFT_DOWN, &DataViewDeferredSelectionGuard::OnLeftDown,
+               this);
+  target->Bind(wxEVT_RIGHT_DOWN, &DataViewDeferredSelectionGuard::OnRightDown,
+               this);
+}
+
+// Removes mouse hooks from the data-view item area.
+void DataViewDeferredSelectionGuard::UnbindMouseEvents() {
+  if (!table)
+    return;
+  wxWindow *target = mainWindow ? mainWindow : table;
+  if (!target)
+    return;
+  target->Unbind(wxEVT_LEFT_DOWN, &DataViewDeferredSelectionGuard::OnLeftDown,
+                 this);
+  target->Unbind(wxEVT_RIGHT_DOWN, &DataViewDeferredSelectionGuard::OnRightDown,
+                 this);
+}
+
+// Detects selected-row clicks that may become double-click bulk edits.
+void DataViewDeferredSelectionGuard::OnLeftDown(wxMouseEvent &event) {
+  Cancel();
+  if (!table || HasModifier(event)) {
+    event.Skip();
+    return;
+  }
+
+  wxDataViewItem item;
+  wxDataViewColumn *column = nullptr;
+  table->HitTest(ToTablePosition(dynamic_cast<wxWindow *>(event.GetEventObject()),
+                                 event.GetPosition()),
+                 item, column);
+  if (!item.IsOk() || !column) {
+    event.Skip();
+    return;
+  }
+
+  wxDataViewItemArray selections;
+  table->GetSelections(selections);
+  if (selections.size() <= 1 || !table->IsSelected(item)) {
+    event.Skip();
+    return;
+  }
+
+  clickedKey = itemKeyProvider(item);
+  if (clickedKey.empty()) {
+    event.Skip();
+    return;
+  }
+
+  snapshotKeys = CurrentSelectionKeys();
+  clickedModelColumn = column->GetModelColumn();
+  pending = snapshotKeys.size() > 1;
+  event.Skip();
+}
+
+// Cancels pending left-click state before native right-click handling.
+void DataViewDeferredSelectionGuard::OnRightDown(wxMouseEvent &event) {
+  NotifyContextActionStarted();
+  event.Skip();
+}
+
+// Commits a deferred selected-row single click after the double-click interval.
+void DataViewDeferredSelectionGuard::OnTimer(wxTimerEvent &WXUNUSED(event)) {
+  if (!pending)
+    return;
+  CommitSingleSelection();
+}
+
+// Restores the original multi-selection while suppressing transient events.
+void DataViewDeferredSelectionGuard::RestoreSnapshotSelection() {
+  if (!table)
+    return;
+
+  wxWindowUpdateLocker locker(table);
+  wxEventBlocker blocker(table, wxEVT_DATAVIEW_SELECTION_CHANGED);
+  restoringSelection = true;
+  table->UnselectAll();
+  for (const auto &key : snapshotKeys) {
+    wxDataViewItem item = FindItem(key);
+    if (item.IsOk())
+      table->Select(item);
+  }
+  wxDataViewItem clickedItem = FindItem(clickedKey);
+  if (clickedItem.IsOk())
+    table->SetCurrentItem(clickedItem);
+  restoringSelection = false;
+  if (highlightCallback)
+    highlightCallback();
+}
+
+// Selects only the clicked row and synchronizes table selection exactly once.
+void DataViewDeferredSelectionGuard::CommitSingleSelection() {
+  if (!table) {
+    Cancel();
+    return;
+  }
+
+  const ItemKey key = clickedKey;
+  Cancel();
+
+  wxDataViewItem item = FindItem(key);
+  if (!item.IsOk())
+    return;
+
+  wxWindowUpdateLocker locker(table);
+  wxEventBlocker blocker(table, wxEVT_DATAVIEW_SELECTION_CHANGED);
+  table->UnselectAll();
+  table->Select(item);
+  table->SetCurrentItem(item);
+  if (selectionSyncCallback)
+    selectionSyncCallback();
+}
+
+// Converts a mouse position from an event source window to table coordinates.
+wxPoint DataViewDeferredSelectionGuard::ToTablePosition(wxWindow *source,
+                                                        const wxPoint &position) const {
+  if (!source || source == table)
+    return position;
+  return table->ScreenToClient(source->ClientToScreen(position));
+}
+
+// Returns selected stable item keys in the current table selection order.
+std::vector<DataViewDeferredSelectionGuard::ItemKey>
+DataViewDeferredSelectionGuard::CurrentSelectionKeys() const {
+  std::vector<ItemKey> keys;
+  if (!table)
+    return keys;
+
+  wxDataViewItemArray selections;
+  table->GetSelections(selections);
+  keys.reserve(selections.size());
+  for (const auto &item : selections) {
+    ItemKey key = itemKeyProvider(item);
+    if (!key.empty())
+      keys.push_back(key);
+  }
+  return keys;
+}
+
+// Finds a table item from its stable key.
+wxDataViewItem DataViewDeferredSelectionGuard::FindItem(const ItemKey &key) const {
+  return itemFinder ? itemFinder(key) : wxDataViewItem();
+}
+
+// Checks whether native multi-selection modifiers are active.
+bool DataViewDeferredSelectionGuard::HasModifier(const wxMouseEvent &event) const {
+  return event.ShiftDown() || event.ControlDown() || event.CmdDown() ||
+         event.AltDown();
+}
+
+// Returns the platform double-click interval with a conservative fallback.
+int DataViewDeferredSelectionGuard::DoubleClickIntervalMs() const {
+  const int interval = wxSystemSettings::GetMetric(wxSYS_DCLICK_MSEC);
+  return interval > 0 ? interval : 500;
+}
+
+} // namespace gui

--- a/gui/dataview_deferred_selection_guard.h
+++ b/gui/dataview_deferred_selection_guard.h
@@ -1,0 +1,81 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <functional>
+#include <string>
+#include <vector>
+#include <wx/dataview.h>
+#include <wx/timer.h>
+#include <wx/window.h>
+
+namespace gui {
+
+// Coordinates native data-view selection timing for direct multi-row cell edits.
+class DataViewDeferredSelectionGuard {
+public:
+  using ItemKey = std::string;
+  using ItemKeyProvider = std::function<ItemKey(const wxDataViewItem &)>;
+  using ItemFinder = std::function<wxDataViewItem(const ItemKey &)>;
+  using SelectionSyncCallback = std::function<void()>;
+  using HighlightCallback = std::function<void()>;
+
+  DataViewDeferredSelectionGuard(wxWindow *owner, wxDataViewCtrl *table,
+                                 ItemKeyProvider itemKeyProvider,
+                                 ItemFinder itemFinder,
+                                 SelectionSyncCallback selectionSyncCallback,
+                                 HighlightCallback highlightCallback);
+  ~DataViewDeferredSelectionGuard();
+
+  void Cancel();
+  bool HandleSelectionChanged();
+  void NotifyItemActivated(const wxDataViewItem &item, int modelColumn);
+  void NotifyContentChanged();
+  void NotifyDragStarted();
+  void NotifyContextActionStarted();
+
+private:
+  void BindMouseEvents();
+  void UnbindMouseEvents();
+  void OnLeftDown(wxMouseEvent &event);
+  void OnRightDown(wxMouseEvent &event);
+  void OnTimer(wxTimerEvent &event);
+  void RestoreSnapshotSelection();
+  void CommitSingleSelection();
+  wxPoint ToTablePosition(wxWindow *source, const wxPoint &position) const;
+  std::vector<ItemKey> CurrentSelectionKeys() const;
+  wxDataViewItem FindItem(const ItemKey &key) const;
+  bool HasModifier(const wxMouseEvent &event) const;
+  int DoubleClickIntervalMs() const;
+
+  wxWindow *owner = nullptr;
+  wxDataViewCtrl *table = nullptr;
+  wxWindow *mainWindow = nullptr;
+  ItemKeyProvider itemKeyProvider;
+  ItemFinder itemFinder;
+  SelectionSyncCallback selectionSyncCallback;
+  HighlightCallback highlightCallback;
+  wxTimer timer;
+  bool pending = false;
+  bool restoringSelection = false;
+  ItemKey clickedKey;
+  int clickedModelColumn = wxNOT_FOUND;
+  std::vector<ItemKey> snapshotKeys;
+};
+
+} // namespace gui

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "fixturetablepanel.h"
+#include "dataview_deferred_selection_guard.h"
 #include "addressdialog.h"
 #include "configmanager.h"
 #include "consolepanel.h"
@@ -233,6 +234,18 @@ FixtureTablePanel::FixtureTablePanel(wxWindow *parent,
   table->Bind(wxEVT_DATAVIEW_COLUMN_SORTED, &FixtureTablePanel::OnColumnSorted,
               this);
 
+  deferredSelectionGuard = std::make_unique<gui::DataViewDeferredSelectionGuard>(
+      this, table,
+      [this](const wxDataViewItem &item) { return UuidForItem(item); },
+      [this](const std::string &uuid) {
+        auto pos = std::find(rowUuids.begin(), rowUuids.end(), uuid);
+        if (pos == rowUuids.end())
+          return wxDataViewItem();
+        return table->RowToItem(static_cast<unsigned int>(pos - rowUuids.begin()));
+      },
+      [this]() { SyncSelectionFromTable(); },
+      [this]() { UpdateSelectionHighlight(); });
+
   InitializeTable();
   ReloadData();
 
@@ -279,6 +292,8 @@ void FixtureTablePanel::InitializeTable() {
 
 // Rebuilds table rows from scene fixtures and reapplies validation highlights.
 void FixtureTablePanel::ReloadData() {
+  if (deferredSelectionGuard)
+    deferredSelectionGuard->NotifyContentChanged();
   if (!table || !store)
     return;
   table->Freeze();
@@ -478,6 +493,8 @@ void FixtureTablePanel::ReloadData() {
 // Handles context-menu editing actions and only applies scene updates when data
 // actually changes.
 void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
+  if (deferredSelectionGuard)
+    deferredSelectionGuard->NotifyItemActivated(event.GetItem(), event.GetColumn());
   wxDataViewItem item = event.GetItem();
   int col = event.GetColumn();
   const auto namedColumn = FixtureTableColumns::FromIndex(col);
@@ -1333,6 +1350,8 @@ void FixtureTablePanel::HighlightPatchConflicts() {
 
 // Clears all current table row selections.
 void FixtureTablePanel::ClearSelection() {
+  if (deferredSelectionGuard)
+    deferredSelectionGuard->NotifyContentChanged();
   table->UnselectAll();
   selectionOrderUuids.clear();
   UpdateSelectionHighlight();
@@ -1378,6 +1397,8 @@ void FixtureTablePanel::SelectByUuid(const std::vector<std::string> &uuids,
 
 // Deletes selected fixtures from the scene and refreshes related panels.
 void FixtureTablePanel::DeleteSelected(bool pushUndoState) {
+  if (deferredSelectionGuard)
+    deferredSelectionGuard->NotifyContentChanged();
   RebuildRowCachesFromRowKeys();
   wxDataViewItemArray selections;
   table->GetSelections(selections);
@@ -1449,6 +1470,8 @@ void FixtureTablePanel::DeleteSelected(bool pushUndoState) {
 
 // Commits inline cell edits and propagates resulting scene updates.
 void FixtureTablePanel::OnItemActivated(wxDataViewEvent &event) {
+  if (deferredSelectionGuard)
+    deferredSelectionGuard->NotifyContextActionStarted();
   wxDataViewItem item = event.GetItem();
   if (!item.IsOk()) {
     event.Skip();
@@ -1544,13 +1567,21 @@ void FixtureTablePanel::UpdateHoverTooltip(const wxPoint &position) {
 
 // Syncs cross-panel selection state when table selection changes.
 void FixtureTablePanel::OnSelectionChanged(wxDataViewEvent &evt) {
+  if (deferredSelectionGuard && deferredSelectionGuard->HandleSelectionChanged())
+    return;
+
+  SyncSelectionFromTable();
+  evt.Skip();
+}
+
+// Synchronizes selected table rows with the shared scene selection state.
+void FixtureTablePanel::SyncSelectionFromTable() {
   RebuildRowCachesFromRowKeys();
   const selection::Origin origin = selection::CurrentOrigin();
   if (origin == selection::Origin::Viewer2D ||
       origin == selection::Origin::Viewer3D) {
     UpdateSelectionHighlight();
-    evt.Skip();
-    return;
+      return;
   }
 
   wxDataViewItemArray selections;
@@ -1600,7 +1631,7 @@ void FixtureTablePanel::OnSelectionChanged(wxDataViewEvent &evt) {
   if (Viewer2DPanel::Instance())
     Viewer2DPanel::Instance()->SetSelectedUuids(mergedSelection);
   UpdateSelectionHighlight();
-  evt.Skip();
+
 }
 
 // Reapplies row highlight styling based on current selection state.
@@ -1960,6 +1991,8 @@ void FixtureTablePanel::SetGdtfPathForRow(unsigned int row,
 
 // Rebuilds row caches after user-driven column sorting changes row order.
 void FixtureTablePanel::OnColumnSorted(wxDataViewEvent &event) {
+  if (deferredSelectionGuard)
+    deferredSelectionGuard->NotifyContentChanged();
   RebuildRowCachesFromRowKeys();
   const std::vector<std::string> selectedUuids =
       guiConfigServices->LegacyConfigManager().GetSelectedFixtures();

--- a/gui/fixturetablepanel.h
+++ b/gui/fixturetablepanel.h
@@ -21,6 +21,7 @@
 #include <wx/dataview.h>
 #include <wx/time.h>
 #include <vector>
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -28,6 +29,8 @@
 #include "positionvalueupdate.h"
 
 class FixtureEditDialog; // forward declaration
+namespace gui { class DataViewDeferredSelectionGuard; }
+
 class IGuiConfigServices;
 
 class FixtureTablePanel : public wxPanel
@@ -101,6 +104,7 @@ private:
     std::vector<std::string> selectionOrderUuids;
     std::unordered_set<std::string> manualCategoryUuidsPending;
     IGuiConfigServices *guiConfigServices = nullptr;
+    std::unique_ptr<gui::DataViewDeferredSelectionGuard> deferredSelectionGuard;
 
     void InitializeTable(); // Set up columns
     void OnContextMenu(wxDataViewEvent& event);
@@ -118,6 +122,7 @@ private:
     void OnMouseLeave(wxMouseEvent& evt);
     void OnCaptureLost(wxMouseCaptureLostEvent& evt);
     void OnSelectionChanged(wxDataViewEvent& evt);
+    void SyncSelectionFromTable();
     void UpdateHoverTooltip(const wxPoint& position);
     void UpdateSelectionHighlight();
     void PropagateTypeValues(const wxDataViewItemArray& selections, int col);

--- a/gui/hoisttablepanel.cpp
+++ b/gui/hoisttablepanel.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "hoisttablepanel.h"
+#include "dataview_deferred_selection_guard.h"
 #include "localized_unit_labels.h"
 
 #include "colorfulrenderers.h"
@@ -438,6 +439,18 @@ HoistTablePanel::HoistTablePanel(wxWindow *parent, IGuiConfigServices *services)
 
   Bind(wxEVT_MOUSE_CAPTURE_LOST, &HoistTablePanel::OnCaptureLost, this);
 
+  deferredSelectionGuard = std::make_unique<gui::DataViewDeferredSelectionGuard>(
+      this, table,
+      [this](const wxDataViewItem &item) { return UuidForItem(item); },
+      [this](const std::string &uuid) {
+        auto pos = std::find(rowUuids.begin(), rowUuids.end(), uuid);
+        if (pos == rowUuids.end())
+          return wxDataViewItem();
+        return table->RowToItem(static_cast<unsigned int>(pos - rowUuids.begin()));
+      },
+      [this]() { SyncSelectionFromTable(); },
+      [this]() { UpdateSelectionHighlight(); });
+
   InitializeTable();
   ReloadData();
 
@@ -496,6 +509,8 @@ void HoistTablePanel::InitializeTable() {
 }
 
 void HoistTablePanel::ReloadData() {
+  if (deferredSelectionGuard)
+    deferredSelectionGuard->NotifyContentChanged();
   const auto distanceUnit = ResolveDistanceUnitSystem();
   const auto weightUnit = ResolveWeightUnitSystem();
   const wxString distanceSuffix =
@@ -659,6 +674,8 @@ void HoistTablePanel::ReloadData() {
 }
 
 void HoistTablePanel::OnContextMenu(wxDataViewEvent &event) {
+  if (deferredSelectionGuard)
+    deferredSelectionGuard->NotifyItemActivated(event.GetItem(), event.GetColumn());
   wxDataViewItem item = event.GetItem();
   int col = event.GetColumn();
   const auto namedColumn = TableColumnIndices::FromIndex<HoistColumn>(col);
@@ -968,8 +985,6 @@ void HoistTablePanel::OnLeftDown(wxMouseEvent &evt) {
   startRow = table->ItemToRow(item);
   if (startRow != wxNOT_FOUND) {
     dragSelecting = true;
-    table->UnselectAll();
-    table->SelectRow(startRow);
     CaptureMouse();
   }
   evt.Skip();
@@ -999,6 +1014,8 @@ void HoistTablePanel::OnMouseMove(wxMouseEvent &evt) {
   table->HitTest(NormalizeMousePositionForTable(table, evt), item, col);
   int row = table->ItemToRow(item);
   if (row != wxNOT_FOUND) {
+    if (deferredSelectionGuard)
+      deferredSelectionGuard->NotifyDragStarted();
     int minRow = std::min(startRow, row);
     int maxRow = std::max(startRow, row);
     table->UnselectAll();
@@ -1056,14 +1073,23 @@ void HoistTablePanel::UpdateHoverTooltip(const wxPoint &position) {
   activeHoverTooltip = tooltip;
 }
 
+// Handles table selection events and defers transient single-click collapses.
 void HoistTablePanel::OnSelectionChanged(wxDataViewEvent &evt) {
+  if (deferredSelectionGuard && deferredSelectionGuard->HandleSelectionChanged())
+    return;
+
+  SyncSelectionFromTable();
+  evt.Skip();
+}
+
+// Synchronizes selected table rows with the shared scene selection state.
+void HoistTablePanel::SyncSelectionFromTable() {
   RebuildRowCachesFromRowKeys();
   const selection::Origin origin = selection::CurrentOrigin();
   if (origin == selection::Origin::Viewer2D ||
       origin == selection::Origin::Viewer3D) {
     UpdateSelectionHighlight();
-    evt.Skip();
-    return;
+      return;
   }
 
   wxDataViewItemArray selections;
@@ -1094,7 +1120,7 @@ void HoistTablePanel::OnSelectionChanged(wxDataViewEvent &evt) {
   if (Viewer2DPanel::Instance())
     Viewer2DPanel::Instance()->SetSelectedUuids(mergedSelection);
   UpdateSelectionHighlight();
-  evt.Skip();
+
 }
 
 void HoistTablePanel::UpdateSelectionHighlight() {
@@ -1435,6 +1461,8 @@ void HoistTablePanel::HighlightHoist(
 }
 
 void HoistTablePanel::ClearSelection() {
+  if (deferredSelectionGuard)
+    deferredSelectionGuard->NotifyContentChanged();
   table->UnselectAll();
   UpdateSelectionHighlight();
 }
@@ -1476,6 +1504,8 @@ void HoistTablePanel::SelectByUuid(const std::vector<std::string> &uuids,
 }
 
 void HoistTablePanel::DeleteSelected(bool pushUndoState) {
+  if (deferredSelectionGuard)
+    deferredSelectionGuard->NotifyContentChanged();
   RebuildRowCachesFromRowKeys();
   wxDataViewItemArray selections;
   table->GetSelections(selections);
@@ -1598,6 +1628,8 @@ void HoistTablePanel::SetLoadStateForRow(
 
 // Reapplies UUID-based selection after user-driven column sorting changes row order.
 void HoistTablePanel::OnColumnSorted(wxDataViewEvent &event) {
+  if (deferredSelectionGuard)
+    deferredSelectionGuard->NotifyContentChanged();
   RebuildRowCachesFromRowKeys();
   const std::vector<std::string> selectedUuids =
       guiConfigServices->LegacyConfigManager().GetSelectedSupports();

--- a/gui/hoisttablepanel.h
+++ b/gui/hoisttablepanel.h
@@ -23,9 +23,12 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+#include <memory>
 #include "colorstore.h"
 #include "hoist_load_limit_utils.h"
 #include "positionvalueupdate.h"
+
+namespace gui { class DataViewDeferredSelectionGuard; }
 
 class IGuiConfigServices;
 
@@ -66,9 +69,11 @@ private:
   bool dragSelecting = false;
   int startRow = -1;
   IGuiConfigServices *guiConfigServices = nullptr;
+    std::unique_ptr<gui::DataViewDeferredSelectionGuard> deferredSelectionGuard;
 
   void InitializeTable();
   void OnSelectionChanged(wxDataViewEvent &evt);
+  void SyncSelectionFromTable();
   void OnContextMenu(wxDataViewEvent &event);
   void OnColumnSorted(wxDataViewEvent &event);
   void RebuildRowCachesFromRowKeys();

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "sceneobjecttablepanel.h"
+#include "dataview_deferred_selection_guard.h"
 #include "localized_unit_labels.h"
 #include "columnutils.h"
 #include "colorfulrenderers.h"
@@ -218,6 +219,18 @@ SceneObjectTablePanel::SceneObjectTablePanel(wxWindow *parent,
 
     Bind(wxEVT_MOUSE_CAPTURE_LOST, &SceneObjectTablePanel::OnCaptureLost, this);
 
+    deferredSelectionGuard = std::make_unique<gui::DataViewDeferredSelectionGuard>(
+            this, table,
+            [this](const wxDataViewItem &item) { return UuidForItem(item); },
+            [this](const std::string &uuid) {
+                auto pos = std::find(rowUuids.begin(), rowUuids.end(), uuid);
+                if (pos == rowUuids.end())
+                    return wxDataViewItem();
+                return table->RowToItem(static_cast<unsigned int>(pos - rowUuids.begin()));
+            },
+            [this]() { SyncSelectionFromTable(); },
+            [this]() { UpdateSelectionHighlight(); });
+
     InitializeTable();
     ReloadData();
 
@@ -260,6 +273,8 @@ void SceneObjectTablePanel::InitializeTable() {
 }
 
 void SceneObjectTablePanel::ReloadData() {
+  if (deferredSelectionGuard)
+    deferredSelectionGuard->NotifyContentChanged();
     const auto distanceUnit = ResolveDistanceUnitSystem();
     const wxString distanceSuffix =
         wxString::FromUTF8(Units::DistanceUnitSuffix(distanceUnit));
@@ -362,6 +377,8 @@ void SceneObjectTablePanel::ReloadData() {
 // Handles context-menu edits and updates scene/rendering only when an actual
 // table value changes.
 void SceneObjectTablePanel::OnContextMenu(wxDataViewEvent &event) {
+  if (deferredSelectionGuard)
+    deferredSelectionGuard->NotifyItemActivated(event.GetItem(), event.GetColumn());
     wxDataViewItem item = event.GetItem();
     int col = event.GetColumn();
   const auto namedColumn =
@@ -396,7 +413,7 @@ void SceneObjectTablePanel::OnContextMenu(wxDataViewEvent &event) {
 
     wxVariant current;
     table->GetValue(current, row, col);
-    
+
   if (*namedColumn == SceneObjectColumn::Layer) {
         auto layers = guiConfigServices->LegacyConfigManager().GetLayerNames();
         wxArrayString choices;
@@ -582,8 +599,6 @@ void SceneObjectTablePanel::OnLeftDown(wxMouseEvent& evt)
     if (startRow != wxNOT_FOUND)
     {
         dragSelecting = true;
-        table->UnselectAll();
-        table->SelectRow(startRow);
         CaptureMouse();
     }
     evt.Skip();
@@ -636,6 +651,8 @@ void SceneObjectTablePanel::OnMouseMove(wxMouseEvent &evt) {
     table->HitTest(evt.GetPosition(), item, col);
     int row = table->ItemToRow(item);
   if (row != wxNOT_FOUND) {
+        if (deferredSelectionGuard)
+            deferredSelectionGuard->NotifyDragStarted();
         int minRow = std::min(startRow, row);
         int maxRow = std::max(startRow, row);
         table->UnselectAll();
@@ -645,14 +662,23 @@ void SceneObjectTablePanel::OnMouseMove(wxMouseEvent &evt) {
     evt.Skip();
 }
 
+// Handles table selection events and defers transient single-click collapses.
 void SceneObjectTablePanel::OnSelectionChanged(wxDataViewEvent &evt) {
+  if (deferredSelectionGuard && deferredSelectionGuard->HandleSelectionChanged())
+    return;
+
+  SyncSelectionFromTable();
+  evt.Skip();
+}
+
+// Synchronizes selected table rows with the shared scene selection state.
+void SceneObjectTablePanel::SyncSelectionFromTable() {
     RebuildRowCachesFromRowKeys();
     const selection::Origin origin = selection::CurrentOrigin();
     if (origin == selection::Origin::Viewer2D ||
         origin == selection::Origin::Viewer3D) {
         UpdateSelectionHighlight();
-        evt.Skip();
-        return;
+              return;
     }
 
     wxDataViewItemArray selections;
@@ -683,7 +709,7 @@ void SceneObjectTablePanel::OnSelectionChanged(wxDataViewEvent &evt) {
     if (Viewer2DPanel::Instance())
         Viewer2DPanel::Instance()->SetSelectedUuids(mergedSelection);
     UpdateSelectionHighlight();
-    evt.Skip();
+
 }
 
 void SceneObjectTablePanel::UpdateSelectionHighlight() {
@@ -951,6 +977,8 @@ void SceneObjectTablePanel::HighlightObject(
 }
 
 void SceneObjectTablePanel::ClearSelection() {
+  if (deferredSelectionGuard)
+    deferredSelectionGuard->NotifyContentChanged();
     table->UnselectAll();
     UpdateSelectionHighlight();
 }
@@ -992,6 +1020,8 @@ void SceneObjectTablePanel::SelectByUuid(const std::vector<std::string>& uuids,
 }
 
 void SceneObjectTablePanel::DeleteSelected(bool pushUndoState) {
+  if (deferredSelectionGuard)
+    deferredSelectionGuard->NotifyContentChanged();
     RebuildRowCachesFromRowKeys();
     wxDataViewItemArray selections;
     table->GetSelections(selections);
@@ -1117,6 +1147,8 @@ void SceneObjectTablePanel::SetModelPathForRow(unsigned int row,
 
 // Reapplies UUID-based selection after user-driven column sorting changes row order.
 void SceneObjectTablePanel::OnColumnSorted(wxDataViewEvent &event) {
+  if (deferredSelectionGuard)
+    deferredSelectionGuard->NotifyContentChanged();
     RebuildRowCachesFromRowKeys();
     const std::vector<std::string> selectedUuids =
         guiConfigServices->LegacyConfigManager().GetSelectedSceneObjects();
@@ -1126,6 +1158,8 @@ void SceneObjectTablePanel::OnColumnSorted(wxDataViewEvent &event) {
 }
 
 void SceneObjectTablePanel::OnItemActivated(wxDataViewEvent &event) {
+  if (deferredSelectionGuard)
+    deferredSelectionGuard->NotifyContextActionStarted();
     const wxDataViewItem item = event.GetItem();
     const int row = table->ItemToRow(item);
     if (row == wxNOT_FOUND || static_cast<size_t>(row) >= rowUuids.size()) {

--- a/gui/sceneobjecttablepanel.h
+++ b/gui/sceneobjecttablepanel.h
@@ -21,10 +21,13 @@
 #include <wx/dataview.h>
 #include <wx/time.h>
 #include <vector>
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include "colorstore.h"
 #include "positionvalueupdate.h"
+
+namespace gui { class DataViewDeferredSelectionGuard; }
 
 class IGuiConfigServices;
 
@@ -67,8 +70,10 @@ private:
     bool modelFileEditCommitPending = false;
     int startRow = -1;
     IGuiConfigServices *guiConfigServices = nullptr;
+    std::unique_ptr<gui::DataViewDeferredSelectionGuard> deferredSelectionGuard;
     void InitializeTable();
     void OnSelectionChanged(wxDataViewEvent& evt);
+    void SyncSelectionFromTable();
     void OnContextMenu(wxDataViewEvent& event);
     void OnColumnSorted(wxDataViewEvent& event);
     void RebuildRowCachesFromRowKeys();

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "trusstablepanel.h"
+#include "dataview_deferred_selection_guard.h"
 #include "localized_unit_labels.h"
 #include "columnutils.h"
 #include "colorfulrenderers.h"
@@ -264,6 +265,18 @@ TrussTablePanel::TrussTablePanel(wxWindow* parent, IGuiConfigServices* services)
 
     Bind(wxEVT_MOUSE_CAPTURE_LOST, &TrussTablePanel::OnCaptureLost, this);
 
+    deferredSelectionGuard = std::make_unique<gui::DataViewDeferredSelectionGuard>(
+            this, table,
+            [this](const wxDataViewItem &item) { return UuidForItem(item); },
+            [this](const std::string &uuid) {
+                auto pos = std::find(rowUuids.begin(), rowUuids.end(), uuid);
+                if (pos == rowUuids.end())
+                    return wxDataViewItem();
+                return table->RowToItem(static_cast<unsigned int>(pos - rowUuids.begin()));
+            },
+            [this]() { SyncSelectionFromTable(); },
+            [this]() { UpdateSelectionHighlight(); });
+
     InitializeTable();
     ReloadData();
 
@@ -308,8 +321,9 @@ void TrussTablePanel::InitializeTable()
 }
 
 // Refreshes truss table rows from the current project data.
-void TrussTablePanel::ReloadData()
-{
+void TrussTablePanel::ReloadData() {
+  if (deferredSelectionGuard)
+    deferredSelectionGuard->NotifyContentChanged();
     ConfigManager& cfg = guiConfigServices->LegacyConfigManager();
     const std::vector<std::string> selectedTrusses = cfg.GetSelectedTrusses();
     const auto distanceUnit = ResolveDistanceUnitSystem();
@@ -472,6 +486,8 @@ void TrussTablePanel::ReloadData()
 // Handles context-menu editing workflows and avoids expensive refreshes when no
 // row values change.
 void TrussTablePanel::OnContextMenu(wxDataViewEvent &event) {
+  if (deferredSelectionGuard)
+    deferredSelectionGuard->NotifyItemActivated(event.GetItem(), event.GetColumn());
     wxDataViewItem item = event.GetItem();
     int col = event.GetColumn();
   const auto namedColumn = TableColumnIndices::FromIndex<TrussColumn>(col);
@@ -776,8 +792,6 @@ void TrussTablePanel::OnLeftDown(wxMouseEvent& evt)
     if (startRow != wxNOT_FOUND)
     {
         dragSelecting = true;
-        table->UnselectAll();
-        table->SelectRow(startRow);
         CaptureMouse();
     }
     evt.Skip();
@@ -805,6 +819,8 @@ void TrussTablePanel::OnMouseMove(wxMouseEvent &evt) {
     table->HitTest(evt.GetPosition(), item, col);
     int row = table->ItemToRow(item);
   if (row != wxNOT_FOUND) {
+        if (deferredSelectionGuard)
+            deferredSelectionGuard->NotifyDragStarted();
         int minRow = std::min(startRow, row);
         int maxRow = std::max(startRow, row);
         table->UnselectAll();
@@ -814,14 +830,23 @@ void TrussTablePanel::OnMouseMove(wxMouseEvent &evt) {
     evt.Skip();
 }
 
+// Handles table selection events and defers transient single-click collapses.
 void TrussTablePanel::OnSelectionChanged(wxDataViewEvent &evt) {
+  if (deferredSelectionGuard && deferredSelectionGuard->HandleSelectionChanged())
+    return;
+
+  SyncSelectionFromTable();
+  evt.Skip();
+}
+
+// Synchronizes selected table rows with the shared scene selection state.
+void TrussTablePanel::SyncSelectionFromTable() {
     RebuildRowCachesFromRowKeys();
     const selection::Origin origin = selection::CurrentOrigin();
     if (origin == selection::Origin::Viewer2D ||
         origin == selection::Origin::Viewer3D) {
         UpdateSelectionHighlight();
-        evt.Skip();
-        return;
+              return;
     }
 
     wxDataViewItemArray selections;
@@ -852,7 +877,7 @@ void TrussTablePanel::OnSelectionChanged(wxDataViewEvent &evt) {
     if (Viewer2DPanel::Instance())
         Viewer2DPanel::Instance()->SetSelectedUuids(mergedSelection);
     UpdateSelectionHighlight();
-    evt.Skip();
+
 }
 
 void TrussTablePanel::UpdateSelectionHighlight() {
@@ -921,6 +946,8 @@ void TrussTablePanel::ApplyPositionValueUpdates(
 
 // Opens the truss edit dialog for the activated table row.
 void TrussTablePanel::OnItemActivated(wxDataViewEvent &event) {
+  if (deferredSelectionGuard)
+    deferredSelectionGuard->NotifyContextActionStarted();
   const wxDataViewItem item =
       event.GetItem().IsOk() ? event.GetItem() : table->GetSelection();
   if (!item.IsOk())
@@ -1286,6 +1313,8 @@ void TrussTablePanel::HighlightTruss(
 }
 
 void TrussTablePanel::ClearSelection() {
+  if (deferredSelectionGuard)
+    deferredSelectionGuard->NotifyContentChanged();
     table->UnselectAll();
     UpdateSelectionHighlight();
 }
@@ -1327,6 +1356,8 @@ void TrussTablePanel::SelectByUuid(const std::vector<std::string>& uuids,
 }
 
 void TrussTablePanel::DeleteSelected(bool pushUndoState) {
+  if (deferredSelectionGuard)
+    deferredSelectionGuard->NotifyContentChanged();
     RebuildRowCachesFromRowKeys();
     wxDataViewItemArray selections;
     table->GetSelections(selections);
@@ -1462,6 +1493,8 @@ void TrussTablePanel::SetModelPathsForRow(unsigned int row,
 
 // Reapplies UUID-based selection after user-driven column sorting changes row order.
 void TrussTablePanel::OnColumnSorted(wxDataViewEvent &event) {
+  if (deferredSelectionGuard)
+    deferredSelectionGuard->NotifyContentChanged();
     RebuildRowCachesFromRowKeys();
     const std::vector<std::string> selectedUuids =
         guiConfigServices->LegacyConfigManager().GetSelectedTrusses();

--- a/gui/trusstablepanel.h
+++ b/gui/trusstablepanel.h
@@ -21,10 +21,13 @@
 #include <wx/dataview.h>
 #include <wx/time.h>
 #include <vector>
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include "colorstore.h"
 #include "positionvalueupdate.h"
+
+namespace gui { class DataViewDeferredSelectionGuard; }
 
 class IGuiConfigServices;
 class TrussEditDialog;
@@ -69,8 +72,10 @@ private:
     bool dragSelecting = false;
     int startRow = -1;
     IGuiConfigServices *guiConfigServices = nullptr;
+    std::unique_ptr<gui::DataViewDeferredSelectionGuard> deferredSelectionGuard;
     void InitializeTable(); // Set up columns
     void OnSelectionChanged(wxDataViewEvent& evt);
+    void SyncSelectionFromTable();
     void OnContextMenu(wxDataViewEvent& event);
     void OnColumnSorted(wxDataViewEvent& event);
     void RebuildRowCachesFromRowKeys();


### PR DESCRIPTION
### Motivation
- Plain double-clicks collapsed native table selection to the clicked row so the existing activated-cell bulk-edit path only saw one row, requiring Shift to keep multi-row edits working.
- The goal is to let a direct left-button double-click open the existing cell editor while preserving the current multi-selection so the existing bulk-edit logic (which calls `GetSelections()`) applies to all selected rows.
- The change must be reusable, confined to GUI timing/selection concerns, and must not duplicate or reimplement any domain/bulk-edit logic or change right-click behaviors.

### Description
- Add a focused helper `gui::DataViewDeferredSelectionGuard` that snapshots UUID-backed selections on selected-row clicks, restores transient native collapses during the system double-click interval, and commits a deferred single selection only if no activation occurs; new files: `gui/dataview_deferred_selection_guard.h` and `gui/dataview_deferred_selection_guard.cpp` and CMake registration in `gui/CMakeLists.txt`.
- Wire the guard into all four Data Views (Fixtures, Trusses, Hoists, Scene Objects) with stable item-key and finder callbacks and reuse each table’s existing selection-sync and activated-item handlers rather than duplicating bulk-edit code; modified files: `gui/fixturetablepanel.h/.cpp`, `gui/trusstablepanel.h/.cpp`, `gui/hoisttablepanel.h/.cpp`, `gui/sceneobjecttablepanel.h/.cpp`.
- Preserve existing activated-cell bulk-edit behavior by notifying the guard at activation start so an activation matching the pending candidate cancels the deferred commit and leaves the restored multi-selection intact, and extract/refactor selection propagation into `SyncSelectionFromTable()` so both real events and deferred commits use the same synchronization path.
- Adjust drag bookkeeping to avoid immediate `UnselectAll()`/`SelectRow()` on left-down in Truss/Hoist/SceneObject panels and cancel pending deferred state when a real drag or content change begins, and update user docs and release notes: `docs/user/views.md` and `docs/release-notes-draft.md`.

### Testing
- Ran repository checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both passed.
- Ran `git diff --check` for whitespace/trailing issues and addressed problems reported (passed after cleanup).
- Attempted to configure/build with `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug`, but configuration failed because the environment is missing `wxWidgets` libraries/includes, so a full build/test on this host could not be completed.
- Note: GUI/manual acceptance tests described in the task (interactive double-click/drag/selection behaviors across platforms) must be performed on a developer machine with `wxWidgets` and a display; no new unit/regression test was added for the guard in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59241d17d88324981daca9ec59da5b)