### PR TITLE
Add safe "Duplicate Current" dictionary workflow

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -10,6 +10,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/diagnostics/DiagnosticPaths.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/diagnostics/DiagnosticReport.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dictionary_bundle.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/dictionary_duplicate.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dummyprofilelibrary.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/file_import_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/filesystem_path_utils.cpp

--- a/core/dictionary_duplicate.cpp
+++ b/core/dictionary_duplicate.cpp
@@ -1,0 +1,353 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+#include "dictionary_duplicate.h"
+
+#include "dictionary_json_contract.h"
+#include "file_import_utils.h"
+#include "filesystem_path_utils.h"
+
+#include <chrono>
+#include <fstream>
+#include <optional>
+#include <system_error>
+
+namespace fs = std::filesystem;
+
+namespace DictionaryDuplicate {
+namespace {
+
+// Returns a canonical path when possible and a normalized absolute path
+// otherwise.
+fs::path CanonicalComparablePath(const fs::path &path) {
+  std::error_code ec;
+  fs::path canonical = fs::weakly_canonical(path, ec);
+  if (!ec)
+    return canonical.lexically_normal();
+  return fs::absolute(path, ec).lexically_normal();
+}
+
+// Adds an error message to the duplicate result.
+void AddError(Result &result, const std::string &message) {
+  result.errors.push_back(message);
+}
+
+// Returns the expected dictionary_type value for a duplicate request.
+std::string ExpectedType(ActiveDictionaryStorage::DictionaryKind kind) {
+  return kind == ActiveDictionaryStorage::DictionaryKind::Fixtures ? "fixtures"
+                                                                   : "trusses";
+}
+
+// Reads and validates a source dictionary JSON document.
+std::optional<nlohmann::json> ReadSourceJson(const Request &request,
+                                             Result &result) {
+  std::ifstream in(request.sourceDictionaryPath);
+  if (!in.is_open()) {
+    AddError(result, "Could not open the source dictionary.");
+    return std::nullopt;
+  }
+
+  nlohmann::json root;
+  try {
+    in >> root;
+  } catch (const std::exception &ex) {
+    AddError(result, std::string("Could not parse the source dictionary: ") +
+                         ex.what());
+    return std::nullopt;
+  }
+
+  std::string error;
+  if (!DictionaryJsonContract::GetEntriesForType(
+          root, ExpectedType(request.kind), error)) {
+    AddError(result, "The source dictionary is not valid: " + error);
+    return std::nullopt;
+  }
+  return root;
+}
+
+// Ensures a save-dialog destination has a JSON extension.
+fs::path NormalizeDestinationPath(fs::path path) {
+  if (path.extension() != ".json")
+    path.replace_extension(".json");
+  return path;
+}
+
+// Builds a unique backup path next to an existing destination.
+fs::path BuildBackupPath(const fs::path &path) {
+  const auto stamp = std::chrono::duration_cast<std::chrono::milliseconds>(
+                         std::chrono::system_clock::now().time_since_epoch())
+                         .count();
+  fs::path backup = path;
+  backup += ".bak." + std::to_string(stamp);
+  return backup;
+}
+
+// Removes a path without reporting cleanup failures.
+void RemoveIfExists(const fs::path &path) {
+  if (path.empty())
+    return;
+  std::error_code ec;
+  fs::remove_all(path, ec);
+}
+
+// Moves an existing path to a backup before replacement.
+bool BackupExistingPath(const fs::path &path, fs::path &backupOut,
+                        std::string &error) {
+  std::error_code ec;
+  if (!fs::exists(path, ec) || ec)
+    return true;
+  backupOut = BuildBackupPath(path);
+  fs::rename(path, backupOut, ec);
+  if (ec) {
+    error =
+        "Could not create backup for " + path.string() + ": " + ec.message();
+    return false;
+  }
+  return true;
+}
+
+// Restores a backup path if final replacement failed.
+void RestoreBackup(const fs::path &backup, const fs::path &target) {
+  if (backup.empty())
+    return;
+  std::error_code ec;
+  RemoveIfExists(target);
+  fs::rename(backup, target, ec);
+}
+
+// Returns a mutable JSON object for dictionary entries.
+nlohmann::json *FindEntries(nlohmann::json &root, const std::string &type) {
+  if (root.value("dictionary_type", "") == "combined")
+    return &root["entries"][type];
+  return &root["entries"];
+}
+
+// Rewrites one serialized asset reference into the destination duplicate.
+void RewriteReference(const Request &request,
+                      const ActiveDictionaryStorage::AssetStorageLayout &layout,
+                      const fs::path &stagingAssetsDir,
+                      const std::string &entryName, nlohmann::json &entryValue,
+                      Result &result) {
+  std::string raw;
+  if (entryValue.is_string())
+    raw = entryValue.get<std::string>();
+  else if (entryValue.is_object() && entryValue.contains("file") &&
+           entryValue["file"].is_string())
+    raw = entryValue["file"].get<std::string>();
+  else if (entryValue.is_object() && entryValue.contains("path") &&
+           entryValue["path"].is_string())
+    raw = entryValue["path"].get<std::string>();
+  if (raw.empty())
+    return;
+
+  const fs::path resolved = ActiveDictionaryStorage::ResolveReference(
+      request.sourceDictionaryPath, raw);
+  std::error_code ec;
+  if (!fs::exists(resolved, ec) || ec) {
+    ++result.unresolvedReferenceCount;
+    result.unresolvedReferences.push_back(entryName + " -> " + raw);
+    return;
+  }
+
+  fs::create_directories(stagingAssetsDir, ec);
+  if (ec) {
+    AddError(result,
+             "Could not create staging asset directory: " + ec.message());
+    return;
+  }
+
+  fs::path destination = stagingAssetsDir / resolved.filename();
+  if (fs::exists(destination, ec) && !ec) {
+    const auto sourceHash = FileImportUtils::ComputeFileSha256(resolved);
+    const auto destHash = FileImportUtils::ComputeFileSha256(destination);
+    if (sourceHash && destHash && *sourceHash != *destHash) {
+      const std::string suffix = sourceHash->substr(0, 12);
+      destination = stagingAssetsDir / (resolved.stem().string() + "_" +
+                                        suffix + resolved.extension().string());
+    }
+  }
+
+  fs::copy_file(resolved, destination, fs::copy_options::overwrite_existing,
+                ec);
+  if (ec) {
+    AddError(result,
+             "Could not copy asset for " + entryName + ": " + ec.message());
+    return;
+  }
+
+  ++result.copiedAssetCount;
+  const fs::path finalAssetPath =
+      layout.ownedAssetDirectory / destination.filename();
+  const std::string serialized =
+      ActiveDictionaryStorage::MakeSerializedReference(layout, finalAssetPath);
+  if (entryValue.is_string())
+    entryValue = serialized;
+  else
+    entryValue[entryValue.contains("file") ? "file" : "path"] = serialized;
+}
+
+// Rewrites all object or array entries in a dictionary JSON document.
+void RewriteEntries(const Request &request,
+                    const ActiveDictionaryStorage::AssetStorageLayout &layout,
+                    const fs::path &stagingAssetsDir, nlohmann::json &root,
+                    Result &result) {
+  nlohmann::json *entries = FindEntries(root, ExpectedType(request.kind));
+  if (!entries)
+    return;
+  if (entries->is_object()) {
+    for (auto it = entries->begin(); it != entries->end(); ++it)
+      RewriteReference(request, layout, stagingAssetsDir, it.key(), it.value(),
+                       result);
+    return;
+  }
+  if (entries->is_array()) {
+    for (size_t i = 0; i < entries->size(); ++i) {
+      nlohmann::json &value = (*entries)[i];
+      std::string name = "entries[" + std::to_string(i) + "]";
+      if (value.is_object() && value.contains("name") &&
+          value["name"].is_string())
+        name = value["name"].get<std::string>();
+      RewriteReference(request, layout, stagingAssetsDir, name, value, result);
+    }
+  }
+}
+
+// Writes JSON to disk and validates it against the dictionary contract.
+bool WriteAndValidate(const Request &request, const fs::path &path,
+                      const nlohmann::json &root, Result &result) {
+  std::ofstream out(path);
+  if (!out.is_open()) {
+    AddError(result, "Could not open the staged duplicate for writing.");
+    return false;
+  }
+  out << root.dump(4);
+  out.close();
+
+  std::string error;
+  std::ifstream in(path);
+  nlohmann::json check;
+  try {
+    in >> check;
+  } catch (const std::exception &ex) {
+    AddError(result,
+             std::string("Could not re-read staged duplicate: ") + ex.what());
+    return false;
+  }
+  if (!DictionaryJsonContract::GetEntriesForType(
+          check, ExpectedType(request.kind), error)) {
+    AddError(result, "The staged duplicate is invalid: " + error);
+    return false;
+  }
+  return true;
+}
+
+} // namespace
+
+// Builds a meaningful default duplicate filename next to the source dictionary.
+fs::path BuildDefaultDuplicatePath(const fs::path &sourceDictionaryPath) {
+  fs::path result = sourceDictionaryPath;
+  result.replace_filename(sourceDictionaryPath.stem().string() + " copy.json");
+  return result;
+}
+
+// Creates an independent duplicate of a fixture or truss dictionary and its
+// assets.
+Result DuplicateDictionary(const Request &request) {
+  Result result;
+  result.destinationDictionaryPath =
+      NormalizeDestinationPath(request.destinationDictionaryPath);
+  if (request.sourceDictionaryPath.empty() ||
+      result.destinationDictionaryPath.empty()) {
+    AddError(result, "Source and destination dictionary paths are required.");
+    return result;
+  }
+  if (CanonicalComparablePath(request.sourceDictionaryPath) ==
+      CanonicalComparablePath(result.destinationDictionaryPath)) {
+    AddError(result,
+             "Destination dictionary must be different from the source.");
+    return result;
+  }
+
+  auto rootOpt = ReadSourceJson(request, result);
+  if (!rootOpt)
+    return result;
+
+  const auto finalLayout = ActiveDictionaryStorage::BuildLayout(
+      request.kind, result.destinationDictionaryPath,
+      request.defaultDictionaryPath);
+  const fs::path stagingJson =
+      result.destinationDictionaryPath.string() + ".tmp";
+  const fs::path stagingAssets =
+      result.destinationDictionaryPath.parent_path() /
+      (result.destinationDictionaryPath.stem().string() + "_assets.tmp");
+  RemoveIfExists(stagingJson);
+  RemoveIfExists(stagingAssets);
+
+  std::error_code createParentError;
+  fs::create_directories(result.destinationDictionaryPath.parent_path(),
+                         createParentError);
+  if (createParentError) {
+    AddError(result, "Could not create destination directory: " +
+                         createParentError.message());
+    return result;
+  }
+
+  nlohmann::json root = std::move(*rootOpt);
+  RewriteEntries(request, finalLayout, stagingAssets, root, result);
+  if (!result.errors.empty()) {
+    RemoveIfExists(stagingJson);
+    RemoveIfExists(stagingAssets);
+    return result;
+  }
+  if (!WriteAndValidate(request, stagingJson, root, result)) {
+    RemoveIfExists(stagingJson);
+    RemoveIfExists(stagingAssets);
+    return result;
+  }
+
+  std::string backupError;
+  if (!BackupExistingPath(result.destinationDictionaryPath,
+                          result.backupDictionaryPath, backupError) ||
+      !BackupExistingPath(finalLayout.ownedAssetDirectory,
+                          result.backupAssetsPath, backupError)) {
+    AddError(result, backupError);
+    RemoveIfExists(stagingJson);
+    RemoveIfExists(stagingAssets);
+    return result;
+  }
+
+  std::error_code ec;
+  fs::rename(stagingJson, result.destinationDictionaryPath, ec);
+  if (ec) {
+    AddError(result, "Could not install duplicate dictionary: " + ec.message());
+    RestoreBackup(result.backupDictionaryPath,
+                  result.destinationDictionaryPath);
+    RestoreBackup(result.backupAssetsPath, finalLayout.ownedAssetDirectory);
+    RemoveIfExists(stagingJson);
+    RemoveIfExists(stagingAssets);
+    return result;
+  }
+  if (fs::exists(stagingAssets, ec) && !ec) {
+    fs::rename(stagingAssets, finalLayout.ownedAssetDirectory, ec);
+    if (ec) {
+      AddError(result, "Could not install duplicate assets: " + ec.message());
+      RemoveIfExists(result.destinationDictionaryPath);
+      RestoreBackup(result.backupDictionaryPath,
+                    result.destinationDictionaryPath);
+      RestoreBackup(result.backupAssetsPath, finalLayout.ownedAssetDirectory);
+      RemoveIfExists(stagingAssets);
+      return result;
+    }
+  }
+
+  result.success = true;
+  return result;
+}
+
+} // namespace DictionaryDuplicate

--- a/core/dictionary_duplicate.h
+++ b/core/dictionary_duplicate.h
@@ -1,0 +1,42 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+#pragma once
+
+#include "active_dictionary_storage.h"
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace DictionaryDuplicate {
+
+struct Request {
+  ActiveDictionaryStorage::DictionaryKind kind;
+  std::filesystem::path sourceDictionaryPath;
+  std::filesystem::path defaultDictionaryPath;
+  std::filesystem::path destinationDictionaryPath;
+};
+
+struct Result {
+  bool success = false;
+  std::filesystem::path destinationDictionaryPath;
+  std::filesystem::path backupDictionaryPath;
+  std::filesystem::path backupAssetsPath;
+  size_t copiedAssetCount = 0;
+  size_t unresolvedReferenceCount = 0;
+  std::vector<std::string> unresolvedReferences;
+  std::vector<std::string> errors;
+};
+
+std::filesystem::path
+BuildDefaultDuplicatePath(const std::filesystem::path &sourceDictionaryPath);
+Result DuplicateDictionary(const Request &request);
+
+} // namespace DictionaryDuplicate

--- a/docs/developer/dictionary_portable_bundle.md
+++ b/docs/developer/dictionary_portable_bundle.md
@@ -18,6 +18,7 @@ The Dictionary Editor exposes separate actions for active dictionary management:
 
 - **Open...** validates an existing JSON dictionary and switches the active path only after the selected file matches the current page type.
 - **New...** creates either an empty dictionary or a self-contained dictionary from application defaults, then activates it after validation succeeds.
+- **Duplicate Current...** creates an independent working copy of the active dictionary, copies resolvable owned assets into the duplicate's storage location, preserves unresolved references with a summary, validates the duplicate before activation, and lets the user choose whether to activate it immediately.
 - **Use Default** switches back to the managed user dictionary path for the current page type. It does not reset dictionary contents.
 
 These actions are distinct from importing snapshots, exporting snapshots, exporting portable bundles, and resetting the active dictionary contents.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -74,7 +74,7 @@ Perastage 1.5.0 is a substantial update focused on GDTF and truss editing, multi
 ## Important fixes
 
 - Improved Dictionary Editor reliability so fixture and truss edits are saved transactionally, unresolved file references remain visible and savable, dirty-state checks catch category/color/path/name changes, and failed saves keep the editor open.
-- Replaced the Dictionary Editor dictionary chooser with explicit **Open**, **New**, and **Use Default** workflows for fixture and truss dictionaries, including type validation before changing the active path.
+- Replaced the Dictionary Editor dictionary chooser with explicit **Open**, **New**, **Duplicate Current**, and **Use Default** workflows for fixture and truss dictionaries, including type validation before changing the active path and safe duplication of referenced assets.
 - Fixed custom fixture and truss dictionaries so newly owned GDTF assets are stored in a sibling `_assets` folder and remain portable when the dictionary is moved with that folder.
 - Fixed Data Views table edits so moving fixtures, trusses, or scene objects between visible and hidden layers rebuilds the relevant viewer resources, invalidates stale 3D visible-set caches, and immediately refreshes both the 2D and 3D viewports, including layout previews.
 - Fixed Windows build and linker issues in the Local Axes viewport integration.

--- a/docs/user/features.md
+++ b/docs/user/features.md
@@ -87,7 +87,8 @@ Additional safeguards include:
 - preflight path validation,
 - missing-reference reporting,
 - collision policy prompts for differing file content,
-- custom active dictionaries store newly owned fixture and truss assets in a sibling `<dictionary name>_assets` folder so the JSON and assets can be moved together.
+- custom active dictionaries store newly owned fixture and truss assets in a sibling `<dictionary name>_assets` folder so the JSON and assets can be moved together;
+- **Duplicate Current...** in the Dictionary Editor creates an independent copy of the active fixture or truss dictionary, including resolvable referenced assets, and can optionally activate the copy after validation.
 
 ## Patch, Data Tables, and Editing Helpers
 

--- a/gui/dictionary_selection_controls.cpp
+++ b/gui/dictionary_selection_controls.cpp
@@ -15,6 +15,7 @@ void BindButton(wxButton *button, const std::function<void()> &callback) {
 DictionarySelectionControls BuildDictionarySelectionControls(
     wxWindow *parent, wxSizer *parentSizer, const wxString &title,
     const std::function<void()> &onOpen, const std::function<void()> &onNew,
+    const std::function<void()> &onDuplicate,
     const std::function<void()> &onUseDefault) {
   DictionarySelectionControls controls;
   if (!parent || !parentSizer)
@@ -24,43 +25,48 @@ DictionarySelectionControls BuildDictionarySelectionControls(
   auto *row = new wxBoxSizer(wxHORIZONTAL);
   auto *buttonRow = new wxBoxSizer(wxHORIZONTAL);
 
-  controls.activeFileLabel = new wxStaticText(parent, wxID_ANY, "Dictionary: -");
+  controls.activeFileLabel =
+      new wxStaticText(parent, wxID_ANY, "Dictionary: -");
   controls.activePathLabel = new wxStaticText(parent, wxID_ANY, "Path: -");
   controls.openButton = new wxButton(parent, wxID_ANY, "Open...");
   controls.newButton = new wxButton(parent, wxID_ANY, "New...");
+  controls.duplicateButton =
+      new wxButton(parent, wxID_ANY, "Duplicate Current...");
   controls.useDefaultButton = new wxButton(parent, wxID_ANY, "Use Default");
 
   buttonRow->Add(controls.openButton, 0, wxRIGHT, 5);
   buttonRow->Add(controls.newButton, 0, wxRIGHT, 5);
+  buttonRow->Add(controls.duplicateButton, 0, wxRIGHT, 5);
   buttonRow->Add(controls.useDefaultButton, 0);
 
   row->Add(controls.activeFileLabel, 1, wxALIGN_CENTER_VERTICAL | wxRIGHT, 10);
   row->Add(buttonRow, 0, wxALIGN_CENTER_VERTICAL);
 
   wrapper->Add(row, 0, wxEXPAND | wxALL, 6);
-  wrapper->Add(controls.activePathLabel, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM,
-               6);
+  wrapper->Add(controls.activePathLabel, 0,
+               wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 6);
   parentSizer->Add(wrapper, 0, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, 8);
 
   BindButton(controls.openButton, onOpen);
   BindButton(controls.newButton, onNew);
+  BindButton(controls.duplicateButton, onDuplicate);
   BindButton(controls.useDefaultButton, onUseDefault);
   return controls;
 }
 
 // Updates the active dictionary file and path labels.
-void UpdateDictionarySelectionControls(const DictionarySelectionControls &controls,
-                                       const wxString &fileName,
-                                       const wxString &fullPath) {
+void UpdateDictionarySelectionControls(
+    const DictionarySelectionControls &controls, const wxString &fileName,
+    const wxString &fullPath) {
   if (controls.activeFileLabel) {
     controls.activeFileLabel->SetLabel(
         fileName.IsEmpty() ? wxString("Dictionary: -")
                            : wxString("Dictionary: ") + fileName);
   }
   if (controls.activePathLabel) {
-    controls.activePathLabel->SetLabel(
-        fullPath.IsEmpty() ? wxString("Path: -")
-                           : wxString("Path: ") + fullPath);
+    controls.activePathLabel->SetLabel(fullPath.IsEmpty()
+                                           ? wxString("Path: -")
+                                           : wxString("Path: ") + fullPath);
     controls.activePathLabel->SetToolTip(fullPath);
   }
 }

--- a/gui/dictionary_selection_controls.h
+++ b/gui/dictionary_selection_controls.h
@@ -12,14 +12,16 @@ struct DictionarySelectionControls {
   wxStaticText *activePathLabel = nullptr;
   wxButton *openButton = nullptr;
   wxButton *newButton = nullptr;
+  wxButton *duplicateButton = nullptr;
   wxButton *useDefaultButton = nullptr;
 };
 
 DictionarySelectionControls BuildDictionarySelectionControls(
     wxWindow *parent, wxSizer *parentSizer, const wxString &title,
     const std::function<void()> &onOpen, const std::function<void()> &onNew,
+    const std::function<void()> &onDuplicate,
     const std::function<void()> &onUseDefault);
 
-void UpdateDictionarySelectionControls(const DictionarySelectionControls &controls,
-                                       const wxString &fileName,
-                                       const wxString &fullPath);
+void UpdateDictionarySelectionControls(
+    const DictionarySelectionControls &controls, const wxString &fileName,
+    const wxString &fullPath);

--- a/gui/dictionaryeditdialog.cpp
+++ b/gui/dictionaryeditdialog.cpp
@@ -17,6 +17,7 @@
  */
 #include "dictionaryeditdialog.h"
 #include "active_dictionary_storage.h"
+#include "dictionary_duplicate.h"
 #include "dictionary_editor_state.h"
 #include "filesystem_path_utils.h"
 
@@ -102,7 +103,7 @@ std::string ExtractFixtureVisualColorText(const wxVariant &value) {
 std::string NormalizeFixtureModeKey(std::string value) {
   std::transform(
       value.begin(), value.end(), value.begin(),
-                 [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+      [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
   value.erase(std::remove_if(value.begin(), value.end(),
                              [](unsigned char ch) {
                                return std::isspace(ch) != 0 || ch == '_' ||
@@ -132,7 +133,7 @@ bool FixturePathsMatchForColorFamily(const std::string &lhs,
 }
 
 void SetFixtureVisualColorCell(wxDataViewListCtrl *table, int row,
-                         const std::string &hexColor) {
+                               const std::string &hexColor) {
   if (!table || row == wxNOT_FOUND)
     return;
 
@@ -344,10 +345,10 @@ bool ConfirmExportReferences(wxWindow *parent, const wxString &title,
   wxString message = "Found file references in the loaded dictionary.\n\n"
                      "Total entries: " +
                      wxString::Format("%zu", summary.total_entries) + "\n" +
-      "Entries with file found: " +
-      wxString::Format("%zu", summary.found_entries) + "\n" +
-      "Entries with missing file: " +
-      wxString::Format("%zu", summary.missing_entries);
+                     "Entries with file found: " +
+                     wxString::Format("%zu", summary.found_entries) + "\n" +
+                     "Entries with missing file: " +
+                     wxString::Format("%zu", summary.missing_entries);
   if (!summary.missing_files.empty()) {
     message += "\nMissing files:";
     for (const auto &file : summary.missing_files)
@@ -419,8 +420,8 @@ std::optional<std::string> CopySnapshotAsset(
 template <typename GatherPathsFn>
 SnapshotExportConflictResolution
 ResolveExportConflicts(wxWindow *parent, const wxString &title,
-    const std::filesystem::path &outputPath,
-    GatherPathsFn &&gatherSourcePaths) {
+                       const std::filesystem::path &outputPath,
+                       GatherPathsFn &&gatherSourcePaths) {
   SnapshotExportConflictResolution resolution;
   const std::filesystem::path outputDir = outputPath.parent_path();
 
@@ -684,7 +685,8 @@ std::optional<CopiedLibraryAsset> CopyToLibrary(wxWindow *parent,
       isFixtures ? GdtfDictionary::GetActiveDictionaryFilePath()
                  : TrussDictionary::GetActiveDictionaryFilePath());
   const std::filesystem::path defaultDictionaryPath =
-      PathUtils::PathFromUtf8(ProjectUtils::GetWritableLibraryPath(libraryName)) /
+      PathUtils::PathFromUtf8(
+          ProjectUtils::GetWritableLibraryPath(libraryName)) /
       (isFixtures ? "gdtf_dictionary.json" : "truss_dictionary.json");
   if (activeDictionaryPath.empty() || defaultDictionaryPath.empty())
     return CopiedLibraryAsset{path, {}};
@@ -711,10 +713,15 @@ std::optional<CopiedLibraryAsset> CopyToLibrary(wxWindow *parent,
     }
   }
 
-  const auto copyResult = ActiveDictionaryStorage::CopyAssetIntoDictionaryStorage(
-      {isFixtures ? ActiveDictionaryStorage::DictionaryKind::Fixtures
-                  : ActiveDictionaryStorage::DictionaryKind::Trusses,
-       activeDictionaryPath, defaultDictionaryPath, src, {}, policy});
+  const auto copyResult =
+      ActiveDictionaryStorage::CopyAssetIntoDictionaryStorage(
+          {isFixtures ? ActiveDictionaryStorage::DictionaryKind::Fixtures
+                      : ActiveDictionaryStorage::DictionaryKind::Trusses,
+           activeDictionaryPath,
+           defaultDictionaryPath,
+           src,
+           {},
+           policy});
   if (!copyResult.success)
     return std::nullopt;
 
@@ -879,9 +886,35 @@ bool SaveFixturesSnapshotToFile(
   return true;
 }
 
+// Summarizes the result of a completed dictionary duplication.
+wxString BuildDuplicateSummary(const DictionaryDuplicate::Result &result) {
+  wxString message = "Dictionary duplicated successfully.";
+  message +=
+      "\nCopied assets: " + wxString::Format("%zu", result.copiedAssetCount);
+  if (result.unresolvedReferenceCount > 0) {
+    message += "\nUnresolved references preserved: " +
+               wxString::Format("%zu", result.unresolvedReferenceCount);
+    const size_t shown =
+        std::min<size_t>(result.unresolvedReferences.size(), 5);
+    for (size_t i = 0; i < shown; ++i)
+      message += "\n- " + wxString::FromUTF8(result.unresolvedReferences[i]);
+    if (result.unresolvedReferences.size() > shown)
+      message += "\n- ...";
+  }
+  return message;
+}
+
+// Summarizes fatal dictionary duplication errors.
+wxString BuildDuplicateErrorSummary(const DictionaryDuplicate::Result &result) {
+  wxString message = "Could not duplicate the dictionary.";
+  for (const auto &error : result.errors)
+    message += "\n- " + wxString::FromUTF8(error);
+  return message;
+}
+
 bool SaveTrussesSnapshotToFile(
     wxWindow *parent, const std::string &outputPath,
-                               const std::unordered_map<std::string, std::string> &dict,
+    const std::unordered_map<std::string, std::string> &dict,
     bool copyReferencedAssets, SnapshotExportResult &exportResult) {
   std::vector<std::string> keys;
   keys.reserve(dict.size());
@@ -1001,6 +1034,10 @@ void DictionaryEditDialog::BuildLayout() {
       },
       [this]() {
         wxCommandEvent dummy;
+        OnDuplicateFixturesDictionary(dummy);
+      },
+      [this]() {
+        wxCommandEvent dummy;
         OnUseDefaultFixturesDictionary(dummy);
       });
   fixtureSizer->Add(fixtureTable, 1, wxEXPAND | wxALL, 8);
@@ -1035,6 +1072,10 @@ void DictionaryEditDialog::BuildLayout() {
       [this]() {
         wxCommandEvent dummy;
         OnNewTrussesDictionary(dummy);
+      },
+      [this]() {
+        wxCommandEvent dummy;
+        OnDuplicateTrussesDictionary(dummy);
       },
       [this]() {
         wxCommandEvent dummy;
@@ -1098,7 +1139,7 @@ bool DictionaryEditDialog::IsFixturesPage() const {
 void DictionaryEditDialog::OnFixtureTableMouseMove(wxMouseEvent &event) {
   UpdateMissingFileTooltip(fixtureTable, fixtureStore,
                            activeFixtureHoverTooltip,
-      NormalizeMousePositionForTable(fixtureTable, event));
+                           NormalizeMousePositionForTable(fixtureTable, event));
   event.Skip();
 }
 
@@ -1112,7 +1153,7 @@ void DictionaryEditDialog::OnFixtureTableMouseLeave(wxMouseEvent &event) {
 
 void DictionaryEditDialog::OnTrussTableMouseMove(wxMouseEvent &event) {
   UpdateMissingFileTooltip(trussTable, trussStore, activeTrussHoverTooltip,
-      NormalizeMousePositionForTable(trussTable, event));
+                           NormalizeMousePositionForTable(trussTable, event));
   event.Skip();
 }
 
@@ -1286,7 +1327,8 @@ bool DictionaryEditDialog::HasTrussChanges() const {
   return BuildTrussSnapshotFromUi() != trussSnapshotAtLoad;
 }
 
-// Prompts for pending table edits before a reload or dictionary mutation continues.
+// Prompts for pending table edits before a reload or dictionary mutation
+// continues.
 bool DictionaryEditDialog::ConfirmDirtyChangesBeforeReload(
     const wxString &operationLabel) {
   const bool fixtureChanged = HasFixtureChanges();
@@ -1367,7 +1409,8 @@ void DictionaryEditDialog::RefreshDictionarySelectionLabels() {
 }
 
 // Opens an existing fixtures dictionary after validating its contract.
-void DictionaryEditDialog::OnOpenFixturesDictionary(wxCommandEvent &WXUNUSED(event)) {
+void DictionaryEditDialog::OnOpenFixturesDictionary(
+    wxCommandEvent &WXUNUSED(event)) {
   if (!ConfirmDirtyChangesBeforeReload("opening a fixtures dictionary"))
     return;
   const std::filesystem::path currentPath =
@@ -1391,7 +1434,8 @@ void DictionaryEditDialog::OnOpenFixturesDictionary(wxCommandEvent &WXUNUSED(eve
 }
 
 // Opens an existing trusses dictionary after validating its contract.
-void DictionaryEditDialog::OnOpenTrussesDictionary(wxCommandEvent &WXUNUSED(event)) {
+void DictionaryEditDialog::OnOpenTrussesDictionary(
+    wxCommandEvent &WXUNUSED(event)) {
   if (!ConfirmDirtyChangesBeforeReload("opening a trusses dictionary"))
     return;
   const std::filesystem::path currentPath =
@@ -1415,14 +1459,16 @@ void DictionaryEditDialog::OnOpenTrussesDictionary(wxCommandEvent &WXUNUSED(even
 }
 
 // Creates and activates a new fixtures dictionary.
-void DictionaryEditDialog::OnNewFixturesDictionary(wxCommandEvent &WXUNUSED(event)) {
+void DictionaryEditDialog::OnNewFixturesDictionary(
+    wxCommandEvent &WXUNUSED(event)) {
   if (!ConfirmDirtyChangesBeforeReload("creating a fixtures dictionary"))
     return;
   wxArrayString choices;
   choices.Add("Empty dictionary");
   choices.Add("From application defaults");
-  wxSingleChoiceDialog choiceDialog(this, "Choose how to create the new fixtures dictionary.",
-                                    "New fixtures dictionary", choices);
+  wxSingleChoiceDialog choiceDialog(
+      this, "Choose how to create the new fixtures dictionary.",
+      "New fixtures dictionary", choices);
   if (choiceDialog.ShowModal() != wxID_OK)
     return;
   wxFileDialog dialog(this, "Create fixtures dictionary", wxString(),
@@ -1437,9 +1483,12 @@ void DictionaryEditDialog::OnNewFixturesDictionary(wxCommandEvent &WXUNUSED(even
     selectedPath += ".json";
   std::string error;
   const bool created = choiceDialog.GetSelection() == 0
-                           ? GdtfDictionary::CreateEmptyDictionaryFile(selectedPath.string(), &error)
-                           : GdtfDictionary::CreateDictionaryFileFromDefaults(selectedPath.string(), &error);
-  if (!created || !GdtfDictionary::SetActiveDictionaryFilePath(selectedPath.string(), &error)) {
+                           ? GdtfDictionary::CreateEmptyDictionaryFile(
+                                 selectedPath.string(), &error)
+                           : GdtfDictionary::CreateDictionaryFileFromDefaults(
+                                 selectedPath.string(), &error);
+  if (!created || !GdtfDictionary::SetActiveDictionaryFilePath(
+                      selectedPath.string(), &error)) {
     wxMessageBox("Could not create fixtures dictionary.\n\n" +
                      wxString::FromUTF8(error),
                  "New dictionary", wxOK | wxICON_ERROR, this);
@@ -1450,14 +1499,16 @@ void DictionaryEditDialog::OnNewFixturesDictionary(wxCommandEvent &WXUNUSED(even
 }
 
 // Creates and activates a new trusses dictionary.
-void DictionaryEditDialog::OnNewTrussesDictionary(wxCommandEvent &WXUNUSED(event)) {
+void DictionaryEditDialog::OnNewTrussesDictionary(
+    wxCommandEvent &WXUNUSED(event)) {
   if (!ConfirmDirtyChangesBeforeReload("creating a trusses dictionary"))
     return;
   wxArrayString choices;
   choices.Add("Empty dictionary");
   choices.Add("From application defaults");
-  wxSingleChoiceDialog choiceDialog(this, "Choose how to create the new trusses dictionary.",
-                                    "New trusses dictionary", choices);
+  wxSingleChoiceDialog choiceDialog(
+      this, "Choose how to create the new trusses dictionary.",
+      "New trusses dictionary", choices);
   if (choiceDialog.ShowModal() != wxID_OK)
     return;
   wxFileDialog dialog(this, "Create trusses dictionary", wxString(),
@@ -1472,9 +1523,12 @@ void DictionaryEditDialog::OnNewTrussesDictionary(wxCommandEvent &WXUNUSED(event
     selectedPath += ".json";
   std::string error;
   const bool created = choiceDialog.GetSelection() == 0
-                           ? TrussDictionary::CreateEmptyDictionaryFile(selectedPath.string(), &error)
-                           : TrussDictionary::CreateDictionaryFileFromDefaults(selectedPath.string(), &error);
-  if (!created || !TrussDictionary::SetActiveDictionaryFilePath(selectedPath.string(), &error)) {
+                           ? TrussDictionary::CreateEmptyDictionaryFile(
+                                 selectedPath.string(), &error)
+                           : TrussDictionary::CreateDictionaryFileFromDefaults(
+                                 selectedPath.string(), &error);
+  if (!created || !TrussDictionary::SetActiveDictionaryFilePath(
+                      selectedPath.string(), &error)) {
     wxMessageBox("Could not create trusses dictionary.\n\n" +
                      wxString::FromUTF8(error),
                  "New dictionary", wxOK | wxICON_ERROR, this);
@@ -1484,9 +1538,128 @@ void DictionaryEditDialog::OnNewTrussesDictionary(wxCommandEvent &WXUNUSED(event
   LoadTrusses();
 }
 
+// Duplicates the active fixtures dictionary and optionally activates it.
+void DictionaryEditDialog::OnDuplicateFixturesDictionary(
+    wxCommandEvent &WXUNUSED(event)) {
+  if (!ConfirmDirtyChangesBeforeReload("duplicating the fixtures dictionary"))
+    return;
+  const std::filesystem::path currentPath =
+      PathUtils::PathFromUtf8(GdtfDictionary::GetActiveDictionaryFilePath());
+  const std::filesystem::path defaultPath =
+      PathUtils::PathFromUtf8(
+          ProjectUtils::GetWritableLibraryPath("fixtures")) /
+      "gdtf_dictionary.json";
+  wxFileDialog dialog(
+      this, "Duplicate fixtures dictionary",
+      wxString::FromUTF8(currentPath.parent_path().string()),
+      wxString::FromUTF8(
+          DictionaryDuplicate::BuildDefaultDuplicatePath(currentPath)
+              .filename()
+              .string()),
+      "JSON dictionary files (*.json)|*.json",
+      wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
+  if (dialog.ShowModal() != wxID_OK)
+    return;
+  std::filesystem::path selectedPath =
+      PathUtils::PathFromUtf8(std::string(dialog.GetPath().ToUTF8()));
+  if (selectedPath.extension() != ".json")
+    selectedPath.replace_extension(".json");
+
+  const auto result = DictionaryDuplicate::DuplicateDictionary(
+      {ActiveDictionaryStorage::DictionaryKind::Fixtures, currentPath,
+       defaultPath, selectedPath});
+  if (!result.success) {
+    wxMessageBox(BuildDuplicateErrorSummary(result),
+                 "Duplicate fixtures dictionary", wxOK | wxICON_ERROR, this);
+    RefreshDictionarySelectionLabels();
+    return;
+  }
+
+  wxMessageDialog activateDialog(
+      this,
+      BuildDuplicateSummary(result) +
+          "\n\nDo you want to activate the duplicate now?",
+      "Duplicate fixtures dictionary", wxYES_NO | wxICON_QUESTION);
+  activateDialog.SetYesNoLabels("Activate duplicate", "Keep current");
+  if (activateDialog.ShowModal() == wxID_YES) {
+    std::string error;
+    if (!GdtfDictionary::SetActiveDictionaryFilePath(selectedPath.string(),
+                                                     &error)) {
+      wxMessageBox("The duplicate was created but could not be activated.\n\n" +
+                       wxString::FromUTF8(error),
+                   "Duplicate fixtures dictionary", wxOK | wxICON_ERROR, this);
+      RefreshDictionarySelectionLabels();
+      return;
+    }
+    LoadFixtures();
+    return;
+  }
+  RefreshDictionarySelectionLabels();
+}
+
+// Duplicates the active trusses dictionary and optionally activates it.
+void DictionaryEditDialog::OnDuplicateTrussesDictionary(
+    wxCommandEvent &WXUNUSED(event)) {
+  if (!ConfirmDirtyChangesBeforeReload("duplicating the trusses dictionary"))
+    return;
+  const std::filesystem::path currentPath =
+      PathUtils::PathFromUtf8(TrussDictionary::GetActiveDictionaryFilePath());
+  const std::filesystem::path defaultPath =
+      PathUtils::PathFromUtf8(ProjectUtils::GetWritableLibraryPath("trusses")) /
+      "truss_dictionary.json";
+  wxFileDialog dialog(
+      this, "Duplicate trusses dictionary",
+      wxString::FromUTF8(currentPath.parent_path().string()),
+      wxString::FromUTF8(
+          DictionaryDuplicate::BuildDefaultDuplicatePath(currentPath)
+              .filename()
+              .string()),
+      "JSON dictionary files (*.json)|*.json",
+      wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
+  if (dialog.ShowModal() != wxID_OK)
+    return;
+  std::filesystem::path selectedPath =
+      PathUtils::PathFromUtf8(std::string(dialog.GetPath().ToUTF8()));
+  if (selectedPath.extension() != ".json")
+    selectedPath.replace_extension(".json");
+
+  const auto result = DictionaryDuplicate::DuplicateDictionary(
+      {ActiveDictionaryStorage::DictionaryKind::Trusses, currentPath,
+       defaultPath, selectedPath});
+  if (!result.success) {
+    wxMessageBox(BuildDuplicateErrorSummary(result),
+                 "Duplicate trusses dictionary", wxOK | wxICON_ERROR, this);
+    RefreshDictionarySelectionLabels();
+    return;
+  }
+
+  wxMessageDialog activateDialog(
+      this,
+      BuildDuplicateSummary(result) +
+          "\n\nDo you want to activate the duplicate now?",
+      "Duplicate trusses dictionary", wxYES_NO | wxICON_QUESTION);
+  activateDialog.SetYesNoLabels("Activate duplicate", "Keep current");
+  if (activateDialog.ShowModal() == wxID_YES) {
+    std::string error;
+    if (!TrussDictionary::SetActiveDictionaryFilePath(selectedPath.string(),
+                                                      &error)) {
+      wxMessageBox("The duplicate was created but could not be activated.\n\n" +
+                       wxString::FromUTF8(error),
+                   "Duplicate trusses dictionary", wxOK | wxICON_ERROR, this);
+      RefreshDictionarySelectionLabels();
+      return;
+    }
+    LoadTrusses();
+    return;
+  }
+  RefreshDictionarySelectionLabels();
+}
+
 // Switches fixtures back to the managed default dictionary path.
-void DictionaryEditDialog::OnUseDefaultFixturesDictionary(wxCommandEvent &WXUNUSED(event)) {
-  if (!ConfirmDirtyChangesBeforeReload("using the default fixtures dictionary path"))
+void DictionaryEditDialog::OnUseDefaultFixturesDictionary(
+    wxCommandEvent &WXUNUSED(event)) {
+  if (!ConfirmDirtyChangesBeforeReload(
+          "using the default fixtures dictionary path"))
     return;
   std::string error;
   if (!GdtfDictionary::SetActiveDictionaryFilePath({}, &error)) {
@@ -1499,8 +1672,10 @@ void DictionaryEditDialog::OnUseDefaultFixturesDictionary(wxCommandEvent &WXUNUS
 }
 
 // Switches trusses back to the managed default dictionary path.
-void DictionaryEditDialog::OnUseDefaultTrussesDictionary(wxCommandEvent &WXUNUSED(event)) {
-  if (!ConfirmDirtyChangesBeforeReload("using the default trusses dictionary path"))
+void DictionaryEditDialog::OnUseDefaultTrussesDictionary(
+    wxCommandEvent &WXUNUSED(event)) {
+  if (!ConfirmDirtyChangesBeforeReload(
+          "using the default trusses dictionary path"))
     return;
   std::string error;
   if (!TrussDictionary::SetActiveDictionaryFilePath({}, &error)) {
@@ -1886,7 +2061,7 @@ bool DictionaryEditDialog::ImportFixturesDictionary() {
   }
   const std::string importPath =
       preparedImport.is_bundle ? preparedImport.rewritten_snapshot_path.string()
-                                     : selectedPath;
+                               : selectedPath;
   const auto validationPreview = GdtfDictionary::PreviewImportFromFile(
       importPath, DictionaryImportPolicy::AddMissing);
   if (validationPreview.HasErrors()) {
@@ -1931,10 +2106,10 @@ bool DictionaryEditDialog::ImportFixturesDictionary() {
   const bool hasErrors = result.HasErrors();
   wxMessageBox((hasErrors
                     ? "Fixtures dictionary import finished with errors.\n\n"
-                 : "Fixtures dictionary import completed.\n\n") +
-          BuildSummaryText(result),
-      "Fixtures dictionary import",
-      wxOK | (hasErrors ? wxICON_WARNING : wxICON_INFORMATION), this);
+                    : "Fixtures dictionary import completed.\n\n") +
+                   BuildSummaryText(result),
+               "Fixtures dictionary import",
+               wxOK | (hasErrors ? wxICON_WARNING : wxICON_INFORMATION), this);
   return !result.HasErrors();
 }
 
@@ -1963,7 +2138,7 @@ bool DictionaryEditDialog::ImportTrussesDictionary() {
   }
   const std::string importPath =
       preparedImport.is_bundle ? preparedImport.rewritten_snapshot_path.string()
-                                     : selectedPath;
+                               : selectedPath;
   const auto validationPreview = TrussDictionary::PreviewImportFromFile(
       importPath, DictionaryImportPolicy::AddMissing);
   if (validationPreview.HasErrors()) {
@@ -2008,10 +2183,10 @@ bool DictionaryEditDialog::ImportTrussesDictionary() {
   const bool hasErrors = result.HasErrors();
   wxMessageBox((hasErrors
                     ? "Trusses dictionary import finished with errors.\n\n"
-                 : "Trusses dictionary import completed.\n\n") +
-          BuildSummaryText(result),
-      "Trusses dictionary import",
-      wxOK | (hasErrors ? wxICON_WARNING : wxICON_INFORMATION), this);
+                    : "Trusses dictionary import completed.\n\n") +
+                   BuildSummaryText(result),
+               "Trusses dictionary import",
+               wxOK | (hasErrors ? wxICON_WARNING : wxICON_INFORMATION), this);
   return !result.HasErrors();
 }
 
@@ -2231,8 +2406,8 @@ bool DictionaryEditDialog::ExportTrussesPortableBundle() {
 
 bool DictionaryEditDialog::ResetFixturesDictionaryToDefault() {
   if (wxMessageBox("Reset fixtures dictionary to application defaults?\n"
-          "Current entries will be replaced.",
-          "Reset fixtures dictionary",
+                   "Current entries will be replaced.",
+                   "Reset fixtures dictionary",
                    wxYES_NO | wxNO_DEFAULT | wxICON_WARNING, this) != wxYES) {
     return false;
   }
@@ -2245,17 +2420,17 @@ bool DictionaryEditDialog::ResetFixturesDictionaryToDefault() {
   const bool hasErrors = result.HasErrors();
   wxMessageBox((hasErrors
                     ? "Fixtures dictionary reset finished with errors.\n\n"
-                 : "Fixtures dictionary restored to defaults.\n\n") +
-          BuildSummaryText(result),
-      "Reset fixtures dictionary",
-      wxOK | (hasErrors ? wxICON_WARNING : wxICON_INFORMATION), this);
+                    : "Fixtures dictionary restored to defaults.\n\n") +
+                   BuildSummaryText(result),
+               "Reset fixtures dictionary",
+               wxOK | (hasErrors ? wxICON_WARNING : wxICON_INFORMATION), this);
   return !result.HasErrors();
 }
 
 bool DictionaryEditDialog::ResetTrussesDictionaryToDefault() {
   if (wxMessageBox("Reset trusses dictionary to application defaults?\n"
-          "Current entries will be replaced.",
-          "Reset trusses dictionary",
+                   "Current entries will be replaced.",
+                   "Reset trusses dictionary",
                    wxYES_NO | wxNO_DEFAULT | wxICON_WARNING, this) != wxYES) {
     return false;
   }
@@ -2267,10 +2442,10 @@ bool DictionaryEditDialog::ResetTrussesDictionaryToDefault() {
   LoadTrusses();
   const bool hasErrors = result.HasErrors();
   wxMessageBox((hasErrors ? "Trusses dictionary reset finished with errors.\n\n"
-                 : "Trusses dictionary restored to defaults.\n\n") +
-          BuildSummaryText(result),
-      "Reset trusses dictionary",
-      wxOK | (hasErrors ? wxICON_WARNING : wxICON_INFORMATION), this);
+                          : "Trusses dictionary restored to defaults.\n\n") +
+                   BuildSummaryText(result),
+               "Reset trusses dictionary",
+               wxOK | (hasErrors ? wxICON_WARNING : wxICON_INFORMATION), this);
   return !result.HasErrors();
 }
 
@@ -2313,9 +2488,9 @@ void DictionaryEditDialog::OnItemActivated(wxDataViewEvent &event) {
       wxVariant current;
       table->GetValue(current, row, col);
       const wxArrayString choices = {
-          "Beam",         "Blinder", "Conventional", "FX",    "Hoist",
-          "Hybrid",       "Laser",   "LED",          "Smoke", "Spot",
-          "Strobe",       "Unknown", "Video",        "Wash"};
+          "Beam",   "Blinder", "Conventional", "FX",    "Hoist",
+          "Hybrid", "Laser",   "LED",          "Smoke", "Spot",
+          "Strobe", "Unknown", "Video",        "Wash"};
       wxSingleChoiceDialog dlg(this, "Select category", "Category", choices);
       if (!current.GetString().empty()) {
         const int currentSelection = choices.Index(current.GetString());
@@ -2326,7 +2501,7 @@ void DictionaryEditDialog::OnItemActivated(wxDataViewEvent &event) {
         return;
       const std::string selectedCategory =
           GdtfFixtureCategory::NormalizeCategory(
-          std::string(dlg.GetStringSelection().ToUTF8()));
+              std::string(dlg.GetStringSelection().ToUTF8()));
       if (selectedCategory.empty())
         return;
       UpdateFixtureCategoryForFile(row, selectedCategory);
@@ -2357,8 +2532,8 @@ void DictionaryEditDialog::OnItemActivated(wxDataViewEvent &event) {
       return;
     wxFileDialog fdlg(
         this, "Select GDTF file",
-                      wxString::FromUTF8(ProjectUtils::GetWritableLibraryPath("fixtures")),
-                      wxEmptyString, "*.gdtf", wxFD_OPEN | wxFD_FILE_MUST_EXIST);
+        wxString::FromUTF8(ProjectUtils::GetWritableLibraryPath("fixtures")),
+        wxEmptyString, "*.gdtf", wxFD_OPEN | wxFD_FILE_MUST_EXIST);
     if (fdlg.ShowModal() != wxID_OK)
       return;
     wxString path = fdlg.GetPath();
@@ -2367,8 +2542,8 @@ void DictionaryEditDialog::OnItemActivated(wxDataViewEvent &event) {
       fixturePaths.resize(row + 1);
     fixturePaths[row] = fullPath;
     table->SetValue(wxVariant(wxString::FromUTF8(
-            std::filesystem::path(fullPath).filename().string())),
-        row, kFixtureFileColumn);
+                        std::filesystem::path(fullPath).filename().string())),
+                    row, kFixtureFileColumn);
 
     std::string mode;
     auto modes = GetSortedModes(fullPath);
@@ -2388,12 +2563,12 @@ void DictionaryEditDialog::OnItemActivated(wxDataViewEvent &event) {
       return;
     wxFileDialog fdlg(
         this, "Select Truss file",
-                      wxString::FromUTF8(ProjectUtils::GetWritableLibraryPath("trusses")),
-                      wxEmptyString,
+        wxString::FromUTF8(ProjectUtils::GetWritableLibraryPath("trusses")),
+        wxEmptyString,
         "Truss files "
         "(*.gdtf;*.gtruss;*.3ds;*.glb)|*.gdtf;*.gtruss;*.3ds;*.glb|All "
         "files|*.*",
-                      wxFD_OPEN | wxFD_FILE_MUST_EXIST);
+        wxFD_OPEN | wxFD_FILE_MUST_EXIST);
     if (fdlg.ShowModal() != wxID_OK)
       return;
     wxString path = fdlg.GetPath();

--- a/gui/dictionaryeditdialog.h
+++ b/gui/dictionaryeditdialog.h
@@ -21,8 +21,8 @@
 #include <wx/notebook.h>
 #include <wx/wx.h>
 
-#include "dictionary_selection_controls.h"
 #include "dictionary_editor_state.h"
+#include "dictionary_selection_controls.h"
 
 #include <string>
 #include <vector>
@@ -63,6 +63,8 @@ private:
   void OnOpenTrussesDictionary(wxCommandEvent &event);
   void OnNewFixturesDictionary(wxCommandEvent &event);
   void OnNewTrussesDictionary(wxCommandEvent &event);
+  void OnDuplicateFixturesDictionary(wxCommandEvent &event);
+  void OnDuplicateTrussesDictionary(wxCommandEvent &event);
   void OnUseDefaultFixturesDictionary(wxCommandEvent &event);
   void OnUseDefaultTrussesDictionary(wxCommandEvent &event);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1784,6 +1784,16 @@ target_include_directories(layer_service_utf8_test PRIVATE ../core ../models)
 target_link_libraries(layer_service_utf8_test PRIVATE ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
 add_test(NAME LayerServiceUtf8 COMMAND layer_service_utf8_test)
 
+
+add_executable(dictionary_duplicate_test
+               dictionary_duplicate_test.cpp
+               ../core/dictionary_duplicate.cpp
+               ../core/active_dictionary_storage.cpp
+               ../core/file_import_utils.cpp
+               ../core/filesystem_path_utils.cpp)
+target_include_directories(dictionary_duplicate_test PRIVATE ../core ../third_party)
+add_test(NAME DictionaryDuplicate COMMAND dictionary_duplicate_test)
+
 add_executable(active_dictionary_storage_test active_dictionary_storage_test.cpp)
 target_include_directories(active_dictionary_storage_test PRIVATE ../core ../third_party)
 target_link_libraries(active_dictionary_storage_test PRIVATE perastage_test_active_dictionary_storage)

--- a/tests/dictionary_duplicate_test.cpp
+++ b/tests/dictionary_duplicate_test.cpp
@@ -1,0 +1,183 @@
+#include "dictionary_duplicate.h"
+#include "dictionary_json_contract.h"
+
+#include <cassert>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+
+namespace fs = std::filesystem;
+
+// Writes text content to a test file.
+static void WriteText(const fs::path &path, const std::string &text) {
+  fs::create_directories(path.parent_path());
+  std::ofstream out(path);
+  out << text;
+}
+
+// Reads a JSON document from a test file.
+static nlohmann::json ReadJson(const fs::path &path) {
+  std::ifstream in(path);
+  nlohmann::json root;
+  in >> root;
+  return root;
+}
+
+// Creates a clean temporary root for dictionary duplication tests.
+static fs::path ResetRoot() {
+  const fs::path root =
+      fs::temp_directory_path() / "perastage_dictionary_duplicate_test";
+  std::error_code ec;
+  fs::remove_all(root, ec);
+  fs::create_directories(root);
+  return root;
+}
+
+// Verifies fixture dictionary duplication copies assets and metadata
+// independently.
+static void TestDuplicateFixturesCopiesAssetsAndMetadata() {
+  const fs::path root = ResetRoot();
+  const fs::path source = root / "source" / "fixtures.json";
+  const fs::path assets = root / "source" / "fixtures_assets";
+  WriteText(assets / "a.gdtf", "fixture-a");
+  WriteText(assets / "b.gdtf", "fixture-b");
+  nlohmann::json entries = nlohmann::json::object();
+  entries["A"] = {{"file", "a.gdtf"},
+                  {"mode", "Mode 1"},
+                  {"category", "Wash"},
+                  {"visual_color", "#112233"},
+                  {"imported_at", "2026-01-01T00:00:00Z"},
+                  {"sha256", "abc"}};
+  entries["B"] = {{"file", "b.gdtf"},
+                  {"mode", "Mode 2"},
+                  {"category", "Spot"},
+                  {"visual_color", "#445566"}};
+  WriteText(source,
+            DictionaryJsonContract::MakeRoot("fixtures", entries).dump(4));
+
+  const fs::path dest = root / "duplicate" / "fixtures_copy.json";
+  const auto result = DictionaryDuplicate::DuplicateDictionary(
+      {ActiveDictionaryStorage::DictionaryKind::Fixtures, source,
+       root / "default" / "gdtf_dictionary.json", dest});
+  assert(result.success);
+  assert(result.copiedAssetCount == 2);
+  assert(fs::exists(root / "duplicate" / "fixtures_copy_assets" / "a.gdtf"));
+  assert(fs::exists(root / "duplicate" / "fixtures_copy_assets" / "b.gdtf"));
+
+  auto duplicated = ReadJson(dest);
+  assert(duplicated["entries"]["A"]["file"] == "a.gdtf");
+  assert(duplicated["entries"]["A"]["mode"] == "Mode 1");
+  assert(duplicated["entries"]["A"]["category"] == "Wash");
+  assert(duplicated["entries"]["A"]["visual_color"] == "#112233");
+  assert(duplicated["entries"]["A"]["imported_at"] == "2026-01-01T00:00:00Z");
+  assert(duplicated["entries"]["A"]["sha256"] == "abc");
+
+  fs::remove_all(source.parent_path());
+  std::string error;
+  assert(
+      DictionaryJsonContract::GetEntriesForType(duplicated, "fixtures", error));
+  assert(fs::exists(root / "duplicate" / "fixtures_copy_assets" / "a.gdtf"));
+}
+
+// Verifies truss dictionary duplication copies multiple files and preserves
+// metadata.
+static void TestDuplicateTrussesCopiesAssetsAndMetadata() {
+  const fs::path root = ResetRoot();
+  const fs::path source = root / "source" / "trusses.json";
+  const fs::path assets = root / "source" / "trusses_assets";
+  WriteText(assets / "box.gdtf", "box");
+  WriteText(assets / "tri.gdtf", "tri");
+  nlohmann::json entries = nlohmann::json::object();
+  entries["box truss"] = {
+      {"file", "box.gdtf"}, {"imported_at", "old"}, {"sha256", "111"}};
+  entries["tri truss"] = {{"file", "tri.gdtf"}, {"sha256", "222"}};
+  WriteText(source,
+            DictionaryJsonContract::MakeRoot("trusses", entries).dump(4));
+
+  const fs::path dest = root / "duplicate" / "trusses_copy.json";
+  const auto result = DictionaryDuplicate::DuplicateDictionary(
+      {ActiveDictionaryStorage::DictionaryKind::Trusses, source,
+       root / "default" / "truss_dictionary.json", dest});
+  assert(result.success);
+  assert(result.copiedAssetCount == 2);
+  assert(fs::exists(root / "duplicate" / "trusses_copy_assets" / "box.gdtf"));
+  assert(fs::exists(root / "duplicate" / "trusses_copy_assets" / "tri.gdtf"));
+  auto duplicated = ReadJson(dest);
+  assert(duplicated["entries"]["box truss"]["file"] == "box.gdtf");
+  assert(duplicated["entries"]["box truss"]["imported_at"] == "old");
+  fs::remove_all(source.parent_path());
+  assert(fs::exists(root / "duplicate" / "trusses_copy_assets" / "tri.gdtf"));
+}
+
+// Verifies unresolved references are preserved and reported.
+static void TestUnresolvedReferencesArePreserved() {
+  const fs::path root = ResetRoot();
+  const fs::path source = root / "source" / "fixtures.json";
+  nlohmann::json entries = nlohmann::json::object();
+  entries["Missing"] = {{"file", "missing.gdtf"}, {"mode", "Mode"}};
+  WriteText(source,
+            DictionaryJsonContract::MakeRoot("fixtures", entries).dump(4));
+
+  const fs::path dest = root / "duplicate" / "fixtures_copy.json";
+  const auto result = DictionaryDuplicate::DuplicateDictionary(
+      {ActiveDictionaryStorage::DictionaryKind::Fixtures, source,
+       root / "default" / "gdtf_dictionary.json", dest});
+  if (!result.success) {
+    for (const auto &error : result.errors)
+      std::cerr << error << "\n";
+  }
+  assert(result.success);
+  assert(result.unresolvedReferenceCount == 1);
+  auto duplicated = ReadJson(dest);
+  assert(duplicated["entries"]["Missing"]["file"] == "missing.gdtf");
+}
+
+// Verifies equal source and destination paths are rejected without output
+// mutation.
+static void TestSameDestinationRejected() {
+  const fs::path root = ResetRoot();
+  const fs::path source = root / "fixtures.json";
+  WriteText(source, DictionaryJsonContract::MakeRoot("fixtures",
+                                                     nlohmann::json::object())
+                        .dump(4));
+  const auto result = DictionaryDuplicate::DuplicateDictionary(
+      {ActiveDictionaryStorage::DictionaryKind::Fixtures, source,
+       root / "gdtf_dictionary.json", source});
+  assert(!result.success);
+  assert(!result.errors.empty());
+}
+
+// Verifies overwrite creates a backup and installs replacement assets.
+static void TestOverwriteCreatesBackup() {
+  const fs::path root = ResetRoot();
+  const fs::path source = root / "source" / "fixtures.json";
+  WriteText(root / "source" / "fixtures_assets" / "a.gdtf", "new");
+  nlohmann::json entries = nlohmann::json::object();
+  entries["A"] = {{"file", "a.gdtf"}};
+  WriteText(source,
+            DictionaryJsonContract::MakeRoot("fixtures", entries).dump(4));
+  const fs::path dest = root / "dest" / "copy.json";
+  WriteText(dest, "old json");
+  WriteText(root / "dest" / "copy_assets" / "old.gdtf", "old");
+
+  const auto result = DictionaryDuplicate::DuplicateDictionary(
+      {ActiveDictionaryStorage::DictionaryKind::Fixtures, source,
+       root / "default" / "gdtf_dictionary.json", dest});
+  assert(result.success);
+  assert(!result.backupDictionaryPath.empty());
+  assert(!result.backupAssetsPath.empty());
+  assert(fs::exists(result.backupDictionaryPath));
+  assert(fs::exists(result.backupAssetsPath / "old.gdtf"));
+  assert(fs::exists(root / "dest" / "copy_assets" / "a.gdtf"));
+}
+
+// Runs all dictionary duplication service regression tests.
+int main() {
+  TestDuplicateFixturesCopiesAssetsAndMetadata();
+  TestDuplicateTrussesCopiesAssetsAndMetadata();
+  TestUnresolvedReferencesArePreserved();
+  TestSameDestinationRejected();
+  TestOverwriteCreatesBackup();
+  std::cout << "dictionary duplicate tests passed\n";
+  return 0;
+}


### PR DESCRIPTION
### Motivation
- Provide a safe, user-facing "Duplicate Current..." workflow for Fixtures and Trusses that produces an independent dictionary copy including owned/referenced assets and an optional immediate activation choice.
- Ensure duplication respects the existing dirty/save/discard guard and does not produce ambiguous mixtures of saved and unsaved state.
- Reuse existing storage, hashing and conflict utilities to stage output, detect conflicts, and enable rollback on fatal errors.

### Description
- Add a testable core service `DictionaryDuplicate` (`core/dictionary_duplicate.h/.cpp`) that validates source JSON, stages output, rewrites asset references, copies resolvable assets into the destination `_assets` layout, creates backups when overwriting, and performs rollback on failure.
- Wire a new "Duplicate Current..." control into the dictionary selection UI (`gui/dictionary_selection_controls.*`) and add fixture/truss handlers in the Dictionary Editor (`gui/dictionaryeditdialog.*`) that enforce the dirty-state guard, open a `wxFileDialog` with `wxFD_SAVE | wxFD_OVERWRITE_PROMPT`, normalize `.json` extension, and present concise success/error summaries with an optional activate-now dialog.
- Add regression tests (`tests/dictionary_duplicate_test.cpp`) and CMake test target to verify multi-asset copying, fixture metadata preservation, duplicate independence after source removal, unresolved-reference preservation/reporting, same-path rejection, and overwrite/backup behavior.
- Update docs to reflect the new workflow (`docs/developer/dictionary_portable_bundle.md`, `docs/user/features.md`) and add a release-note entry in `docs/release-notes-draft.md`.

### Testing
- Built and ran the isolated dictionary duplicate test binary with `g++` and the required core helpers and the test suite, and the tests passed: `dictionary duplicate tests passed`.
- Ran repository checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both completed OK.
- Full CMake configuration/build in this container failed due to missing wxWidgets development files, so an application-level build/test was not run here; the duplication service and tests are written to be testable without native dialogs and were validated via the unit test binary added to the test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a597abed3108324b8e11b4a81235166)