### PR TITLE
Fix Dictionary Editor save reliability

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -73,6 +73,7 @@ Perastage 1.5.0 is a substantial update focused on GDTF and truss editing, multi
 
 ## Important fixes
 
+- Improved Dictionary Editor reliability so fixture and truss edits are saved transactionally, unresolved file references remain visible and savable, dirty-state checks catch category/color/path/name changes, and failed saves keep the editor open.
 - Fixed Data Views table edits so moving fixtures, trusses, or scene objects between visible and hidden layers rebuilds the relevant viewer resources, invalidates stale 3D visible-set caches, and immediately refreshes both the 2D and 3D viewports, including layout previews.
 - Fixed Windows build and linker issues in the Local Axes viewport integration.
 

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -10,6 +10,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/ui_feature_flags.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/wx_text_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dictionaryeditdialog.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/dictionary_editor_state.h
     ${CMAKE_CURRENT_SOURCE_DIR}/dictionary_selection_controls.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dictionary_export_conflict_dialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dataview_edit_commit.cpp

--- a/gui/dictionary_editor_state.h
+++ b/gui/dictionary_editor_state.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+namespace DictionaryEditorState {
+
+struct FixtureSnapshotRow {
+  std::string name;
+  std::string path;
+  std::string mode;
+  std::string category;
+  std::string visualColorHex;
+};
+
+struct TrussSnapshotRow {
+  std::string name;
+  std::string path;
+};
+
+enum class DirtyGuardChoice { Save, Discard, Cancel };
+
+enum class DirtyGuardResult { Continue, Abort };
+
+// Builds a stable fixture snapshot from all user-editable dictionary fields.
+inline std::vector<std::string>
+BuildFixtureSnapshot(std::vector<FixtureSnapshotRow> rows) {
+  std::vector<std::string> snapshot;
+  snapshot.reserve(rows.size());
+  for (const auto &row : rows) {
+    if (row.name.empty())
+      continue;
+    snapshot.push_back(row.name + '\n' + row.path + '\n' + row.mode + '\n' +
+                       row.category + '\n' + row.visualColorHex);
+  }
+  std::sort(snapshot.begin(), snapshot.end());
+  return snapshot;
+}
+
+// Builds a stable truss snapshot from all user-editable dictionary fields.
+inline std::vector<std::string>
+BuildTrussSnapshot(std::vector<TrussSnapshotRow> rows) {
+  std::vector<std::string> snapshot;
+  snapshot.reserve(rows.size());
+  for (const auto &row : rows) {
+    if (row.name.empty())
+      continue;
+    snapshot.push_back(row.name + '\n' + row.path);
+  }
+  std::sort(snapshot.begin(), snapshot.end());
+  return snapshot;
+}
+
+// Resolves whether an operation guarded by dirty state should continue.
+inline DirtyGuardResult ResolveDirtyGuard(bool hasChanges,
+                                          DirtyGuardChoice choice,
+                                          bool saveSucceeded) {
+  if (!hasChanges)
+    return DirtyGuardResult::Continue;
+  if (choice == DirtyGuardChoice::Cancel)
+    return DirtyGuardResult::Abort;
+  if (choice == DirtyGuardChoice::Discard)
+    return DirtyGuardResult::Continue;
+  return saveSucceeded ? DirtyGuardResult::Continue : DirtyGuardResult::Abort;
+}
+
+} // namespace DictionaryEditorState

--- a/gui/dictionaryeditdialog.cpp
+++ b/gui/dictionaryeditdialog.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "dictionaryeditdialog.h"
+#include "dictionary_editor_state.h"
 #include "filesystem_path_utils.h"
 
 #include "colorfulrenderers.h"
@@ -1201,64 +1202,51 @@ void DictionaryEditDialog::LoadTrusses() {
   trussSnapshotAtLoad = BuildTrussSnapshotFromUi();
 }
 
+// Builds a dirty-state snapshot for every editable fixture row.
 std::vector<std::string>
 DictionaryEditDialog::BuildFixtureSnapshotFromUi() const {
-  std::vector<std::string> snapshot;
+  std::vector<DictionaryEditorState::FixtureSnapshotRow> rows;
   if (!fixtureTable)
-    return snapshot;
+    return {};
 
   const int count = fixtureTable->GetItemCount();
-  snapshot.reserve(static_cast<size_t>(count));
+  rows.reserve(static_cast<size_t>(count));
   for (int i = 0; i < count; ++i) {
-    wxVariant nameVar;
-    fixtureTable->GetValue(nameVar, i, kFixtureNameColumn);
-    const std::string name = std::string(nameVar.GetString().ToUTF8());
-    if (name.empty())
-      continue;
     if (static_cast<size_t>(i) >= fixturePaths.size())
       continue;
-    const std::string &path = fixturePaths[i];
-    if (path.empty())
-      continue;
-    if (!std::filesystem::exists(path))
-      continue;
+    wxVariant nameVar;
+    fixtureTable->GetValue(nameVar, i, kFixtureNameColumn);
     wxVariant modeVar;
     fixtureTable->GetValue(modeVar, i, kFixtureModeColumn);
-    const std::string mode = std::string(modeVar.GetString().ToUTF8());
+    wxVariant categoryVar;
+    fixtureTable->GetValue(categoryVar, i, kFixtureCategoryColumn);
     wxVariant colorVar;
     fixtureTable->GetValue(colorVar, i, kFixtureVisualColorColumn);
-    const std::string color = ExtractFixtureVisualColorText(colorVar);
-    snapshot.push_back(name + '\n' + path + '\n' + mode + '\n' + color);
+    rows.push_back({std::string(nameVar.GetString().ToUTF8()), fixturePaths[i],
+                    std::string(modeVar.GetString().ToUTF8()),
+                    std::string(categoryVar.GetString().ToUTF8()),
+                    ExtractFixtureVisualColorText(colorVar)});
   }
-  std::sort(snapshot.begin(), snapshot.end());
-  return snapshot;
+  return DictionaryEditorState::BuildFixtureSnapshot(std::move(rows));
 }
 
+// Builds a dirty-state snapshot for every editable truss row.
 std::vector<std::string>
 DictionaryEditDialog::BuildTrussSnapshotFromUi() const {
-  std::vector<std::string> snapshot;
+  std::vector<DictionaryEditorState::TrussSnapshotRow> rows;
   if (!trussTable)
-    return snapshot;
+    return {};
 
   const int count = trussTable->GetItemCount();
-  snapshot.reserve(static_cast<size_t>(count));
+  rows.reserve(static_cast<size_t>(count));
   for (int i = 0; i < count; ++i) {
-    wxVariant nameVar;
-    trussTable->GetValue(nameVar, i, kTrussNameColumn);
-    const std::string name = std::string(nameVar.GetString().ToUTF8());
-    if (name.empty())
-      continue;
     if (static_cast<size_t>(i) >= trussPaths.size())
       continue;
-    const std::string &path = trussPaths[i];
-    if (path.empty())
-      continue;
-    if (!std::filesystem::exists(path))
-      continue;
-    snapshot.push_back(name + '\n' + path);
+    wxVariant nameVar;
+    trussTable->GetValue(nameVar, i, kTrussNameColumn);
+    rows.push_back({std::string(nameVar.GetString().ToUTF8()), trussPaths[i]});
   }
-  std::sort(snapshot.begin(), snapshot.end());
-  return snapshot;
+  return DictionaryEditorState::BuildTrussSnapshot(std::move(rows));
 }
 
 bool DictionaryEditDialog::HasFixtureChanges() const {
@@ -1267,6 +1255,44 @@ bool DictionaryEditDialog::HasFixtureChanges() const {
 
 bool DictionaryEditDialog::HasTrussChanges() const {
   return BuildTrussSnapshotFromUi() != trussSnapshotAtLoad;
+}
+
+// Prompts for pending table edits before a reload or dictionary mutation continues.
+bool DictionaryEditDialog::ConfirmDirtyChangesBeforeReload(
+    const wxString &operationLabel) {
+  const bool fixtureChanged = HasFixtureChanges();
+  const bool trussChanged = HasTrussChanges();
+  const bool hasChanges = fixtureChanged || trussChanged;
+  if (!hasChanges)
+    return true;
+
+  wxMessageDialog dialog(
+      this,
+      "The Dictionary Editor has unsaved table edits. Save them before " +
+          operationLabel + "?",
+      "Unsaved dictionary edits",
+      wxYES_NO | wxCANCEL | wxCANCEL_DEFAULT | wxICON_WARNING);
+  dialog.SetYesNoCancelLabels("Save", "Discard", "Cancel");
+  const int response = dialog.ShowModal();
+  DictionaryEditorState::DirtyGuardChoice choice =
+      DictionaryEditorState::DirtyGuardChoice::Cancel;
+  if (response == wxID_YES)
+    choice = DictionaryEditorState::DirtyGuardChoice::Save;
+  else if (response == wxID_NO)
+    choice = DictionaryEditorState::DirtyGuardChoice::Discard;
+
+  bool saveSucceeded = false;
+  if (choice == DictionaryEditorState::DirtyGuardChoice::Save) {
+    saveSucceeded = true;
+    if (fixtureChanged)
+      saveSucceeded = SaveFixtures() && saveSucceeded;
+    if (trussChanged)
+      saveSucceeded = SaveTrusses() && saveSucceeded;
+  }
+
+  return DictionaryEditorState::ResolveDirtyGuard(hasChanges, choice,
+                                                  saveSucceeded) ==
+         DictionaryEditorState::DirtyGuardResult::Continue;
 }
 
 void DictionaryEditDialog::ShowDictionaryLoadStatusMessages() {
@@ -1311,8 +1337,11 @@ void DictionaryEditDialog::RefreshDictionarySelectionLabels() {
       wxString::FromUTF8(TrussDictionary::GetActiveDictionaryFilePath()));
 }
 
+// Opens a file picker for changing the active fixtures dictionary.
 void DictionaryEditDialog::OnSelectFixturesDictionary(
     wxCommandEvent &WXUNUSED(event)) {
+  if (!ConfirmDirtyChangesBeforeReload("selecting a fixtures dictionary"))
+    return;
   const std::filesystem::path currentPath =
       PathUtils::PathFromUtf8(GdtfDictionary::GetActiveDictionaryFilePath());
   const wxString initialDir = wxString::FromUTF8(
@@ -1346,8 +1375,11 @@ void DictionaryEditDialog::OnSelectFixturesDictionary(
   LoadFixtures();
 }
 
+// Opens a file picker for changing the active trusses dictionary.
 void DictionaryEditDialog::OnSelectTrussesDictionary(
     wxCommandEvent &WXUNUSED(event)) {
+  if (!ConfirmDirtyChangesBeforeReload("selecting a trusses dictionary"))
+    return;
   const std::filesystem::path currentPath =
       PathUtils::PathFromUtf8(TrussDictionary::GetActiveDictionaryFilePath());
   const wxString initialDir = wxString::FromUTF8(
@@ -1381,6 +1413,7 @@ void DictionaryEditDialog::OnSelectTrussesDictionary(
   LoadTrusses();
 }
 
+// Persists fixture table rows without dropping unresolved entries.
 bool DictionaryEditDialog::SaveFixtures() {
   std::vector<FixtureRow> rows;
   int count = fixtureTable->GetItemCount();
@@ -1396,14 +1429,20 @@ bool DictionaryEditDialog::SaveFixtures() {
     const std::string &path = fixturePaths[i];
     if (path.empty())
       continue;
-    if (!std::filesystem::exists(path))
-      continue;
     wxVariant modeVar;
     fixtureTable->GetValue(modeVar, i, kFixtureModeColumn);
     std::string mode = std::string(modeVar.GetString().ToUTF8());
-    auto copied = CopyToLibrary(this, path, "fixtures");
-    if (!copied)
-      continue;
+    CopiedLibraryAsset asset{path, {}};
+    if (std::filesystem::exists(path)) {
+      auto copied = CopyToLibrary(this, path, "fixtures");
+      if (!copied) {
+        wxMessageBox("Could not copy fixture file into the library. The "
+                     "dictionary was not saved.",
+                     "Save fixtures dictionary", wxICON_ERROR | wxOK, this);
+        return false;
+      }
+      asset = *copied;
+    }
     wxVariant categoryVar;
     fixtureTable->GetValue(categoryVar, i, kFixtureCategoryColumn);
     const std::string category = GdtfFixtureCategory::NormalizeCategory(
@@ -1420,7 +1459,7 @@ bool DictionaryEditDialog::SaveFixtures() {
       return false;
     }
     rows.push_back(
-        {name, copied->path, mode, category, *normalizedColor, copied->sha256});
+        {name, asset.path, mode, category, *normalizedColor, asset.sha256});
   }
 
   SortFixtureRows(rows);
@@ -1452,6 +1491,7 @@ bool DictionaryEditDialog::SaveFixtures() {
   return true;
 }
 
+// Persists truss table rows without dropping unresolved entries.
 bool DictionaryEditDialog::SaveTrusses() {
   std::vector<TrussRow> rows;
   int count = trussTable->GetItemCount();
@@ -1467,12 +1507,18 @@ bool DictionaryEditDialog::SaveTrusses() {
     const std::string &path = trussPaths[i];
     if (path.empty())
       continue;
-    if (!std::filesystem::exists(path))
-      continue;
-    auto copied = CopyToLibrary(this, path, "trusses");
-    if (!copied)
-      continue;
-    rows.push_back({name, copied->path});
+    std::string savedPath = path;
+    if (std::filesystem::exists(path)) {
+      auto copied = CopyToLibrary(this, path, "trusses");
+      if (!copied) {
+        wxMessageBox("Could not copy truss file into the library. The "
+                     "dictionary was not saved.",
+                     "Save trusses dictionary", wxICON_ERROR | wxOK, this);
+        return false;
+      }
+      savedPath = copied->path;
+    }
+    rows.push_back({name, savedPath});
   }
 
   SortTrussRows(rows);
@@ -1671,6 +1717,7 @@ void DictionaryEditDialog::SyncFixtureVisualColorForFileAndMode(int row) {
   }
 }
 
+// Propagates a fixture category edit to matching visible table rows.
 void DictionaryEditDialog::UpdateFixtureCategoryForFile(
     int row, const std::string &category) {
   if (!fixtureTable || row < 0 ||
@@ -1680,7 +1727,6 @@ void DictionaryEditDialog::UpdateFixtureCategoryForFile(
   if (targetPath.empty())
     return;
 
-  std::vector<std::string> matchingNames;
   const int rowCount = fixtureTable->GetItemCount();
   for (int i = 0; i < rowCount; ++i) {
     if (static_cast<size_t>(i) >= fixturePaths.size())
@@ -1690,50 +1736,25 @@ void DictionaryEditDialog::UpdateFixtureCategoryForFile(
 
     fixtureTable->SetValue(wxVariant(wxString::FromUTF8(category)), i,
                            kFixtureCategoryColumn);
-    wxVariant nameVar;
-    fixtureTable->GetValue(nameVar, i, kFixtureNameColumn);
-    const std::string name = std::string(nameVar.GetString().ToUTF8());
-    if (!name.empty())
-      matchingNames.push_back(name);
   }
-
-  if (matchingNames.empty())
-    return;
-  auto dictOpt = GdtfDictionary::Load();
-  if (!dictOpt)
-    return;
-  auto &dict = *dictOpt;
-  bool changed = false;
-  for (const auto &name : matchingNames) {
-    auto it = dict.find(name);
-    if (it == dict.end())
-      continue;
-    if (it->second.category == category)
-      continue;
-    it->second.category = category;
-    changed = true;
-  }
-  if (changed)
-    GdtfDictionary::Save(dict);
 }
 
+// Saves changed dictionaries and closes only after every save succeeds.
 void DictionaryEditDialog::OnOk(wxCommandEvent &WXUNUSED(event)) {
   const bool fixtureChanged = HasFixtureChanges();
   const bool trussChanged = HasTrussChanges();
 
-  if (!fixtureChanged && !trussChanged) {
-    EndModal(wxID_OK);
+  if (fixtureChanged && !SaveFixtures())
     return;
-  }
-
-  if (fixtureChanged)
-    (void)SaveFixtures();
-  if (trussChanged)
-    (void)SaveTrusses();
+  if (trussChanged && !SaveTrusses())
+    return;
   EndModal(wxID_OK);
 }
 
+// Imports into the active dictionary after resolving unsaved table edits.
 void DictionaryEditDialog::OnImportDictionary(wxCommandEvent &WXUNUSED(event)) {
+  if (!ConfirmDirtyChangesBeforeReload("importing a dictionary"))
+    return;
   if (IsFixturesPage()) {
     (void)ImportFixturesDictionary();
     return;
@@ -1912,7 +1933,10 @@ void DictionaryEditDialog::OnExportPortableBundle(
   (void)ExportTrussesPortableBundle();
 }
 
+// Resets the active dictionary after resolving unsaved table edits.
 void DictionaryEditDialog::OnResetDictionary(wxCommandEvent &WXUNUSED(event)) {
+  if (!ConfirmDirtyChangesBeforeReload("resetting a dictionary"))
+    return;
   if (IsFixturesPage()) {
     (void)ResetFixturesDictionaryToDefault();
     return;

--- a/gui/dictionaryeditdialog.h
+++ b/gui/dictionaryeditdialog.h
@@ -22,6 +22,7 @@
 #include <wx/wx.h>
 
 #include "dictionary_selection_controls.h"
+#include "dictionary_editor_state.h"
 
 #include <string>
 #include <vector>
@@ -42,6 +43,7 @@ private:
   std::vector<std::string> BuildTrussSnapshotFromUi() const;
   bool HasFixtureChanges() const;
   bool HasTrussChanges() const;
+  bool ConfirmDirtyChangesBeforeReload(const wxString &operationLabel);
   void ShowDictionaryLoadStatusMessages();
   bool IsFixturesPage() const;
   void SyncFixtureVisualColorForFileAndMode(int row);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -141,6 +141,11 @@ if(PERASTAGE_ENABLE_LOCALIZATION)
                      -P "${CMAKE_CURRENT_SOURCE_DIR}/PerastageGettextHelperRegression.cmake")
 endif()
 
+
+add_executable(dictionary_editor_state_test dictionary_editor_state_test.cpp)
+target_include_directories(dictionary_editor_state_test PRIVATE ../gui)
+add_test(NAME DictionaryEditorState COMMAND dictionary_editor_state_test)
+
 add_executable(platform_locale_test
                platform_locale_test.cpp
                ../core/platform_locale.cpp)

--- a/tests/dictionary_editor_state_test.cpp
+++ b/tests/dictionary_editor_state_test.cpp
@@ -1,0 +1,84 @@
+#include "dictionary_editor_state.h"
+
+#include <cassert>
+#include <string>
+#include <vector>
+
+namespace {
+using DictionaryEditorState::DirtyGuardChoice;
+using DictionaryEditorState::DirtyGuardResult;
+using DictionaryEditorState::FixtureSnapshotRow;
+using DictionaryEditorState::TrussSnapshotRow;
+
+// Verifies fixture snapshots include category edits.
+void FixtureCategoryChangesAreDirty() {
+  std::vector<FixtureSnapshotRow> before = {
+      {"Fixture", "/missing/fixture.gdtf", "Mode", "Spot", "#112233"}};
+  std::vector<FixtureSnapshotRow> after = before;
+  after[0].category = "Wash";
+  assert(DictionaryEditorState::BuildFixtureSnapshot(before) !=
+         DictionaryEditorState::BuildFixtureSnapshot(after));
+}
+
+// Verifies deleting an unresolved fixture entry changes the snapshot.
+void DeletingMissingFixtureEntryIsDirty() {
+  std::vector<FixtureSnapshotRow> before = {
+      {"Missing A", "/missing/a.gdtf", "Mode", "Spot", "#112233"},
+      {"Missing B", "/missing/b.gdtf", "Mode", "Wash", "#445566"}};
+  std::vector<FixtureSnapshotRow> after = {before[1]};
+  assert(DictionaryEditorState::BuildFixtureSnapshot(before) !=
+         DictionaryEditorState::BuildFixtureSnapshot(after));
+}
+
+// Verifies deleting one unresolved truss entry changes the snapshot.
+void DeletingMissingTrussEntryIsDirty() {
+  std::vector<TrussSnapshotRow> before = {
+      {"Missing A", "/missing/a.gdtf"}, {"Missing B", "/missing/b.gdtf"}};
+  std::vector<TrussSnapshotRow> after = {before[1]};
+  assert(DictionaryEditorState::BuildTrussSnapshot(before) !=
+         DictionaryEditorState::BuildTrussSnapshot(after));
+}
+
+// Verifies unresolved fixture entries remain represented next to edited rows.
+void UnresolvedFixtureEntriesRemainRepresented() {
+  std::vector<FixtureSnapshotRow> rows = {
+      {"Missing A", "/missing/a.gdtf", "Mode A", "Spot", "#112233"},
+      {"Edited B", "/existing/b.gdtf", "Mode B", "Wash", "#445566"}};
+  auto snapshot = DictionaryEditorState::BuildFixtureSnapshot(rows);
+  assert(snapshot.size() == 2);
+  assert(snapshot[0].find("Missing A") != std::string::npos ||
+         snapshot[1].find("Missing A") != std::string::npos);
+}
+
+// Verifies a failed dirty-save decision aborts the close or reload path.
+void FailedSaveAbortsGuardedPath() {
+  assert(DictionaryEditorState::ResolveDirtyGuard(
+             true, DirtyGuardChoice::Save, false) == DirtyGuardResult::Abort);
+  assert(DictionaryEditorState::ResolveDirtyGuard(
+             true, DirtyGuardChoice::Save, true) == DirtyGuardResult::Continue);
+}
+
+// Verifies discard and cancel decisions can be tested without native dialogs.
+void DirtyGuardDecisionHandlingIsDialogIndependent() {
+  assert(DictionaryEditorState::ResolveDirtyGuard(
+             true, DirtyGuardChoice::Discard, false) ==
+         DirtyGuardResult::Continue);
+  assert(DictionaryEditorState::ResolveDirtyGuard(
+             true, DirtyGuardChoice::Cancel, true) == DirtyGuardResult::Abort);
+  assert(DictionaryEditorState::ResolveDirtyGuard(
+             false, DirtyGuardChoice::Cancel, false) ==
+         DirtyGuardResult::Continue);
+}
+
+} // namespace
+
+// Runs Dictionary Editor state regression checks.
+int main() {
+  FixtureCategoryChangesAreDirty();
+  DeletingMissingFixtureEntryIsDirty();
+  DeletingMissingTrussEntryIsDirty();
+  UnresolvedFixtureEntriesRemainRepresented();
+  FailedSaveAbortsGuardedPath();
+  DirtyGuardDecisionHandlingIsDialogIndependent();
+  return 0;
+}


### PR DESCRIPTION
### Motivation
- The Dictionary Editor was losing edits, silently dropping unresolved entries, and closing on partial save failures because dirty snapshots and save flows omitted editable fields and performed immediate persistence during UI edits.
- Edits must be transactional in the dialog so the active dictionaries are only mutated when the user confirms, and unresolved file references must remain representable and savable.
- Operations that can reload or replace the editor contents must prompt the user with a consistent Save / Discard / Cancel decision flow to avoid accidental data loss.

### Description
- Added `gui/dictionary_editor_state.h` containing `FixtureSnapshotRow`, `TrussSnapshotRow`, `Build*Snapshot` helpers, and `ResolveDirtyGuard` to centralize stable snapshot building and decision logic.
- Rewrote `BuildFixtureSnapshotFromUi` and `BuildTrussSnapshotFromUi` in `DictionaryEditDialog` to include every user-editable field (name, referenced path, mode, category, visual color for fixtures; name and referenced path for trusses) and to not exclude missing-file rows when computing dirty state.
- Made table edits transactional by removing immediate dictionary writes: `UpdateFixtureCategoryForFile` now propagates category changes only in the UI, and persistence is deferred to the normal `SaveFixtures`/`SaveTrusses` flow (Cancel discards table edits).
- Changed `SaveFixtures`/`SaveTrusses` so unresolved rows are preserved (missing-file entries are represented and saved as-is), while existing referenced files are copied into the library and a copy failure produces a clear save error and aborts the save (preventing silent drops).
- Changed `OnOk` to only call `EndModal(wxID_OK)` after each changed page saves successfully so the dialog remains open and reports failures when saves fail or only a partial save would occur.
- Added `ConfirmDirtyChangesBeforeReload` to the dialog and wired it into dictionary-selection, import, and reset paths to present a Save / Discard / Cancel prompt and use the `DictionaryEditorState` helper to resolve the outcome.
- Removed direct `GdtfDictionary::Save` side-effects from category propagation logic to keep fixture and truss handling symmetrical and to retain transactional semantics.
- Added focused unit tests in `tests/dictionary_editor_state_test.cpp` and a `tests/CMakeLists.txt` entry to cover fixture category dirty detection, deletion of missing entries, unresolved-entry preservation, and dialog-independent dirty-guard decision handling, and updated `docs/release-notes-draft.md` with a release-note entry.

### Testing
- Built and ran the focused state tests with `g++ -std=c++20 -Igui tests/dictionary_editor_state_test.cpp -o /tmp/dictionary_editor_state_test && /tmp/dictionary_editor_state_test`, and the binary passed.
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, and both returned OK.
- Attempted a full CMake-configured build for the GUI test target but the container lacked wxWidgets development files (`wxWidgets_LIBRARIES` / `wxWidgets_INCLUDE_DIRS`), so the CMake-generated test could not be built here; CI or a developer environment with wxWidgets should build the full project and the added test target normally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59711a9244832484be8c2ea33b15c2)