### PR TITLE
Make portable dictionary ZIP import transactional

### DIFF
--- a/core/dictionary_bundle.cpp
+++ b/core/dictionary_bundle.cpp
@@ -324,6 +324,60 @@ bool WriteBundle(const fs::path &outputZipPath,
   return true;
 }
 
+
+// Returns true when a ZIP archive path is relative and cannot escape staging.
+bool IsSafeArchivePath(const std::string &name) {
+  if (name.empty())
+    return false;
+  const fs::path path = PathUtils::PathFromUtf8(name);
+  if (path.is_absolute())
+    return false;
+  for (const auto &part : path) {
+    const std::string text = part.string();
+    if (text == ".." || text.empty())
+      return false;
+  }
+  return true;
+}
+
+// Removes a path without surfacing cleanup failures.
+void RemoveIfExists(const fs::path &path) {
+  if (path.empty())
+    return;
+  std::error_code ec;
+  fs::remove_all(path, ec);
+}
+
+// Moves an existing file or directory aside for transactional rollback.
+bool BackupPath(const fs::path &path, fs::path &backupPath) {
+  std::error_code ec;
+  if (!fs::exists(path, ec) || ec)
+    return true;
+  backupPath = path;
+  backupPath += ".bundle-import.bak";
+  RemoveIfExists(backupPath);
+  fs::rename(path, backupPath, ec);
+  if (!ec)
+    return true;
+  ec.clear();
+  fs::copy(path, backupPath,
+           fs::copy_options::recursive | fs::copy_options::overwrite_existing,
+           ec);
+  if (ec)
+    return false;
+  RemoveIfExists(path);
+  return true;
+}
+
+// Restores a previously backed up path after a failed transaction.
+void RestoreBackup(const fs::path &backupPath, const fs::path &targetPath) {
+  if (backupPath.empty())
+    return;
+  RemoveIfExists(targetPath);
+  std::error_code ec;
+  fs::rename(backupPath, targetPath, ec);
+}
+
 bool ExtractArchive(const fs::path &zipPath, const fs::path &destination,
                     std::string &error) {
   wxFileInputStream input(zipPath.string());
@@ -338,8 +392,13 @@ bool ExtractArchive(const fs::path &zipPath, const fs::path &destination,
     if (entry->IsDir())
       continue;
 
+    const std::string entryName = entry->GetName().ToStdString();
+    if (!IsSafeArchivePath(entryName)) {
+      error = "ZIP entry uses an unsafe path: " + entryName;
+      return false;
+    }
     const fs::path outPath =
-        destination / PathUtils::PathFromUtf8(entry->GetName().ToStdString());
+        destination / PathUtils::PathFromUtf8(entryName);
     std::error_code ec;
     fs::create_directories(outPath.parent_path(), ec);
 
@@ -423,8 +482,10 @@ bool ExportFixturesBundle(
   if (!error.empty())
     return false;
 
-  return WriteBundle(PathUtils::PathFromUtf8(outputZipPath), "fixtures",
-                     entries, assets, error);
+  if (!WriteBundle(PathUtils::PathFromUtf8(outputZipPath), "fixtures",
+                   entries, assets, error))
+    return false;
+  return ValidateBundleFile(outputZipPath, Type::Fixtures, error);
 }
 
 bool ExportTrussesBundle(
@@ -435,13 +496,16 @@ bool ExportTrussesBundle(
   if (!error.empty())
     return false;
 
-  return WriteBundle(PathUtils::PathFromUtf8(outputZipPath), "trusses", entries,
-                     assets, error);
+  if (!WriteBundle(PathUtils::PathFromUtf8(outputZipPath), "trusses", entries,
+                   assets, error))
+    return false;
+  return ValidateBundleFile(outputZipPath, Type::Trusses, error);
 }
 
 PreparedImport PrepareBundleImport(const std::string &importPath,
                                    Type expectedType) {
   PreparedImport result;
+  result.type = expectedType;
 
   const fs::path path = PathUtils::PathFromUtf8(importPath);
   if (!fs::exists(path))
@@ -512,18 +576,11 @@ PreparedImport PrepareBundleImport(const std::string &importPath,
   }
 
   std::unordered_map<std::string, std::string> importedAssetToLibraryPath;
+  std::unordered_map<std::string, std::pair<std::string, uintmax_t>> seenAssets;
   if (!manifest.contains("assets") || !manifest["assets"].is_array()) {
     result.errors.push_back("Bundle manifest missing 'assets' array");
     return result;
   }
-
-  const bool isFixtures = expectedTypeText == "fixtures";
-  const fs::path activeDictionaryPath = PathUtils::PathFromUtf8(
-      isFixtures ? GdtfDictionary::GetActiveDictionaryFilePath()
-                 : TrussDictionary::GetActiveDictionaryFilePath());
-  const fs::path defaultDictionaryPath =
-      PathUtils::PathFromUtf8(ProjectUtils::GetWritableLibraryPath(expectedTypeText)) /
-      (isFixtures ? "gdtf_dictionary.json" : "truss_dictionary.json");
 
   for (const auto &assetJson : manifest["assets"]) {
     if (!assetJson.is_object()) {
@@ -537,8 +594,26 @@ PreparedImport PrepareBundleImport(const std::string &importPath,
     }
 
     const std::string archivePath = assetJson["path"].get<std::string>();
+    if (!IsSafeArchivePath(archivePath)) {
+      result.errors.push_back("Bundle asset uses an unsafe path: " + archivePath);
+      continue;
+    }
     const std::string expectedChecksum =
         assetJson["checksum"].get<std::string>();
+    const uintmax_t expectedSize =
+        assetJson.contains("size") && assetJson["size"].is_number_unsigned()
+            ? assetJson["size"].get<uintmax_t>()
+            : 0;
+    auto seenIt = seenAssets.find(archivePath);
+    if (seenIt != seenAssets.end() &&
+        (seenIt->second.first != expectedChecksum ||
+         seenIt->second.second != expectedSize)) {
+      result.errors.push_back("Bundle asset has inconsistent duplicate metadata: " +
+                              archivePath);
+      continue;
+    }
+    seenAssets[archivePath] = {expectedChecksum, expectedSize};
+
     const fs::path extractedPath =
         stagingDir / PathUtils::PathFromUtf8(archivePath);
     if (!fs::exists(extractedPath)) {
@@ -552,6 +627,10 @@ PreparedImport PrepareBundleImport(const std::string &importPath,
                               archivePath);
       continue;
     }
+    if (expectedSize != 0 && bytes.size() != expectedSize) {
+      result.errors.push_back("Size mismatch for asset: " + archivePath);
+      continue;
+    }
 
     const std::string actualChecksum = BuildChecksumLabel(bytes);
     if (actualChecksum != expectedChecksum) {
@@ -559,18 +638,7 @@ PreparedImport PrepareBundleImport(const std::string &importPath,
       continue;
     }
 
-    const auto copied = ActiveDictionaryStorage::CopyAssetIntoDictionaryStorage(
-        {isFixtures ? ActiveDictionaryStorage::DictionaryKind::Fixtures
-                    : ActiveDictionaryStorage::DictionaryKind::Trusses,
-         activeDictionaryPath, defaultDictionaryPath, extractedPath, {},
-         FileImportUtils::ConflictPolicy::Overwrite});
-    if (!copied.success) {
-      result.errors.push_back("Could not copy bundle asset into dictionary storage: " +
-                              extractedPath.string());
-      continue;
-    }
-
-    importedAssetToLibraryPath[archivePath] = copied.finalPath.string();
+    importedAssetToLibraryPath[archivePath] = extractedPath.string();
   }
 
   if (!result.errors.empty())
@@ -624,6 +692,162 @@ PreparedImport PrepareBundleImport(const std::string &importPath,
   out << rewrittenRoot.dump(2);
   result.rewritten_snapshot_path = rewrittenPath;
 
+  return result;
+}
+
+
+// Validates a ZIP bundle without copying files into active dictionary storage.
+bool ValidateBundleFile(const std::string &bundlePath, Type expectedType,
+                        std::string &error) {
+  error.clear();
+  PreparedImport prepared = PrepareBundleImport(bundlePath, expectedType);
+  const bool isValid = prepared.is_bundle && prepared.errors.empty() &&
+                       !prepared.rewritten_snapshot_path.empty();
+  if (!isValid) {
+    if (!prepared.errors.empty())
+      error = prepared.errors.front();
+    else
+      error = "File is not a valid Perastage dictionary ZIP bundle";
+  }
+  CleanupPreparedImport(prepared);
+  return isValid;
+}
+
+// Applies a prepared bundle import after the user has confirmed the operation.
+ApplyResult ApplyPreparedBundleImport(const PreparedImport &preparedImport,
+                                      DictionaryImportPolicy policy) {
+  ApplyResult result;
+  if (!preparedImport.is_bundle || preparedImport.rewritten_snapshot_path.empty()) {
+    result.summary.errors.push_back("No prepared bundle import is available");
+    return result;
+  }
+
+  const bool isFixtures = preparedImport.type == Type::Fixtures;
+  const fs::path activeDictionaryPath = PathUtils::PathFromUtf8(
+      isFixtures ? GdtfDictionary::GetActiveDictionaryFilePath()
+                 : TrussDictionary::GetActiveDictionaryFilePath());
+  const fs::path defaultDictionaryPath =
+      PathUtils::PathFromUtf8(ProjectUtils::GetWritableLibraryPath(
+          isFixtures ? "fixtures" : "trusses")) /
+      (isFixtures ? "gdtf_dictionary.json" : "truss_dictionary.json");
+  const auto kind = isFixtures ? ActiveDictionaryStorage::DictionaryKind::Fixtures
+                              : ActiveDictionaryStorage::DictionaryKind::Trusses;
+  const auto layout = ActiveDictionaryStorage::BuildLayout(
+      kind, activeDictionaryPath, defaultDictionaryPath);
+
+  nlohmann::json root;
+  std::string error;
+  if (!ReadJsonFile(preparedImport.rewritten_snapshot_path, root, error)) {
+    result.summary.errors.push_back(error);
+    return result;
+  }
+  auto entriesPtr = DictionaryJsonContract::GetEntriesForType(
+      root, isFixtures ? "fixtures" : "trusses", error);
+  if (!entriesPtr || (!(*entriesPtr)->is_object() && !(*entriesPtr)->is_array())) {
+    result.summary.errors.push_back(
+        error.empty() ? "Prepared bundle entries are invalid" : error);
+    return result;
+  }
+
+  fs::path stagingAssets =
+      layout.ownedAssetDirectory.string() + ".bundle-import.tmp";
+  fs::path stagedJson = activeDictionaryPath.string() + ".bundle-import.tmp";
+  RemoveIfExists(stagingAssets);
+  RemoveIfExists(stagedJson);
+  std::error_code ec;
+  if (fs::exists(layout.ownedAssetDirectory, ec) && !ec)
+    fs::copy(layout.ownedAssetDirectory, stagingAssets,
+             fs::copy_options::recursive |
+                 fs::copy_options::skip_existing,
+             ec);
+  fs::create_directories(stagingAssets, ec);
+  if (ec) {
+    result.summary.errors.push_back("Could not create staged asset directory");
+    RemoveIfExists(stagingAssets);
+    return result;
+  }
+  nlohmann::json entries = **entriesPtr;
+  ActiveDictionaryStorage::AssetStorageLayout stagingLayout = layout;
+  stagingLayout.ownedAssetDirectory = stagingAssets;
+  auto stageEntryAsset = [&](nlohmann::json &entryJson) {
+    std::string stagedPathText;
+    if (!ResolveEntryFileField(entryJson, stagedPathText))
+      return true;
+    const fs::path stagedSource = PathUtils::PathFromUtf8(stagedPathText);
+    const auto copied = FileImportUtils::CopyWithConflictPolicy(
+        stagedSource, stagingAssets / stagedSource.filename(),
+        FileImportUtils::ConflictPolicy::Rename);
+    if (!copied.success) {
+      result.summary.errors.push_back("Could not stage bundle asset: " +
+                                      stagedPathText);
+      return false;
+    }
+    RewriteEntryFileField(
+        entryJson, ActiveDictionaryStorage::MakeSerializedReference(
+                       stagingLayout, copied.finalPath));
+    return true;
+  };
+  if (entries.is_object()) {
+    for (auto it = entries.begin(); it != entries.end(); ++it) {
+      if (!stageEntryAsset(it.value())) {
+        RemoveIfExists(stagingAssets);
+        return result;
+      }
+    }
+  } else {
+    for (auto &entryJson : entries) {
+      if (!stageEntryAsset(entryJson)) {
+        RemoveIfExists(stagingAssets);
+        return result;
+      }
+    }
+  }
+
+  const nlohmann::json stagedRoot = DictionaryJsonContract::MakeRoot(
+      isFixtures ? "fixtures" : "trusses", entries);
+  std::ofstream out(stagedJson, std::ios::binary | std::ios::trunc);
+  if (!out.is_open()) {
+    result.summary.errors.push_back("Could not write staged bundle dictionary JSON");
+    RemoveIfExists(stagingAssets);
+    return result;
+  }
+  out << stagedRoot.dump(2);
+  out.close();
+  result.staged_snapshot_path = stagedJson;
+
+  result.summary = isFixtures
+                       ? GdtfDictionary::PreviewImportFromFile(stagedJson.string(), policy)
+                       : TrussDictionary::PreviewImportFromFile(stagedJson.string(), policy);
+  if (result.summary.HasErrors()) {
+    RemoveIfExists(stagingAssets);
+    RemoveIfExists(stagedJson);
+    return result;
+  }
+
+  fs::path assetBackup;
+  if (!BackupPath(layout.ownedAssetDirectory, assetBackup)) {
+    result.summary.errors.push_back("Could not back up active dictionary assets");
+    RemoveIfExists(stagingAssets);
+    RemoveIfExists(stagedJson);
+    return result;
+  }
+  fs::rename(stagingAssets, layout.ownedAssetDirectory, ec);
+  if (ec) {
+    result.summary.errors.push_back("Could not install bundled dictionary assets");
+    RestoreBackup(assetBackup, layout.ownedAssetDirectory);
+    RemoveIfExists(stagingAssets);
+    RemoveIfExists(stagedJson);
+    return result;
+  }
+
+  result.summary = isFixtures
+                       ? GdtfDictionary::ApplyImportFromFile(stagedJson.string(), policy)
+                       : TrussDictionary::ApplyImportFromFile(stagedJson.string(), policy);
+  if (result.summary.HasErrors())
+    RestoreBackup(assetBackup, layout.ownedAssetDirectory);
+  else
+    RemoveIfExists(assetBackup);
+  RemoveIfExists(stagedJson);
   return result;
 }
 

--- a/core/dictionary_bundle.h
+++ b/core/dictionary_bundle.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "dictionary_import.h"
 #include "gdtfdictionary.h"
 
 #include <filesystem>
@@ -18,7 +19,13 @@ struct PreparedImport {
   bool is_bundle = false;
   std::filesystem::path rewritten_snapshot_path;
   std::filesystem::path staging_directory;
+  Type type = Type::Fixtures;
   std::vector<std::string> errors;
+};
+
+struct ApplyResult {
+  DictionaryImportSummary summary;
+  std::filesystem::path staged_snapshot_path;
 };
 
 bool ExportFixturesBundle(
@@ -29,6 +36,10 @@ bool ExportTrussesBundle(
     const std::string &outputZipPath, std::string &error);
 
 PreparedImport PrepareBundleImport(const std::string &importPath, Type expectedType);
+ApplyResult ApplyPreparedBundleImport(const PreparedImport &preparedImport,
+                                      DictionaryImportPolicy policy);
+bool ValidateBundleFile(const std::string &bundlePath, Type expectedType,
+                        std::string &error);
 void CleanupPreparedImport(const PreparedImport &preparedImport);
 
 } // namespace DictionaryBundle

--- a/docs/developer/dictionary_portable_bundle.md
+++ b/docs/developer/dictionary_portable_bundle.md
@@ -80,26 +80,21 @@ No custom file extension is required.
 
 ## Import behavior for ZIP bundles
 
-When a bundle is imported:
+Portable ZIP bundle import has two separate core phases:
 
-1. The ZIP is extracted to a temporary staging directory.
-2. `manifest.json` is validated (`kind`, `dictionary_type`, required fields).
-3. Every declared `assets[]` item is validated with its checksum.
-4. Assets are copied to the target library directory:
-   - fixtures -> `library/fixtures`
-   - trusses -> `library/trusses`
-5. Dictionary entries are rewritten so `file` references point to the imported library assets.
-6. The rewritten dictionary is imported using the same import policy flow used for JSON snapshots.
+1. **Prepare** identifies ZIP input, extracts it to a unique temporary staging directory, rejects unsafe archive paths, validates `manifest.json`, validates required files, checks declared sizes and checksums, rejects inconsistent duplicate asset metadata, and writes a staged preview snapshot whose asset references still point at staging. Preparation is read-only with respect to active dictionary JSON and active asset storage. Cancelling after prepare must not leave copied assets, backups, rewritten active JSON, or other active-storage side effects.
+2. **Apply** runs only after the user selects the import policy and confirms. It stages destination assets, reuses same-content assets, deterministically renames different-content filename conflicts, rewrites entries to final owned references, validates the staged result, backs up active asset storage, installs assets, applies the dictionary merge policy, and restores the asset backup if the import fails.
+
+JSON snapshots remain separate from portable ZIP bundles. Snapshot import continues to use the existing JSON workflow and never changes the active dictionary path.
+
+Exported portable ZIP bundles are validated through the same side-effect-free bundle validation path after creation. Export validation must not copy the exported bundle back into active storage.
 
 ## Collision policy when copying into library
 
-When a source file would overwrite an existing filename in the target library
-(`library/fixtures` or `library/trusses`) and contents differ, the user is
-prompted to choose one policy:
-
-- **Rename** to a deterministic `<basename>_<hash>.<ext>` target.
-- **Overwrite** existing file.
-- **Cancel** import for that asset.
+Bundle preparation never overwrites active assets. During Apply, same-content
+assets reuse the existing final file. If a staged bundle asset has the same
+filename as an unrelated active asset, the imported asset is renamed
+deterministically to `<basename>_<hash>.<ext>`.
 
 Fixture and truss dictionary entries may include optional provenance/hash
 metadata to aid diagnostics:

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -75,6 +75,7 @@ Perastage 1.5.0 is a substantial update focused on GDTF and truss editing, multi
 
 - Improved Dictionary Editor reliability so fixture and truss edits are saved transactionally, unresolved file references remain visible and savable, dirty-state checks catch category/color/path/name changes, and failed saves keep the editor open.
 - Improved Dictionary Editor asset ownership so saved truss additions and replacements ingest supported source files as owned GDTF assets, and fixture/truss resets create portable self-contained dictionaries with rollback.
+- Fixed portable dictionary ZIP import so previewing or cancelling a bundle no longer copies assets into the active dictionary storage; bundle assets are staged and installed only after final confirmation with rollback on failure.
 - Fixed dictionary lookups and truss dictionary loading so missing asset references remain visible for repair and no longer trigger silent saves, entry deletion, backups, or load-time truss migration.
 - Improved Dictionary Editor safety by scoping dirty-edit prompts to the affected fixture or truss page, making **Discard** reload only that page, stopping saves after the first failure, and blocking writes to invalid or missing custom dictionaries until an explicit recovery action is chosen.
 - Replaced the Dictionary Editor dictionary chooser with explicit **Open**, **New**, **Duplicate Current**, and **Use Default** workflows for fixture and truss dictionaries, including type validation before changing the active path and safe duplication of referenced assets.

--- a/gui/dictionaryeditdialog.cpp
+++ b/gui/dictionaryeditdialog.cpp
@@ -2289,7 +2289,10 @@ bool DictionaryEditDialog::ImportFixturesDictionary() {
     return false;
   }
 
-  const auto result = GdtfDictionary::ApplyImportFromFile(importPath, policy);
+  const auto result =
+      preparedImport.is_bundle
+          ? DictionaryBundle::ApplyPreparedBundleImport(preparedImport, policy).summary
+          : GdtfDictionary::ApplyImportFromFile(importPath, policy);
   DictionaryBundle::CleanupPreparedImport(preparedImport);
   LoadFixtures();
   const bool hasErrors = result.HasErrors();
@@ -2370,7 +2373,10 @@ bool DictionaryEditDialog::ImportTrussesDictionary() {
     return false;
   }
 
-  const auto result = TrussDictionary::ApplyImportFromFile(importPath, policy);
+  const auto result =
+      preparedImport.is_bundle
+          ? DictionaryBundle::ApplyPreparedBundleImport(preparedImport, policy).summary
+          : TrussDictionary::ApplyImportFromFile(importPath, policy);
   DictionaryBundle::CleanupPreparedImport(preparedImport);
   LoadTrusses();
   const bool hasErrors = result.HasErrors();

--- a/tests/check_dictionary_bundle_transactional_import.sh
+++ b/tests/check_dictionary_bundle_transactional_import.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+prepare_body=$(python3 - <<'PY'
+from pathlib import Path
+s=Path('core/dictionary_bundle.cpp').read_text()
+start=s.index('PreparedImport PrepareBundleImport(')
+end=s.index('// Validates a ZIP bundle', start)
+print(s[start:end])
+PY
+)
+
+if grep -q 'CopyAssetIntoDictionaryStorage\|ApplyImportFromFile\|BackupPath' <<<"${prepare_body}"; then
+  echo "PrepareBundleImport must remain side-effect free for active storage." >&2
+  exit 1
+fi
+
+if ! rg -q 'ApplyPreparedBundleImport\(preparedImport, policy\)' gui/dictionaryeditdialog.cpp; then
+  echo "Dictionary Editor ZIP imports must apply prepared bundles only after confirmation." >&2
+  exit 1
+fi
+
+if ! rg -q 'ValidateBundleFile\(outputZipPath' core/dictionary_bundle.cpp; then
+  echo "Portable ZIP exports must validate through the read-only bundle validator." >&2
+  exit 1
+fi
+
+echo "OK: portable dictionary bundle preparation remains transactional."


### PR DESCRIPTION
### Motivation
- Preparing a portable ZIP bundle previously copied assets into active dictionary storage during preview, leaving orphaned or overwritten assets when the user cancelled, so preparation must be side-effect free and apply must be explicit and transactional. 
- The change enforces clear separation between read-only validation/preview (Prepare) and the destructive install phase (Apply), plus export-time validation that is side-effect free.

### Description
- Made `PrepareBundleImport` read-only by extracting archives into a unique staging directory, rejecting unsafe archive paths, validating manifest entries, sizes, and checksums, rejecting duplicate asset metadata inconsistencies, and writing a rewritten preview snapshot that points to staging files without touching active storage. 
- Added a GUI-independent `ApplyPreparedBundleImport` API and `ApplyResult` that stages destination assets (reusing same-content files and deterministically renaming conflicting names), rewrites entries to final owned references, validates the staged result, backs up active asset storage, installs staged assets and JSON atomically, and rolls back on fatal errors. 
- Export paths now run a read-only `ValidateBundleFile` on the produced ZIP so export success is reported only after the generated bundle validates without importing or copying it into active storage. 
- Updated Dictionary Editor import flows to use the two-phase model: preview via `PrepareBundleImport`, show policy/preview to the user, then call `ApplyPreparedBundleImport` only after final confirmation while preserving the existing JSON snapshot import path. 
- Added helpers for safe ZIP path checks and transactional backup/restore, a regression guard test `tests/check_dictionary_bundle_transactional_import.sh`, and documentation updates in `docs/developer/dictionary_portable_bundle.md` and `docs/release-notes-draft.md` describing the new semantics.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed. 
- Added and ran `tests/check_dictionary_bundle_transactional_import.sh` which verifies `PrepareBundleImport` remains side-effect free and the GUI uses the apply API, and it passed. 
- Ran `git diff --check` which passed. 
- Attempted a full CMake configure/build (`cmake -S . -B build -DBUILD_TESTING=ON`) but configuration could not complete in this environment because the wxWidgets development libraries are missing, so a full build/test run was not possible here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b3da190108324895224dffc11f4f8)