### PR TITLE
Make dictionary activation workflows explicit

### DIFF
--- a/core/gdtfdictionary.cpp
+++ b/core/gdtfdictionary.cpp
@@ -690,11 +690,112 @@ MergeDictionaryEntries(std::unordered_map<std::string, Entry> &current,
 
 } // namespace
 
+
+// Validates that a fixtures dictionary file can be loaded without changing configuration.
+bool ValidateDictionaryFile(const std::string &path, std::string *errorOut) {
+  if (errorOut)
+    errorOut->clear();
+  std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
+  std::string loadError;
+  if (!LoadFromFile(PathUtils::PathFromUtf8(path), loadError)) {
+    if (errorOut)
+      *errorOut = loadError;
+    return false;
+  }
+  return true;
+}
+
+// Creates an empty fixtures dictionary file with the supported JSON contract.
+bool CreateEmptyDictionaryFile(const std::string &path, std::string *errorOut) {
+  if (errorOut)
+    errorOut->clear();
+  std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
+  const fs::path target = PathUtils::PathFromUtf8(path);
+  if (target.empty()) {
+    if (errorOut)
+      *errorOut = "Dictionary file path is empty";
+    return false;
+  }
+  std::error_code ec;
+  fs::create_directories(target.parent_path(), ec);
+  if (ec) {
+    if (errorOut)
+      *errorOut = "Could not create dictionary folder: " + ec.message();
+    return false;
+  }
+  if (fs::exists(target) && !WriteDictionaryBackup(target)) {
+    if (errorOut)
+      *errorOut = "Could not create a backup before replacing dictionary";
+    return false;
+  }
+  std::ofstream out(target, std::ios::binary | std::ios::trunc);
+  if (!out.is_open()) {
+    if (errorOut)
+      *errorOut = "Could not create dictionary file";
+    return false;
+  }
+  out << DictionaryJsonContract::MakeRoot("fixtures", nlohmann::json::object()).dump(4);
+  out.close();
+  return ValidateDictionaryFile(target.string(), errorOut);
+}
+
+// Creates a fixtures dictionary from application defaults with copied assets.
+bool CreateDictionaryFileFromDefaults(const std::string &path,
+                                      std::string *errorOut) {
+  if (errorOut)
+    errorOut->clear();
+  std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
+  const fs::path target = PathUtils::PathFromUtf8(path);
+  if (target.empty()) {
+    if (errorOut)
+      *errorOut = "Dictionary file path is empty";
+    return false;
+  }
+  std::error_code ec;
+  fs::create_directories(target.parent_path(), ec);
+  if (ec) {
+    if (errorOut)
+      *errorOut = "Could not create dictionary folder: " + ec.message();
+    return false;
+  }
+  if (fs::exists(target) && !WriteDictionaryBackup(target)) {
+    if (errorOut)
+      *errorOut = "Could not create a backup before replacing dictionary";
+    return false;
+  }
+  std::string baseError;
+  auto baseDict = LoadFromFile(GetBaseDictFile(), baseError);
+  if (!baseDict) {
+    if (errorOut)
+      *errorOut = "Could not load default fixtures dictionary: " + baseError;
+    return false;
+  }
+  std::unordered_map<std::string, Entry> customDict = *baseDict;
+  CopySeedAssetsIntoCustomDictionary(target, *baseDict, customDict);
+  const auto previousValue =
+      ConfigManager::Get().GetValue(kFixturesDictionaryPathConfigKey);
+  ConfigManager::Get().SetValue(kFixturesDictionaryPathConfigKey, target.string());
+  std::string saveError;
+  const bool saved = Save(customDict, &saveError);
+  if (previousValue)
+    ConfigManager::Get().SetValue(kFixturesDictionaryPathConfigKey, *previousValue);
+  else
+    ConfigManager::Get().RemoveKey(kFixturesDictionaryPathConfigKey);
+  if (!saved) {
+    if (errorOut)
+      *errorOut = "Could not create dictionary from defaults: " + saveError;
+    return false;
+  }
+  return ValidateDictionaryFile(target.string(), errorOut);
+}
+
+// Returns the active fixtures dictionary path.
 std::string GetActiveDictionaryFilePath() {
   std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
   return GetConfiguredUserDictFile().string();
 }
 
+// Returns the active fixtures dictionary file name.
 std::string GetActiveDictionaryFileName() {
   std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
   const fs::path path = GetConfiguredUserDictFile();
@@ -703,6 +804,7 @@ std::string GetActiveDictionaryFileName() {
   return path.filename().string();
 }
 
+// Changes the active fixtures dictionary after validating the selected file.
 bool SetActiveDictionaryFilePath(const std::string &path,
                                  std::string *errorOut) {
   if (errorOut)
@@ -726,6 +828,16 @@ bool SetActiveDictionaryFilePath(const std::string &path,
     return false;
   }
 
+  if (resolvedPath == defaultPath && !fs::exists(resolvedPath))
+    RecreateUserDictionaryFromBase(resolvedPath, GetBaseDictFile());
+
+  std::string loadError;
+  if (!LoadFromFile(resolvedPath, loadError)) {
+    if (errorOut)
+      *errorOut = "Could not load selected fixtures dictionary: " + loadError;
+    return false;
+  }
+
   const auto previousValue =
       ConfigManager::Get().GetValue(kFixturesDictionaryPathConfigKey);
 
@@ -745,49 +857,6 @@ bool SetActiveDictionaryFilePath(const std::string &path,
       ConfigManager::Get().RemoveKey(kFixturesDictionaryPathConfigKey);
     if (errorOut)
       *errorOut = "Could not persist dictionary selection in user config";
-    return false;
-  }
-
-  const bool creatingDictionary = !fs::exists(resolvedPath);
-  if (creatingDictionary) {
-    if (!RecreateUserDictionaryFromBase(resolvedPath, GetBaseDictFile())) {
-      std::string createError;
-      if (!Save({}, &createError)) {
-        if (previousValue)
-          ConfigManager::Get().SetValue(kFixturesDictionaryPathConfigKey,
-                                        *previousValue);
-        else
-          ConfigManager::Get().RemoveKey(kFixturesDictionaryPathConfigKey);
-        ConfigManager::Get().SaveUserConfig();
-        if (errorOut)
-          *errorOut = "Could not create selected fixtures dictionary file: " +
-                      createError;
-        return false;
-      }
-    }
-  }
-
-  if (creatingDictionary && resolvedPath != defaultPath) {
-    std::string baseError;
-    std::string customError;
-    auto baseDict = LoadFromFile(GetBaseDictFile(), baseError);
-    auto customDict = LoadFromFile(resolvedPath, customError);
-    if (baseDict && customDict &&
-        CopySeedAssetsIntoCustomDictionary(resolvedPath, *baseDict, *customDict)) {
-      Save(*customDict);
-    }
-  }
-
-  std::string loadError;
-  if (!LoadFromFile(resolvedPath, loadError)) {
-    if (previousValue)
-      ConfigManager::Get().SetValue(kFixturesDictionaryPathConfigKey,
-                                    *previousValue);
-    else
-      ConfigManager::Get().RemoveKey(kFixturesDictionaryPathConfigKey);
-    ConfigManager::Get().SaveUserConfig();
-    if (errorOut)
-      *errorOut = "Could not load selected fixtures dictionary: " + loadError;
     return false;
   }
 

--- a/core/gdtfdictionary.h
+++ b/core/gdtfdictionary.h
@@ -45,6 +45,12 @@ namespace GdtfDictionary {
 
     std::string GetActiveDictionaryFilePath();
     std::string GetActiveDictionaryFileName();
+    bool ValidateDictionaryFile(const std::string &path,
+                                std::string *errorOut = nullptr);
+    bool CreateEmptyDictionaryFile(const std::string &path,
+                                   std::string *errorOut = nullptr);
+    bool CreateDictionaryFileFromDefaults(const std::string &path,
+                                          std::string *errorOut = nullptr);
     bool SetActiveDictionaryFilePath(const std::string &path,
                                      std::string *errorOut = nullptr);
     // Saves the dictionary map back to disk.

--- a/core/trussdictionary.cpp
+++ b/core/trussdictionary.cpp
@@ -483,11 +483,105 @@ bool ImportTrussFile(const std::string &inputPath, std::string &storedPath,
   return true;
 }
 
+
+// Validates that a trusses dictionary file can be loaded without changing configuration.
+bool ValidateDictionaryFile(const std::string &path, std::string *errorOut) {
+  if (errorOut)
+    errorOut->clear();
+  std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
+  std::string loadError;
+  if (!LoadFromFile(PathUtils::PathFromUtf8(path), loadError)) {
+    if (errorOut)
+      *errorOut = loadError;
+    return false;
+  }
+  return true;
+}
+
+// Creates an empty trusses dictionary file with the supported JSON contract.
+bool CreateEmptyDictionaryFile(const std::string &path, std::string *errorOut) {
+  if (errorOut)
+    errorOut->clear();
+  std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
+  const fs::path target = PathUtils::PathFromUtf8(path);
+  if (target.empty()) {
+    if (errorOut)
+      *errorOut = "Dictionary file path is empty";
+    return false;
+  }
+  std::error_code ec;
+  fs::create_directories(target.parent_path(), ec);
+  if (ec) {
+    if (errorOut)
+      *errorOut = "Could not create dictionary folder: " + ec.message();
+    return false;
+  }
+  if (fs::exists(target) && !WriteDictionaryBackup(target)) {
+    if (errorOut)
+      *errorOut = "Could not create a backup before replacing dictionary";
+    return false;
+  }
+  std::ofstream out(target, std::ios::binary | std::ios::trunc);
+  if (!out.is_open()) {
+    if (errorOut)
+      *errorOut = "Could not create dictionary file";
+    return false;
+  }
+  out << DictionaryJsonContract::MakeRoot("trusses", nlohmann::json::object()).dump(4);
+  out.close();
+  return ValidateDictionaryFile(target.string(), errorOut);
+}
+
+// Creates a trusses dictionary from application defaults with copied assets.
+bool CreateDictionaryFileFromDefaults(const std::string &path,
+                                      std::string *errorOut) {
+  if (errorOut)
+    errorOut->clear();
+  std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
+  const fs::path target = PathUtils::PathFromUtf8(path);
+  if (target.empty()) {
+    if (errorOut)
+      *errorOut = "Dictionary file path is empty";
+    return false;
+  }
+  if (fs::exists(target) && !WriteDictionaryBackup(target)) {
+    if (errorOut)
+      *errorOut = "Could not create a backup before replacing dictionary";
+    return false;
+  }
+  std::string baseError;
+  auto baseDict = LoadFromFile(GetBaseDictFile(), baseError);
+  if (!baseDict) {
+    if (errorOut)
+      *errorOut = "Could not load default trusses dictionary: " + baseError;
+    return false;
+  }
+  std::unordered_map<std::string, std::string> customDict = *baseDict;
+  CopySeedAssetsIntoCustomDictionary(target, *baseDict, customDict);
+  const auto previousValue =
+      ConfigManager::Get().GetValue(kTrussDictionaryPathConfigKey);
+  ConfigManager::Get().SetValue(kTrussDictionaryPathConfigKey, target.string());
+  std::string saveError;
+  const bool saved = Save(customDict, &saveError);
+  if (previousValue)
+    ConfigManager::Get().SetValue(kTrussDictionaryPathConfigKey, *previousValue);
+  else
+    ConfigManager::Get().RemoveKey(kTrussDictionaryPathConfigKey);
+  if (!saved) {
+    if (errorOut)
+      *errorOut = "Could not create dictionary from defaults: " + saveError;
+    return false;
+  }
+  return ValidateDictionaryFile(target.string(), errorOut);
+}
+
+// Returns the active trusses dictionary path.
 std::string GetActiveDictionaryFilePath() {
   std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
   return GetConfiguredUserDictFile().string();
 }
 
+// Returns the active trusses dictionary file name.
 std::string GetActiveDictionaryFileName() {
   std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
   const fs::path path = GetConfiguredUserDictFile();
@@ -496,6 +590,7 @@ std::string GetActiveDictionaryFileName() {
   return path.filename().string();
 }
 
+// Changes the active trusses dictionary after validating the selected file.
 bool SetActiveDictionaryFilePath(const std::string &path, std::string *errorOut) {
   if (errorOut)
     errorOut->clear();
@@ -518,14 +613,24 @@ bool SetActiveDictionaryFilePath(const std::string &path, std::string *errorOut)
     return false;
   }
 
+  if (resolvedPath == defaultPath && !fs::exists(resolvedPath))
+    RecreateUserDictionaryFromBase(resolvedPath, GetBaseDictFile());
+
+  std::string loadError;
+  if (!LoadFromFile(resolvedPath, loadError)) {
+    if (errorOut)
+      *errorOut = "Could not load selected trusses dictionary: " + loadError;
+    return false;
+  }
+
   const auto previousValue =
       ConfigManager::Get().GetValue(kTrussDictionaryPathConfigKey);
+
   const std::string trimmedInput = TrimAsciiWhitespace(path);
   if (trimmedInput.empty() || resolvedPath == defaultPath) {
     ConfigManager::Get().RemoveKey(kTrussDictionaryPathConfigKey);
   } else {
-    ConfigManager::Get().SetValue(kTrussDictionaryPathConfigKey,
-                                  resolvedPath.string());
+    ConfigManager::Get().SetValue(kTrussDictionaryPathConfigKey, resolvedPath.string());
   }
 
   if (!ConfigManager::Get().SaveUserConfig()) {
@@ -537,48 +642,6 @@ bool SetActiveDictionaryFilePath(const std::string &path, std::string *errorOut)
       *errorOut = "Could not persist dictionary selection in user config";
     return false;
   }
-
-  const bool creatingDictionary = !fs::exists(resolvedPath);
-  if (creatingDictionary) {
-    if (!RecreateUserDictionaryFromBase(resolvedPath, GetBaseDictFile())) {
-      std::string createError;
-      if (!Save({}, &createError)) {
-        if (previousValue)
-          ConfigManager::Get().SetValue(kTrussDictionaryPathConfigKey, *previousValue);
-        else
-          ConfigManager::Get().RemoveKey(kTrussDictionaryPathConfigKey);
-        ConfigManager::Get().SaveUserConfig();
-        if (errorOut)
-          *errorOut = "Could not create selected trusses dictionary file: " +
-                      createError;
-        return false;
-      }
-    }
-  }
-
-  if (creatingDictionary && resolvedPath != defaultPath) {
-    std::string baseError;
-    std::string customError;
-    auto baseDict = LoadFromFile(GetBaseDictFile(), baseError);
-    auto customDict = LoadFromFile(resolvedPath, customError);
-    if (baseDict && customDict &&
-        CopySeedAssetsIntoCustomDictionary(resolvedPath, *baseDict, *customDict)) {
-      Save(*customDict);
-    }
-  }
-
-  std::string loadError;
-  if (!LoadFromFile(resolvedPath, loadError)) {
-    if (previousValue)
-      ConfigManager::Get().SetValue(kTrussDictionaryPathConfigKey, *previousValue);
-    else
-      ConfigManager::Get().RemoveKey(kTrussDictionaryPathConfigKey);
-    ConfigManager::Get().SaveUserConfig();
-    if (errorOut)
-      *errorOut = "Could not load selected trusses dictionary: " + loadError;
-    return false;
-  }
-
   return true;
 }
 

--- a/core/trussdictionary.h
+++ b/core/trussdictionary.h
@@ -35,6 +35,12 @@ LoadStatus GetLastLoadStatus();
 
 std::string GetActiveDictionaryFilePath();
 std::string GetActiveDictionaryFileName();
+bool ValidateDictionaryFile(const std::string &path,
+                            std::string *errorOut = nullptr);
+bool CreateEmptyDictionaryFile(const std::string &path,
+                               std::string *errorOut = nullptr);
+bool CreateDictionaryFileFromDefaults(const std::string &path,
+                                      std::string *errorOut = nullptr);
 bool SetActiveDictionaryFilePath(const std::string &path,
                                  std::string *errorOut = nullptr);
 bool Save(const std::unordered_map<std::string, std::string> &dict,

--- a/docs/developer/dictionary_portable_bundle.md
+++ b/docs/developer/dictionary_portable_bundle.md
@@ -5,11 +5,22 @@ Perastage keeps JSON dictionary snapshots for backward compatibility and also su
 ## Backward compatibility
 
 - Existing `.json` snapshots are still valid for import/export.
-- The current **Import dictionary...** action accepts both JSON snapshots and ZIP bundles.
-- The current **Export dictionary...** action still writes JSON snapshots.
-- A new **Export portable bundle...** action writes a ZIP bundle that includes dictionary data and required assets.
+- The **Import into active...** action accepts both JSON snapshots and ZIP bundles and merges them into the active dictionary without changing the active path.
+- The **Export snapshot...** action still writes JSON snapshots of the active dictionary.
+- The **Export portable bundle...** action writes a ZIP bundle that includes dictionary data and required assets.
 - JSON snapshot export can optionally copy referenced files to a sibling
   `<snapshot>_assets/assets/` folder and write `assets/...` relative paths.
+
+
+## Active dictionary workflows
+
+The Dictionary Editor exposes separate actions for active dictionary management:
+
+- **Open...** validates an existing JSON dictionary and switches the active path only after the selected file matches the current page type.
+- **New...** creates either an empty dictionary or a self-contained dictionary from application defaults, then activates it after validation succeeds.
+- **Use Default** switches back to the managed user dictionary path for the current page type. It does not reset dictionary contents.
+
+These actions are distinct from importing snapshots, exporting snapshots, exporting portable bundles, and resetting the active dictionary contents.
 
 ## Preflight validation and warnings
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -74,6 +74,7 @@ Perastage 1.5.0 is a substantial update focused on GDTF and truss editing, multi
 ## Important fixes
 
 - Improved Dictionary Editor reliability so fixture and truss edits are saved transactionally, unresolved file references remain visible and savable, dirty-state checks catch category/color/path/name changes, and failed saves keep the editor open.
+- Replaced the Dictionary Editor dictionary chooser with explicit **Open**, **New**, and **Use Default** workflows for fixture and truss dictionaries, including type validation before changing the active path.
 - Fixed custom fixture and truss dictionaries so newly owned GDTF assets are stored in a sibling `_assets` folder and remain portable when the dictionary is moved with that folder.
 - Fixed Data Views table edits so moving fixtures, trusses, or scene objects between visible and hidden layers rebuilds the relevant viewer resources, invalidates stale 3D visible-set caches, and immediately refreshes both the 2D and 3D viewports, including layout previews.
 - Fixed Windows build and linker issues in the Local Axes viewport integration.

--- a/gui/dictionary_selection_controls.cpp
+++ b/gui/dictionary_selection_controls.cpp
@@ -1,36 +1,54 @@
 #include "dictionary_selection_controls.h"
 
-#include <wx/button.h>
+namespace {
 
+// Binds a button click to an optional callback.
+void BindButton(wxButton *button, const std::function<void()> &callback) {
+  if (!button || !callback)
+    return;
+  button->Bind(wxEVT_BUTTON, [callback](wxCommandEvent &) { callback(); });
+}
+
+} // namespace
+
+// Builds the active dictionary path display and explicit dictionary actions.
 DictionarySelectionControls BuildDictionarySelectionControls(
     wxWindow *parent, wxSizer *parentSizer, const wxString &title,
-    const wxString &buttonLabel, const std::function<void()> &onSelect) {
+    const std::function<void()> &onOpen, const std::function<void()> &onNew,
+    const std::function<void()> &onUseDefault) {
   DictionarySelectionControls controls;
   if (!parent || !parentSizer)
     return controls;
 
   auto *wrapper = new wxStaticBoxSizer(wxVERTICAL, parent, title);
   auto *row = new wxBoxSizer(wxHORIZONTAL);
+  auto *buttonRow = new wxBoxSizer(wxHORIZONTAL);
 
   controls.activeFileLabel = new wxStaticText(parent, wxID_ANY, "Dictionary: -");
   controls.activePathLabel = new wxStaticText(parent, wxID_ANY, "Path: -");
-  controls.selectButton = new wxButton(parent, wxID_ANY, buttonLabel);
+  controls.openButton = new wxButton(parent, wxID_ANY, "Open...");
+  controls.newButton = new wxButton(parent, wxID_ANY, "New...");
+  controls.useDefaultButton = new wxButton(parent, wxID_ANY, "Use Default");
+
+  buttonRow->Add(controls.openButton, 0, wxRIGHT, 5);
+  buttonRow->Add(controls.newButton, 0, wxRIGHT, 5);
+  buttonRow->Add(controls.useDefaultButton, 0);
 
   row->Add(controls.activeFileLabel, 1, wxALIGN_CENTER_VERTICAL | wxRIGHT, 10);
-  row->Add(controls.selectButton, 0, wxALIGN_CENTER_VERTICAL);
+  row->Add(buttonRow, 0, wxALIGN_CENTER_VERTICAL);
 
   wrapper->Add(row, 0, wxEXPAND | wxALL, 6);
   wrapper->Add(controls.activePathLabel, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM,
                6);
   parentSizer->Add(wrapper, 0, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, 8);
 
-  if (controls.selectButton && onSelect) {
-    controls.selectButton->Bind(wxEVT_BUTTON,
-                                [onSelect](wxCommandEvent &) { onSelect(); });
-  }
+  BindButton(controls.openButton, onOpen);
+  BindButton(controls.newButton, onNew);
+  BindButton(controls.useDefaultButton, onUseDefault);
   return controls;
 }
 
+// Updates the active dictionary file and path labels.
 void UpdateDictionarySelectionControls(const DictionarySelectionControls &controls,
                                        const wxString &fileName,
                                        const wxString &fullPath) {

--- a/gui/dictionary_selection_controls.h
+++ b/gui/dictionary_selection_controls.h
@@ -2,6 +2,7 @@
 
 #include <functional>
 
+#include <wx/button.h>
 #include <wx/sizer.h>
 #include <wx/stattext.h>
 #include <wx/window.h>
@@ -9,12 +10,15 @@
 struct DictionarySelectionControls {
   wxStaticText *activeFileLabel = nullptr;
   wxStaticText *activePathLabel = nullptr;
-  wxButton *selectButton = nullptr;
+  wxButton *openButton = nullptr;
+  wxButton *newButton = nullptr;
+  wxButton *useDefaultButton = nullptr;
 };
 
 DictionarySelectionControls BuildDictionarySelectionControls(
     wxWindow *parent, wxSizer *parentSizer, const wxString &title,
-    const wxString &buttonLabel, const std::function<void()> &onSelect);
+    const std::function<void()> &onOpen, const std::function<void()> &onNew,
+    const std::function<void()> &onUseDefault);
 
 void UpdateDictionarySelectionControls(const DictionarySelectionControls &controls,
                                        const wxString &fileName,

--- a/gui/dictionaryeditdialog.cpp
+++ b/gui/dictionaryeditdialog.cpp
@@ -991,9 +991,17 @@ void DictionaryEditDialog::BuildLayout() {
   ColumnUtils::EnforceMinColumnWidth(fixtureTable);
   fixturesSelection = BuildDictionarySelectionControls(
       fixturePanel, fixtureSizer, "Active fixtures dictionary",
-      "Select dictionary...", [this]() {
+      [this]() {
         wxCommandEvent dummy;
-        OnSelectFixturesDictionary(dummy);
+        OnOpenFixturesDictionary(dummy);
+      },
+      [this]() {
+        wxCommandEvent dummy;
+        OnNewFixturesDictionary(dummy);
+      },
+      [this]() {
+        wxCommandEvent dummy;
+        OnUseDefaultFixturesDictionary(dummy);
       });
   fixtureSizer->Add(fixtureTable, 1, wxEXPAND | wxALL, 8);
   fixturePanel->SetSizer(fixtureSizer);
@@ -1020,9 +1028,17 @@ void DictionaryEditDialog::BuildLayout() {
   ColumnUtils::EnforceMinColumnWidth(trussTable);
   trussesSelection = BuildDictionarySelectionControls(
       trussPanel, trussSizer, "Active trusses dictionary",
-      "Select dictionary...", [this]() {
+      [this]() {
         wxCommandEvent dummy;
-        OnSelectTrussesDictionary(dummy);
+        OnOpenTrussesDictionary(dummy);
+      },
+      [this]() {
+        wxCommandEvent dummy;
+        OnNewTrussesDictionary(dummy);
+      },
+      [this]() {
+        wxCommandEvent dummy;
+        OnUseDefaultTrussesDictionary(dummy);
       });
   trussSizer->Add(trussTable, 1, wxEXPAND | wxALL, 8);
   trussPanel->SetSizer(trussSizer);
@@ -1036,10 +1052,10 @@ void DictionaryEditDialog::BuildLayout() {
   addBtn = new wxButton(this, wxID_ADD, "Add");
   deleteBtn = new wxButton(this, wxID_DELETE, "Delete");
   downloadBtn = new wxButton(this, wxID_ANY, "Download GDTF");
-  importBtn = new wxButton(this, wxID_ANY, "Import dictionary...");
-  exportBtn = new wxButton(this, wxID_ANY, "Export dictionary...");
+  importBtn = new wxButton(this, wxID_ANY, "Import into active...");
+  exportBtn = new wxButton(this, wxID_ANY, "Export snapshot...");
   exportPortableBtn = new wxButton(this, wxID_ANY, "Export portable bundle...");
-  resetBtn = new wxButton(this, wxID_ANY, "Reset to default");
+  resetBtn = new wxButton(this, wxID_ANY, "Reset contents");
   okBtn = new wxButton(this, wxID_OK, "OK");
   cancelBtn = new wxButton(this, wxID_CANCEL, "Cancel");
 
@@ -1350,77 +1366,147 @@ void DictionaryEditDialog::RefreshDictionarySelectionLabels() {
       wxString::FromUTF8(TrussDictionary::GetActiveDictionaryFilePath()));
 }
 
-// Opens a file picker for changing the active fixtures dictionary.
-void DictionaryEditDialog::OnSelectFixturesDictionary(
-    wxCommandEvent &WXUNUSED(event)) {
-  if (!ConfirmDirtyChangesBeforeReload("selecting a fixtures dictionary"))
+// Opens an existing fixtures dictionary after validating its contract.
+void DictionaryEditDialog::OnOpenFixturesDictionary(wxCommandEvent &WXUNUSED(event)) {
+  if (!ConfirmDirtyChangesBeforeReload("opening a fixtures dictionary"))
     return;
   const std::filesystem::path currentPath =
       PathUtils::PathFromUtf8(GdtfDictionary::GetActiveDictionaryFilePath());
-  const wxString initialDir = wxString::FromUTF8(
-      (currentPath.empty()
-           ? PathUtils::PathFromUtf8(
-                                 ProjectUtils::GetWritableLibraryPath("fixtures"))
-                           : currentPath.parent_path())
-          .string());
-  const wxString initialFile =
-      currentPath.empty() ? wxString("gdtf_dictionary.json")
-                                   : wxString::FromUTF8(currentPath.filename().string());
-  wxFileDialog dialog(this, "Select fixtures dictionary file", initialDir,
-                      initialFile, "JSON files (*.json)|*.json",
-                      wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
+  wxFileDialog dialog(this, "Open fixtures dictionary",
+                      wxString::FromUTF8(currentPath.parent_path().string()),
+                      wxString(), "JSON dictionary files (*.json)|*.json",
+                      wxFD_OPEN | wxFD_FILE_MUST_EXIST);
   if (dialog.ShowModal() != wxID_OK)
     return;
-
   std::string error;
-  std::filesystem::path selectedPath =
-      PathUtils::PathFromUtf8(std::string(dialog.GetPath().ToUTF8()));
-  if (!selectedPath.has_extension())
-    selectedPath += ".json";
-  const std::string selected = selectedPath.string();
+  const std::string selected = std::string(dialog.GetPath().ToUTF8());
   if (!GdtfDictionary::SetActiveDictionaryFilePath(selected, &error)) {
-    wxMessageBox("Could not select fixtures dictionary.\n\n" +
+    wxMessageBox("Could not open fixtures dictionary.\n\n" +
                      wxString::FromUTF8(error),
-                 "Dictionary selection", wxOK | wxICON_ERROR, this);
+                 "Open dictionary", wxOK | wxICON_ERROR, this);
     RefreshDictionarySelectionLabels();
     return;
   }
   LoadFixtures();
 }
 
-// Opens a file picker for changing the active trusses dictionary.
-void DictionaryEditDialog::OnSelectTrussesDictionary(
-    wxCommandEvent &WXUNUSED(event)) {
-  if (!ConfirmDirtyChangesBeforeReload("selecting a trusses dictionary"))
+// Opens an existing trusses dictionary after validating its contract.
+void DictionaryEditDialog::OnOpenTrussesDictionary(wxCommandEvent &WXUNUSED(event)) {
+  if (!ConfirmDirtyChangesBeforeReload("opening a trusses dictionary"))
     return;
   const std::filesystem::path currentPath =
       PathUtils::PathFromUtf8(TrussDictionary::GetActiveDictionaryFilePath());
-  const wxString initialDir = wxString::FromUTF8(
-      (currentPath.empty()
-           ? PathUtils::PathFromUtf8(
-                                 ProjectUtils::GetWritableLibraryPath("trusses"))
-                           : currentPath.parent_path())
-          .string());
-  const wxString initialFile =
-      currentPath.empty() ? wxString("truss_dictionary.json")
-                                   : wxString::FromUTF8(currentPath.filename().string());
-  wxFileDialog dialog(this, "Select trusses dictionary file", initialDir,
-                      initialFile, "JSON files (*.json)|*.json",
+  wxFileDialog dialog(this, "Open trusses dictionary",
+                      wxString::FromUTF8(currentPath.parent_path().string()),
+                      wxString(), "JSON dictionary files (*.json)|*.json",
+                      wxFD_OPEN | wxFD_FILE_MUST_EXIST);
+  if (dialog.ShowModal() != wxID_OK)
+    return;
+  std::string error;
+  const std::string selected = std::string(dialog.GetPath().ToUTF8());
+  if (!TrussDictionary::SetActiveDictionaryFilePath(selected, &error)) {
+    wxMessageBox("Could not open trusses dictionary.\n\n" +
+                     wxString::FromUTF8(error),
+                 "Open dictionary", wxOK | wxICON_ERROR, this);
+    RefreshDictionarySelectionLabels();
+    return;
+  }
+  LoadTrusses();
+}
+
+// Creates and activates a new fixtures dictionary.
+void DictionaryEditDialog::OnNewFixturesDictionary(wxCommandEvent &WXUNUSED(event)) {
+  if (!ConfirmDirtyChangesBeforeReload("creating a fixtures dictionary"))
+    return;
+  wxArrayString choices;
+  choices.Add("Empty dictionary");
+  choices.Add("From application defaults");
+  wxSingleChoiceDialog choiceDialog(this, "Choose how to create the new fixtures dictionary.",
+                                    "New fixtures dictionary", choices);
+  if (choiceDialog.ShowModal() != wxID_OK)
+    return;
+  wxFileDialog dialog(this, "Create fixtures dictionary", wxString(),
+                      "gdtf_dictionary.json",
+                      "JSON dictionary files (*.json)|*.json",
                       wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
   if (dialog.ShowModal() != wxID_OK)
     return;
-
-  std::string error;
   std::filesystem::path selectedPath =
       PathUtils::PathFromUtf8(std::string(dialog.GetPath().ToUTF8()));
   if (!selectedPath.has_extension())
     selectedPath += ".json";
-  const std::string selected = selectedPath.string();
-  if (!TrussDictionary::SetActiveDictionaryFilePath(selected, &error)) {
-    wxMessageBox("Could not select trusses dictionary.\n\n" +
+  std::string error;
+  const bool created = choiceDialog.GetSelection() == 0
+                           ? GdtfDictionary::CreateEmptyDictionaryFile(selectedPath.string(), &error)
+                           : GdtfDictionary::CreateDictionaryFileFromDefaults(selectedPath.string(), &error);
+  if (!created || !GdtfDictionary::SetActiveDictionaryFilePath(selectedPath.string(), &error)) {
+    wxMessageBox("Could not create fixtures dictionary.\n\n" +
                      wxString::FromUTF8(error),
-                 "Dictionary selection", wxOK | wxICON_ERROR, this);
+                 "New dictionary", wxOK | wxICON_ERROR, this);
     RefreshDictionarySelectionLabels();
+    return;
+  }
+  LoadFixtures();
+}
+
+// Creates and activates a new trusses dictionary.
+void DictionaryEditDialog::OnNewTrussesDictionary(wxCommandEvent &WXUNUSED(event)) {
+  if (!ConfirmDirtyChangesBeforeReload("creating a trusses dictionary"))
+    return;
+  wxArrayString choices;
+  choices.Add("Empty dictionary");
+  choices.Add("From application defaults");
+  wxSingleChoiceDialog choiceDialog(this, "Choose how to create the new trusses dictionary.",
+                                    "New trusses dictionary", choices);
+  if (choiceDialog.ShowModal() != wxID_OK)
+    return;
+  wxFileDialog dialog(this, "Create trusses dictionary", wxString(),
+                      "truss_dictionary.json",
+                      "JSON dictionary files (*.json)|*.json",
+                      wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
+  if (dialog.ShowModal() != wxID_OK)
+    return;
+  std::filesystem::path selectedPath =
+      PathUtils::PathFromUtf8(std::string(dialog.GetPath().ToUTF8()));
+  if (!selectedPath.has_extension())
+    selectedPath += ".json";
+  std::string error;
+  const bool created = choiceDialog.GetSelection() == 0
+                           ? TrussDictionary::CreateEmptyDictionaryFile(selectedPath.string(), &error)
+                           : TrussDictionary::CreateDictionaryFileFromDefaults(selectedPath.string(), &error);
+  if (!created || !TrussDictionary::SetActiveDictionaryFilePath(selectedPath.string(), &error)) {
+    wxMessageBox("Could not create trusses dictionary.\n\n" +
+                     wxString::FromUTF8(error),
+                 "New dictionary", wxOK | wxICON_ERROR, this);
+    RefreshDictionarySelectionLabels();
+    return;
+  }
+  LoadTrusses();
+}
+
+// Switches fixtures back to the managed default dictionary path.
+void DictionaryEditDialog::OnUseDefaultFixturesDictionary(wxCommandEvent &WXUNUSED(event)) {
+  if (!ConfirmDirtyChangesBeforeReload("using the default fixtures dictionary path"))
+    return;
+  std::string error;
+  if (!GdtfDictionary::SetActiveDictionaryFilePath({}, &error)) {
+    wxMessageBox("Could not use the default fixtures dictionary path.\n\n" +
+                     wxString::FromUTF8(error),
+                 "Use Default", wxOK | wxICON_ERROR, this);
+    return;
+  }
+  LoadFixtures();
+}
+
+// Switches trusses back to the managed default dictionary path.
+void DictionaryEditDialog::OnUseDefaultTrussesDictionary(wxCommandEvent &WXUNUSED(event)) {
+  if (!ConfirmDirtyChangesBeforeReload("using the default trusses dictionary path"))
+    return;
+  std::string error;
+  if (!TrussDictionary::SetActiveDictionaryFilePath({}, &error)) {
+    wxMessageBox("Could not use the default trusses dictionary path.\n\n" +
+                     wxString::FromUTF8(error),
+                 "Use Default", wxOK | wxICON_ERROR, this);
     return;
   }
   LoadTrusses();

--- a/gui/dictionaryeditdialog.h
+++ b/gui/dictionaryeditdialog.h
@@ -59,8 +59,12 @@ private:
                                 wxString &activeTooltip,
                                 const wxPoint &position);
   void RefreshDictionarySelectionLabels();
-  void OnSelectFixturesDictionary(wxCommandEvent &event);
-  void OnSelectTrussesDictionary(wxCommandEvent &event);
+  void OnOpenFixturesDictionary(wxCommandEvent &event);
+  void OnOpenTrussesDictionary(wxCommandEvent &event);
+  void OnNewFixturesDictionary(wxCommandEvent &event);
+  void OnNewTrussesDictionary(wxCommandEvent &event);
+  void OnUseDefaultFixturesDictionary(wxCommandEvent &event);
+  void OnUseDefaultTrussesDictionary(wxCommandEvent &event);
 
   void OnAdd(wxCommandEvent &event);
   void OnDelete(wxCommandEvent &event);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -493,6 +493,28 @@ target_link_libraries(dictionary_seed_merge_backup_test PRIVATE
                       ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
 add_test(NAME DictionarySeedMergeBackup COMMAND dictionary_seed_merge_backup_test)
 
+add_executable(active_dictionary_workflow_test
+               active_dictionary_workflow_test.cpp
+               mvr_io_stubs.cpp
+               ../core/configmanager.cpp
+               ../core/configservices.cpp
+               ../core/projectutils.cpp
+               ../core/library/library_bootstrap.cpp
+               ../core/gdtfdictionary.cpp
+               ../core/layouts/LayoutManager.cpp
+               ../core/layouts/LayoutImageResourceRegistry.cpp
+               ../core/layouts/LayoutDefaultsLoader.cpp
+               ../core/layouts/LayoutCollection.cpp
+               ../core/layouts/LayoutTemplateSerializer.cpp
+               ../core/trussdictionary.cpp
+               ../models/truss.cpp
+               ../models/mvrscene.cpp)
+target_include_directories(active_dictionary_workflow_test PRIVATE
+                           . ../core ../models ../third_party)
+target_link_libraries(active_dictionary_workflow_test PRIVATE
+                      ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
+add_test(NAME ActiveDictionaryWorkflow COMMAND active_dictionary_workflow_test)
+
 add_executable(layout_template_serializer_test
                layout_template_serializer_test.cpp
                ../core/layouts/LayoutTemplateSerializer.cpp)

--- a/tests/active_dictionary_workflow_test.cpp
+++ b/tests/active_dictionary_workflow_test.cpp
@@ -1,0 +1,126 @@
+/*
+ * This file is part of Perastage.
+ */
+#include <cassert>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+#include <wx/init.h>
+
+#include "configmanager.h"
+#include "dictionary_json_contract.h"
+#include "filesystem_path_utils.h"
+#include "gdtfdictionary.h"
+#include "json.hpp"
+#include "projectutils.h"
+#include "trussdictionary.h"
+
+namespace fs = std::filesystem;
+
+namespace {
+
+// Writes UTF-8 text to a file for test setup.
+void WriteFile(const fs::path &path, const std::string &content) {
+  fs::create_directories(path.parent_path());
+  std::ofstream out(path, std::ios::binary | std::ios::trunc);
+  assert(out.is_open());
+  out << content;
+  assert(out.good());
+}
+
+// Sets the writable library root used by dictionary code.
+void SetLibraryPathEnv(const std::string &value) {
+#ifdef _WIN32
+  _putenv_s("PERASTAGE_LIBRARY_PATH", value.c_str());
+#else
+  setenv("PERASTAGE_LIBRARY_PATH", value.c_str(), 1);
+#endif
+}
+
+// Creates a contract-compliant fixture dictionary.
+void WriteFixtureDictionary(const fs::path &path) {
+  nlohmann::json entries = nlohmann::json::object();
+  entries["Fixture A"] = {{"file", "fixture.gdtf"}, {"mode", "Mode 1"}};
+  WriteFile(path, DictionaryJsonContract::MakeRoot("fixtures", entries).dump(2));
+}
+
+// Creates a contract-compliant truss dictionary.
+void WriteTrussDictionary(const fs::path &path) {
+  nlohmann::json entries = nlohmann::json::object();
+  entries["Truss A"] = {{"file", "truss.gdtf"}};
+  WriteFile(path, DictionaryJsonContract::MakeRoot("trusses", entries).dump(2));
+}
+
+// Verifies explicit open, new, and default active dictionary workflows.
+void VerifyActiveDictionaryWorkflows(const fs::path &root) {
+  ConfigManager::Get().Reset();
+  SetLibraryPathEnv(root.string());
+
+  const fs::path defaultFixture = root / "fixtures" / "gdtf_dictionary.json";
+  const fs::path defaultTruss = root / "trusses" / "truss_dictionary.json";
+  WriteFixtureDictionary(defaultFixture);
+  WriteTrussDictionary(defaultTruss);
+
+  const fs::path fixturePath = root / "custom" / "fixture_custom.json";
+  const fs::path trussPath = root / "custom" / "truss_custom.json";
+  WriteFixtureDictionary(fixturePath);
+  WriteTrussDictionary(trussPath);
+
+  std::string error;
+  assert(GdtfDictionary::SetActiveDictionaryFilePath(fixturePath.string(), &error));
+  assert(GdtfDictionary::GetActiveDictionaryFilePath() == fixturePath.string());
+  assert(!GdtfDictionary::SetActiveDictionaryFilePath(trussPath.string(), &error));
+  assert(GdtfDictionary::GetActiveDictionaryFilePath() == fixturePath.string());
+
+  assert(TrussDictionary::SetActiveDictionaryFilePath(trussPath.string(), &error));
+  assert(TrussDictionary::GetActiveDictionaryFilePath() == trussPath.string());
+  assert(!TrussDictionary::SetActiveDictionaryFilePath(fixturePath.string(), &error));
+  assert(TrussDictionary::GetActiveDictionaryFilePath() == trussPath.string());
+
+  const fs::path missingPath = root / "custom" / "missing.json";
+  assert(!GdtfDictionary::SetActiveDictionaryFilePath(missingPath.string(), &error));
+  assert(!fs::exists(missingPath));
+  assert(GdtfDictionary::GetActiveDictionaryFilePath() == fixturePath.string());
+
+  const fs::path emptyFixture = root / "custom" / "empty_fixture.json";
+  const fs::path emptyTruss = root / "custom" / "empty_truss.json";
+  assert(GdtfDictionary::CreateEmptyDictionaryFile(emptyFixture.string(), &error));
+  assert(GdtfDictionary::ValidateDictionaryFile(emptyFixture.string(), &error));
+  assert(TrussDictionary::CreateEmptyDictionaryFile(emptyTruss.string(), &error));
+  assert(TrussDictionary::ValidateDictionaryFile(emptyTruss.string(), &error));
+
+  const fs::path defaultsFixture = root / "custom" / "defaults_fixture.json";
+  const fs::path defaultsTruss = root / "custom" / "defaults_truss.json";
+  assert(GdtfDictionary::CreateDictionaryFileFromDefaults(defaultsFixture.string(), &error));
+  assert(GdtfDictionary::ValidateDictionaryFile(defaultsFixture.string(), &error));
+  assert(TrussDictionary::CreateDictionaryFileFromDefaults(defaultsTruss.string(), &error));
+  assert(TrussDictionary::ValidateDictionaryFile(defaultsTruss.string(), &error));
+
+  const fs::path invalidNew = root / "custom" / "invalid_new.json";
+  WriteFile(invalidNew, "not json");
+  assert(!GdtfDictionary::ValidateDictionaryFile(invalidNew.string(), &error));
+  assert(GdtfDictionary::GetActiveDictionaryFilePath() == fixturePath.string());
+
+  assert(GdtfDictionary::SetActiveDictionaryFilePath({}, &error));
+  assert(GdtfDictionary::GetActiveDictionaryFilePath() == defaultFixture.string());
+  assert(TrussDictionary::SetActiveDictionaryFilePath({}, &error));
+  assert(TrussDictionary::GetActiveDictionaryFilePath() == defaultTruss.string());
+}
+
+} // namespace
+
+// Runs active dictionary workflow regression checks.
+int main() {
+  wxInitializer initializer;
+  assert(initializer.IsOk());
+
+  const fs::path tempRoot = fs::temp_directory_path() /
+                            PathUtils::PathFromUtf8("perastage_active_dictionary_workflow_test");
+  std::error_code ec;
+  fs::remove_all(tempRoot, ec);
+  VerifyActiveDictionaryWorkflows(tempRoot);
+  fs::remove_all(tempRoot, ec);
+  return 0;
+}


### PR DESCRIPTION
### Motivation
- The previous single “Select dictionary...” control mixed open/create semantics and showed a save/overwrite dialog for open operations, which is confusing and unsafe.  
- The change makes active-dictionary management explicit (Open / New / Use Default) and ensures activation is transactional and validated before persisting.  

### Description
- Replaced the single chooser with explicit controls by extending `dictionary_selection_controls` to expose `Open...`, `New...`, and `Use Default` buttons and kept active file/name/path display visible.  
- Added dialog handlers `OnOpen*`, `OnNew*` and `OnUseDefault*` in `DictionaryEditDialog` that use `wxFD_OPEN | wxFD_FILE_MUST_EXIST` for open, `wxFD_SAVE | wxFD_OVERWRITE_PROMPT` for create, and the existing dirty-change guard before switching.  
- Introduced transactional core helpers in `core/gdtfdictionary.*` and `core/trussdictionary.*`: `ValidateDictionaryFile`, `CreateEmptyDictionaryFile`, and `CreateDictionaryFileFromDefaults`, and refactored `SetActiveDictionaryFilePath` to validate candidate files before persisting config and to avoid leaving invalid configuration on disk.  
- Renamed ambiguous UI labels to make workflows distinct (`Import into active...`, `Export snapshot...`, `Reset contents`) and updated developer docs and release notes to describe the new active-dictionary workflows.  
- Added an automated regression test `active_dictionary_workflow_test` and wired it into `tests/CMakeLists.txt` to cover open/new/type-rejection/missing-file/create-from-default/Use Default behaviors.  

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed.  
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed.  
- Ran `git diff --check` and fixed trailing-whitespace; check passed.  
- Added `ActiveDictionaryWorkflow` test and attempted to build it with `cmake --build`, but the build could not be executed in this environment because `wxWidgets` is not installed (test source is present and the CMake target was added).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a597811708c8324a61463522cc2a34d)