### PR TITLE
Add dictionary-owned truss ingest and reset transactions

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/diagnostics/DiagnosticReport.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dictionary_bundle.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dictionary_duplicate.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/dictionary_reset_service.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dummyprofilelibrary.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/file_import_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/filesystem_path_utils.cpp
@@ -73,6 +74,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/symbols/Symbol2DBuilder.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/symbols/PerastageSvgSymbol.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/trussdictionary.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/truss_asset_ingestion.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/truss_gdtf_builder.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/trussloader.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ui_render_size.cpp

--- a/core/active_dictionary_storage.cpp
+++ b/core/active_dictionary_storage.cpp
@@ -133,6 +133,7 @@ AssetCopyResult CopyAssetIntoDictionaryStorage(const AssetCopyRequest &request) 
   result.finalPath = copyResult.finalPath;
   result.serializedPath = MakeSerializedReference(layout, copyResult.finalPath);
   result.finalSha256 = copyResult.finalSha256;
+  result.reusedExisting = copyResult.reusedExisting;
   return result;
 }
 

--- a/core/active_dictionary_storage.h
+++ b/core/active_dictionary_storage.h
@@ -40,6 +40,7 @@ struct AssetCopyResult {
   std::filesystem::path finalPath;
   std::string serializedPath;
   std::string finalSha256;
+  bool reusedExisting = false;
 };
 
 std::filesystem::path GetOwnedAssetDirectory(

--- a/core/dictionary_reset_service.cpp
+++ b/core/dictionary_reset_service.cpp
@@ -1,0 +1,223 @@
+#include "dictionary_reset_service.h"
+
+#include "active_dictionary_storage.h"
+#include "dictionary_json_contract.h"
+#include "file_import_utils.h"
+#include "filesystem_path_utils.h"
+#include "json.hpp"
+
+#include <filesystem>
+#include <fstream>
+#include <system_error>
+
+namespace fs = std::filesystem;
+
+namespace DictionaryResetService {
+namespace {
+
+// Returns the JSON dictionary type name for a dictionary kind.
+std::string DictionaryType(ActiveDictionaryStorage::DictionaryKind kind) {
+  return kind == ActiveDictionaryStorage::DictionaryKind::Fixtures ? "fixtures"
+                                                                   : "trusses";
+}
+
+// Returns the file path field name for dictionary entries.
+const char *FileField(ActiveDictionaryStorage::DictionaryKind kind) {
+  return kind == ActiveDictionaryStorage::DictionaryKind::Fixtures ? "gdtf" : "file";
+}
+
+// Loads JSON from disk and reports parse failures as summary errors.
+bool LoadJson(const fs::path &path, nlohmann::json &root,
+              DictionaryImportSummary &summary) {
+  std::ifstream in(path);
+  if (!in.is_open()) {
+    summary.errors.push_back("Could not open default dictionary: " + path.string());
+    return false;
+  }
+  try {
+    in >> root;
+  } catch (const std::exception &e) {
+    summary.errors.push_back(std::string("Could not parse default dictionary: ") + e.what());
+    return false;
+  }
+  return true;
+}
+
+// Removes a path when it exists without surfacing cleanup failures.
+void RemoveIfExists(const fs::path &path) {
+  std::error_code ec;
+  fs::remove_all(path, ec);
+}
+
+// Moves an existing path to a backup path.
+bool BackupPath(const fs::path &path, fs::path &backupPath) {
+  std::error_code ec;
+  if (!fs::exists(path, ec) || ec)
+    return true;
+  backupPath = path;
+  backupPath += ".bak";
+  RemoveIfExists(backupPath);
+  fs::rename(path, backupPath, ec);
+  if (!ec)
+    return true;
+  ec.clear();
+  fs::copy(path, backupPath, fs::copy_options::recursive |
+                            fs::copy_options::overwrite_existing, ec);
+  if (ec)
+    return false;
+  RemoveIfExists(path);
+  return true;
+}
+
+// Restores a path from its backup.
+void RestoreBackup(const fs::path &backupPath, const fs::path &targetPath) {
+  if (backupPath.empty())
+    return;
+  RemoveIfExists(targetPath);
+  std::error_code ec;
+  fs::rename(backupPath, targetPath, ec);
+}
+
+} // namespace
+
+// Replaces active dictionary contents with a self-contained copy of application defaults.
+DictionaryImportSummary ResetToDefaults(const Request &request) {
+  DictionaryImportSummary summary;
+  if (request.activeJsonPath.empty() || request.applicationBaseJsonPath.empty()) {
+    summary.errors.push_back("Dictionary reset paths are incomplete");
+    return summary;
+  }
+
+  nlohmann::json baseRoot;
+  if (!LoadJson(request.applicationBaseJsonPath, baseRoot, summary))
+    return summary;
+
+  std::string error;
+  const std::string type = DictionaryType(request.kind);
+  auto entriesOpt = DictionaryJsonContract::GetEntriesForType(baseRoot, type, error);
+  if (!entriesOpt) {
+    summary.errors.push_back(error);
+    return summary;
+  }
+  if (!(*entriesOpt)->is_object()) {
+    summary.errors.push_back("Default dictionary entries must be an object");
+    return summary;
+  }
+
+  const auto layout = ActiveDictionaryStorage::BuildLayout(
+      request.kind, request.activeJsonPath, request.managedDefaultJsonPath);
+  const fs::path stagingJson = request.activeJsonPath.string() + ".reset.tmp";
+  const fs::path stagingAssets = layout.isDefaultManagedDictionary
+                                     ? layout.ownedAssetDirectory / ".reset_assets_tmp"
+                                     : fs::path(layout.ownedAssetDirectory.string() + ".reset.tmp");
+  RemoveIfExists(stagingJson);
+  RemoveIfExists(stagingAssets);
+
+  std::error_code ec;
+  fs::create_directories(request.activeJsonPath.parent_path(), ec);
+  if (!layout.isDefaultManagedDictionary)
+    fs::create_directories(stagingAssets, ec);
+  else
+    fs::create_directories(stagingAssets, ec);
+  if (ec) {
+    summary.errors.push_back("Could not create dictionary reset staging storage");
+    return summary;
+  }
+
+  nlohmann::json stagedEntries = nlohmann::json::object();
+  for (auto it = (*entriesOpt)->begin(); it != (*entriesOpt)->end(); ++it) {
+    nlohmann::json entry = it.value();
+    if (!entry.is_object()) {
+      ++summary.skipped_count;
+      continue;
+    }
+    const char *fileField = FileField(request.kind);
+    const auto fileIt = entry.find(fileField);
+    if (fileIt == entry.end() || !fileIt->is_string()) {
+      ++summary.missing_files_count;
+      summary.missing_file_examples.push_back(it.key());
+      continue;
+    }
+    const fs::path sourcePath = ActiveDictionaryStorage::ResolveReference(
+        request.applicationBaseJsonPath, fileIt->get<std::string>());
+    if (!fs::exists(sourcePath)) {
+      ++summary.missing_files_count;
+      if (summary.missing_file_examples.size() < 10)
+        summary.missing_file_examples.push_back(it.key() + " -> " + sourcePath.string());
+      continue;
+    }
+
+    ActiveDictionaryStorage::AssetStorageLayout stagingLayout = layout;
+    stagingLayout.ownedAssetDirectory = stagingAssets;
+    const auto copied = FileImportUtils::CopyWithConflictPolicy(
+        sourcePath, stagingAssets / sourcePath.filename(),
+        FileImportUtils::ConflictPolicy::Rename);
+    if (!copied.success) {
+      summary.errors.push_back("Could not copy default asset: " + sourcePath.string());
+      continue;
+    }
+    entry[fileField] = ActiveDictionaryStorage::MakeSerializedReference(
+        stagingLayout, copied.finalPath);
+    if (request.kind == ActiveDictionaryStorage::DictionaryKind::Fixtures)
+      entry["sha256"] = copied.finalSha256;
+    stagedEntries[it.key()] = std::move(entry);
+    ++summary.added_count;
+  }
+
+  if (summary.HasErrors()) {
+    RemoveIfExists(stagingJson);
+    RemoveIfExists(stagingAssets);
+    return summary;
+  }
+
+  std::ofstream out(stagingJson);
+  if (!out.is_open()) {
+    summary.errors.push_back("Could not write staged dictionary JSON");
+    RemoveIfExists(stagingAssets);
+    return summary;
+  }
+  out << DictionaryJsonContract::MakeRoot(type, std::move(stagedEntries)).dump(4);
+  out.close();
+
+  fs::path jsonBackup;
+  fs::path assetBackup;
+  if (!BackupPath(request.activeJsonPath, jsonBackup) ||
+      (!layout.isDefaultManagedDictionary &&
+       !BackupPath(layout.ownedAssetDirectory, assetBackup))) {
+    summary.errors.push_back("Could not back up the active dictionary before reset");
+    RestoreBackup(jsonBackup, request.activeJsonPath);
+    RestoreBackup(assetBackup, layout.ownedAssetDirectory);
+    RemoveIfExists(stagingJson);
+    RemoveIfExists(stagingAssets);
+    return summary;
+  }
+
+  fs::rename(stagingJson, request.activeJsonPath, ec);
+  if (!ec) {
+    if (layout.isDefaultManagedDictionary) {
+      fs::create_directories(layout.ownedAssetDirectory, ec);
+      for (const auto &entry : fs::directory_iterator(stagingAssets)) {
+        fs::rename(entry.path(), layout.ownedAssetDirectory / entry.path().filename(), ec);
+        if (ec)
+          break;
+      }
+      RemoveIfExists(stagingAssets);
+    } else {
+      fs::rename(stagingAssets, layout.ownedAssetDirectory, ec);
+    }
+  }
+  if (ec) {
+    summary.errors.push_back("Could not install the reset dictionary");
+    RestoreBackup(jsonBackup, request.activeJsonPath);
+    RestoreBackup(assetBackup, layout.ownedAssetDirectory);
+    RemoveIfExists(stagingJson);
+    RemoveIfExists(stagingAssets);
+    return summary;
+  }
+
+  RemoveIfExists(jsonBackup);
+  RemoveIfExists(assetBackup);
+  return summary;
+}
+
+} // namespace DictionaryResetService

--- a/core/dictionary_reset_service.h
+++ b/core/dictionary_reset_service.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "active_dictionary_storage.h"
+#include "dictionary_import.h"
+
+#include <filesystem>
+
+namespace DictionaryResetService {
+
+struct Request {
+  ActiveDictionaryStorage::DictionaryKind kind;
+  std::filesystem::path activeJsonPath;
+  std::filesystem::path managedDefaultJsonPath;
+  std::filesystem::path applicationBaseJsonPath;
+};
+
+DictionaryImportSummary ResetToDefaults(const Request &request);
+
+} // namespace DictionaryResetService

--- a/core/truss_asset_ingestion.cpp
+++ b/core/truss_asset_ingestion.cpp
@@ -1,0 +1,139 @@
+#include "truss_asset_ingestion.h"
+
+#include "active_dictionary_storage.h"
+#include "file_import_utils.h"
+#include "filesystem_path_utils.h"
+#include "gdtf_metadata_summary.h"
+#include "truss.h"
+#include "truss_gdtf_builder.h"
+
+#include <algorithm>
+#include <cctype>
+#include <filesystem>
+
+namespace fs = std::filesystem;
+
+namespace TrussAssetIngestion {
+namespace {
+
+// Returns a lowercase extension for supported source comparisons.
+std::string LowerExt(const fs::path &path) {
+  std::string ext = path.extension().string();
+  std::transform(ext.begin(), ext.end(), ext.begin(), [](unsigned char ch) {
+    return static_cast<char>(std::tolower(ch));
+  });
+  return ext;
+}
+
+// Returns true when the path is already stored in the active owned asset directory.
+bool IsAlreadyOwned(const fs::path &path,
+                    const ActiveDictionaryStorage::AssetStorageLayout &layout) {
+  std::error_code ec;
+  return fs::exists(path, ec) && !ec && fs::exists(layout.ownedAssetDirectory, ec) &&
+         !ec && fs::equivalent(path.parent_path(), layout.ownedAssetDirectory, ec) &&
+         !ec;
+}
+
+// Creates an intermediate GDTF in staging for non-GDTF truss source formats.
+bool ConvertToStagedGdtf(const fs::path &sourcePath, const fs::path &stagingPath,
+                         std::string &error) {
+  const std::string ext = LowerExt(sourcePath);
+  if (ext == ".gtruss")
+    return ConvertLegacyGtrussToGdtf(sourcePath, stagingPath, &error);
+  if (ext == ".glb" || ext == ".3ds") {
+    Truss truss;
+    truss.modelFile = PathUtils::PathToUtf8(sourcePath);
+    truss.model = sourcePath.stem().string();
+    return BuildTrussGdtfFromInstance(truss, stagingPath, &error);
+  }
+  error = "Unsupported truss format";
+  return false;
+}
+
+// Verifies that the GDTF can be opened as a metadata-bearing GDTF archive.
+bool ValidateGdtf(const fs::path &path, std::string &error) {
+  GdtfMetadataSummary summary;
+  if (LoadGdtfMetadataSummary(PathUtils::PathToUtf8(path), summary))
+    return true;
+  error = "Generated truss GDTF could not be validated";
+  return false;
+}
+
+} // namespace
+
+// Ingests a selected truss source into the active dictionary-owned asset storage.
+Result Ingest(const Request &request) {
+  Result result;
+  if (request.sourcePath.empty() || !fs::exists(request.sourcePath)) {
+    result.error = "Truss source file does not exist";
+    return result;
+  }
+
+  const std::string ext = LowerExt(request.sourcePath);
+  if (ext != ".gdtf" && ext != ".gtruss" && ext != ".3ds" && ext != ".glb") {
+    result.error = "Unsupported truss format";
+    return result;
+  }
+
+  const auto layout = ActiveDictionaryStorage::BuildLayout(
+      ActiveDictionaryStorage::DictionaryKind::Trusses, request.activeDictionaryPath,
+      request.defaultDictionaryPath);
+  if (ext == ".gdtf" && IsAlreadyOwned(request.sourcePath, layout)) {
+    std::string validationError;
+    if (!ValidateGdtf(request.sourcePath, validationError)) {
+      result.error = validationError;
+      return result;
+    }
+    result.success = true;
+    result.finalPath = request.sourcePath;
+    result.serializedPath = ActiveDictionaryStorage::MakeSerializedReference(
+        layout, request.sourcePath);
+    if (const auto hash = FileImportUtils::ComputeFileSha256(request.sourcePath))
+      result.sha256 = *hash;
+    result.reusedExisting = true;
+    return result;
+  }
+
+  fs::path sourceForCopy = request.sourcePath;
+  fs::path stagingDir;
+  std::error_code ec;
+  if (ext != ".gdtf") {
+    stagingDir = fs::temp_directory_path() /
+                 ("perastage-truss-ingest-" + request.sourcePath.stem().string());
+    fs::remove_all(stagingDir, ec);
+    fs::create_directories(stagingDir, ec);
+    if (ec) {
+      result.error = "Failed to create truss conversion staging directory";
+      return result;
+    }
+    sourceForCopy = stagingDir / (request.sourcePath.stem().string() + ".gdtf");
+    if (!ConvertToStagedGdtf(request.sourcePath, sourceForCopy, result.error)) {
+      fs::remove_all(stagingDir, ec);
+      return result;
+    }
+  }
+
+  if (!ValidateGdtf(sourceForCopy, result.error)) {
+    fs::remove_all(stagingDir, ec);
+    return result;
+  }
+
+  const auto copyResult = ActiveDictionaryStorage::CopyAssetIntoDictionaryStorage(
+      {ActiveDictionaryStorage::DictionaryKind::Trusses, request.activeDictionaryPath,
+       request.defaultDictionaryPath, sourceForCopy, {},
+       FileImportUtils::ConflictPolicy::Rename});
+  fs::remove_all(stagingDir, ec);
+  if (!copyResult.success) {
+    result.error = "Failed to copy truss GDTF into dictionary-owned storage";
+    return result;
+  }
+
+  result.success = true;
+  result.finalPath = copyResult.finalPath;
+  result.serializedPath = copyResult.serializedPath;
+  result.sha256 = copyResult.finalSha256;
+  result.reusedExisting = copyResult.reusedExisting;
+  return result;
+}
+
+} // namespace TrussAssetIngestion

--- a/core/truss_asset_ingestion.h
+++ b/core/truss_asset_ingestion.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+
+namespace TrussAssetIngestion {
+
+struct Request {
+  std::filesystem::path activeDictionaryPath;
+  std::filesystem::path defaultDictionaryPath;
+  std::filesystem::path sourcePath;
+};
+
+struct Result {
+  bool success = false;
+  std::filesystem::path finalPath;
+  std::string serializedPath;
+  std::string sha256;
+  bool reusedExisting = false;
+  std::string error;
+};
+
+Result Ingest(const Request &request);
+
+} // namespace TrussAssetIngestion

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -74,6 +74,7 @@ Perastage 1.5.0 is a substantial update focused on GDTF and truss editing, multi
 ## Important fixes
 
 - Improved Dictionary Editor reliability so fixture and truss edits are saved transactionally, unresolved file references remain visible and savable, dirty-state checks catch category/color/path/name changes, and failed saves keep the editor open.
+- Improved Dictionary Editor asset ownership so saved truss additions and replacements ingest supported source files as owned GDTF assets, and fixture/truss resets create portable self-contained dictionaries with rollback.
 - Fixed dictionary lookups and truss dictionary loading so missing asset references remain visible for repair and no longer trigger silent saves, entry deletion, backups, or load-time truss migration.
 - Improved Dictionary Editor safety by scoping dirty-edit prompts to the affected fixture or truss page, making **Discard** reload only that page, stopping saves after the first failure, and blocking writes to invalid or missing custom dictionaries until an explicit recovery action is chosen.
 - Replaced the Dictionary Editor dictionary chooser with explicit **Open**, **New**, **Duplicate Current**, and **Use Default** workflows for fixture and truss dictionaries, including type validation before changing the active path and safe duplication of referenced assets.

--- a/docs/user/features.md
+++ b/docs/user/features.md
@@ -87,6 +87,8 @@ Additional safeguards include:
 - missing-reference reporting,
 - collision policy prompts for differing file content,
 - custom active dictionaries store newly owned fixture and truss assets in a sibling `<dictionary name>_assets` folder so the JSON and assets can be moved together;
+- truss Add/Replace selections remain pending until the Dictionary Editor is saved, then supported `.gdtf`, `.gtruss`, `.3ds`, and `.glb` sources are ingested as real owned GDTF assets;
+- **More... → Reset Contents...** rebuilds fixture and truss dictionaries from application defaults into dictionary-owned storage, reports missing default assets, and keeps **Use Default** as a separate active-dictionary selection action;
 - The Dictionary Editor keeps common actions visible while moving less frequent active-dictionary actions into **More...**. **Duplicate Current...** creates an independent copy of the active fixture or truss dictionary, including resolvable referenced assets, and can optionally activate the copy after validation. **Export...** clearly offers **JSON Snapshot** or **Portable ZIP Bundle** without changing the active dictionary.
 
 ## Patch, Data Tables, and Editing Helpers

--- a/gui/dictionaryeditdialog.cpp
+++ b/gui/dictionaryeditdialog.cpp
@@ -27,6 +27,7 @@
 #include "dictionary_bundle.h"
 #include "dictionary_export_conflict_dialog.h"
 #include "dictionary_json_contract.h"
+#include "dictionary_reset_service.h"
 #include "dictionary_selection_controls.h"
 #include "file_import_utils.h"
 #include "gdtf_fixture_category.h"
@@ -37,6 +38,7 @@
 #include "projectutils.h"
 #include "table_column_indices.h"
 #include "trussdictionary.h"
+#include "truss_asset_ingestion.h"
 
 #include <algorithm>
 #include <cctype>
@@ -1920,6 +1922,13 @@ bool DictionaryEditDialog::SaveTrusses() {
   std::vector<TrussRow> rows;
   int count = trussTable->GetItemCount();
   rows.reserve(static_cast<size_t>(count));
+  std::vector<std::filesystem::path> ingestedPaths;
+  auto cleanupIngestedPaths = [&ingestedPaths]() {
+    for (const auto &ingestedPath : ingestedPaths) {
+      std::error_code ec;
+      std::filesystem::remove(ingestedPath, ec);
+    }
+  };
   for (int i = 0; i < count; ++i) {
     wxVariant nameVar;
     trussTable->GetValue(nameVar, i, kTrussNameColumn);
@@ -1933,14 +1942,22 @@ bool DictionaryEditDialog::SaveTrusses() {
       continue;
     std::string savedPath = path;
     if (std::filesystem::exists(path)) {
-      auto copied = CopyToLibrary(this, path, "trusses");
-      if (!copied) {
-        wxMessageBox("Could not copy truss file into the library. The "
-                     "dictionary was not saved.",
+      const auto ingested = TrussAssetIngestion::Ingest(
+          {PathUtils::PathFromUtf8(TrussDictionary::GetActiveDictionaryFilePath()),
+           PathUtils::PathFromUtf8(ProjectUtils::GetWritableLibraryPath("trusses")) /
+               "truss_dictionary.json",
+           PathUtils::PathFromUtf8(path)});
+      if (!ingested.success) {
+        wxMessageBox("Could not ingest the truss file into dictionary-owned "
+                     "GDTF storage. The dictionary was not saved.\n\n" +
+                         wxString::FromUTF8(ingested.error),
                      "Save trusses dictionary", wxICON_ERROR | wxOK, this);
+        cleanupIngestedPaths();
         return false;
       }
-      savedPath = copied->path;
+      if (!ingested.reusedExisting)
+        ingestedPaths.push_back(ingested.finalPath);
+      savedPath = ingested.finalPath.string();
     }
     rows.push_back({name, savedPath});
   }
@@ -1952,6 +1969,7 @@ bool DictionaryEditDialog::SaveTrusses() {
     dict[row.name] = row.path;
   std::string saveError;
   if (!TrussDictionary::Save(dict, &saveError)) {
+    cleanupIngestedPaths();
     wxMessageBox("Could not save trusses dictionary.\n\n" +
                      wxString::FromUTF8(saveError),
                  "Save trusses dictionary", wxICON_ERROR | wxOK, this);
@@ -2601,26 +2619,17 @@ bool DictionaryEditDialog::ResetFixturesDictionaryToDefault() {
 
   const std::filesystem::path activePath =
       PathUtils::PathFromUtf8(GdtfDictionary::GetActiveDictionaryFilePath());
-  if (!activePath.empty() && std::filesystem::exists(activePath)) {
-    std::error_code ec;
-    std::filesystem::copy_file(
-        activePath, activePath.string() + ".bak",
-        std::filesystem::copy_options::overwrite_existing, ec);
-    if (ec) {
-      wxMessageBox(
-          "Could not create a backup before resetting the fixtures dictionary.",
-          "Reset fixtures dictionary", wxOK | wxICON_ERROR, this);
-      return false;
-    }
-  }
   const std::filesystem::path basePath =
       ProjectUtils::GetBaseLibraryPath("fixtures") / "gdtf_dictionary.json";
-  const auto result = GdtfDictionary::ApplyImportFromFile(
-      basePath.string(), DictionaryImportPolicy::ReplaceAll);
+  const auto result = DictionaryResetService::ResetToDefaults(
+      {ActiveDictionaryStorage::DictionaryKind::Fixtures, activePath,
+       PathUtils::PathFromUtf8(ProjectUtils::GetWritableLibraryPath("fixtures")) /
+           "gdtf_dictionary.json",
+       basePath});
   LoadFixtures();
-  const bool hasErrors = result.HasErrors();
+  const bool hasErrors = result.HasErrors() || result.missing_files_count > 0;
   wxMessageBox((hasErrors
-                    ? "Fixtures dictionary reset finished with errors.\n\n"
+                    ? "Fixtures dictionary reset finished with issues.\n\n"
                     : "Fixtures dictionary restored to defaults.\n\n") +
                    BuildSummaryText(result),
                "Reset fixtures dictionary",
@@ -2643,25 +2652,16 @@ bool DictionaryEditDialog::ResetTrussesDictionaryToDefault() {
 
   const std::filesystem::path activePath =
       PathUtils::PathFromUtf8(TrussDictionary::GetActiveDictionaryFilePath());
-  if (!activePath.empty() && std::filesystem::exists(activePath)) {
-    std::error_code ec;
-    std::filesystem::copy_file(
-        activePath, activePath.string() + ".bak",
-        std::filesystem::copy_options::overwrite_existing, ec);
-    if (ec) {
-      wxMessageBox(
-          "Could not create a backup before resetting the trusses dictionary.",
-          "Reset trusses dictionary", wxOK | wxICON_ERROR, this);
-      return false;
-    }
-  }
   const std::filesystem::path basePath =
       ProjectUtils::GetBaseLibraryPath("trusses") / "truss_dictionary.json";
-  const auto result = TrussDictionary::ApplyImportFromFile(
-      basePath.string(), DictionaryImportPolicy::ReplaceAll);
+  const auto result = DictionaryResetService::ResetToDefaults(
+      {ActiveDictionaryStorage::DictionaryKind::Trusses, activePath,
+       PathUtils::PathFromUtf8(ProjectUtils::GetWritableLibraryPath("trusses")) /
+           "truss_dictionary.json",
+       basePath});
   LoadTrusses();
-  const bool hasErrors = result.HasErrors();
-  wxMessageBox((hasErrors ? "Trusses dictionary reset finished with errors.\n\n"
+  const bool hasErrors = result.HasErrors() || result.missing_files_count > 0;
+  wxMessageBox((hasErrors ? "Trusses dictionary reset finished with issues.\n\n"
                           : "Trusses dictionary restored to defaults.\n\n") +
                    BuildSummaryText(result),
                "Reset trusses dictionary",

--- a/tests/check_dictionary_core_services_no_wx.sh
+++ b/tests/check_dictionary_core_services_no_wx.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+files=(
+  core/truss_asset_ingestion.h
+  core/truss_asset_ingestion.cpp
+  core/dictionary_reset_service.h
+  core/dictionary_reset_service.cpp
+)
+
+if rg -n "wx[A-Za-z_]*|<wx/" "${files[@]}"; then
+  echo "Dictionary core services must not depend on wxWidgets UI APIs." >&2
+  exit 1
+fi
+
+echo "OK: dictionary core transaction services remain GUI-independent."


### PR DESCRIPTION
### Motivation
- Ensure Add/Replace truss selections become real owned GDTF assets and make Reset Contents produce self-contained, portable dictionaries with safe staging, backups, and rollback. 
- Prevent UI-driven file copying that left active dictionaries referencing legacy/model files instead of owned GDTFs and make core services GUI-agnostic for future reuse.

### Description
- Added a GUI-independent truss ingestion service `TrussAssetIngestion` (`core/truss_asset_ingestion.h`, `core/truss_asset_ingestion.cpp`) that validates supported extensions, converts `.gtruss`, `.glb`, and `.3ds` to GDTF using the existing builder path, validates the produced GDTF metadata, and stages/copies the final GDTF into active dictionary-owned storage. 
- Added a GUI-independent dictionary reset transaction `DictionaryResetService` (`core/dictionary_reset_service.h`, `core/dictionary_reset_service.cpp`) that stages default JSON and assets, rewrites entries to portable owned references, backs up active JSON/assets, atomically installs staged results, and restores backups on failure while reporting copied/missing/skipped/failed entries. 
- Extended `ActiveDictionaryStorage::AssetCopyResult` with `reusedExisting` and propagated reuse semantics so callers can avoid duplicating or deleting already-owned assets (`core/active_dictionary_storage.{h,cpp}`). 
- Wired the Dictionary Editor to use the new services: `SaveTrusses()` now ingests selected/replaced truss sources only on confirmed save and preserves unresolved rows with cleanup on failure, and `ResetFixturesDictionaryToDefault()` / `ResetTrussesDictionaryToDefault()` now call `DictionaryResetService::ResetToDefaults()` while keeping confirmations and result presentation in the GUI (`gui/dictionaryeditdialog.cpp`). 
- Added an automated architectural check `tests/check_dictionary_core_services_no_wx.sh` to ensure the new core services remain free of wxWidgets UI dependencies, updated `core/CMakeLists.txt` to include the new sources, and updated user docs and release notes to describe the behavior changes. 

### Testing
- Performed static/syntax checks with `g++ -std=c++20 -Icore -Ithird_party -fsyntax-only core/active_dictionary_storage.cpp`, `core/truss_asset_ingestion.cpp`, and `core/dictionary_reset_service.cpp`, which succeeded. 
- Ran repository health checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both succeeded. 
- Ran the new architecture check `tests/check_dictionary_core_services_no_wx.sh`, which succeeded and confirmed no wxWidgets dependencies in core services. 
- Ran `git diff --check` and other local validations (compilation checks of modified core units), which passed; full CMake configure/build could not be completed in this container due to missing `wxWidgets` development files (configuration failure), so full application build/test was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59cdaaa2fc8324952d4b85f4d6f16e)