### PR TITLE
Fix active dictionary asset ownership

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,4 +1,5 @@
 target_sources(${PROJECT_NAME} PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/active_dictionary_storage.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/autopatcher.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/apppaths.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/configmanager.cpp

--- a/core/active_dictionary_storage.cpp
+++ b/core/active_dictionary_storage.cpp
@@ -1,0 +1,139 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+#include "active_dictionary_storage.h"
+#include "filesystem_path_utils.h"
+
+#include <system_error>
+
+namespace fs = std::filesystem;
+
+namespace ActiveDictionaryStorage {
+namespace {
+
+// Returns true when both paths identify the same normalized location.
+bool PathsEquivalentOrEqual(const fs::path &lhs, const fs::path &rhs) {
+  if (lhs.empty() || rhs.empty())
+    return false;
+  const fs::path left = lhs.lexically_normal();
+  const fs::path right = rhs.lexically_normal();
+  if (left == right)
+    return true;
+  std::error_code ec;
+  return fs::exists(left, ec) && !ec && fs::exists(right, ec) && !ec &&
+         fs::equivalent(left, right, ec) && !ec;
+}
+
+// Returns the writable library directory for the selected dictionary kind.
+fs::path GetDefaultAssetDirectory(DictionaryKind kind,
+                                  const fs::path &defaultDictionaryPath) {
+  (void)kind;
+  return defaultDictionaryPath.parent_path();
+}
+
+} // namespace
+
+// Returns true when the active dictionary is the managed default user file.
+bool IsDefaultManagedDictionary(const fs::path &dictionaryPath,
+                                const fs::path &defaultDictionaryPath) {
+  return PathsEquivalentOrEqual(dictionaryPath, defaultDictionaryPath);
+}
+
+// Returns the directory where assets owned by the active dictionary are stored.
+fs::path GetOwnedAssetDirectory(const fs::path &dictionaryPath,
+                                const fs::path &defaultDictionaryPath) {
+  if (IsDefaultManagedDictionary(dictionaryPath, defaultDictionaryPath))
+    return defaultDictionaryPath.parent_path();
+  return dictionaryPath.parent_path() / (dictionaryPath.stem().string() + "_assets");
+}
+
+// Builds the storage layout for an active dictionary.
+AssetStorageLayout BuildLayout(DictionaryKind kind, const fs::path &dictionaryPath,
+                               const fs::path &defaultDictionaryPath) {
+  AssetStorageLayout layout;
+  layout.dictionaryPath = dictionaryPath;
+  layout.defaultDictionaryPath = defaultDictionaryPath;
+  layout.isDefaultManagedDictionary =
+      IsDefaultManagedDictionary(dictionaryPath, defaultDictionaryPath);
+  layout.ownedAssetDirectory = layout.isDefaultManagedDictionary
+                                   ? GetDefaultAssetDirectory(kind, defaultDictionaryPath)
+                                   : GetOwnedAssetDirectory(dictionaryPath, defaultDictionaryPath);
+  return layout;
+}
+
+// Resolves a stored dictionary reference using supported legacy and owned layouts.
+fs::path ResolveReference(const fs::path &dictionaryPath,
+                          const std::string &storedPath) {
+  const fs::path parsedPath = PathUtils::PathFromUtf8(storedPath);
+  if (parsedPath.is_absolute())
+    return parsedPath;
+
+  const fs::path jsonDir = dictionaryPath.parent_path();
+  const fs::path directPath = jsonDir / parsedPath;
+  if (fs::exists(directPath))
+    return directPath;
+
+  const fs::path assetPath =
+      jsonDir / (dictionaryPath.stem().string() + "_assets") / parsedPath;
+  if (fs::exists(assetPath))
+    return assetPath;
+  return directPath;
+}
+
+// Creates the path text that should be serialized for an owned asset.
+std::string MakeSerializedReference(const AssetStorageLayout &layout,
+                                    const fs::path &assetPath) {
+  if (assetPath.empty())
+    return {};
+  if (!layout.isDefaultManagedDictionary &&
+      PathsEquivalentOrEqual(assetPath.parent_path(), layout.ownedAssetDirectory))
+    return assetPath.filename().string();
+  if (layout.isDefaultManagedDictionary &&
+      PathsEquivalentOrEqual(assetPath.parent_path(), layout.ownedAssetDirectory))
+    return assetPath.filename().string();
+  return assetPath.string();
+}
+
+// Returns the deterministic destination path for importing an owned asset.
+fs::path GetAssetDestination(const AssetStorageLayout &layout,
+                             const fs::path &sourcePath) {
+  if (sourcePath.empty() || sourcePath.filename().empty())
+    return {};
+  return layout.ownedAssetDirectory / sourcePath.filename();
+}
+
+// Copies an asset into active dictionary ownership using caller-selected conflict policy.
+AssetCopyResult CopyAssetIntoDictionaryStorage(const AssetCopyRequest &request) {
+  AssetCopyResult result;
+  if (request.sourcePath.empty() || !fs::exists(request.sourcePath))
+    return result;
+
+  const AssetStorageLayout layout = BuildLayout(
+      request.kind, request.activeDictionaryPath, request.defaultDictionaryPath);
+  std::error_code ec;
+  fs::create_directories(layout.ownedAssetDirectory, ec);
+  if (ec)
+    return result;
+
+  fs::path dest = GetAssetDestination(layout, request.sourcePath);
+  if (!request.destinationFileName.empty())
+    dest = layout.ownedAssetDirectory / request.destinationFileName.filename();
+  const auto copyResult = FileImportUtils::CopyWithConflictPolicy(
+      request.sourcePath, dest, request.conflictPolicy);
+  if (!copyResult.success)
+    return result;
+
+  result.success = true;
+  result.finalPath = copyResult.finalPath;
+  result.serializedPath = MakeSerializedReference(layout, copyResult.finalPath);
+  result.finalSha256 = copyResult.finalSha256;
+  return result;
+}
+
+} // namespace ActiveDictionaryStorage

--- a/core/active_dictionary_storage.h
+++ b/core/active_dictionary_storage.h
@@ -1,0 +1,63 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+#pragma once
+
+#include "file_import_utils.h"
+
+#include <filesystem>
+#include <string>
+
+namespace ActiveDictionaryStorage {
+
+enum class DictionaryKind { Fixtures, Trusses };
+
+struct AssetStorageLayout {
+  std::filesystem::path dictionaryPath;
+  std::filesystem::path defaultDictionaryPath;
+  std::filesystem::path ownedAssetDirectory;
+  bool isDefaultManagedDictionary = false;
+};
+
+struct AssetCopyRequest {
+  DictionaryKind kind;
+  std::filesystem::path activeDictionaryPath;
+  std::filesystem::path defaultDictionaryPath;
+  std::filesystem::path sourcePath;
+  std::filesystem::path destinationFileName;
+  FileImportUtils::ConflictPolicy conflictPolicy =
+      FileImportUtils::ConflictPolicy::Rename;
+};
+
+struct AssetCopyResult {
+  bool success = false;
+  std::filesystem::path finalPath;
+  std::string serializedPath;
+  std::string finalSha256;
+};
+
+std::filesystem::path GetOwnedAssetDirectory(
+    const std::filesystem::path &dictionaryPath,
+    const std::filesystem::path &defaultDictionaryPath);
+bool IsDefaultManagedDictionary(
+    const std::filesystem::path &dictionaryPath,
+    const std::filesystem::path &defaultDictionaryPath);
+AssetStorageLayout BuildLayout(DictionaryKind kind,
+                               const std::filesystem::path &dictionaryPath,
+                               const std::filesystem::path &defaultDictionaryPath);
+std::filesystem::path ResolveReference(
+    const std::filesystem::path &dictionaryPath,
+    const std::string &storedPath);
+std::string MakeSerializedReference(const AssetStorageLayout &layout,
+                                    const std::filesystem::path &assetPath);
+std::filesystem::path GetAssetDestination(const AssetStorageLayout &layout,
+                                          const std::filesystem::path &sourcePath);
+AssetCopyResult CopyAssetIntoDictionaryStorage(const AssetCopyRequest &request);
+
+} // namespace ActiveDictionaryStorage

--- a/core/dictionary_bundle.cpp
+++ b/core/dictionary_bundle.cpp
@@ -1,4 +1,7 @@
 #include "dictionary_bundle.h"
+#include "active_dictionary_storage.h"
+#include "gdtfdictionary.h"
+#include "trussdictionary.h"
 #include "filesystem_path_utils.h"
 
 #include "dictionary_json_contract.h"
@@ -514,10 +517,13 @@ PreparedImport PrepareBundleImport(const std::string &importPath,
     return result;
   }
 
-  const fs::path libraryDir = PathUtils::PathFromUtf8(
-      ProjectUtils::GetWritableLibraryPath(expectedTypeText));
-  std::error_code ec;
-  fs::create_directories(libraryDir, ec);
+  const bool isFixtures = expectedTypeText == "fixtures";
+  const fs::path activeDictionaryPath = PathUtils::PathFromUtf8(
+      isFixtures ? GdtfDictionary::GetActiveDictionaryFilePath()
+                 : TrussDictionary::GetActiveDictionaryFilePath());
+  const fs::path defaultDictionaryPath =
+      PathUtils::PathFromUtf8(ProjectUtils::GetWritableLibraryPath(expectedTypeText)) /
+      (isFixtures ? "gdtf_dictionary.json" : "truss_dictionary.json");
 
   for (const auto &assetJson : manifest["assets"]) {
     if (!assetJson.is_object()) {
@@ -553,17 +559,18 @@ PreparedImport PrepareBundleImport(const std::string &importPath,
       continue;
     }
 
-    const fs::path destPath = libraryDir / extractedPath.filename();
-    std::error_code copyEc;
-    fs::copy_file(extractedPath, destPath, fs::copy_options::overwrite_existing,
-                  copyEc);
-    if (copyEc) {
-      result.errors.push_back("Could not copy bundle asset into library: " +
-                              destPath.string());
+    const auto copied = ActiveDictionaryStorage::CopyAssetIntoDictionaryStorage(
+        {isFixtures ? ActiveDictionaryStorage::DictionaryKind::Fixtures
+                    : ActiveDictionaryStorage::DictionaryKind::Trusses,
+         activeDictionaryPath, defaultDictionaryPath, extractedPath, {},
+         FileImportUtils::ConflictPolicy::Overwrite});
+    if (!copied.success) {
+      result.errors.push_back("Could not copy bundle asset into dictionary storage: " +
+                              extractedPath.string());
       continue;
     }
 
-    importedAssetToLibraryPath[archivePath] = destPath.string();
+    importedAssetToLibraryPath[archivePath] = copied.finalPath.string();
   }
 
   if (!result.errors.empty())

--- a/core/gdtfdictionary.cpp
+++ b/core/gdtfdictionary.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "gdtfdictionary.h"
+#include "active_dictionary_storage.h"
 #include "configmanager.h"
 #include "dictionary_json_contract.h"
 #include "file_import_utils.h"
@@ -436,6 +437,32 @@ bool RecreateUserDictionaryFromBase(const fs::path &userFile,
   return true;
 }
 
+// Copies default seed assets into a newly created custom dictionary.
+bool CopySeedAssetsIntoCustomDictionary(
+    const fs::path &customFile, const std::unordered_map<std::string, Entry> &seedDict,
+    std::unordered_map<std::string, Entry> &targetDict) {
+  bool changed = false;
+  for (const auto &[key, seedEntry] : seedDict) {
+    if (seedEntry.path.empty())
+      continue;
+    const fs::path seedPath = PathUtils::PathFromUtf8(seedEntry.path);
+    if (!fs::exists(seedPath))
+      continue;
+    const auto copied = ActiveDictionaryStorage::CopyAssetIntoDictionaryStorage(
+        {ActiveDictionaryStorage::DictionaryKind::Fixtures, customFile, GetUserDictFile(),
+         seedPath, {}, FileImportUtils::ConflictPolicy::Rename});
+    if (!copied.success)
+      continue;
+    Entry ownedEntry = seedEntry;
+    ownedEntry.path = copied.finalPath.string();
+    if (!copied.finalSha256.empty())
+      ownedEntry.sha256 = copied.finalSha256;
+    targetDict[key] = std::move(ownedEntry);
+    changed = true;
+  }
+  return changed;
+}
+
 bool WriteDictionaryBackup(const fs::path &sourceFile) {
   if (sourceFile.empty() || !fs::exists(sourceFile))
     return false;
@@ -469,20 +496,7 @@ bool MergeSeedEntriesIntoUserDictionary(
 
 fs::path ResolveImportedPath(const fs::path &jsonFile,
                              const std::string &rawPathText) {
-  const fs::path parsedPath = PathUtils::PathFromUtf8(rawPathText);
-  if (parsedPath.is_absolute())
-    return parsedPath;
-
-  const fs::path jsonDir = jsonFile.parent_path();
-  const fs::path directPath = jsonDir / parsedPath;
-  if (fs::exists(directPath))
-    return directPath;
-
-  const fs::path snapshotAssetsPath =
-      jsonDir / (jsonFile.stem().string() + "_assets") / parsedPath;
-  if (fs::exists(snapshotAssetsPath))
-    return snapshotAssetsPath;
-  return directPath;
+  return ActiveDictionaryStorage::ResolveReference(jsonFile, rawPathText);
 }
 
 std::optional<std::unordered_map<std::string, Entry>>
@@ -734,7 +748,8 @@ bool SetActiveDictionaryFilePath(const std::string &path,
     return false;
   }
 
-  if (!fs::exists(resolvedPath)) {
+  const bool creatingDictionary = !fs::exists(resolvedPath);
+  if (creatingDictionary) {
     if (!RecreateUserDictionaryFromBase(resolvedPath, GetBaseDictFile())) {
       std::string createError;
       if (!Save({}, &createError)) {
@@ -749,6 +764,17 @@ bool SetActiveDictionaryFilePath(const std::string &path,
                       createError;
         return false;
       }
+    }
+  }
+
+  if (creatingDictionary && resolvedPath != defaultPath) {
+    std::string baseError;
+    std::string customError;
+    auto baseDict = LoadFromFile(GetBaseDictFile(), baseError);
+    auto customDict = LoadFromFile(resolvedPath, customError);
+    if (baseDict && customDict &&
+        CopySeedAssetsIntoCustomDictionary(resolvedPath, *baseDict, *customDict)) {
+      Save(*customDict);
     }
   }
 
@@ -831,6 +857,8 @@ bool Save(const std::unordered_map<std::string, Entry> &dict,
   for (const auto &[type, entry] : dict)
     keys.push_back(type);
   std::sort(keys.begin(), keys.end());
+  const auto layout = ActiveDictionaryStorage::BuildLayout(
+      ActiveDictionaryStorage::DictionaryKind::Fixtures, file, GetUserDictFile());
   for (const auto &type : keys) {
     const auto &entry = dict.at(type);
     if (entry.path.empty() && entry.mode.empty() && entry.category.empty() &&
@@ -838,10 +866,11 @@ bool Save(const std::unordered_map<std::string, Entry> &dict,
       continue;
     nlohmann::json obj;
     if (!entry.path.empty()) {
-      fs::path p = PathUtils::PathFromUtf8(entry.path);
-      const std::string fileName = p.filename().string();
-      if (!fileName.empty())
-        obj["file"] = fileName;
+      const fs::path p = PathUtils::PathFromUtf8(entry.path);
+      const std::string serialized =
+          ActiveDictionaryStorage::MakeSerializedReference(layout, p);
+      if (!serialized.empty())
+        obj["file"] = serialized;
     }
     if (!entry.mode.empty())
       obj["mode"] = entry.mode;
@@ -1016,13 +1045,13 @@ std::optional<Entry> CreateOrUpdatePerastageLibraryDerivative(
   if (file.empty())
     return std::nullopt;
 
-  const fs::path dest =
+  const fs::path destinationName =
       IsPerastageNamedGdtfFilePath(src)
-          ? file.parent_path() / src.filename()
-          : file.parent_path() /
-                BuildPerastageCanonicalGdtfFileName(src.string());
-  const auto copyResult = FileImportUtils::CopyWithConflictPolicy(
-      src, dest, FileImportUtils::ConflictPolicy::Overwrite);
+          ? src.filename()
+          : fs::path(BuildPerastageCanonicalGdtfFileName(src.string()));
+  const auto copyResult = ActiveDictionaryStorage::CopyAssetIntoDictionaryStorage(
+      {ActiveDictionaryStorage::DictionaryKind::Fixtures, file, GetUserDictFile(),
+       src, destinationName, FileImportUtils::ConflictPolicy::Overwrite});
   if (!copyResult.success)
     return std::nullopt;
 

--- a/core/trussdictionary.cpp
+++ b/core/trussdictionary.cpp
@@ -18,6 +18,7 @@
 #include "trussdictionary.h"
 #include "filesystem_path_utils.h"
 
+#include "active_dictionary_storage.h"
 #include "configmanager.h"
 #include "dictionary_json_contract.h"
 #include "file_import_utils.h"
@@ -164,6 +165,26 @@ static bool RecreateUserDictionaryFromBase(const fs::path &userFile,
   return true;
 }
 
+// Copies default seed assets into a newly created custom dictionary.
+static bool CopySeedAssetsIntoCustomDictionary(
+    const fs::path &customFile, const std::unordered_map<std::string, std::string> &seedDict,
+    std::unordered_map<std::string, std::string> &targetDict) {
+  bool changed = false;
+  for (const auto &[key, seedPathText] : seedDict) {
+    const fs::path seedPath = PathUtils::PathFromUtf8(seedPathText);
+    if (!fs::exists(seedPath))
+      continue;
+    const auto copied = ActiveDictionaryStorage::CopyAssetIntoDictionaryStorage(
+        {ActiveDictionaryStorage::DictionaryKind::Trusses, customFile, GetUserDictFile(),
+         seedPath, {}, FileImportUtils::ConflictPolicy::Rename});
+    if (!copied.success)
+      continue;
+    targetDict[key] = copied.finalPath.string();
+    changed = true;
+  }
+  return changed;
+}
+
 static bool WriteDictionaryBackup(const fs::path &sourceFile) {
   if (sourceFile.empty() || !fs::exists(sourceFile))
     return false;
@@ -196,20 +217,7 @@ static bool MergeSeedEntriesIntoUserDictionary(
 
 static fs::path ResolveImportedPath(const fs::path &jsonFile,
                                     const std::string &rawPathText) {
-  const fs::path parsedPath = PathUtils::PathFromUtf8(rawPathText);
-  if (parsedPath.is_absolute())
-    return parsedPath;
-
-  const fs::path jsonDir = jsonFile.parent_path();
-  const fs::path directPath = jsonDir / parsedPath;
-  if (fs::exists(directPath))
-    return directPath;
-
-  const fs::path snapshotAssetsPath =
-      jsonDir / (jsonFile.stem().string() + "_assets") / parsedPath;
-  if (fs::exists(snapshotAssetsPath))
-    return snapshotAssetsPath;
-  return directPath;
+  return ActiveDictionaryStorage::ResolveReference(jsonFile, rawPathText);
 }
 
 static bool EnsureMigratedToGdtf(fs::path &pathInOut, std::string &error) {
@@ -459,14 +467,13 @@ bool ImportTrussFile(const std::string &inputPath, std::string &storedPath,
     return false;
   }
 
-  fs::path dir = dictFile.parent_path();
   fs::path working = src;
   if (!EnsureMigratedToGdtf(working, error))
     return false;
 
-  const fs::path dest = dir / working.filename();
-  const auto copyResult = FileImportUtils::CopyWithConflictPolicy(
-      working, dest, FileImportUtils::ConflictPolicy::Rename);
+  const auto copyResult = ActiveDictionaryStorage::CopyAssetIntoDictionaryStorage(
+      {ActiveDictionaryStorage::DictionaryKind::Trusses, dictFile, GetUserDictFile(),
+       working, {}, FileImportUtils::ConflictPolicy::Rename});
   if (!copyResult.success) {
     error = "Failed to copy truss file into library";
     return false;
@@ -531,7 +538,8 @@ bool SetActiveDictionaryFilePath(const std::string &path, std::string *errorOut)
     return false;
   }
 
-  if (!fs::exists(resolvedPath)) {
+  const bool creatingDictionary = !fs::exists(resolvedPath);
+  if (creatingDictionary) {
     if (!RecreateUserDictionaryFromBase(resolvedPath, GetBaseDictFile())) {
       std::string createError;
       if (!Save({}, &createError)) {
@@ -545,6 +553,17 @@ bool SetActiveDictionaryFilePath(const std::string &path, std::string *errorOut)
                       createError;
         return false;
       }
+    }
+  }
+
+  if (creatingDictionary && resolvedPath != defaultPath) {
+    std::string baseError;
+    std::string customError;
+    auto baseDict = LoadFromFile(GetBaseDictFile(), baseError);
+    auto customDict = LoadFromFile(resolvedPath, customError);
+    if (baseDict && customDict &&
+        CopySeedAssetsIntoCustomDictionary(resolvedPath, *baseDict, *customDict)) {
+      Save(*customDict);
     }
   }
 
@@ -634,6 +653,8 @@ bool Save(const std::unordered_map<std::string, std::string> &dict,
     keys.push_back(model);
   std::sort(keys.begin(), keys.end());
 
+  const auto layout = ActiveDictionaryStorage::BuildLayout(
+      ActiveDictionaryStorage::DictionaryKind::Trusses, file, GetUserDictFile());
   for (const auto &model : keys) {
     fs::path p = PathUtils::PathFromUtf8(normalizedDict.at(model));
     fs::path forced = p;
@@ -641,7 +662,7 @@ bool Save(const std::unordered_map<std::string, std::string> &dict,
       forced.replace_extension(".gdtf");
 
     nlohmann::json entry;
-    entry["file"] = forced.filename().string();
+    entry["file"] = ActiveDictionaryStorage::MakeSerializedReference(layout, forced);
     entry["imported_at"] = FileImportUtils::NowUtcIso8601();
     if (const auto sha = FileImportUtils::ComputeFileSha256(forced))
       entry["sha256"] = *sha;

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -74,6 +74,7 @@ Perastage 1.5.0 is a substantial update focused on GDTF and truss editing, multi
 ## Important fixes
 
 - Improved Dictionary Editor reliability so fixture and truss edits are saved transactionally, unresolved file references remain visible and savable, dirty-state checks catch category/color/path/name changes, and failed saves keep the editor open.
+- Fixed custom fixture and truss dictionaries so newly owned GDTF assets are stored in a sibling `_assets` folder and remain portable when the dictionary is moved with that folder.
 - Fixed Data Views table edits so moving fixtures, trusses, or scene objects between visible and hidden layers rebuilds the relevant viewer resources, invalidates stale 3D visible-set caches, and immediately refreshes both the 2D and 3D viewports, including layout previews.
 - Fixed Windows build and linker issues in the Local Axes viewport integration.
 

--- a/docs/user/features.md
+++ b/docs/user/features.md
@@ -86,7 +86,8 @@ Additional safeguards include:
 
 - preflight path validation,
 - missing-reference reporting,
-- collision policy prompts for differing file content.
+- collision policy prompts for differing file content,
+- custom active dictionaries store newly owned fixture and truss assets in a sibling `<dictionary name>_assets` folder so the JSON and assets can be moved together.
 
 ## Patch, Data Tables, and Editing Helpers
 

--- a/gui/dictionaryeditdialog.cpp
+++ b/gui/dictionaryeditdialog.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "dictionaryeditdialog.h"
+#include "active_dictionary_storage.h"
 #include "dictionary_editor_state.h"
 #include "filesystem_path_utils.h"
 
@@ -678,12 +679,22 @@ std::optional<CopiedLibraryAsset> CopyToLibrary(wxWindow *parent,
   if (!std::filesystem::exists(src))
     return std::nullopt;
 
-  const std::filesystem::path dir = PathUtils::PathFromUtf8(
-      ProjectUtils::GetWritableLibraryPath(libraryName));
-  if (dir.empty())
+  const bool isFixtures = std::string(libraryName) == "fixtures";
+  const std::filesystem::path activeDictionaryPath = PathUtils::PathFromUtf8(
+      isFixtures ? GdtfDictionary::GetActiveDictionaryFilePath()
+                 : TrussDictionary::GetActiveDictionaryFilePath());
+  const std::filesystem::path defaultDictionaryPath =
+      PathUtils::PathFromUtf8(ProjectUtils::GetWritableLibraryPath(libraryName)) /
+      (isFixtures ? "gdtf_dictionary.json" : "truss_dictionary.json");
+  if (activeDictionaryPath.empty() || defaultDictionaryPath.empty())
     return CopiedLibraryAsset{path, {}};
+  const auto layout = ActiveDictionaryStorage::BuildLayout(
+      isFixtures ? ActiveDictionaryStorage::DictionaryKind::Fixtures
+                 : ActiveDictionaryStorage::DictionaryKind::Trusses,
+      activeDictionaryPath, defaultDictionaryPath);
 
-  const std::filesystem::path dest = dir / src.filename();
+  const std::filesystem::path dest =
+      ActiveDictionaryStorage::GetAssetDestination(layout, src);
   FileImportUtils::ConflictPolicy policy =
       FileImportUtils::ConflictPolicy::Overwrite;
 
@@ -700,8 +711,10 @@ std::optional<CopiedLibraryAsset> CopyToLibrary(wxWindow *parent,
     }
   }
 
-  const auto copyResult =
-      FileImportUtils::CopyWithConflictPolicy(src, dest, policy);
+  const auto copyResult = ActiveDictionaryStorage::CopyAssetIntoDictionaryStorage(
+      {isFixtures ? ActiveDictionaryStorage::DictionaryKind::Fixtures
+                  : ActiveDictionaryStorage::DictionaryKind::Trusses,
+       activeDictionaryPath, defaultDictionaryPath, src, {}, policy});
   if (!copyResult.success)
     return std::nullopt;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,6 +25,13 @@ add_library(perastage_test_path_utils STATIC
             ../core/filesystem_path_utils.cpp)
 target_include_directories(perastage_test_path_utils PRIVATE ../core)
 
+
+add_library(perastage_test_active_dictionary_storage STATIC
+            ../core/active_dictionary_storage.cpp
+            ../core/file_import_utils.cpp
+            ../core/filesystem_path_utils.cpp)
+target_include_directories(perastage_test_active_dictionary_storage PRIVATE ../core ../third_party)
+
 add_library(perastage_test_gdtf_archive_reader STATIC
             ../core/gdtf_archive_reader.cpp)
 target_include_directories(perastage_test_gdtf_archive_reader PRIVATE ../core)
@@ -81,6 +88,8 @@ if(Python3_Interpreter_FOUND)
     add_test(NAME DocsLinks
              COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_docs_links.py)
 endif()
+
+link_libraries(perastage_test_active_dictionary_storage)
 
 include_directories(
     .
@@ -1752,3 +1761,8 @@ add_executable(layer_service_utf8_test layer_service_utf8_test.cpp
 target_include_directories(layer_service_utf8_test PRIVATE ../core ../models)
 target_link_libraries(layer_service_utf8_test PRIVATE ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
 add_test(NAME LayerServiceUtf8 COMMAND layer_service_utf8_test)
+
+add_executable(active_dictionary_storage_test active_dictionary_storage_test.cpp)
+target_include_directories(active_dictionary_storage_test PRIVATE ../core ../third_party)
+target_link_libraries(active_dictionary_storage_test PRIVATE perastage_test_active_dictionary_storage)
+add_test(NAME ActiveDictionaryStorage COMMAND active_dictionary_storage_test)

--- a/tests/active_dictionary_storage_test.cpp
+++ b/tests/active_dictionary_storage_test.cpp
@@ -1,0 +1,100 @@
+#include "active_dictionary_storage.h"
+#include "filesystem_path_utils.h"
+
+#include <cassert>
+#include <filesystem>
+#include <fstream>
+
+namespace fs = std::filesystem;
+
+// Writes deterministic test content to a file.
+static void WriteText(const fs::path &path, const std::string &text) {
+  fs::create_directories(path.parent_path());
+  std::ofstream out(path, std::ios::binary);
+  out << text;
+}
+
+// Verifies default and custom dictionary storage layouts.
+static void TestStorageLayouts(const fs::path &root) {
+  const fs::path defaultFixture = root / "fixtures" / "gdtf_dictionary.json";
+  const fs::path defaultTruss = root / "trusses" / "truss_dictionary.json";
+  const fs::path customFixture = root / "shows" / "MyTour.json";
+  const fs::path customTruss = root / "shows" / "RigTour.json";
+
+  auto fixtureDefault = ActiveDictionaryStorage::BuildLayout(
+      ActiveDictionaryStorage::DictionaryKind::Fixtures, defaultFixture,
+      defaultFixture);
+  assert(fixtureDefault.isDefaultManagedDictionary);
+  assert(fixtureDefault.ownedAssetDirectory == defaultFixture.parent_path());
+
+  auto trussDefault = ActiveDictionaryStorage::BuildLayout(
+      ActiveDictionaryStorage::DictionaryKind::Trusses, defaultTruss,
+      defaultTruss);
+  assert(trussDefault.isDefaultManagedDictionary);
+  assert(trussDefault.ownedAssetDirectory == defaultTruss.parent_path());
+
+  auto fixtureCustom = ActiveDictionaryStorage::BuildLayout(
+      ActiveDictionaryStorage::DictionaryKind::Fixtures, customFixture,
+      defaultFixture);
+  assert(!fixtureCustom.isDefaultManagedDictionary);
+  assert(fixtureCustom.ownedAssetDirectory == root / "shows" / "MyTour_assets");
+
+  auto trussCustom = ActiveDictionaryStorage::BuildLayout(
+      ActiveDictionaryStorage::DictionaryKind::Trusses, customTruss,
+      defaultTruss);
+  assert(!trussCustom.isDefaultManagedDictionary);
+  assert(trussCustom.ownedAssetDirectory == root / "shows" / "RigTour_assets");
+}
+
+// Verifies supported legacy and owned reference resolution forms.
+static void TestReferenceResolution(const fs::path &root) {
+  const fs::path dict = root / "external" / "Tour.json";
+  const fs::path beside = dict.parent_path() / "beside.gdtf";
+  const fs::path asset = dict.parent_path() / "Tour_assets" / "owned.gdtf";
+  const fs::path absolute = root / "absolute.gdtf";
+  WriteText(beside, "beside");
+  WriteText(asset, "owned");
+  WriteText(absolute, "absolute");
+
+  assert(ActiveDictionaryStorage::ResolveReference(dict, "beside.gdtf") == beside);
+  assert(ActiveDictionaryStorage::ResolveReference(dict, "owned.gdtf") == asset);
+  assert(ActiveDictionaryStorage::ResolveReference(dict, absolute.string()) == absolute);
+}
+
+// Verifies deterministic same-name conflict handling for copied assets.
+static void TestConflictHandling(const fs::path &root) {
+  const fs::path defaultDict = root / "fixtures" / "gdtf_dictionary.json";
+  const fs::path customDict = root / "shows" / "Tour.json";
+  const fs::path first = root / "src1" / "fixture.gdtf";
+  const fs::path second = root / "src2" / "fixture.gdtf";
+  WriteText(first, "first");
+  WriteText(second, "second");
+
+  auto copiedFirst = ActiveDictionaryStorage::CopyAssetIntoDictionaryStorage(
+      {ActiveDictionaryStorage::DictionaryKind::Fixtures, customDict, defaultDict,
+       first, {}, FileImportUtils::ConflictPolicy::Rename});
+  assert(copiedFirst.success);
+  assert(copiedFirst.finalPath == root / "shows" / "Tour_assets" / "fixture.gdtf");
+  assert(copiedFirst.serializedPath == "fixture.gdtf");
+
+  auto copiedSecond = ActiveDictionaryStorage::CopyAssetIntoDictionaryStorage(
+      {ActiveDictionaryStorage::DictionaryKind::Fixtures, customDict, defaultDict,
+       second, {}, FileImportUtils::ConflictPolicy::Rename});
+  assert(copiedSecond.success);
+  assert(copiedSecond.finalPath != copiedFirst.finalPath);
+  assert(copiedSecond.finalPath.filename() != copiedFirst.finalPath.filename());
+}
+
+int main() {
+  const fs::path root = fs::temp_directory_path() / "perastage_active_dictionary_storage_test";
+  std::error_code ec;
+  fs::remove_all(root, ec);
+  fs::create_directories(root);
+
+  TestStorageLayouts(root);
+  TestReferenceResolution(root);
+  TestConflictHandling(root);
+
+  fs::remove_all(root, ec);
+  return 0;
+}


### PR DESCRIPTION
### Motivation
- Custom active dictionaries could reference assets with paths that broke when the JSON lived outside the standard writable library, so a single, testable ownership and serialization policy was required. 
- The goal was to preserve backward compatibility for the default managed dictionaries while making custom dictionaries reliably portable by placing owned assets in a sibling `<dictionary_stem>_assets` folder and serializing compatible relative references. 
- Helpers and file-copy logic must be centralized in core code (not GUI) and loading must remain compatible with absolute paths, files beside JSON, `_assets` sibling folders, and legacy library layouts.

### Description
- Added a new core helper `ActiveDictionaryStorage` (`core/active_dictionary_storage.h/.cpp`) that exposes layout discovery, destination selection, resolution, serialization, and a dialog-free `CopyAssetIntoDictionaryStorage` API. 
- Updated fixture/truss dictionary code to use the shared helpers: `core/gdtfdictionary.cpp` and `core/trussdictionary.cpp` now resolve references via the new helper, serialize owned assets as simple filenames when appropriate, and copy imported/derived assets into the correct owned directory. 
- Implemented seed-copy logic so newly created custom dictionaries initialized from defaults copy resolvable seed assets into the sibling `<stem>_assets` folder (`CopySeedAssetsIntoCustomDictionary` for fixtures and trusses). 
- Rewrote GUI and bundle import paths that previously used `GetWritableLibraryPath(...)` for dictionary-owned assets to call the central helpers (`gui/dictionaryeditdialog.cpp`, `core/dictionary_bundle.cpp`) so conflict handling and final destinations are consistent. 
- Added a focused unit-style test `tests/active_dictionary_storage_test.cpp` and updated `tests/CMakeLists.txt` and `core/CMakeLists.txt` to include the new helper; also updated `docs/release-notes-draft.md` and `docs/user/features.md` to document the policy change.

### Testing
- Ran the standalone active-dictionary test by compiling and executing `tests/active_dictionary_storage_test.cpp` with `g++` and it succeeded locally (tested `ResolveReference`, default/custom layouts, and deterministic same-name conflict handling). 
- Ran repository checks `tests/check_perastage_tree_modules.sh`, `tests/check_no_configmanager_get_in_gui.sh`, `tests/check_library_user_data_policy.sh`, and `tests/check_dictionary_paths.sh` and they all returned OK. 
- Attempted an in-tree `cmake` build of the test target but full `cmake --build` could not complete inside this container because the platform lacked `wxWidgets` development files; this does not affect the added core unit test which was compiled and executed directly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59756a0fb48324b3f268530224b490)