### PR TITLE
Make dictionary lookups and truss loading read-only; preserve unresolved entries

### DIFF
--- a/core/gdtfdictionary.cpp
+++ b/core/gdtfdictionary.cpp
@@ -1020,11 +1020,8 @@ std::optional<Entry> Get(const std::string &type) {
   if (!keyOpt)
     return std::nullopt;
   auto it = dict.find(*keyOpt);
-  if (!it->second.path.empty() && !fs::exists(it->second.path)) {
-    dict.erase(it);
-    Save(dict);
+  if (!it->second.path.empty() && !fs::exists(it->second.path))
     return std::nullopt;
-  }
   return it->second;
 }
 

--- a/core/gdtfdictionary.h
+++ b/core/gdtfdictionary.h
@@ -73,8 +73,8 @@ namespace GdtfDictionary {
     // Returns false and optionally fills errorOut when writing fails.
     bool Save(const std::unordered_map<std::string, Entry>& dict,
               std::string* errorOut = nullptr);
-    // Returns the stored entry for a given type if it exists and file exists.
-    // If the file is missing, the entry is removed and std::nullopt returned.
+    // Returns the stored entry for a given type when the referenced file exists.
+    // Missing referenced files return std::nullopt without mutating the dictionary.
     std::optional<Entry> Get(const std::string& type);
     // Looks up a type in an already loaded dictionary without reloading from disk.
     std::optional<Entry> FindInLoadedDictionary(

--- a/core/trussdictionary.cpp
+++ b/core/trussdictionary.cpp
@@ -43,6 +43,7 @@ namespace TrussDictionary {
 namespace {
 
 LoadStatus g_lastLoadStatus;
+size_t g_saveCallCountForTesting = 0;
 constexpr const char *kTrussDictionaryPathConfigKey =
     "trusses_dictionary_active_path";
 
@@ -274,7 +275,6 @@ LoadFromFile(const fs::path &file, std::string &error) {
   }
 
   const nlohmann::json &entries = **entriesOpt;
-  bool changed = false;
 
   auto resolveEntryPath = [&file](const nlohmann::json &value, fs::path &entryPath,
                                   std::string &entryError,
@@ -317,24 +317,13 @@ LoadFromFile(const fs::path &file, std::string &error) {
       return false;
     }
 
-    if (!fs::exists(path)) {
-      if (!PathUtils::PathFromUtf8(rawPath).is_absolute()) {
-        std::cerr << "Warning: trusses dictionary " << sourceLabel
-                  << " references missing relative path '" << rawPath
-                  << "' resolved from '" << file.string() << "'."
-                  << std::endl;
-      }
-      return true;
+    if (!fs::exists(path) && !PathUtils::PathFromUtf8(rawPath).is_absolute()) {
+      std::cerr << "Warning: trusses dictionary " << sourceLabel
+                << " references missing relative path '" << rawPath
+                << "' resolved from '" << file.string() << "'."
+                << std::endl;
     }
-
-    std::string migrationError;
-    fs::path migrated = path;
-    if (!EnsureMigratedToGdtf(migrated, migrationError))
-      return true;
-
-    if (migrated != path || normalizedKey != rawKey)
-      changed = true;
-    dict[normalizedKey] = ToUtf8String(migrated);
+    dict[normalizedKey] = ToUtf8String(path);
     return true;
   };
 
@@ -361,12 +350,9 @@ LoadFromFile(const fs::path &file, std::string &error) {
     }
   }
 
-  if (changed) {
-    WriteDictionaryBackup(file);
-    Save(dict);
-  }
   return dict;
 }
+
 
 DictionaryImportSummary MergeDictionaryEntries(
     std::unordered_map<std::string, std::string> &current,
@@ -728,14 +714,11 @@ bool Save(const std::unordered_map<std::string, std::string> &dict,
       ActiveDictionaryStorage::DictionaryKind::Trusses, file, GetUserDictFile());
   for (const auto &model : keys) {
     fs::path p = PathUtils::PathFromUtf8(normalizedDict.at(model));
-    fs::path forced = p;
-    if (forced.extension() != ".gdtf")
-      forced.replace_extension(".gdtf");
 
     nlohmann::json entry;
-    entry["file"] = ActiveDictionaryStorage::MakeSerializedReference(layout, forced);
+    entry["file"] = ActiveDictionaryStorage::MakeSerializedReference(layout, p);
     entry["imported_at"] = FileImportUtils::NowUtcIso8601();
-    if (const auto sha = FileImportUtils::ComputeFileSha256(forced))
+    if (const auto sha = FileImportUtils::ComputeFileSha256(p))
       entry["sha256"] = *sha;
     entries[model] = std::move(entry);
   }
@@ -762,6 +745,7 @@ bool Save(const std::unordered_map<std::string, std::string> &dict,
                   file.string();
     return false;
   }
+  ++g_saveCallCountForTesting;
   return true;
 }
 
@@ -795,11 +779,8 @@ std::optional<std::string> Get(const std::string &model) {
   if (it == dict.end())
     return std::nullopt;
 
-  if (!fs::exists(PathUtils::PathFromUtf8(it->second))) {
-    dict.erase(it);
-    Save(dict);
+  if (!fs::exists(PathUtils::PathFromUtf8(it->second)))
     return std::nullopt;
-  }
 
   return it->second;
 }
@@ -847,6 +828,7 @@ DictionaryImportSummary PreviewImportFromFile(const std::string &filePath,
   return MergeDictionaryEntries(current, *importedOpt, policy, false);
 }
 
+// Applies a truss dictionary import file to the active dictionary.
 DictionaryImportSummary ApplyImportFromFile(const std::string &filePath,
                                             DictionaryImportPolicy policy) {
   std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
@@ -872,6 +854,18 @@ DictionaryImportSummary ApplyImportFromFile(const std::string &filePath,
   if (!Save(current, &saveError))
     summary.errors.push_back("Failed to save current dictionary: " + saveError);
   return summary;
+}
+
+// Returns the number of active truss dictionary saves performed during tests.
+size_t GetSaveCallCountForTesting() {
+  std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
+  return g_saveCallCountForTesting;
+}
+
+// Resets the active truss dictionary save counter used by tests.
+void ResetSaveCallCountForTesting() {
+  std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
+  g_saveCallCountForTesting = 0;
 }
 
 } // namespace TrussDictionary

--- a/core/trussdictionary.h
+++ b/core/trussdictionary.h
@@ -19,6 +19,7 @@
 
 #include "dictionary_import.h"
 
+#include <cstddef>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -61,6 +62,7 @@ bool SetActiveDictionaryFilePath(const std::string &path,
                                  std::string *errorOut = nullptr);
 bool Save(const std::unordered_map<std::string, std::string> &dict,
           std::string *errorOut = nullptr);
+// Returns the stored path for a model when the referenced file exists.
 std::optional<std::string> Get(const std::string &model);
 // Looks up a model in an already loaded dictionary without reloading from disk.
 std::optional<std::string> FindInLoadedDictionary(
@@ -73,4 +75,6 @@ DictionaryImportSummary PreviewImportFromFile(
     const std::string &filePath, DictionaryImportPolicy policy);
 DictionaryImportSummary ApplyImportFromFile(
     const std::string &filePath, DictionaryImportPolicy policy);
+size_t GetSaveCallCountForTesting();
+void ResetSaveCallCountForTesting();
 } // namespace TrussDictionary

--- a/docs/developer/dictionary_portable_bundle.md
+++ b/docs/developer/dictionary_portable_bundle.md
@@ -12,6 +12,10 @@ Perastage keeps JSON dictionary snapshots for backward compatibility and also su
   `<snapshot>_assets/assets/` folder and write `assets/...` relative paths.
 
 
+## Read-only load and lookup rules
+
+Dictionary loading and ordinary lookup operations must be side-effect free. Missing fixture and truss asset references remain in the active dictionary so the Dictionary Editor can display, repair, replace, or delete them explicitly. Lookups that validate asset paths return no match for unresolved references, but they must not delete entries, save the dictionary, create backups, normalize truss keys on disk, or migrate legacy truss assets during load. Truss legacy/model conversion belongs only in explicit import, add, replace, repair, or save workflows that own the asset-copy transaction.
+
 ## Active dictionary workflows
 
 The Dictionary Editor exposes separate actions for active dictionary management:

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -74,6 +74,7 @@ Perastage 1.5.0 is a substantial update focused on GDTF and truss editing, multi
 ## Important fixes
 
 - Improved Dictionary Editor reliability so fixture and truss edits are saved transactionally, unresolved file references remain visible and savable, dirty-state checks catch category/color/path/name changes, and failed saves keep the editor open.
+- Fixed dictionary lookups and truss dictionary loading so missing asset references remain visible for repair and no longer trigger silent saves, entry deletion, backups, or load-time truss migration.
 - Replaced the Dictionary Editor dictionary chooser with explicit **Open**, **New**, **Duplicate Current**, and **Use Default** workflows for fixture and truss dictionaries, including type validation before changing the active path and safe duplication of referenced assets.
 - Fixed custom fixture and truss dictionaries so newly owned GDTF assets are stored in a sibling `_assets` folder and remain portable when the dictionary is moved with that folder.
 - Fixed Data Views table edits so moving fixtures, trusses, or scene objects between visible and hidden layers rebuilds the relevant viewer resources, invalidates stale 3D visible-set caches, and immediately refreshes both the 2D and 3D viewports, including layout previews.

--- a/tests/dictionary_seed_merge_backup_test.cpp
+++ b/tests/dictionary_seed_merge_backup_test.cpp
@@ -113,6 +113,66 @@ void VerifyTrussLoadIsReadOnly(const fs::path &root) {
   assert(!fs::exists(userPath.string() + ".bak"));
 }
 
+
+void VerifyMissingFixtureLookupIsReadOnly(const fs::path &root) {
+  const fs::path userPath = root / "fixtures" / "gdtf_dictionary.json";
+  const fs::path missingAsset = userPath.parent_path() / "missing_fixture.gdtf";
+  nlohmann::json entries = nlohmann::json::object();
+  entries["MISSING FIXTURE KEEP"] = {{"file", missingAsset.filename().string()},
+                                      {"mode", "Default"}};
+  WriteFile(userPath, DictionaryJsonContract::MakeRoot("fixtures", entries).dump(2));
+  const std::string before = ReadFile(userPath);
+  const auto timeBefore = fs::last_write_time(userPath);
+  std::this_thread::sleep_for(std::chrono::milliseconds(5));
+
+  GdtfDictionary::ResetSaveCallCountForTesting();
+  auto loadedOpt = GdtfDictionary::Load();
+  assert(loadedOpt.has_value());
+  assert(loadedOpt->find("MISSING FIXTURE KEEP") != loadedOpt->end());
+  assert(!GdtfDictionary::Get("MISSING FIXTURE KEEP").has_value());
+  assert(!GdtfDictionary::FindInLoadedDictionary(*loadedOpt, "MISSING FIXTURE KEEP").has_value());
+  assert(GdtfDictionary::FindInLoadedDictionary(*loadedOpt, "MISSING FIXTURE KEEP", false).has_value());
+  assert(ReadFile(userPath) == before);
+  assert(fs::last_write_time(userPath) == timeBefore);
+  assert(!fs::exists(userPath.string() + ".bak"));
+  assert(GdtfDictionary::GetSaveCallCountForTesting() == 0);
+}
+
+void VerifyMissingTrussEntriesSurviveLookupAndSave(const fs::path &root) {
+  const fs::path userPath = root / "trusses" / "truss_dictionary.json";
+  nlohmann::json entries = nlohmann::json::object();
+  entries["MISSING TRUSS A"] = {{"file", "missing_a.gtruss"}};
+  entries["MISSING TRUSS B"] = {{"file", "missing_b.glb"}};
+  WriteFile(userPath, DictionaryJsonContract::MakeRoot("trusses", entries).dump(2));
+  const std::string before = ReadFile(userPath);
+  const auto timeBefore = fs::last_write_time(userPath);
+  std::this_thread::sleep_for(std::chrono::milliseconds(5));
+
+  TrussDictionary::ResetSaveCallCountForTesting();
+  auto loadedOpt = TrussDictionary::Load();
+  assert(loadedOpt.has_value());
+  assert(loadedOpt->find(TrussDictionary::NormalizeModelKey("MISSING TRUSS A")) != loadedOpt->end());
+  assert(loadedOpt->find(TrussDictionary::NormalizeModelKey("MISSING TRUSS B")) != loadedOpt->end());
+  assert(!TrussDictionary::Get("MISSING TRUSS A").has_value());
+  assert(!TrussDictionary::FindInLoadedDictionary(*loadedOpt, "MISSING TRUSS A").has_value());
+  assert(TrussDictionary::FindInLoadedDictionary(*loadedOpt, "MISSING TRUSS A", false).has_value());
+  assert(ReadFile(userPath) == before);
+  assert(fs::last_write_time(userPath) == timeBefore);
+  assert(!fs::exists(userPath.string() + ".bak"));
+  assert(TrussDictionary::GetSaveCallCountForTesting() == 0);
+
+  assert(TrussDictionary::Save(*loadedOpt));
+  auto reloadedOpt = TrussDictionary::Load();
+  assert(reloadedOpt.has_value());
+  assert(reloadedOpt->size() == 2);
+  reloadedOpt->erase(TrussDictionary::NormalizeModelKey("MISSING TRUSS A"));
+  assert(TrussDictionary::Save(*reloadedOpt));
+  auto afterDeleteOpt = TrussDictionary::Load();
+  assert(afterDeleteOpt.has_value());
+  assert(afterDeleteOpt->find(TrussDictionary::NormalizeModelKey("MISSING TRUSS A")) == afterDeleteOpt->end());
+  assert(afterDeleteOpt->find(TrussDictionary::NormalizeModelKey("MISSING TRUSS B")) != afterDeleteOpt->end());
+}
+
 void VerifyManagedDefaultRecoveryCreatesBackup(const fs::path &root) {
   const fs::path userPath = root / "fixtures" / "gdtf_dictionary.json";
   WriteFile(userPath, "{ invalid json");
@@ -155,6 +215,8 @@ int main() {
   SetLibraryPathEnv(tempRoot.string());
   VerifyFixtureLoadIsReadOnly(tempRoot);
   VerifyTrussLoadIsReadOnly(tempRoot);
+  VerifyMissingFixtureLookupIsReadOnly(tempRoot);
+  VerifyMissingTrussEntriesSurviveLookupAndSave(tempRoot);
   VerifyManagedDefaultRecoveryCreatesBackup(tempRoot);
   VerifyInvalidCustomDictionaryIsPreserved(tempRoot);
 


### PR DESCRIPTION
### Motivation
- Prevent ordinary dictionary loads and lookups from mutating on-disk dictionaries, creating backups, or performing implicit truss migrations so the Dictionary Editor can surface unresolved references for explicit repair workflows.
- Ensure fixture/truss lookup APIs are side-effect free when referenced asset files are missing, avoiding unexpected `Save`/erase cycles that break transactional behaviour.
- Keep conversion/migration and asset-copy ownership inside explicit import/add/replace/repair/save flows instead of during passive `Load`/`Get` operations.

### Description
- Made `GdtfDictionary::Get` return `std::nullopt` for missing referenced files without erasing the dictionary entry or calling `Save`, and updated the public header comment to document the read-only behaviour.
- Rewrote `TrussDictionary::LoadFromFile` to preserve every valid dictionary entry (including unresolved references), stop legacy conversion/migration at load time, and remove creation of `.bak` files or automatic `Save` calls during load.
- Made `TrussDictionary::Get` read-only for missing assets (returns `std::nullopt` without mutating disk) and changed `Save` to serialize the actual stored path (no forced `.gdtf` extension rewrite for unresolved inputs) while still computing hash when the file exists.
- Added test-only save counters: `GetSaveCallCountForTesting`/`ResetSaveCallCountForTesting` to allow regression checks that no unexpected saves occurred.
- Added focused regression tests in `tests/dictionary_seed_merge_backup_test.cpp` that verify missing fixture lookups do not save/delete, missing truss entries survive load/save/load and that deleting one unresolved truss preserves the other.
- Updated developer docs `docs/developer/dictionary_portable_bundle.md` with explicit read-only load/lookup rules and added a short release-note entry in `docs/release-notes-draft.md`.

### Testing
- Ran repository policy checks and scripts: `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both passed.
- Performed unit compilation of modified core units with `c++ -std=c++20 ...` (`core/trussdictionary.cpp` and `core/gdtfdictionary.cpp`) to validate build-local changes; compilation succeeded.
- Added regression tests (`tests/dictionary_seed_merge_backup_test.cpp`) and verified test logic compiles, but a full CMake/CTest run could not be completed in this container because the environment lacked an `mdns` CMake package required by the project; therefore the new tests were not executed under `ctest` here.
- All changes were committed locally and prepared as this PR (`Fix read-only dictionary lookups`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59c23a194083248d83a3685cb3a4d4)