### PR TITLE
Harden installer vcpkg workflows against transient source outages

### DIFF
--- a/.github/scripts/get_vcpkg_baseline.py
+++ b/.github/scripts/get_vcpkg_baseline.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Print the vcpkg builtin-baseline from a manifest and validate its shape."""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+BASELINE_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+
+
+def read_baseline(manifest: Path) -> str:
+    with manifest.open("r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    baseline = data.get("builtin-baseline")
+    if not isinstance(baseline, str) or not BASELINE_RE.fullmatch(baseline):
+        raise ValueError(f"{manifest} must contain a 40-character builtin-baseline")
+    return baseline.lower()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("manifest", type=Path, nargs="?", default=Path("vcpkg.json"))
+    parser.add_argument("--github-output", type=Path, help="Optional GITHUB_OUTPUT file to receive baseline=<value>.")
+    args = parser.parse_args(argv)
+    try:
+        baseline = read_baseline(args.manifest)
+    except Exception as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    print(baseline)
+    if args.github_output is not None:
+        with args.github_output.open("a", encoding="utf-8") as handle:
+            handle.write(f"baseline={baseline}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/vcpkg_install_retry.py
+++ b/.github/scripts/vcpkg_install_retry.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Run vcpkg install with bounded retries for transient network failures."""
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+TRANSIENT_PATTERNS = [
+    re.compile(r"\b(?:HTTP|response code)\s*(?:408|425|429|500|502|503|504)\b", re.I),
+    re.compile(r"curl.*(?:timed? out|timeout|operation timed out|couldn't connect|connection.*(?:reset|refused)|temporarily unavailable)", re.I),
+    re.compile(r"(?:could not|couldn't|failed to) resolve (?:host|hostname)", re.I),
+    re.compile(r"(?:connection (?:reset|refused)|network is unreachable|temporarily unavailable|temporary failure|proxy.*temporary)", re.I),
+    re.compile(r"(?:TLS|SSL) connection timeout", re.I),
+]
+PERMANENT_PATTERNS = [
+    re.compile(r"\b(?:configure|configuration|compil(?:e|ation)|link(?:er|ing)?|patch|ABI|manifest|validation) (?:error|failed|failure)\b", re.I),
+    re.compile(r"\berror C\d{4}\b|undefined reference|No such file or directory", re.I),
+]
+
+@dataclass(frozen=True)
+class Classification:
+    transient: bool
+    reason: str
+
+
+def classify_failure(output: str) -> Classification:
+    for pattern in TRANSIENT_PATTERNS:
+        match = pattern.search(output)
+        if match:
+            return Classification(True, match.group(0))
+    for pattern in PERMANENT_PATTERNS:
+        match = pattern.search(output)
+        if match:
+            return Classification(False, match.group(0))
+    return Classification(False, "no transient network/download signature found")
+
+
+def build_command(args: argparse.Namespace) -> list[str]:
+    return [
+        str(args.vcpkg), "install", "--triplet", args.triplet,
+        f"--x-manifest-root={args.manifest_root}",
+        f"--x-install-root={args.install_root}",
+        f"--x-packages-root={args.packages_root}",
+        f"--downloads-root={args.downloads_root}",
+    ] + list(args.extra_args)
+
+
+def run_attempt(command: list[str], log_path: Path, attempt: int) -> tuple[int, str]:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    collected: list[str] = []
+    with log_path.open("a", encoding="utf-8", errors="replace") as log:
+        header = f"\n=== vcpkg install attempt {attempt} ===\nCommand: {' '.join(command)}\n"
+        print(header, end="")
+        log.write(header)
+        process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, encoding="utf-8", errors="replace")
+        assert process.stdout is not None
+        for line in process.stdout:
+            print(line, end="")
+            log.write(line)
+            collected.append(line)
+        return_code = process.wait()
+        footer = f"=== attempt {attempt} exit code: {return_code} ===\n"
+        print(footer, end="")
+        log.write(footer)
+    return return_code, "".join(collected)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--vcpkg", required=True, type=Path)
+    parser.add_argument("--triplet", required=True)
+    parser.add_argument("--manifest-root", required=True, type=Path)
+    parser.add_argument("--install-root", required=True, type=Path)
+    parser.add_argument("--packages-root", required=True, type=Path)
+    parser.add_argument("--downloads-root", required=True, type=Path)
+    parser.add_argument("--attempts", type=int, default=4)
+    parser.add_argument("--initial-delay-seconds", type=float, default=30.0)
+    parser.add_argument("--max-delay-seconds", type=float, default=120.0)
+    parser.add_argument("--log", required=True, type=Path)
+    parser.add_argument("extra_args", nargs=argparse.REMAINDER)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    if args.attempts < 1:
+        print("error: --attempts must be at least 1", file=sys.stderr)
+        return 2
+    for directory in (args.install_root, args.packages_root, args.downloads_root, args.log.parent):
+        directory.mkdir(parents=True, exist_ok=True)
+    command = build_command(args)
+    last_code = 0
+    for attempt in range(1, args.attempts + 1):
+        last_code, output = run_attempt(command, args.log, attempt)
+        if last_code == 0:
+            print(f"vcpkg install succeeded on attempt {attempt}. Log: {args.log}")
+            return 0
+        classification = classify_failure(output)
+        if not classification.transient:
+            print(f"vcpkg install failed permanently: {classification.reason}. Log: {args.log}")
+            return last_code
+        if attempt == args.attempts:
+            print(f"vcpkg install failed after {args.attempts} transient attempts: {classification.reason}. Log: {args.log}")
+            return last_code
+        delay = min(args.initial_delay_seconds * (2 ** (attempt - 1)), args.max_delay_seconds)
+        print(f"Transient vcpkg failure detected ({classification.reason}); retrying in {delay:g} seconds...")
+        time.sleep(delay)
+    return last_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/arch-package.yml
+++ b/.github/workflows/arch-package.yml
@@ -32,7 +32,9 @@ jobs:
       VCPKG_INSTALLED: ${{ github.workspace }}/.vcpkg-cache/installed
       VCPKG_DOWNLOADS: ${{ github.workspace }}/.vcpkg-cache/downloads
       VCPKG_PACKAGES: ${{ github.workspace }}/.vcpkg-cache/packages
-      VCPKG_BASELINE: 0878b5224d4a4968940ee296a2e7fae2d3b62983
+      VCPKG_BINARY_CACHE: ${{ github.workspace }}/.vcpkg-cache/binary
+      CI_LOG_DIR: ${{ github.workspace }}/out/ci-logs
+      VCPKG_BINARY_SOURCES: clear;files,${{ github.workspace }}/.vcpkg-cache/binary,readwrite
       VCPKG_CACHE_SCHEMA: securestore-v2
       VCPKG_TARGET_TRIPLET: x64-linux
 
@@ -43,9 +45,18 @@ jobs:
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.source_ref != '' && inputs.source_ref || github.ref }}
+
+      - name: Read vcpkg baseline
+        id: vcpkg-baseline
+        shell: bash
+        run: |
+          set -euo pipefail
+          baseline="$(python3 .github/scripts/get_vcpkg_baseline.py vcpkg.json)"
+          echo "baseline=${baseline}" >> "$GITHUB_OUTPUT"
+          echo "VCPKG_BASELINE=${baseline}" >> "$GITHUB_ENV"
 
       - name: Install Arch build dependencies
         run: |
@@ -88,6 +99,25 @@ jobs:
           command -v libtoolize
           command -v autopoint
 
+      - name: Restore vcpkg downloads
+        id: vcpkg-downloads-cache
+        uses: actions/cache/restore@v5
+        with:
+          path: .vcpkg-cache/downloads
+          key: ${{ runner.os }}-${{ runner.arch }}-arch-vcpkg-downloads-${{ steps.vcpkg-baseline.outputs.baseline }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-arch-vcpkg-downloads-${{ steps.vcpkg-baseline.outputs.baseline }}-
+            ${{ runner.os }}-${{ runner.arch }}-arch-vcpkg-downloads-
+
+      - name: Cache vcpkg installed packages and binary archives
+        uses: actions/cache@v5
+        with:
+          path: |
+            .vcpkg-cache/installed
+            .vcpkg-cache/packages
+            .vcpkg-cache/binary
+          key: ${{ runner.os }}-${{ runner.arch }}-arch-vcpkg-installed-${{ steps.vcpkg-baseline.outputs.baseline }}-x64-linux-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
+
       - name: Prepare vcpkg folders
         run: |
           mkdir -p "$VCPKG_DOWNLOADS" "$VCPKG_INSTALLED" "$VCPKG_PACKAGES"
@@ -110,10 +140,34 @@ jobs:
           rm -rf "$VCPKG_PACKAGES"/gperf_* "$VCPKG_INSTALLED"/vcpkg/issue_body.md
           # Perastage still uses vcpkg for Linux CI because nanovg, PoDoFo, and
           # meshoptimizer availability can vary across distro repositories.
-          "$VCPKG_ROOT/vcpkg" install --triplet x64-linux --x-manifest-root="$GITHUB_WORKSPACE" \
-            --x-install-root="$VCPKG_INSTALLED" \
-            --x-packages-root="$VCPKG_PACKAGES" \
-            --downloads-root="$VCPKG_DOWNLOADS"
+          python3 .github/scripts/vcpkg_install_retry.py --vcpkg "$VCPKG_ROOT/vcpkg" --triplet x64-linux --manifest-root "$GITHUB_WORKSPACE" \
+            --install-root "$VCPKG_INSTALLED" \
+            --packages-root "$VCPKG_PACKAGES" \
+            --downloads-root "$VCPKG_DOWNLOADS" \
+            --attempts 4 --initial-delay-seconds 30 --max-delay-seconds 120 \
+            --log "$CI_LOG_DIR/vcpkg-install-x64-linux.log"
+      - name: Save vcpkg downloads cache
+        if: ${{ always() && steps.vcpkg-downloads-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v5
+        with:
+          path: .vcpkg-cache/downloads
+          key: ${{ steps.vcpkg-downloads-cache.outputs.cache-primary-key }}
+
+      - name: Upload CI diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ github.job }}-diagnostics
+          if-no-files-found: ignore
+          path: |
+            out/ci-logs/**
+            vcpkg/buildtrees/**/*.log
+            vcpkg/buildtrees/**/config-*.txt
+            vcpkg/buildtrees/**/issue_body.md
+            .vcpkg-cache/installed/vcpkg/issue_body.md
+            build/**/*.log
+            build/**/CMakeOutput.log
+            build/**/CMakeError.log
 
       - name: Create makepkg user
         run: |
@@ -189,13 +243,13 @@ jobs:
           test -f "out/Perastage-$VERSION-ArchLinux-symbols.zip"
 
       - name: Upload Arch Linux symbols
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Perastage-archlinux-symbols
           path: out/Perastage-*-ArchLinux-symbols.zip
 
       - name: Upload Arch package artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Perastage-arch-package
           path: Perastage-*-arch-x86_64.pkg.tar.zst

--- a/.github/workflows/linux-installer.yml
+++ b/.github/workflows/linux-installer.yml
@@ -30,15 +30,26 @@ jobs:
       VCPKG_ROOT: ${{ github.workspace }}/vcpkg
       VCPKG_INSTALLED: ${{ github.workspace }}/.vcpkg-cache/installed
       VCPKG_DOWNLOADS: ${{ github.workspace }}/.vcpkg-cache/downloads
-      VCPKG_BASELINE:     0878b5224d4a4968940ee296a2e7fae2d3b62983
       VCPKG_CACHE_SCHEMA: securestore-v2
       VCPKG_PACKAGES: ${{ github.workspace }}/.vcpkg-cache/packages
+      VCPKG_BINARY_CACHE: ${{ github.workspace }}/.vcpkg-cache/binary
+      CI_LOG_DIR: ${{ github.workspace }}/out/ci-logs
+      VCPKG_BINARY_SOURCES: clear;files,${{ github.workspace }}/.vcpkg-cache/binary,readwrite
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.source_ref != '' && inputs.source_ref || github.ref }}
+
+      - name: Read vcpkg baseline
+        id: vcpkg-baseline
+        shell: bash
+        run: |
+          set -euo pipefail
+          baseline="$(python3 .github/scripts/get_vcpkg_baseline.py vcpkg.json)"
+          echo "baseline=${baseline}" >> "$GITHUB_OUTPUT"
+          echo "VCPKG_BASELINE=${baseline}" >> "$GITHUB_ENV"
 
       - name: Install Linux build dependencies
         run: |
@@ -85,16 +96,27 @@ jobs:
             shared-mime-info \
             libglib2.0-bin
 
-      - name: Cache vcpkg
-        uses: actions/cache@v4
+      - name: Restore vcpkg downloads
+        id: vcpkg-downloads-cache
+        uses: actions/cache/restore@v5
         with:
           path: |
             .vcpkg-cache/downloads
+          key: ${{ runner.os }}-${{ runner.arch }}-vcpkg-downloads-${{ steps.vcpkg-baseline.outputs.baseline }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-vcpkg-downloads-${{ steps.vcpkg-baseline.outputs.baseline }}-
+            ${{ runner.os }}-${{ runner.arch }}-vcpkg-downloads-
+
+      - name: Cache vcpkg installed packages and binary archives
+        uses: actions/cache@v5
+        with:
+          path: |
             .vcpkg-cache/installed
             .vcpkg-cache/packages
-          key: ${{ runner.os }}-${{ runner.arch }}-ubuntu-latest-vcpkg-securestore-v2-${{ env.VCPKG_BASELINE }}-x64-linux-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', '.github/workflows/linux-installer.yml') }}
+            .vcpkg-cache/binary
+          key: ${{ runner.os }}-${{ runner.arch }}-ubuntu-latest-vcpkg-securestore-v2-${{ steps.vcpkg-baseline.outputs.baseline }}-x64-linux-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', '.github/workflows/linux-installer.yml') }}
           restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-ubuntu-latest-vcpkg-securestore-v2-${{ env.VCPKG_BASELINE }}-x64-linux-
+            ${{ runner.os }}-${{ runner.arch }}-ubuntu-latest-vcpkg-securestore-v2-${{ steps.vcpkg-baseline.outputs.baseline }}-x64-linux-
 
       - name: Prepare vcpkg folders
         run: |
@@ -114,10 +136,34 @@ jobs:
 
       - name: Install vcpkg packages
         run: |
-          "$VCPKG_ROOT/vcpkg" install --triplet x64-linux --x-manifest-root="$GITHUB_WORKSPACE" \
-            --x-install-root="$VCPKG_INSTALLED" \
-            --x-packages-root="$VCPKG_PACKAGES" \
-            --downloads-root="$VCPKG_DOWNLOADS"
+          python3 .github/scripts/vcpkg_install_retry.py --vcpkg "$VCPKG_ROOT/vcpkg" --triplet x64-linux --manifest-root "$GITHUB_WORKSPACE" \
+            --install-root "$VCPKG_INSTALLED" \
+            --packages-root "$VCPKG_PACKAGES" \
+            --downloads-root "$VCPKG_DOWNLOADS" \
+            --attempts 4 --initial-delay-seconds 30 --max-delay-seconds 120 \
+            --log "$CI_LOG_DIR/vcpkg-install-x64-linux.log"
+      - name: Save vcpkg downloads cache
+        if: ${{ always() && steps.vcpkg-downloads-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v5
+        with:
+          path: .vcpkg-cache/downloads
+          key: ${{ steps.vcpkg-downloads-cache.outputs.cache-primary-key }}
+
+      - name: Upload CI diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ github.job }}-diagnostics
+          if-no-files-found: ignore
+          path: |
+            out/ci-logs/**
+            vcpkg/buildtrees/**/*.log
+            vcpkg/buildtrees/**/config-*.txt
+            vcpkg/buildtrees/**/issue_body.md
+            .vcpkg-cache/installed/vcpkg/issue_body.md
+            build/**/*.log
+            build/**/CMakeOutput.log
+            build/**/CMakeError.log
 
       - name: Configure CMake
         run: |
@@ -160,13 +206,13 @@ jobs:
           ls -la "$STAGE_DIR"
 
       - name: Upload Linux symbols
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Perastage-linux-symbols
           path: out/Perastage-*-Linux-symbols.zip
 
       - name: Upload staged distribution
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Perastage-linux-staged
           path: out/install/Release
@@ -313,7 +359,7 @@ jobs:
           ldd squashfs-root/usr/bin/Perastage | grep -E 'gtk|gdk|pixbuf|glib|gio|pango|cairo|atk|harfbuzz|rsvg' || true
 
       - name: Upload AppImage artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Perastage-linux-appimage
           path: Perastage-*-x86_64.AppImage

--- a/.github/workflows/macos-15-manual-installer.yml
+++ b/.github/workflows/macos-15-manual-installer.yml
@@ -27,9 +27,11 @@ jobs:
       VCPKG_ROOT:        ${{ github.workspace }}/vcpkg
       VCPKG_INSTALLED:   ${{ github.workspace }}/.vcpkg-cache/installed
       VCPKG_DOWNLOADS:   ${{ github.workspace }}/.vcpkg-cache/downloads
-      VCPKG_BASELINE:     0878b5224d4a4968940ee296a2e7fae2d3b62983
       VCPKG_CACHE_SCHEMA: securestore-v2
       VCPKG_PACKAGES:    ${{ github.workspace }}/.vcpkg-cache/packages
+      VCPKG_BINARY_CACHE: ${{ github.workspace }}/.vcpkg-cache/binary
+      CI_LOG_DIR: ${{ github.workspace }}/out/ci-logs
+      VCPKG_BINARY_SOURCES: clear;files,${{ github.workspace }}/.vcpkg-cache/binary,readwrite
       VCPKG_TRIPLET:     arm64-osx
 
       # Keep this workflow compatible with macOS 15.x Apple Silicon systems.
@@ -38,9 +40,18 @@ jobs:
     steps:
       # ── 1. Checkout ────────────────────────────────────────────────────────
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.source_ref != '' && inputs.source_ref || github.ref }}
+
+      - name: Read vcpkg baseline
+        id: vcpkg-baseline
+        shell: bash
+        run: |
+          set -euo pipefail
+          baseline="$(python3 .github/scripts/get_vcpkg_baseline.py vcpkg.json)"
+          echo "baseline=${baseline}" >> "$GITHUB_OUTPUT"
+          echo "VCPKG_BASELINE=${baseline}" >> "$GITHUB_ENV"
 
       # ── 2. Record macOS toolchain diagnostics ───────────────────────────────
       - name: Record macOS toolchain diagnostics
@@ -71,17 +82,28 @@ jobs:
           done
 
       # ── 4. Cache vcpkg installed tree + downloads ───────────────────────────
-      - name: Cache vcpkg
-        uses: actions/cache@v4
-        id: vcpkg-cache
+      - name: Restore vcpkg downloads
+        id: vcpkg-downloads-cache
+        uses: actions/cache/restore@v5
         with:
           path: |
             .vcpkg-cache/downloads
+          key: ${{ runner.os }}-${{ runner.arch }}-vcpkg-downloads-${{ steps.vcpkg-baseline.outputs.baseline }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-vcpkg-downloads-${{ steps.vcpkg-baseline.outputs.baseline }}-
+            ${{ runner.os }}-${{ runner.arch }}-vcpkg-downloads-
+
+      - name: Cache vcpkg installed packages and binary archives
+        uses: actions/cache@v5
+        id: vcpkg-cache
+        with:
+          path: |
             .vcpkg-cache/installed
             .vcpkg-cache/packages
-          key: macos-15-deployment-${{ env.MACOSX_DEPLOYMENT_TARGET }}-vcpkg-securestore-v2-${{ env.VCPKG_BASELINE }}-arm64-osx-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', '.github/workflows/macos-15-manual-installer.yml') }}
+            .vcpkg-cache/binary
+          key: macos-15-deployment-${{ env.MACOSX_DEPLOYMENT_TARGET }}-vcpkg-securestore-v2-${{ steps.vcpkg-baseline.outputs.baseline }}-arm64-osx-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', '.github/workflows/macos-15-manual-installer.yml') }}
           restore-keys: |
-            macos-15-deployment-${{ env.MACOSX_DEPLOYMENT_TARGET }}-vcpkg-securestore-v2-${{ env.VCPKG_BASELINE }}-arm64-osx-
+            macos-15-deployment-${{ env.MACOSX_DEPLOYMENT_TARGET }}-vcpkg-securestore-v2-${{ steps.vcpkg-baseline.outputs.baseline }}-arm64-osx-
 
       # ── 5. Prepare vcpkg cache folders ──────────────────────────────────────
       # These folders must exist before bootstrap because VCPKG_DOWNLOADS is
@@ -156,10 +178,35 @@ jobs:
             echo "No stale macOS SDK path metadata found in the restored vcpkg cache."
           fi
 
-          "$VCPKG_ROOT/vcpkg" install --triplet arm64-osx --x-manifest-root="$GITHUB_WORKSPACE" \
-            --x-install-root="$VCPKG_INSTALLED" \
-            --x-packages-root="$VCPKG_PACKAGES" \
-            --downloads-root="$VCPKG_DOWNLOADS"
+          python3 .github/scripts/vcpkg_install_retry.py --vcpkg "$VCPKG_ROOT/vcpkg" --triplet arm64-osx --manifest-root "$GITHUB_WORKSPACE" \
+            --install-root "$VCPKG_INSTALLED" \
+            --packages-root "$VCPKG_PACKAGES" \
+            --downloads-root "$VCPKG_DOWNLOADS" \
+            --attempts 4 --initial-delay-seconds 30 --max-delay-seconds 120 \
+            --log "$CI_LOG_DIR/vcpkg-install-arm64-osx.log"
+
+      - name: Save vcpkg downloads cache
+        if: ${{ always() && steps.vcpkg-downloads-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v5
+        with:
+          path: .vcpkg-cache/downloads
+          key: ${{ steps.vcpkg-downloads-cache.outputs.cache-primary-key }}
+
+      - name: Upload CI diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ github.job }}-diagnostics
+          if-no-files-found: ignore
+          path: |
+            out/ci-logs/**
+            vcpkg/buildtrees/**/*.log
+            vcpkg/buildtrees/**/config-*.txt
+            vcpkg/buildtrees/**/issue_body.md
+            .vcpkg-cache/installed/vcpkg/issue_body.md
+            build/**/*.log
+            build/**/CMakeOutput.log
+            build/**/CMakeError.log
 
       # ── 9. Configure CMake ──────────────────────────────────────────────────
       - name: Configure CMake
@@ -220,7 +267,7 @@ jobs:
 
       - name: Upload macOS build diagnostics
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Perastage-macos15-build-diagnostics
           if-no-files-found: warn
@@ -261,7 +308,7 @@ jobs:
           test -d "$SYMBOLS_DIR/Perastage.dSYM"
 
       - name: Upload macOS symbols
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Perastage-macos15-symbols
           path: out/symbols/macos15/Perastage.dSYM
@@ -431,7 +478,7 @@ jobs:
 
       # ── 16. Upload staged build ─────────────────────────────────────────────
       - name: Upload staged distribution
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Perastage-macos15-staged
           path: out/install/Release
@@ -505,7 +552,7 @@ jobs:
 
       # ── 20. Upload DMG package ──────────────────────────────────────────────
       - name: Upload macOS DMG
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Perastage-macos15-dmg
           path: out/installer/*.dmg

--- a/.github/workflows/macos-installer.yml
+++ b/.github/workflows/macos-installer.yml
@@ -31,17 +31,28 @@ jobs:
       VCPKG_ROOT:        ${{ github.workspace }}/vcpkg
       VCPKG_INSTALLED:   ${{ github.workspace }}/.vcpkg-cache/installed
       VCPKG_DOWNLOADS:   ${{ github.workspace }}/.vcpkg-cache/downloads
-      VCPKG_BASELINE:     0878b5224d4a4968940ee296a2e7fae2d3b62983
       VCPKG_CACHE_SCHEMA: securestore-v2
       VCPKG_PACKAGES:    ${{ github.workspace }}/.vcpkg-cache/packages
+      VCPKG_BINARY_CACHE: ${{ github.workspace }}/.vcpkg-cache/binary
+      CI_LOG_DIR: ${{ github.workspace }}/out/ci-logs
+      VCPKG_BINARY_SOURCES: clear;files,${{ github.workspace }}/.vcpkg-cache/binary,readwrite
       VCPKG_TRIPLET:     arm64-osx
 
     steps:
       # ── 1. Checkout ────────────────────────────────────────────────────────
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.source_ref != '' && inputs.source_ref || github.ref }}
+
+      - name: Read vcpkg baseline
+        id: vcpkg-baseline
+        shell: bash
+        run: |
+          set -euo pipefail
+          baseline="$(python3 .github/scripts/get_vcpkg_baseline.py vcpkg.json)"
+          echo "baseline=${baseline}" >> "$GITHUB_OUTPUT"
+          echo "VCPKG_BASELINE=${baseline}" >> "$GITHUB_ENV"
 
       # ── 2. Record macOS toolchain diagnostics ───────────────────────────────
       - name: Record macOS toolchain diagnostics
@@ -67,17 +78,28 @@ jobs:
           done
 
       # ── 4. Cache vcpkg installed tree + downloads ───────────────────────────
-      - name: Cache vcpkg
-        uses: actions/cache@v4
-        id: vcpkg-cache
+      - name: Restore vcpkg downloads
+        id: vcpkg-downloads-cache
+        uses: actions/cache/restore@v5
         with:
           path: |
             .vcpkg-cache/downloads
+          key: ${{ runner.os }}-${{ runner.arch }}-vcpkg-downloads-${{ steps.vcpkg-baseline.outputs.baseline }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-vcpkg-downloads-${{ steps.vcpkg-baseline.outputs.baseline }}-
+            ${{ runner.os }}-${{ runner.arch }}-vcpkg-downloads-
+
+      - name: Cache vcpkg installed packages and binary archives
+        uses: actions/cache@v5
+        id: vcpkg-cache
+        with:
+          path: |
             .vcpkg-cache/installed
             .vcpkg-cache/packages
-          key: macos-26-xcode-26-v2-vcpkg-securestore-v2-${{ env.VCPKG_BASELINE }}-arm64-osx-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', '.github/workflows/macos-installer.yml') }}
+            .vcpkg-cache/binary
+          key: macos-26-xcode-26-v2-vcpkg-securestore-v2-${{ steps.vcpkg-baseline.outputs.baseline }}-arm64-osx-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', '.github/workflows/macos-installer.yml') }}
           restore-keys: |
-            macos-26-xcode-26-v2-vcpkg-securestore-v2-${{ env.VCPKG_BASELINE }}-arm64-osx-
+            macos-26-xcode-26-v2-vcpkg-securestore-v2-${{ steps.vcpkg-baseline.outputs.baseline }}-arm64-osx-
 
       # ── 5. Prepare vcpkg cache folders ──────────────────────────────────────
       # These folders must exist before bootstrap because VCPKG_DOWNLOADS is
@@ -150,10 +172,35 @@ jobs:
             echo "No stale macOS SDK path metadata found in the restored vcpkg cache."
           fi
 
-          "$VCPKG_ROOT/vcpkg" install --triplet arm64-osx --x-manifest-root="$GITHUB_WORKSPACE" \
-            --x-install-root="$VCPKG_INSTALLED" \
-            --x-packages-root="$VCPKG_PACKAGES" \
-            --downloads-root="$VCPKG_DOWNLOADS"
+          python3 .github/scripts/vcpkg_install_retry.py --vcpkg "$VCPKG_ROOT/vcpkg" --triplet arm64-osx --manifest-root "$GITHUB_WORKSPACE" \
+            --install-root "$VCPKG_INSTALLED" \
+            --packages-root "$VCPKG_PACKAGES" \
+            --downloads-root "$VCPKG_DOWNLOADS" \
+            --attempts 4 --initial-delay-seconds 30 --max-delay-seconds 120 \
+            --log "$CI_LOG_DIR/vcpkg-install-arm64-osx.log"
+
+      - name: Save vcpkg downloads cache
+        if: ${{ always() && steps.vcpkg-downloads-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v5
+        with:
+          path: .vcpkg-cache/downloads
+          key: ${{ steps.vcpkg-downloads-cache.outputs.cache-primary-key }}
+
+      - name: Upload CI diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ github.job }}-diagnostics
+          if-no-files-found: ignore
+          path: |
+            out/ci-logs/**
+            vcpkg/buildtrees/**/*.log
+            vcpkg/buildtrees/**/config-*.txt
+            vcpkg/buildtrees/**/issue_body.md
+            .vcpkg-cache/installed/vcpkg/issue_body.md
+            build/**/*.log
+            build/**/CMakeOutput.log
+            build/**/CMakeError.log
 
       # ── 9. Configure CMake ──────────────────────────────────────────────────
       - name: Configure CMake
@@ -211,7 +258,7 @@ jobs:
 
       - name: Upload macOS build diagnostics
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Perastage-macos-build-diagnostics
           if-no-files-found: warn
@@ -250,7 +297,7 @@ jobs:
           test -d "$SYMBOLS_DIR/Perastage.dSYM"
 
       - name: Upload macOS symbols
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Perastage-macos26-symbols
           path: out/symbols/macos26/Perastage.dSYM
@@ -330,7 +377,7 @@ jobs:
 
       # ── 13. Upload staged build ─────────────────────────────────────────────
       - name: Upload staged distribution
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Perastage-macos26-staged
           path: out/install/Release
@@ -401,7 +448,7 @@ jobs:
 
       # ── 17. Upload DMG package ──────────────────────────────────────────────
       - name: Upload macOS DMG
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Perastage-macos26-dmg
           path: out/installer/*.dmg

--- a/.github/workflows/main-patch-test-build.yml
+++ b/.github/workflows/main-patch-test-build.yml
@@ -1,4 +1,4 @@
-# Main branch patch version bump and test installer dispatch workflow.
+# Main branch patch version bump and tracked installer validation workflow.
 
 name: Main Patch Version and Test Installer Builds
 
@@ -10,14 +10,14 @@ on:
 
 permissions:
   contents: write
-  actions: write
+  actions: read
 
 concurrency:
   group: main-patch-version-bump
   cancel-in-progress: false
 
 jobs:
-  bump-and-dispatch:
+  bump-version:
     if: >
       github.event_name == 'workflow_dispatch' ||
       (
@@ -26,10 +26,12 @@ jobs:
         !contains(github.event.head_commit.message, '[skip version-bump]')
       )
     runs-on: ubuntu-latest
+    outputs:
+      source_ref: ${{ steps.commit.outputs.source_ref }}
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 0
@@ -38,41 +40,44 @@ jobs:
         id: bump
         run: |
           set -euo pipefail
-
           VERSION_RAW="$(tr -d '[:space:]' < VERSION)"
           if ! [[ "$VERSION_RAW" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "VERSION must be MAJOR.MINOR.PATCH, got: '$VERSION_RAW'"
             exit 1
           fi
-
           IFS='.' read -r major minor patch <<< "$VERSION_RAW"
-          next_patch=$((patch + 1))
-          NEW_VERSION="${major}.${minor}.${next_patch}"
-
+          NEW_VERSION="${major}.${minor}.$((patch + 1))"
           printf '%s\n' "$NEW_VERSION" > VERSION
-
           echo "previous_version=$VERSION_RAW" >> "$GITHUB_OUTPUT"
           echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Commit and push VERSION bump
+        id: commit
         env:
           NEW_VERSION: ${{ steps.bump.outputs.new_version }}
         run: |
           set -euo pipefail
-
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
           git add VERSION
           git commit -m "chore: bump patch version to ${NEW_VERSION} [skip version-bump]"
           git push origin HEAD:main
+          echo "source_ref=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: Dispatch installer workflows
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
+  windows-installer:
+    needs: bump-version
+    uses: ./.github/workflows/windows-installer.yml
+    with:
+      source_ref: ${{ needs.bump-version.outputs.source_ref }}
 
-          gh workflow run windows-installer.yml --ref main
-          gh workflow run linux-installer.yml --ref main
-          gh workflow run macos-installer.yml --ref main
+  linux-installer:
+    needs: bump-version
+    uses: ./.github/workflows/linux-installer.yml
+    with:
+      source_ref: ${{ needs.bump-version.outputs.source_ref }}
+
+  macos-installer:
+    needs: bump-version
+    uses: ./.github/workflows/macos-installer.yml
+    with:
+      source_ref: ${{ needs.bump-version.outputs.source_ref }}

--- a/.github/workflows/minor-draft-release.yml
+++ b/.github/workflows/minor-draft-release.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 0
@@ -172,12 +172,12 @@ jobs:
 
     steps:
       - name: Checkout release tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.prepare-release.outputs.new_tag }}
 
       - name: Download installer artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: release-assets
           pattern: Perastage-*

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -30,31 +30,53 @@ jobs:
       VCPKG_ROOT:         ${{ github.workspace }}\vcpkg
       VCPKG_INSTALLED:    ${{ github.workspace }}\.vcpkg-cache\installed
       VCPKG_DOWNLOADS:    ${{ github.workspace }}\.vcpkg-cache\downloads
-      VCPKG_BASELINE:     0878b5224d4a4968940ee296a2e7fae2d3b62983
       VCPKG_CACHE_SCHEMA: securestore-v2
       VCPKG_PACKAGES:     ${{ github.workspace }}\.vcpkg-cache\packages
+      VCPKG_BINARY_CACHE: ${{ github.workspace }}\.vcpkg-cache\binary
+      CI_LOG_DIR: ${{ github.workspace }}\out\ci-logs
+      VCPKG_BINARY_SOURCES: clear;files,${{ github.workspace }}\.vcpkg-cache\binary,readwrite
 
     steps:
       # ── 1. Checkout ────────────────────────────────────────────────────────
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.source_ref != '' && inputs.source_ref || github.ref }}
+
+      - name: Read vcpkg baseline
+        id: vcpkg-baseline
+        shell: bash
+        run: |
+          set -euo pipefail
+          baseline="$(python3 .github/scripts/get_vcpkg_baseline.py vcpkg.json)"
+          echo "baseline=${baseline}" >> "$GITHUB_OUTPUT"
+          echo "VCPKG_BASELINE=${baseline}" >> "$GITHUB_ENV"
 
       # ── 2. Cache vcpkg installed tree + downloads ───────────────────────────
       # The cache key includes the workflow file itself so a change in the
       # package list busts the cache automatically.
-      - name: Cache vcpkg
-        uses: actions/cache@v4
+      - name: Restore vcpkg downloads
+        id: vcpkg-downloads-cache
+        uses: actions/cache/restore@v5
+        with:
+          path: |
+            .vcpkg-cache/downloads
+          key: ${{ runner.os }}-${{ runner.arch }}-vcpkg-downloads-${{ steps.vcpkg-baseline.outputs.baseline }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-vcpkg-downloads-${{ steps.vcpkg-baseline.outputs.baseline }}-
+            ${{ runner.os }}-${{ runner.arch }}-vcpkg-downloads-
+
+      - name: Cache vcpkg installed packages and binary archives
+        uses: actions/cache@v5
         id: vcpkg-cache
         with:
           path: |
-            .vcpkg-cache\downloads
             .vcpkg-cache\installed
             .vcpkg-cache\packages
-          key: ${{ runner.os }}-${{ runner.arch }}-vcpkg-securestore-v2-${{ env.VCPKG_BASELINE }}-x64-windows-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', '.github/workflows/windows-installer.yml') }}
+            .vcpkg-cache\binary
+          key: ${{ runner.os }}-${{ runner.arch }}-vcpkg-securestore-v2-${{ steps.vcpkg-baseline.outputs.baseline }}-x64-windows-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', '.github/workflows/windows-installer.yml') }}
           restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-vcpkg-securestore-v2-${{ env.VCPKG_BASELINE }}-x64-windows-
+            ${{ runner.os }}-${{ runner.arch }}-vcpkg-securestore-v2-${{ steps.vcpkg-baseline.outputs.baseline }}-x64-windows-
 
       # ── 3. Bootstrap vcpkg (always needed; the binary is never cached) ──────
       - name: Bootstrap vcpkg
@@ -83,10 +105,35 @@ jobs:
           New-Item -ItemType Directory -Path $env:VCPKG_INSTALLED   -Force | Out-Null
           New-Item -ItemType Directory -Path $env:VCPKG_PACKAGES    -Force | Out-Null
 
-          & "$env:VCPKG_ROOT\vcpkg.exe" install --triplet x64-windows --x-manifest-root="$env:GITHUB_WORKSPACE" `
-            --x-install-root="$env:VCPKG_INSTALLED" `
-            --x-packages-root="$env:VCPKG_PACKAGES" `
-            --downloads-root="$env:VCPKG_DOWNLOADS"
+          # The wrapper forwards --x-install-root, --x-packages-root, and --downloads-root to vcpkg.
+          python .github/scripts/vcpkg_install_retry.py --vcpkg "$env:VCPKG_ROOT\vcpkg.exe" --triplet x64-windows --manifest-root "$env:GITHUB_WORKSPACE" `
+            --install-root "$env:VCPKG_INSTALLED" `
+            --packages-root "$env:VCPKG_PACKAGES" `
+            --downloads-root "$env:VCPKG_DOWNLOADS" `
+            --attempts 4 --initial-delay-seconds 30 --max-delay-seconds 120 `
+            --log "$env:CI_LOG_DIR\vcpkg-install-x64-windows.log"
+      - name: Save vcpkg downloads cache
+        if: ${{ always() && steps.vcpkg-downloads-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v5
+        with:
+          path: .vcpkg-cache/downloads
+          key: ${{ steps.vcpkg-downloads-cache.outputs.cache-primary-key }}
+
+      - name: Upload CI diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ github.job }}-diagnostics
+          if-no-files-found: ignore
+          path: |
+            out/ci-logs/**
+            vcpkg/buildtrees/**/*.log
+            vcpkg/buildtrees/**/config-*.txt
+            vcpkg/buildtrees/**/issue_body.md
+            .vcpkg-cache/installed/vcpkg/issue_body.md
+            build/**/*.log
+            build/**/CMakeOutput.log
+            build/**/CMakeError.log
 
       - name: Validate vcpkg gettext tools
         shell: pwsh
@@ -152,14 +199,14 @@ jobs:
           Get-ChildItem -Path $symbolsDir -Recurse
 
       - name: Upload Windows symbols
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Perastage-windows-symbols
           path: out/symbols/windows
 
       # ── 8. Upload staged build ───────────────────────────────────────────────
       - name: Upload staged distribution
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Perastage-windows-staged
           path: out/install/Release
@@ -209,39 +256,62 @@ jobs:
 
       # ── 12. Upload installer artifact ────────────────────────────────────────
       - name: Upload Windows installer
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Perastage-windows-installer
           path: out/installer
 
 
   test-windows-secure-store:
+    needs: build-windows-installer
     runs-on: windows-latest
 
     env:
       VCPKG_ROOT:         ${{ github.workspace }}\vcpkg
       VCPKG_INSTALLED:    ${{ github.workspace }}\.vcpkg-cache\installed
       VCPKG_DOWNLOADS:    ${{ github.workspace }}\.vcpkg-cache\downloads
-      VCPKG_BASELINE:     0878b5224d4a4968940ee296a2e7fae2d3b62983
       VCPKG_CACHE_SCHEMA: securestore-v2
       VCPKG_PACKAGES:     ${{ github.workspace }}\.vcpkg-cache\packages
+      VCPKG_BINARY_CACHE: ${{ github.workspace }}\.vcpkg-cache\binary
+      CI_LOG_DIR: ${{ github.workspace }}\out\ci-logs
+      VCPKG_BINARY_SOURCES: clear;files,${{ github.workspace }}\.vcpkg-cache\binary,readwrite
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.source_ref != '' && inputs.source_ref || github.ref }}
 
-      - name: Cache vcpkg
-        uses: actions/cache@v4
+      - name: Read vcpkg baseline
+        id: vcpkg-baseline
+        shell: bash
+        run: |
+          set -euo pipefail
+          baseline="$(python3 .github/scripts/get_vcpkg_baseline.py vcpkg.json)"
+          echo "baseline=${baseline}" >> "$GITHUB_OUTPUT"
+          echo "VCPKG_BASELINE=${baseline}" >> "$GITHUB_ENV"
+
+      - name: Restore vcpkg downloads
+        id: vcpkg-downloads-cache
+        uses: actions/cache/restore@v5
         with:
           path: |
-            .vcpkg-cache\downloads
+            .vcpkg-cache/downloads
+          key: ${{ runner.os }}-${{ runner.arch }}-vcpkg-downloads-${{ steps.vcpkg-baseline.outputs.baseline }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-vcpkg-downloads-${{ steps.vcpkg-baseline.outputs.baseline }}-
+            ${{ runner.os }}-${{ runner.arch }}-vcpkg-downloads-
+
+      - name: Cache vcpkg installed packages and binary archives
+        uses: actions/cache@v5
+        with:
+          path: |
             .vcpkg-cache\installed
             .vcpkg-cache\packages
-          key: ${{ runner.os }}-${{ runner.arch }}-vcpkg-securestore-v2-tests-${{ env.VCPKG_BASELINE }}-x64-windows-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', '.github/workflows/windows-installer.yml') }}
+            .vcpkg-cache\binary
+          key: ${{ runner.os }}-${{ runner.arch }}-vcpkg-securestore-v2-${{ steps.vcpkg-baseline.outputs.baseline }}-x64-windows-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', '.github/workflows/windows-installer.yml') }}
           restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-vcpkg-securestore-v2-tests-${{ env.VCPKG_BASELINE }}-x64-windows-
+            ${{ runner.os }}-${{ runner.arch }}-vcpkg-securestore-v2-${{ steps.vcpkg-baseline.outputs.baseline }}-x64-windows-
 
       - name: Bootstrap vcpkg
         shell: pwsh
@@ -260,10 +330,35 @@ jobs:
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Path $env:VCPKG_DOWNLOADS,$env:VCPKG_INSTALLED,$env:VCPKG_PACKAGES -Force | Out-Null
-          & "$env:VCPKG_ROOT\vcpkg.exe" install --triplet x64-windows --x-manifest-root="$env:GITHUB_WORKSPACE" `
-            --x-install-root="$env:VCPKG_INSTALLED" `
-            --x-packages-root="$env:VCPKG_PACKAGES" `
-            --downloads-root="$env:VCPKG_DOWNLOADS"
+          python .github/scripts/vcpkg_install_retry.py --vcpkg "$env:VCPKG_ROOT\vcpkg.exe" --triplet x64-windows --manifest-root "$env:GITHUB_WORKSPACE" `
+            --install-root "$env:VCPKG_INSTALLED" `
+            --packages-root "$env:VCPKG_PACKAGES" `
+            --downloads-root "$env:VCPKG_DOWNLOADS" `
+            --attempts 4 --initial-delay-seconds 30 --max-delay-seconds 120 `
+            --log "$env:CI_LOG_DIR\vcpkg-install-x64-windows.log"
+
+      - name: Save vcpkg downloads cache
+        if: ${{ always() && steps.vcpkg-downloads-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v5
+        with:
+          path: .vcpkg-cache/downloads
+          key: ${{ steps.vcpkg-downloads-cache.outputs.cache-primary-key }}
+
+      - name: Upload CI diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ github.job }}-diagnostics
+          if-no-files-found: ignore
+          path: |
+            out/ci-logs/**
+            vcpkg/buildtrees/**/*.log
+            vcpkg/buildtrees/**/config-*.txt
+            vcpkg/buildtrees/**/issue_body.md
+            .vcpkg-cache/installed/vcpkg/issue_body.md
+            build/**/*.log
+            build/**/CMakeOutput.log
+            build/**/CMakeError.log
 
       - name: Configure focused security tests
         shell: pwsh

--- a/docs/developer/build.md
+++ b/docs/developer/build.md
@@ -282,3 +282,13 @@ Use `-CleanBuild` to force the same safe cleanup for the selected build director
 ```
 
 Use `-VisualStudioPath` or `-VisualStudioVersion` to make multi-install selection explicit. The cleanup does not delete source files, `C:\vcpkg`, `C:\vcpkg\installed`, global vcpkg downloads, packages, buildtrees, or unrelated build directories.
+
+## CI vcpkg retry, cache, and diagnostics policy
+
+Installer and package workflows keep `vcpkg.json` as the single source of truth for the pinned vcpkg `builtin-baseline`. Each workflow reads and validates that 40-character baseline before checking out vcpkg, so dependency cache keys and the vcpkg checkout cannot drift from the manifest.
+
+All GitHub Actions installer workflows run vcpkg through `.github/scripts/vcpkg_install_retry.py` instead of invoking `vcpkg install` directly. The helper retries only failures that match transient download or network signatures, such as HTTP 408, 425, 429, 500, 502, 503, or 504 responses, DNS failures, timeouts, connection resets, refused connections, and temporary proxy or remote-server failures. Configure, compile, link, manifest, ABI, patch, and package-validation failures are treated as permanent and fail without hiding the original vcpkg exit code.
+
+The workflows keep source downloads separate from toolchain-sensitive installed and package trees. Downloads are restored with broad baseline-aware restore prefixes and are saved even after a failed install, allowing later runs to reuse any archives that were fetched before an outage. Installed trees, package directories, and vcpkg binary-cache archives remain keyed by operating system, architecture, triplet, SDK/toolchain scope, the manifest/configuration hash, and the current cache schema so incompatible binaries are not shared across platforms or macOS SDK generations.
+
+The retry helper always writes a complete UTF-8 log under `out/ci-logs/` while streaming vcpkg output live to the Actions log. Failure diagnostics upload `out/ci-logs/**`, vcpkg buildtree logs, vcpkg issue bodies, and CMake logs when CMake was reached. Missing CMake logs after an earlier vcpkg download failure are expected and should not be treated as a separate diagnostic problem.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -231,6 +231,7 @@ You can also contact the project at **perastage.app@gmail.com**.
 - Fixed embedded Layout 2D fixture symbols so rotated GDTF fixtures choose the visible representative symbol plane and preserve the same orientation in preview and PDF export.
 
 ## Internal changes
+- Hardened installer and release CI dependency installation with transient vcpkg retry handling, separated caches, improved failure diagnostics, and Node 24-compatible GitHub Actions.
 - Improved fixture symbol generation performance by avoiding redundant 2D scene reloads during orthographic capture, reusing offscreen framebuffer resources, memoizing unchanged GDTF semantic fingerprints in-process, and converting independent rendered symbol views in bounded parallel workers while preserving exact generated geometry.
 - Refactored runtime temporary storage so imports, exports, generated resources, and session caches use explicit Perastage-owned lifecycles.
 - Dictionary loading is now read-only for valid custom fixture and truss dictionaries; default seeding, reset, and managed-default recovery are explicit operations.

--- a/tests/check_securestore_build_policy.sh
+++ b/tests/check_securestore_build_policy.sh
@@ -46,13 +46,14 @@ rg -qi 'hostx86.*x86' setup_windows.ps1
 rg -q 'cached compiler Visual Studio root' setup_windows.ps1
 rg -q 'VCPKG_MANIFEST_MODE=OFF|VCPKG_MANIFEST_MODE.*OFF' setup_windows.ps1 CMakePresets.json .github/workflows/windows-installer.yml .github/workflows/linux-installer.yml .github/workflows/arch-package.yml .github/workflows/macos-installer.yml .github/workflows/macos-15-manual-installer.yml
 rg -q 'securestore-v2' .github/workflows/windows-installer.yml .github/workflows/linux-installer.yml .github/workflows/arch-package.yml .github/workflows/macos-installer.yml .github/workflows/macos-15-manual-installer.yml
-rg -q '0878b5224d4a4968940ee296a2e7fae2d3b62983' vcpkg.json .github/workflows/windows-installer.yml .github/workflows/linux-installer.yml .github/workflows/arch-package.yml .github/workflows/macos-installer.yml .github/workflows/macos-15-manual-installer.yml
+rg -q '0878b5224d4a4968940ee296a2e7fae2d3b62983' vcpkg.json
+rg -q 'get_vcpkg_baseline.py vcpkg.json' .github/workflows/windows-installer.yml .github/workflows/linux-installer.yml .github/workflows/arch-package.yml .github/workflows/macos-installer.yml .github/workflows/macos-15-manual-installer.yml
 rg -q 'ctest --test-dir .* -L release-gate' .github/workflows/windows-installer.yml .github/workflows/linux-installer.yml .github/workflows/macos-installer.yml .github/workflows/macos-15-manual-installer.yml
 rg -q 'gdtf_share_security_test' .github/workflows/windows-installer.yml tests/CMakeLists.txt
 rg -q 'credential_store_native_roundtrip_test' .github/workflows/windows-installer.yml tests/CMakeLists.txt
 rg -q 'libsecret-1-dev' .github/workflows/linux-installer.yml
 rg -q "'libsecret'" packaging/arch/PKGBUILD
-rg -q -- '--x-manifest-root' .github/workflows/macos-installer.yml .github/workflows/macos-15-manual-installer.yml
+rg -q -- '--manifest-root' .github/workflows/macos-installer.yml .github/workflows/macos-15-manual-installer.yml
 
 python3 - <<'PY'
 import json

--- a/tests/ci/test_vcpkg_install_retry.py
+++ b/tests/ci/test_vcpkg_install_retry.py
@@ -1,0 +1,99 @@
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[2] / ".github" / "scripts" / "vcpkg_install_retry.py"
+
+
+def fake_vcpkg(tmp_path: Path, body: str) -> Path:
+    exe = tmp_path / ("fake vcpkg.py")
+    exe.write_text(body, encoding="utf-8")
+    exe.chmod(exe.stat().st_mode | stat.S_IEXEC)
+    return exe
+
+
+def run_wrapper(tmp_path: Path, exe: Path, attempts: int = 4) -> subprocess.CompletedProcess[str]:
+    return subprocess.run([
+        sys.executable, str(SCRIPT), "--vcpkg", str(exe), "--triplet", "x64-test",
+        "--manifest-root", str(tmp_path / "manifest root"), "--install-root", str(tmp_path / "installed root"),
+        "--packages-root", str(tmp_path / "packages root"), "--downloads-root", str(tmp_path / "downloads root"),
+        "--attempts", str(attempts), "--initial-delay-seconds", "0", "--max-delay-seconds", "0",
+        "--log", str(tmp_path / "logs" / "vcpkg install.log"), "--", "--debug-extra"],
+        text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
+
+def test_transient_504_twice_then_success(tmp_path):
+    exe = fake_vcpkg(tmp_path, """#!/usr/bin/env python3
+import pathlib, sys
+count = pathlib.Path(__file__).with_suffix('.count')
+n = int(count.read_text() if count.exists() else '0') + 1
+count.write_text(str(n))
+print('ARGS=' + repr(sys.argv[1:]))
+if n < 3:
+    print('error: curl operation failed with response code 504')
+    sys.exit(7)
+sys.exit(0)
+""")
+    result = run_wrapper(tmp_path, exe)
+    assert result.returncode == 0
+    assert result.stdout.count("vcpkg install attempt") == 3
+    assert "--debug-extra" in result.stdout
+
+
+def test_transient_dns_timeout_then_success(tmp_path):
+    exe = fake_vcpkg(tmp_path, """#!/usr/bin/env python3
+import pathlib, sys
+count = pathlib.Path(__file__).with_suffix('.count')
+n = int(count.read_text() if count.exists() else '0') + 1
+count.write_text(str(n))
+if n == 1:
+    print('curl: (28) operation timed out; could not resolve host gitlab.freedesktop.org')
+    sys.exit(11)
+sys.exit(0)
+""")
+    result = run_wrapper(tmp_path, exe)
+    assert result.returncode == 0
+    assert result.stdout.count("vcpkg install attempt") == 2
+
+
+def test_permanent_compiler_failure_no_retry(tmp_path):
+    exe = fake_vcpkg(tmp_path, """#!/usr/bin/env python3
+import sys
+print('compilation failed: error C2143')
+sys.exit(42)
+""")
+    result = run_wrapper(tmp_path, exe)
+    assert result.returncode == 42
+    assert result.stdout.count("vcpkg install attempt") == 1
+    assert "failed permanently" in result.stdout
+
+
+def test_final_transient_failure_preserves_exit_code(tmp_path):
+    exe = fake_vcpkg(tmp_path, """#!/usr/bin/env python3
+import sys
+print('error: curl operation failed with response code 503')
+sys.exit(9)
+""")
+    result = run_wrapper(tmp_path, exe, attempts=3)
+    assert result.returncode == 9
+    assert result.stdout.count("vcpkg install attempt") == 3
+    log_path = tmp_path / "logs" / "vcpkg install.log"
+    assert log_path.exists()
+    assert "response code 503" in log_path.read_text(encoding="utf-8")
+
+
+def test_paths_with_spaces_and_argument_forwarding(tmp_path):
+    args_file = tmp_path / "args.txt"
+    exe = fake_vcpkg(tmp_path, f"""#!/usr/bin/env python3
+import pathlib, sys
+pathlib.Path({str(args_file)!r}).write_text('\\n'.join(sys.argv[1:]), encoding='utf-8')
+sys.exit(0)
+""")
+    result = run_wrapper(tmp_path, exe)
+    assert result.returncode == 0
+    args = args_file.read_text(encoding="utf-8")
+    assert "install" in args
+    assert f"--x-manifest-root={tmp_path / 'manifest root'}" in args
+    assert "--debug-extra" in args


### PR DESCRIPTION
### Motivation
- Upstream FreeDesktop GitLab returned HTTP 504 for the FreeType source archive, causing vcpkg installs to fail across Windows, Linux, and macOS; workflows lacked an outer retry/backoff and had duplicate work and weak diagnostics. 
- Improve CI resilience without changing project dependencies, disabling TLS, vendoring archives, or hiding permanent build failures. 
- Centralize vcpkg baseline handling to keep `vcpkg.json` as the single source of truth and reduce accidental workflow drift. 

### Description
- Added a cross-platform retry wrapper `.github/scripts/vcpkg_install_retry.py` that runs vcpkg without shell-string construction, streams stdout/stderr live, writes a UTF-8 log under `out/ci-logs/`, classifies transient vs permanent failures, and retries with bounded exponential backoff. 
- Added `.github/scripts/get_vcpkg_baseline.py` to read and validate the 40-character `builtin-baseline` from `vcpkg.json` and export it into workflow environment/cache keys. 
- Replaced direct one-shot `vcpkg install` invocations in the Windows, Linux, macOS (26), macOS 15, and Arch workflows with the shared retry wrapper, preserved platform triplets and packaging logic, and ensured wrapper logs are always written. 
- Separated caches: downloads are restored/saved separately from installed/packages/binary caches, downloads are persisted even after failed installs, binary-cache paths are isolated per OS/SDK/triplet, and workflows now upload useful diagnostics ( `out/ci-logs/**`, `vcpkg/buildtrees/**/*.log`, `vcpkg/buildtrees/**/issue_body.md`, `.vcpkg-cache/installed/vcpkg/issue_body.md`, and CMake logs only when present). 
- Removed duplicate Windows dependency work by making the focused secure-store test job depend on the installer build and reuse the same keyed caches instead of performing a parallel cold install. 
- Reworked `main-patch-test-build.yml` to call installer workflows as tracked reusable jobs that pass the exact bumped commit SHA so the parent run fails if any tracked installer fails. 
- Upgraded official GitHub actions to Node 24-compatible majors (`actions/checkout@v6`, `actions/cache@v5` / `actions/cache/restore@v5` / `actions/cache/save@v5`, `actions/upload-artifact@v7`, `actions/download-artifact@v8`) and adjusted cache logic/keys to use the manifest baseline. 
- Added unit tests `tests/ci/test_vcpkg_install_retry.py` for transient 504 recovery, DNS/timeout recovery, permanent compiler failures (no retry), final transient failure exit-code preservation, paths-with-spaces and argument forwarding, and documented CI retry/cache/diagnostic policy in `docs/developer/build.md` and `docs/release-notes-draft.md`. 

### Testing
- Compiled and syntax-checked helper scripts: `python -m py_compile .github/scripts/get_vcpkg_baseline.py .github/scripts/vcpkg_install_retry.py` (succeeded). 
- Ran the retry-wrapper unit tests: `python -m pytest tests/ci/test_vcpkg_install_retry.py` (5 tests passed). 
- Validated workflow YAML parsing with Ruby YAML loader and ran `actionlint` against `.github/workflows/*.yml` (both passed after fixes). 
- Ran repository policy checks: `tests/check_perastage_tree_modules.sh`, `tests/check_no_configmanager_get_in_gui.sh`, and `tests/check_securestore_build_policy.sh` (all checks passed after adapting checks to baseline-parsing step). 
- Verified updated workflows for Node 24-compatible action majors and YAML/CI invariants via the above tools and local workflow validations; no automated workflow runs were executed here (changes affect CI runtime behavior and will be validated by subsequent GitHub runs).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5d310998bc832484261ce1d184a33e)