### PR TITLE
Optimize fixture symbol generation pipeline (reuse FBO, single scene reload, parallel vectorization, fingerprint cache)

### DIFF
--- a/core/symbol_cache_manifest.cpp
+++ b/core/symbol_cache_manifest.cpp
@@ -12,8 +12,10 @@
 #include <iomanip>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <sstream>
 #include <utility>
+#include <unordered_map>
 #include <vector>
 
 #include <wx/wfstream.h>
@@ -336,9 +338,37 @@ static void UpdateFnv1a(std::uint64_t &hash, const void *data, size_t size) {
   }
 }
 
+struct FingerprintCacheEntry {
+  std::uintmax_t fileSize = 0;
+  std::filesystem::file_time_type lastWriteTime{};
+  std::string fingerprint;
+};
+
+std::mutex g_fingerprintCacheMutex;
+std::unordered_map<std::string, FingerprintCacheEntry> g_fingerprintCache;
+SemanticFingerprintCacheStats g_fingerprintCacheStats;
+
+// Returns the canonical cache path used for in-process semantic fingerprint memoization.
+std::string NormalizeFingerprintCachePath(const std::string &path) {
+  std::error_code ec;
+  const std::filesystem::path fsPath = std::filesystem::weakly_canonical(path, ec);
+  return (ec ? std::filesystem::absolute(path, ec) : fsPath).generic_string();
+}
+
+// Reads file metadata that must match before a cached semantic fingerprint is reused.
+bool ReadFingerprintFileMetadata(const std::string &path, std::uintmax_t &fileSize,
+                                 std::filesystem::file_time_type &lastWriteTime) {
+  std::error_code ec;
+  fileSize = std::filesystem::file_size(path, ec);
+  if (ec)
+    return false;
+  lastWriteTime = std::filesystem::last_write_time(path, ec);
+  return !ec;
+}
+
 // Computes a versioned semantic fingerprint over symbol-relevant uncompressed GDTF entries.
-std::string ComputeGdtfSemanticFingerprint(const std::string &path,
-                                           std::string &errorMessage) {
+static std::string ComputeGdtfSemanticFingerprintUncached(const std::string &path,
+                                                          std::string &errorMessage) {
   wxFileInputStream input(WxStringFromUtf8Path(path));
   if (!input.IsOk()) {
     errorMessage = "Could not open GDTF archive for semantic fingerprinting.";
@@ -398,6 +428,51 @@ std::string ComputeGdtfSemanticFingerprint(const std::string &path,
   out << "gdtfsymfnv1a64v1:" << std::hex << std::setw(16) << std::setfill('0')
       << hash << ":" << std::dec << entries.size() << ":" << payloadSize;
   return out.str();
+}
+
+// Computes a memoized semantic GDTF content fingerprint for unchanged files.
+std::string ComputeGdtfSemanticFingerprint(const std::string &path,
+                                           std::string &errorMessage) {
+  const std::string cachePath = NormalizeFingerprintCachePath(path);
+  std::uintmax_t fileSize = 0;
+  std::filesystem::file_time_type lastWriteTime{};
+  if (ReadFingerprintFileMetadata(path, fileSize, lastWriteTime)) {
+    std::lock_guard<std::mutex> lock(g_fingerprintCacheMutex);
+    const auto it = g_fingerprintCache.find(cachePath);
+    if (it != g_fingerprintCache.end() && it->second.fileSize == fileSize &&
+        it->second.lastWriteTime == lastWriteTime) {
+      ++g_fingerprintCacheStats.hits;
+      errorMessage.clear();
+      return it->second.fingerprint;
+    }
+    ++g_fingerprintCacheStats.misses;
+  }
+
+  std::string fingerprint = ComputeGdtfSemanticFingerprintUncached(path, errorMessage);
+  if (!fingerprint.empty() && ReadFingerprintFileMetadata(path, fileSize, lastWriteTime)) {
+    std::lock_guard<std::mutex> lock(g_fingerprintCacheMutex);
+    g_fingerprintCache[cachePath] = FingerprintCacheEntry{fileSize, lastWriteTime, fingerprint};
+  }
+  return fingerprint;
+}
+
+// Invalidates the cached semantic fingerprint for one GDTF path.
+void InvalidateGdtfSemanticFingerprintCache(const std::string &path) {
+  std::lock_guard<std::mutex> lock(g_fingerprintCacheMutex);
+  g_fingerprintCache.erase(NormalizeFingerprintCachePath(path));
+}
+
+// Clears all cached semantic fingerprints and cache counters.
+void ClearGdtfSemanticFingerprintCache() {
+  std::lock_guard<std::mutex> lock(g_fingerprintCacheMutex);
+  g_fingerprintCache.clear();
+  g_fingerprintCacheStats = {};
+}
+
+// Returns semantic fingerprint cache hit/miss counters.
+SemanticFingerprintCacheStats GetGdtfSemanticFingerprintCacheStats() {
+  std::lock_guard<std::mutex> lock(g_fingerprintCacheMutex);
+  return g_fingerprintCacheStats;
 }
 
 // Computes the current semantic GDTF content fingerprint used by symbol cache validation.

--- a/core/symbol_cache_manifest.h
+++ b/core/symbol_cache_manifest.h
@@ -83,8 +83,16 @@ private:
   std::vector<FixtureSymbolCacheEntry> entries;
 };
 
+struct SemanticFingerprintCacheStats {
+  int hits = 0;
+  int misses = 0;
+};
+
 std::string ComputeGdtfSemanticFingerprint(const std::string &path,
                                            std::string &errorMessage);
+void InvalidateGdtfSemanticFingerprintCache(const std::string &path);
+void ClearGdtfSemanticFingerprintCache();
+SemanticFingerprintCacheStats GetGdtfSemanticFingerprintCacheStats();
 std::string ComputeFileContentHash(const std::string &path,
                                    std::string &errorMessage);
 std::set<std::string> RequiredPerastageSymbolViews();

--- a/core/symbols/Symbol2DImageBuilder.cpp
+++ b/core/symbols/Symbol2DImageBuilder.cpp
@@ -5,10 +5,12 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <future>
 #include <iterator>
 #include <optional>
 #include <queue>
 #include <set>
+#include <thread>
 #include <limits>
 #include <unordered_map>
 
@@ -696,43 +698,80 @@ std::vector<Polyline2D> ExtractPolylines(const PixelMask &skeleton,
 
 } // namespace
 
-std::vector<Symbol2D>
-Symbol2DImageBuilder::BuildFromRenderedImages(
+// Converts one rendered RGBA image into one 2D symbol without shared mutable state.
+std::optional<Symbol2D> Symbol2DImageBuilder::BuildFromRenderedImage(
+    const RenderedSymbolImage &render, const ImageBuildParams &params) {
+  const size_t expectedBytes = static_cast<size_t>(render.width) *
+                               static_cast<size_t>(render.height) * 4;
+  if (render.width <= 0 || render.height <= 0 || render.rgba.size() < expectedBytes)
+    return std::nullopt;
+
+  PixelMask fillMask = BuildFillMask(render, params);
+  PixelMask lineMask = BuildLineMask(render, params);
+  CloseMaskGaps(fillMask, params.fillGapClosurePixels);
+  CloseMaskGaps(lineMask, params.lineGapClosurePixels);
+  ThinZhangSuen(lineMask);
+
+  Symbol2D symbol;
+  symbol.view = render.view;
+  symbol.strokeWidthPx = params.previewStrokeWidthPx;
+
+  symbol.fill = ExtractFillPolygons(fillMask);
+  symbol.strokes = ExtractPolylines(lineMask, params);
+  AddFillBoundaryStrokeFallback(symbol);
+
+  for (const auto &polygon : symbol.fill)
+    for (const auto &p : polygon.outer)
+      ExtendBounds(symbol.bounds, p);
+  for (const auto &line : symbol.strokes)
+    for (const auto &p : line)
+      ExtendBounds(symbol.bounds, p);
+
+  return symbol;
+}
+
+// Converts rendered images sequentially for deterministic tests and fallback.
+std::vector<Symbol2D> Symbol2DImageBuilder::BuildFromRenderedImagesSequential(
     const std::vector<RenderedSymbolImage> &renders, const ImageBuildParams &params) {
   std::vector<Symbol2D> symbols;
   symbols.reserve(renders.size());
-
   for (const auto &render : renders) {
-    const size_t expectedBytes = static_cast<size_t>(render.width) *
-                                 static_cast<size_t>(render.height) * 4;
-    if (render.width <= 0 || render.height <= 0 || render.rgba.size() < expectedBytes)
-      continue;
+    auto symbol = BuildFromRenderedImage(render, params);
+    if (symbol)
+      symbols.push_back(std::move(*symbol));
+  }
+  return symbols;
+}
 
-    PixelMask fillMask = BuildFillMask(render, params);
-    PixelMask lineMask = BuildLineMask(render, params);
-    CloseMaskGaps(fillMask, params.fillGapClosurePixels);
-    CloseMaskGaps(lineMask, params.lineGapClosurePixels);
-    ThinZhangSuen(lineMask);
+// Converts rendered images in bounded parallel tasks while preserving input order.
+std::vector<Symbol2D> Symbol2DImageBuilder::BuildFromRenderedImages(
+    const std::vector<RenderedSymbolImage> &renders, const ImageBuildParams &params) {
+  const unsigned int hardware = std::thread::hardware_concurrency();
+  if (renders.size() < 2 || hardware < 2)
+    return BuildFromRenderedImagesSequential(renders, params);
 
-    Symbol2D symbol;
-    symbol.view = render.view;
-    symbol.strokeWidthPx = params.previewStrokeWidthPx;
+  const size_t workerCount =
+      std::min(renders.size(), static_cast<size_t>(std::max(2u, hardware)));
+  std::vector<std::optional<Symbol2D>> ordered(renders.size());
+  std::vector<std::future<void>> futures;
+  futures.reserve(workerCount);
 
-    symbol.fill = ExtractFillPolygons(fillMask);
-
-    symbol.strokes = ExtractPolylines(lineMask, params);
-    AddFillBoundaryStrokeFallback(symbol);
-
-    for (const auto &polygon : symbol.fill)
-      for (const auto &p : polygon.outer)
-        ExtendBounds(symbol.bounds, p);
-    for (const auto &line : symbol.strokes)
-      for (const auto &p : line)
-        ExtendBounds(symbol.bounds, p);
-
-    symbols.push_back(std::move(symbol));
+  for (size_t worker = 0; worker < workerCount; ++worker) {
+    futures.push_back(std::async(std::launch::async, [&, worker]() {
+      for (size_t index = worker; index < renders.size(); index += workerCount)
+        ordered[index] = BuildFromRenderedImage(renders[index], params);
+    }));
   }
 
+  for (auto &future : futures)
+    future.get();
+
+  std::vector<Symbol2D> symbols;
+  symbols.reserve(renders.size());
+  for (auto &symbol : ordered) {
+    if (symbol)
+      symbols.push_back(std::move(*symbol));
+  }
   return symbols;
 }
 

--- a/core/symbols/Symbol2DImageBuilder.h
+++ b/core/symbols/Symbol2DImageBuilder.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include <vector>
 
 #include "Symbol2D.h"
@@ -26,6 +27,15 @@ struct ImageBuildParams {
 
 class Symbol2DImageBuilder {
 public:
+  static std::optional<Symbol2D>
+  BuildFromRenderedImage(const RenderedSymbolImage &render,
+                         const ImageBuildParams &params = ImageBuildParams{});
+
+  static std::vector<Symbol2D>
+  BuildFromRenderedImagesSequential(
+      const std::vector<RenderedSymbolImage> &renders,
+      const ImageBuildParams &params = ImageBuildParams{});
+
   static std::vector<Symbol2D>
   BuildFromRenderedImages(const std::vector<RenderedSymbolImage> &renders,
                           const ImageBuildParams &params = ImageBuildParams{});

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -231,5 +231,6 @@ You can also contact the project at **perastage.app@gmail.com**.
 - Fixed embedded Layout 2D fixture symbols so rotated GDTF fixtures choose the visible representative symbol plane and preserve the same orientation in preview and PDF export.
 
 ## Internal changes
+- Improved fixture symbol generation performance by avoiding redundant 2D scene reloads during orthographic capture, reusing offscreen framebuffer resources, memoizing unchanged GDTF semantic fingerprints in-process, and converting independent rendered symbol views in bounded parallel workers while preserving exact generated geometry.
 - Refactored runtime temporary storage so imports, exports, generated resources, and session caches use explicit Perastage-owned lifecycles.
 - Dictionary loading is now read-only for valid custom fixture and truss dictionaries; default seeding, reset, and managed-default recovery are explicit operations.

--- a/gui/tools/scene_model_symbol_capture_service.cpp
+++ b/gui/tools/scene_model_symbol_capture_service.cpp
@@ -1,6 +1,7 @@
 #include "tools/scene_model_symbol_capture_service.h"
 
 #include <array>
+#include <chrono>
 #include <string>
 #include <unordered_map>
 
@@ -66,15 +67,10 @@ public:
                                  bool alignToLocalAxes)
       : cfg_(cfg) {
     auto &scene = cfg_.GetScene();
-    originalFixtures_ = scene.fixtures;
-    originalTrusses_ = scene.trusses;
-    originalSceneObjects_ = scene.sceneObjects;
-    originalSupports_ = scene.supports;
-
-    scene.fixtures.clear();
-    scene.trusses.clear();
-    scene.sceneObjects.clear();
-    scene.supports.clear();
+    originalFixtures_.swap(scene.fixtures);
+    originalTrusses_.swap(scene.trusses);
+    originalSceneObjects_.swap(scene.sceneObjects);
+    originalSupports_.swap(scene.supports);
 
     switch (target.kind) {
     case SceneModelKind::Fixture: {
@@ -116,10 +112,14 @@ public:
   // Restores the original scene content after isolated capture is complete.
   ~ScopedSingleModelSceneOverride() {
     auto &scene = cfg_.GetScene();
-    scene.fixtures = std::move(originalFixtures_);
-    scene.trusses = std::move(originalTrusses_);
-    scene.sceneObjects = std::move(originalSceneObjects_);
-    scene.supports = std::move(originalSupports_);
+    scene.fixtures.clear();
+    scene.trusses.clear();
+    scene.sceneObjects.clear();
+    scene.supports.clear();
+    scene.fixtures.swap(originalFixtures_);
+    scene.trusses.swap(originalTrusses_);
+    scene.sceneObjects.swap(originalSceneObjects_);
+    scene.supports.swap(originalSupports_);
   }
 
 private:
@@ -163,7 +163,7 @@ public:
     panel_.SetRenderOverrides(renderOverrides_);
     panel_.SetPreferPerastageSvgSymbolsForLayouts(
         preferPerastageSvgSymbolsForLayouts_);
-    panel_.UpdateScene(true);
+    panel_.UpdateScene(false);
   }
 
 private:
@@ -291,6 +291,7 @@ SceneModelSymbolCaptureResult CaptureSceneModelOrthographicSymbols(
   renderer.SetViewportSize(options.viewportSize);
   renderer.PrepareForCapture();
   renderer.ApplySymbolCaptureDefaults();
+  capturePanel->UpdateScene(true);
 
   {
     std::vector<unsigned char> warmupPixels;
@@ -344,7 +345,6 @@ SceneModelSymbolCaptureResult CaptureSceneModelOrthographicSymbols(
     capturePanel->SetRenderOverrides(renderOverrides);
     capturePanel->SetRenderMode(Viewer2DRenderMode::ByFixtureType);
     capturePanel->SetView(request.view);
-    capturePanel->UpdateScene(true);
     capturePanel->FitViewToScene();
 
     symbols::RenderedSymbolImage render;

--- a/gui/windows/symbol_fixture_applier.cpp
+++ b/gui/windows/symbol_fixture_applier.cpp
@@ -27,6 +27,7 @@
 #include "gdtfdictionary.h"
 #include "gdtf_mutation_audit.h"
 #include "gdtf_canonicalizer.h"
+#include "symbol_cache_manifest.h"
 #include "windows/symbol_preview_exporter.h"
 
 namespace fs = std::filesystem;
@@ -470,6 +471,7 @@ bool VerifyArchiveEntries(const fs::path &archivePath,
   return true;
 }
 
+// Rewrites a fixture GDTF archive with generated SVG symbols and updated metadata.
 bool RewriteGdtf(const fs::path &sourcePath,
                  const std::unordered_map<std::string, SymbolPayload> &payloads,
                  const std::string &topPath,
@@ -571,9 +573,12 @@ bool RewriteGdtf(const fs::path &sourcePath,
   fs::rename(tempPath, sourcePath, ec);
 #endif
   if (ec) {
+    fs::remove(tempPath);
     errorMessage = "Could not replace the original GDTF file.";
     return false;
   }
+
+  symbol_cache::InvalidateGdtfSemanticFingerprintCache(sourcePath.string());
 
   if (!VerifyArchiveEntries(sourcePath, payloads)) {
     errorMessage = "GDTF was saved but generated SVG views were not found in archive.";

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1750,6 +1750,13 @@ add_executable(support_resolution_test
 target_include_directories(support_resolution_test PRIVATE ../models)
 add_test(NAME SupportResolution COMMAND support_resolution_test)
 
+add_executable(symbol2d_image_builder_parallel_test
+               symbol2d_image_builder_parallel_test.cpp
+               ../core/symbols/Symbol2DImageBuilder.cpp)
+target_include_directories(symbol2d_image_builder_parallel_test PRIVATE ../core)
+add_test(NAME Symbol2DImageBuilderParallelExactEquality
+         COMMAND symbol2d_image_builder_parallel_test)
+
 add_executable(symbol_cache_manifest_test symbol_cache_manifest_test.cpp
                ../core/symbol_cache_manifest.cpp
                ../core/filesystem_path_utils.cpp)

--- a/tests/symbol2d_image_builder_parallel_test.cpp
+++ b/tests/symbol2d_image_builder_parallel_test.cpp
@@ -1,0 +1,117 @@
+#include "symbols/Symbol2DImageBuilder.h"
+
+#include <cassert>
+#include <cstddef>
+#include <vector>
+
+namespace {
+
+// Creates a transparent RGBA test render for one symbol view.
+symbols::RenderedSymbolImage MakeImage(symbols::SymbolView view, int width,
+                                       int height) {
+  symbols::RenderedSymbolImage image;
+  image.view = view;
+  image.width = width;
+  image.height = height;
+  image.rgba.assign(static_cast<size_t>(width) * static_cast<size_t>(height) * 4,
+                    0);
+  return image;
+}
+
+// Sets one image pixel to an opaque black source sample.
+void SetBlackPixel(symbols::RenderedSymbolImage &image, int x, int y) {
+  const size_t offset = (static_cast<size_t>(y) * static_cast<size_t>(image.width) +
+                         static_cast<size_t>(x)) *
+                        4;
+  image.rgba[offset + 0] = 0;
+  image.rgba[offset + 1] = 0;
+  image.rgba[offset + 2] = 0;
+  image.rgba[offset + 3] = 255;
+}
+
+// Draws a filled black rectangle into the source image.
+void FillRect(symbols::RenderedSymbolImage &image, int x0, int y0, int x1,
+              int y1) {
+  for (int y = y0; y <= y1; ++y)
+    for (int x = x0; x <= x1; ++x)
+      SetBlackPixel(image, x, y);
+}
+
+// Builds deterministic synthetic images that exercise independent conversion paths.
+std::vector<symbols::RenderedSymbolImage> BuildInputs() {
+  std::vector<symbols::RenderedSymbolImage> renders;
+  renders.push_back(MakeImage(symbols::SymbolView::Front, 32, 32));
+  FillRect(renders.back(), 6, 7, 24, 22);
+
+  renders.push_back(MakeImage(symbols::SymbolView::Top, 32, 32));
+  FillRect(renders.back(), 4, 4, 27, 27);
+  FillRect(renders.back(), 11, 11, 20, 20);
+  for (int y = 11; y <= 20; ++y)
+    for (int x = 11; x <= 20; ++x)
+      renders.back().rgba[(static_cast<size_t>(y) * 32 + static_cast<size_t>(x)) * 4 + 3] = 0;
+
+  renders.push_back(MakeImage(symbols::SymbolView::Left, 32, 32));
+  for (int i = 3; i < 29; ++i)
+    SetBlackPixel(renders.back(), i, i);
+
+  renders.push_back(MakeImage(symbols::SymbolView::Bottom, 32, 32));
+  FillRect(renders.back(), 2, 2, 6, 6);
+  FillRect(renders.back(), 23, 23, 29, 29);
+  return renders;
+}
+
+// Compares all symbol fields through exact value equality.
+void AssertEqualSymbols(const std::vector<symbols::Symbol2D> &expected,
+                        const std::vector<symbols::Symbol2D> &actual) {
+  assert(expected.size() == actual.size());
+  for (size_t i = 0; i < expected.size(); ++i) {
+    assert(expected[i].view == actual[i].view);
+    assert(expected[i].strokeWidthPx == actual[i].strokeWidthPx);
+    assert(expected[i].bounds.valid == actual[i].bounds.valid);
+    assert(expected[i].bounds.min.x == actual[i].bounds.min.x);
+    assert(expected[i].bounds.min.y == actual[i].bounds.min.y);
+    assert(expected[i].bounds.max.x == actual[i].bounds.max.x);
+    assert(expected[i].bounds.max.y == actual[i].bounds.max.y);
+    assert(expected[i].fill.size() == actual[i].fill.size());
+    for (size_t polygon = 0; polygon < expected[i].fill.size(); ++polygon) {
+      assert(expected[i].fill[polygon].outer.size() == actual[i].fill[polygon].outer.size());
+      for (size_t point = 0; point < expected[i].fill[polygon].outer.size(); ++point) {
+        assert(expected[i].fill[polygon].outer[point].x == actual[i].fill[polygon].outer[point].x);
+        assert(expected[i].fill[polygon].outer[point].y == actual[i].fill[polygon].outer[point].y);
+      }
+      assert(expected[i].fill[polygon].holes.size() == actual[i].fill[polygon].holes.size());
+      for (size_t hole = 0; hole < expected[i].fill[polygon].holes.size(); ++hole) {
+        assert(expected[i].fill[polygon].holes[hole].size() == actual[i].fill[polygon].holes[hole].size());
+        for (size_t point = 0; point < expected[i].fill[polygon].holes[hole].size(); ++point) {
+          assert(expected[i].fill[polygon].holes[hole][point].x == actual[i].fill[polygon].holes[hole][point].x);
+          assert(expected[i].fill[polygon].holes[hole][point].y == actual[i].fill[polygon].holes[hole][point].y);
+        }
+      }
+    }
+    assert(expected[i].strokes.size() == actual[i].strokes.size());
+    for (size_t stroke = 0; stroke < expected[i].strokes.size(); ++stroke) {
+      assert(expected[i].strokes[stroke].size() == actual[i].strokes[stroke].size());
+      for (size_t point = 0; point < expected[i].strokes[stroke].size(); ++point) {
+        assert(expected[i].strokes[stroke][point].x == actual[i].strokes[stroke][point].x);
+        assert(expected[i].strokes[stroke][point].y == actual[i].strokes[stroke][point].y);
+      }
+    }
+  }
+}
+
+} // namespace
+
+// Verifies parallel image vectorization preserves sequential output and order exactly.
+int main() {
+  const auto renders = BuildInputs();
+  const auto sequential =
+      symbols::Symbol2DImageBuilder::BuildFromRenderedImagesSequential(renders);
+  const auto parallel = symbols::Symbol2DImageBuilder::BuildFromRenderedImages(renders);
+  AssertEqualSymbols(sequential, parallel);
+  assert(parallel.size() == renders.size());
+  assert(parallel[0].view == symbols::SymbolView::Front);
+  assert(parallel[1].view == symbols::SymbolView::Top);
+  assert(parallel[2].view == symbols::SymbolView::Left);
+  assert(parallel[3].view == symbols::SymbolView::Bottom);
+  return 0;
+}

--- a/viewer2d/viewer2doffscreenrenderer.cpp
+++ b/viewer2d/viewer2doffscreenrenderer.cpp
@@ -84,5 +84,4 @@ void Viewer2DOffscreenRenderer::ApplySymbolCaptureDefaults() {
   panel_->SetPreferPerastageSvgSymbolsForLayouts(false);
   panel_->ApplyViewState(0.0f, 0.0f, 1.0f, Viewer2DView::Top,
                          Viewer2DRenderMode::ByFixtureType);
-  panel_->UpdateScene(true);
 }

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -595,6 +595,10 @@ Viewer2DPanel::Viewer2DPanel(wxWindow *parent, bool allowOffscreenRender,
 }
 
 Viewer2DPanel::~Viewer2DPanel() {
+  if (m_glContext) {
+    SetCurrent(*m_glContext);
+    ReleaseCaptureFramebufferTarget();
+  }
   if (HasCapture())
     ReleaseMouse();
   if (g_instance == this)
@@ -1471,10 +1475,13 @@ bool Viewer2DPanel::RenderToRGBA(std::vector<unsigned char> &pixels, int &width,
     return false;
   }
 
-  glcapture::FramebufferCaptureTarget target;
+  if (!m_captureFramebufferTarget)
+    m_captureFramebufferTarget = std::make_unique<glcapture::FramebufferCaptureTarget>();
+
+  glcapture::FramebufferCaptureTarget &target = *m_captureFramebufferTarget;
   ScopedReadBufferPackAlignmentState readStateGuard;
   glstate::ScopedFramebufferViewportScissorState framebufferStateGuard;
-  if (!target.Initialize(w, h) || !target.IsComplete()) {
+  if (!target.EnsureSize(w, h) || !target.IsComplete()) {
     const std::string diagnostic = target.Diagnostic();
     diagnostics::DiagnosticReport::RecordViewer2DBackBufferFallback(
         w, h, diagnostic.empty() ? "FBO unavailable" : diagnostic);
@@ -1502,6 +1509,12 @@ bool Viewer2DPanel::RenderToRGBA(std::vector<unsigned char> &pixels, int &width,
   diagnostics::DiagnosticReport::RecordViewer2DFboCapture(w, h);
 
   return true;
+}
+
+// Releases reusable capture framebuffer resources while the GL context is current.
+void Viewer2DPanel::ReleaseCaptureFramebufferTarget() {
+  if (m_captureFramebufferTarget)
+    m_captureFramebufferTarget->Release();
 }
 
 // Captures RGBA pixels from the legacy back buffer path when FBO capture fails.

--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -65,6 +65,10 @@ struct Viewer2DRenderOverrides {
   std::optional<bool> symbolCaptureIncludeCoplanarEdges;
 };
 
+namespace glcapture {
+class FramebufferCaptureTarget;
+}
+
 class Viewer2DPanel : public wxGLCanvas {
 public:
   explicit Viewer2DPanel(wxWindow *parent, bool allowOffscreenRender = false,
@@ -214,6 +218,7 @@ private:
   void TrackRefreshTelemetry();
   bool RenderToRGBABackBufferFallback(std::vector<unsigned char> &pixels,
                                       int width, int height);
+  void ReleaseCaptureFramebufferTarget();
 
   std::array<float, 3> MapDragDelta(float dxMeters, float dyMeters) const;
   std::optional<std::array<float, 3>> ComputeSelectionDragCenterMeters() const;
@@ -397,6 +402,7 @@ private:
   std::optional<wxSize> m_layoutEditBaseSize;
   std::optional<wxSize> m_layoutEditViewportSize;
   std::optional<wxSize> m_captureFramebufferSizeOverride;
+  std::unique_ptr<glcapture::FramebufferCaptureTarget> m_captureFramebufferTarget;
   float m_layoutEditScale = 1.0f;
   bool m_preferPerastageSvgSymbolsForLayouts = false;
   std::optional<Viewer2DRenderOverrides> m_renderOverrides;

--- a/viewer_common/gl_framebuffer_capture_target.cpp
+++ b/viewer_common/gl_framebuffer_capture_target.cpp
@@ -62,6 +62,7 @@ FramebufferCaptureTarget &FramebufferCaptureTarget::operator=(
   depthStencilRenderbuffer_ = other.depthStencilRenderbuffer_;
   width_ = other.width_;
   height_ = other.height_;
+  allocationCount_ = other.allocationCount_;
   complete_ = other.complete_;
   diagnostic_ = std::move(other.diagnostic_);
 
@@ -70,9 +71,19 @@ FramebufferCaptureTarget &FramebufferCaptureTarget::operator=(
   other.depthStencilRenderbuffer_ = 0;
   other.width_ = 0;
   other.height_ = 0;
+  other.allocationCount_ = 0;
   other.complete_ = false;
   other.diagnostic_.clear();
   return *this;
+}
+
+// Creates or reuses framebuffer resources when the requested size is unchanged.
+bool FramebufferCaptureTarget::EnsureSize(int width, int height) {
+  if (complete_ && width_ == width && height_ == height) {
+    diagnostic_.clear();
+    return true;
+  }
+  return Initialize(width, height);
 }
 
 // Creates the framebuffer, color texture, and depth/stencil attachment.
@@ -130,6 +141,7 @@ bool FramebufferCaptureTarget::Initialize(int width, int height) {
   }
 
   complete_ = true;
+  ++allocationCount_;
   diagnostic_.clear();
   return true;
 }
@@ -144,6 +156,9 @@ void FramebufferCaptureTarget::BindForReading() const {
   glBindFramebuffer(GL_FRAMEBUFFER, framebuffer_);
   glReadBuffer(GL_COLOR_ATTACHMENT0);
 }
+
+// Releases all OpenGL resources owned by this target.
+void FramebufferCaptureTarget::Release() { Reset(); }
 
 // Releases any OpenGL objects owned by this target.
 void FramebufferCaptureTarget::Reset() {

--- a/viewer_common/gl_framebuffer_capture_target.h
+++ b/viewer_common/gl_framebuffer_capture_target.h
@@ -17,8 +17,14 @@ public:
   FramebufferCaptureTarget(FramebufferCaptureTarget &&other) noexcept;
   FramebufferCaptureTarget &operator=(FramebufferCaptureTarget &&other) noexcept;
 
+  // Creates or reuses the framebuffer resources for the requested size.
+  bool EnsureSize(int width, int height);
+
   // Creates the framebuffer, color texture, and depth/stencil attachment.
   bool Initialize(int width, int height);
+
+  // Releases all OpenGL resources owned by this target.
+  void Release();
 
   // Binds the framebuffer so callers can render into the capture target.
   void BindForRendering() const;
@@ -38,6 +44,9 @@ public:
   // Returns the most recent creation or completeness diagnostic.
   const std::string &Diagnostic() const { return diagnostic_; }
 
+  // Returns how many framebuffer allocations were needed by this target.
+  int AllocationCount() const { return allocationCount_; }
+
 private:
   // Releases any OpenGL objects owned by this target.
   void Reset();
@@ -47,6 +56,7 @@ private:
   GLuint depthStencilRenderbuffer_ = 0;
   int width_ = 0;
   int height_ = 0;
+  int allocationCount_ = 0;
   bool complete_ = false;
   std::string diagnostic_;
 };


### PR DESCRIPTION
### Motivation
- Symbol generation did repeated, avoidable work: per-view full scene reloads, full-scene deep-copy isolation, per-capture GL FBO reallocations, sequential image-to-vector conversion, and repeated GDTF ZIP semantic scans which scaled poorly with project size.
- The goal is a conservative refactor that improves throughput while preserving exact visual output, geometry, calibration, GDTF semantics, and existing fallback behaviors.
- Make the hot-path costs visible with low-noise counters and keep optimizations safe and reversible when exact equivalence could not be proven.

### Description
- Capture orchestration: changed the orthographic capture flow so the isolated scene does exactly one `UpdateScene(true)` after capture defaults are applied and then renders the four views without per-view full reloads; relevant changes in `gui/tools/scene_model_symbol_capture_service.cpp` and `viewer2d/viewer2doffscreenrenderer.cpp`.
- O(1) isolation: replaced deep-copy scene container moves with swap-based RAII in `ScopedSingleModelSceneOverride` to avoid copying large maps while restoring the original maps exactly on scope exit (no observable state change).
- Reusable FBO: added `EnsureSize()`/`Release()` and allocation counters to the framebuffer helper in `viewer_common/gl_framebuffer_capture_target.{h,cpp}` and made `Viewer2DPanel` hold a reusable per-panel target to avoid repeated allocations in `RenderToRGBA` while preserving `GL_RGBA8`/`GL_DEPTH24_STENCIL8`, diagnostics, and back-buffer fallback.
- Parallel, order-preserving vectorization: split the image-to-symbol pipeline into `BuildFromRenderedImage(...)` and a sequential fallback, then added a bounded `std::async` worker implementation that converts independent rendered views in parallel while preserving exact ordering and deterministic fallback in `core/symbols/Symbol2DImageBuilder.{h,cpp}`.
- Semantic-fingerprint memoization: added an in-process fingerprint cache keyed by canonical path, file size, and mtime with hit/miss counters and invalidation APIs in `core/symbol_cache_manifest.{h,cpp}` and invalidated cache entries after a successful GDTF rewrite in `gui/windows/symbol_fixture_applier.cpp` (and removed temporary rewrite file on failure).
- Tests & docs: added an exact equality unit test `tests/symbol2d_image_builder_parallel_test.cpp` to assert parallel == sequential outputs and registered it in `tests/CMakeLists.txt`, and added a short internal entry to `docs/release-notes-draft.md` describing the improvement.

### Testing
- Built and ran the exact-equality unit test with: `g++ -std=c++20 -Icore tests/symbol2d_image_builder_parallel_test.cpp core/symbols/Symbol2DImageBuilder.cpp -pthread -o /tmp/symbol2d_image_builder_parallel_test && /tmp/symbol2d_image_builder_parallel_test`, which succeeded.
- Ran repository checks: `bash tests/check_perastage_tree_modules.sh` and `bash tests/check_no_configmanager_get_in_gui.sh`, both succeeded in this environment.
- Ran viewer2D capture boundary diagnostics: `bash tests/check_viewer2d_render_to_rgba_fbo_boundary.sh` and `bash tests/check_viewer2d_fbo_capture_diagnostics.sh`, and they passed after wiring the reuse/fallback diagnostic correctly.
- CMake/CI note: attempting full CMake + test-target build with `-DBUILD_TESTING=ON` failed to configure in this container because `wxWidgets` was not present (`Could NOT find wxWidgets`), so full test-suite execution was not possible here; added unit and shell checks exercise the changes that do not require the full GUI build.
- Observability: added lightweight counters (FBO allocation count and fingerprint hit/miss stats) and kept all instrumentation quiet by default (APIs added in `core/symbol_cache_manifest.h` and allocation accessor in `viewer_common/gl_framebuffer_capture_target.h`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5d22abee9483249e84e054a0db8f02)