### PR TITLE
Fix Layout Viewer automatic fit lifecycle

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -17,6 +17,7 @@ Perastage 1.5.0 is a substantial update focused on GDTF and truss editing, multi
 
 ### Interface and workflow
 
+- Layout Viewer now fits pages reliably after opening Layout Mode, switching layouts, loading projects, changing page setup, or restoring a visible layout perspective, while preserving user zoom and pan during routine content edits.
 - Replaced standalone JSON layout-template export with portable `.pslayout` packages. Layout packages are ZIP-based, self-contained, include referenced layout images, and remain importable alongside legacy JSON templates for compatibility.
 - Added interface-language selection for **English** and **Spanish**. The selected language is stored in Preferences and is applied after restarting the application.
 - Added **Cross-table Actions** to the viewport toolbar. When enabled, hover, selection, measurement, and compatible tools can work across all supported object types instead of being limited to the active Data Views table.

--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -497,13 +497,11 @@ LayoutViewerPanel::LayoutViewerPanel(wxWindow *parent)
   glContext_ = new wxGLContext(this);
   currentLayout.pageSetup.pageSize = print::PageSize::A4;
   currentLayout.pageSetup.landscape = true;
-  pendingFitOnResize = true;
   loadingTimer_.SetOwner(this, kLoadingTimerId);
   renderDelayTimer_.SetOwner(this, kRenderDelayTimerId);
   Bind(wxEVT_TIMER, &LayoutViewerPanel::OnLoadingTimer, this, kLoadingTimerId);
   Bind(wxEVT_TIMER, &LayoutViewerPanel::OnRenderDelayTimer, this,
        kRenderDelayTimerId);
-  ResetViewToFit();
 }
 
 LayoutViewerPanel::~LayoutViewerPanel() {
@@ -519,6 +517,12 @@ LayoutViewerPanel::~LayoutViewerPanel() {
   loadingTimer_.Stop();
   renderDelayTimer_.Stop();
   delete glContext_;
+}
+
+// Requests a deferred automatic fit once the pane has a stable visible size.
+void LayoutViewerPanel::RequestFitToViewport() {
+  pendingFitOnResize = true;
+  SchedulePendingFitToViewport();
 }
 
 // Clears project-scoped Layout preview render caches before applying a new project.
@@ -668,8 +672,6 @@ void LayoutViewerPanel::SetLayoutDefinition(
     legendItems_.clear();
     legendDataHash = 0;
     legendDataDirty_ = false;
-    pendingFitOnResize = true;
-    ResetViewToFit();
     Refresh();
     NotifyRenderReady();
     return;
@@ -678,8 +680,6 @@ void LayoutViewerPanel::SetLayoutDefinition(
   loadingRequested = false;
   legendDataDirty_ = true;
   RefreshLegendData();
-  pendingFitOnResize = true;
-  ResetViewToFit();
   InvalidateRenderIfFrameChanged(true);
   RequestRenderRebuild();
   Refresh();
@@ -1340,13 +1340,10 @@ void LayoutViewerPanel::DrawSelectionHandles(const wxRect &frameRect) const {
 
 // Updates cached render state and repaint scheduling after viewport size changes.
 void LayoutViewerPanel::OnSize(wxSizeEvent &) {
-  wxSize size = layoutviewerpanel::GetLogicalClientSize(this);
-  if (pendingFitOnResize && size.GetWidth() > 0 && size.GetHeight() > 0) {
-    ResetViewToFit();
-    pendingFitOnResize = false;
-  } else {
-    InvalidateRenderIfFrameChanged(false);
-  }
+  if (TryCompletePendingFitToViewport())
+    return;
+
+  InvalidateRenderIfFrameChanged(false);
   RequestRenderRebuild();
   Refresh();
 }
@@ -1493,9 +1490,11 @@ void LayoutViewerPanel::OnKeyDown(wxKeyEvent &event) {
   event.Skip();
 }
 
+// Handles pane visibility changes and resumes pending automatic fits.
 void LayoutViewerPanel::OnShow(wxShowEvent &event) {
   if (event.IsShown()) {
     InitGL();
+    SchedulePendingFitToViewport();
     if (isReadyToRender_ && NeedsRenderRebuild()) {
       RequestRenderRebuild();
     }
@@ -1957,6 +1956,45 @@ void LayoutViewerPanel::OnSendToBack(wxCommandEvent &) {
   renderDirty = true;
   RequestRenderRebuild();
   Refresh();
+}
+
+// Reports whether the current client area can produce a reliable automatic fit.
+bool LayoutViewerPanel::IsViewportReadyForAutomaticFit() const {
+  constexpr int kMinimumStableFitSizePx = 100;
+  const wxSize size = layoutviewerpanel::GetLogicalClientSize(this);
+  return size.GetWidth() >= kMinimumStableFitSizePx &&
+         size.GetHeight() >= kMinimumStableFitSizePx && IsShownOnScreen();
+}
+
+// Attempts to consume the pending automatic fit with the current viewport.
+bool LayoutViewerPanel::TryCompletePendingFitToViewport() {
+  if (!pendingFitOnResize || !IsViewportReadyForAutomaticFit())
+    return false;
+
+  ResetViewToFit();
+  pendingFitOnResize = false;
+  InvalidateRenderIfFrameChanged(false);
+  RequestRenderRebuild();
+  Refresh();
+  return true;
+}
+
+// Schedules at most one deferred automatic-fit attempt for the pending request.
+void LayoutViewerPanel::SchedulePendingFitToViewport() {
+  if (!pendingFitOnResize || deferredFitToViewportScheduled_)
+    return;
+
+  deferredFitToViewportScheduled_ = true;
+  wxWeakRef<LayoutViewerPanel> weakThis(this);
+  CallAfter([weakThis]() {
+    if (!weakThis)
+      return;
+    LayoutViewerPanel *panel = weakThis.get();
+    if (!panel)
+      return;
+    panel->deferredFitToViewportScheduled_ = false;
+    panel->TryCompletePendingFitToViewport();
+  });
 }
 
 // Resets the layout camera so the page fits within the current viewport.

--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -46,6 +46,7 @@ public:
   ~LayoutViewerPanel();
 
   void SetLayoutDefinition(const layouts::LayoutDefinition &layout);
+  void RequestFitToViewport();
   void ResetPreviewCachesForProjectLoad();
   layouts::Layout2DViewDefinition *GetEditableView();
   const layouts::Layout2DViewDefinition *GetEditableView() const;
@@ -197,6 +198,9 @@ private:
   void ClearLoadingTextTexture();
 
   void ResetViewToFit();
+  bool IsViewportReadyForAutomaticFit() const;
+  bool TryCompletePendingFitToViewport();
+  void SchedulePendingFitToViewport();
   wxRect GetPageRect() const;
   bool GetFrameRect(const layouts::Layout2DViewFrame &frame,
                     wxRect &rect) const;
@@ -375,7 +379,8 @@ private:
   std::vector<LegendItem> legendItems_;
   size_t legendDataHash = 0;
   bool legendDataDirty_ = true;
-  bool pendingFitOnResize = true;
+  bool pendingFitOnResize = false;
+  bool deferredFitToViewportScheduled_ = false;
   bool pendingFrameCommit_ = false;
   SelectionIndexCache selectionIndexCache_;
 

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1420,6 +1420,7 @@ void MainWindow::ActivateLayoutView(const std::string &layoutName) {
         else
           Update();
         layoutViewerPanel->SetLayoutDefinition(layout);
+        layoutViewerPanel->RequestFitToViewport();
         appliedLayout = true;
       }
       break;

--- a/gui/mainwindow_layout.cpp
+++ b/gui/mainwindow_layout.cpp
@@ -524,6 +524,11 @@ void MainWindow::ApplyLayoutPreset(const LayoutViewPreset &preset,
 
   layoutModeActive = layoutMode;
 
+  if (layoutMode && layoutViewerPanel &&
+      IsPaneShown(auiManager, "LayoutViewer")) {
+    layoutViewerPanel->RequestFitToViewport();
+  }
+
   if (persistPerspective) {
     ConfigManager &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
     cfg.SetValue("layout_view_mode", preset.name);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -68,6 +68,8 @@ if(BASH_EXECUTABLE)
              COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_layout_preview_failure_diagnostics.sh)
     add_test(NAME LayoutProjectLoadCacheReset
              COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_layout_project_load_cache_reset.sh)
+    add_test(NAME LayoutViewerFitLifecycle
+             COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_layout_viewer_fit_lifecycle.sh)
     add_test(NAME LibraryUserDataPolicy
              COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_library_user_data_policy.sh)
     add_test(NAME DictionaryPathsPolicy

--- a/tests/check_layout_viewer_fit_lifecycle.sh
+++ b/tests/check_layout_viewer_fit_lifecycle.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+panel_cpp="$repo_root/gui/layoutviewerpanel.cpp"
+panel_h="$repo_root/gui/layoutviewerpanel.h"
+mainwindow_cpp="$repo_root/gui/mainwindow.cpp"
+mainwindow_layout_cpp="$repo_root/gui/mainwindow_layout.cpp"
+
+for required in "$panel_cpp" "$panel_h" "$mainwindow_cpp" "$mainwindow_layout_cpp"; do
+  if [[ ! -f "$required" ]]; then
+    echo "Missing required Layout Viewer fit lifecycle file: ${required#$repo_root/}" >&2
+    exit 1
+  fi
+done
+
+if ! rg -q "void RequestFitToViewport\(\);" "$panel_h"; then
+  echo "LayoutViewerPanel must expose an explicit RequestFitToViewport API" >&2
+  exit 1
+fi
+
+request_body="$(python3 - "$panel_cpp" <<'PY'
+import re
+import sys
+text = open(sys.argv[1], encoding='utf-8').read()
+match = re.search(r'void LayoutViewerPanel::RequestFitToViewport\(\) \{[\s\S]*?\n\}', text)
+if not match:
+    sys.exit(1)
+print(match.group(0))
+PY
+)"
+
+for token in "pendingFitOnResize = true" "SchedulePendingFitToViewport"; do
+  if [[ "$request_body" != *"$token"* ]]; then
+    echo "RequestFitToViewport is missing expected token: $token" >&2
+    exit 1
+  fi
+done
+
+ready_body="$(python3 - "$panel_cpp" <<'PY'
+import re
+import sys
+text = open(sys.argv[1], encoding='utf-8').read()
+match = re.search(r'bool LayoutViewerPanel::IsViewportReadyForAutomaticFit\(\) const \{[\s\S]*?\n\}', text)
+if not match:
+    sys.exit(1)
+print(match.group(0))
+PY
+)"
+
+for token in "GetLogicalClientSize" "kMinimumStableFitSizePx" "IsShownOnScreen"; do
+  if [[ "$ready_body" != *"$token"* ]]; then
+    echo "Automatic fit readiness must verify stable visible client geometry: $token" >&2
+    exit 1
+  fi
+done
+
+attempt_body="$(python3 - "$panel_cpp" <<'PY'
+import re
+import sys
+text = open(sys.argv[1], encoding='utf-8').read()
+match = re.search(r'bool LayoutViewerPanel::TryCompletePendingFitToViewport\(\) \{[\s\S]*?\n\}', text)
+if not match:
+    sys.exit(1)
+print(match.group(0))
+PY
+)"
+
+for token in "pendingFitOnResize" "IsViewportReadyForAutomaticFit" "ResetViewToFit" "pendingFitOnResize = false" "RequestRenderRebuild" "Refresh"; do
+  if [[ "$attempt_body" != *"$token"* ]]; then
+    echo "Automatic fit completion is missing expected token: $token" >&2
+    exit 1
+  fi
+done
+
+schedule_body="$(python3 - "$panel_cpp" <<'PY'
+import re
+import sys
+text = open(sys.argv[1], encoding='utf-8').read()
+match = re.search(r'void LayoutViewerPanel::SchedulePendingFitToViewport\(\) \{[\s\S]*?\n\}', text)
+if not match:
+    sys.exit(1)
+print(match.group(0))
+PY
+)"
+
+for token in "deferredFitToViewportScheduled_" "wxWeakRef<LayoutViewerPanel>" "CallAfter" "TryCompletePendingFitToViewport"; do
+  if [[ "$schedule_body" != *"$token"* ]]; then
+    echo "Deferred automatic fit scheduling is missing expected token: $token" >&2
+    exit 1
+  fi
+done
+
+onsize_body="$(python3 - "$panel_cpp" <<'PY'
+import re
+import sys
+text = open(sys.argv[1], encoding='utf-8').read()
+match = re.search(r'void LayoutViewerPanel::OnSize\(wxSizeEvent &\) \{[\s\S]*?\n\}', text)
+if not match:
+    sys.exit(1)
+print(match.group(0))
+PY
+)"
+
+if [[ "$onsize_body" != *"TryCompletePendingFitToViewport"* ]]; then
+  echo "OnSize must consume pending fits only through the guarded completion helper" >&2
+  exit 1
+fi
+if [[ "$onsize_body" == *"ResetViewToFit"* ]]; then
+  echo "OnSize must not bypass automatic-fit readiness checks" >&2
+  exit 1
+fi
+
+python3 - "$panel_cpp" <<'PYCHECK'
+import re
+import sys
+text = open(sys.argv[1], encoding='utf-8').read()
+allowed_functions = {
+    'LayoutViewerPanel::RequestFitToViewport',
+    'LayoutViewerPanel::OnKeyDown',
+    'LayoutViewerPanel::TryCompletePendingFitToViewport',
+    'LayoutViewerPanel::ResetViewToFit',
+}
+violations = []
+for match in re.finditer(r'(pendingFitOnResize = true|ResetViewToFit\(\);)', text):
+    prefix = text[:match.start()]
+    funcs = re.findall(r'(?:bool|void|wxRect|double)\s+(LayoutViewerPanel::\w+)\([^;]*?\)\s*(?:const\s*)?\{', prefix)
+    current = funcs[-1] if funcs else '<unknown>'
+    if current not in allowed_functions:
+        line = prefix.count('\n') + 1
+        violations.append(f'{line}: {match.group(1)} in {current}')
+if violations:
+    print('Routine LayoutViewerPanel refresh paths must not directly request or perform automatic fits:', file=sys.stderr)
+    for violation in violations:
+        print(violation, file=sys.stderr)
+    sys.exit(1)
+PYCHECK
+if ! rg -q "RequestFitToViewport" "$mainwindow_cpp"; then
+  echo "Activating or switching layouts must explicitly request a fit" >&2
+  exit 1
+fi
+if ! rg -q "RequestFitToViewport" "$mainwindow_layout_cpp"; then
+  echo "Applying a visible Layout Mode perspective must explicitly request a fit" >&2
+  exit 1
+fi
+
+echo "OK: Layout Viewer automatic fit lifecycle is explicitly requested, guarded, and deferred."


### PR DESCRIPTION
### Motivation
- The automatic fit-to-page could run while the Layout Viewer was hidden or using a transient/minimum size, producing incorrect initial zoom on some platforms (notably Linux); the intent is to make automatic fits deterministic after wxAUI layout/perspective changes settle. 
- Provide a clear public API to request an automatic fit from higher-level transitions (layout activation, entering Layout Mode, project load), avoiding inference from frequent low-level layout refresh paths. 
- Keep the change focused on viewport lifecycle and fit behavior only, not on OpenGL/offscreen rendering or #1778 diagnostics. 
- Note: `gui/layoutviewerpanel.cpp` is a large hotspot; extraction was considered but not feasible in this focused change, so a follow-up split is recommended for layout viewer lifecycle helpers and render-invalidation logic.

### Description
- Added a public API `LayoutViewerPanel::RequestFitToViewport()` that marks a fit as pending and schedules a single deferred attempt via `CallAfter()` with a `wxWeakRef` to avoid lifetime races. 
- Implemented guarded helpers: `IsViewportReadyForAutomaticFit()`, `TryCompletePendingFitToViewport()`, and `SchedulePendingFitToViewport()`, plus a `deferredFitToViewportScheduled_` flag to suppress duplicate deferred callbacks; these call the existing `ResetViewToFit()` and then request render rebuild/refresh. 
- Strengthened `OnSize()` and `OnShow()` so pending fits are consumed only when the panel has a stable visible client size and is shown on screen; ordinary resize invalidation no longer resets user zoom/pan once a pending fit was completed. 
- Moved automatic-fit intent to explicit higher-level transitions by calling `RequestFitToViewport()` from `MainWindow::ActivateLayoutView()` (layout selection/activation) and `MainWindow::ApplyLayoutPreset()` when entering a visible Layout Mode perspective; removed earlier direct immediate `ResetViewToFit()` calls in those routine refresh paths. 
- Added a static regression script `tests/check_layout_viewer_fit_lifecycle.sh` (registered in `tests/CMakeLists.txt`) that enforces the API presence, guarded completion flow, deferred scheduling using `CallAfter` + `wxWeakRef`, and ensures routine code paths do not directly call `ResetViewToFit()` or set pending fit except in allowed functions. 
- Small developer-facing touches: concise one-line comments were added above the new functions to explain their purpose, and `docs/release-notes-draft.md` was updated with a user-facing improvement entry.

### Testing
- Ran the new lifecycle regression check: `./tests/check_layout_viewer_fit_lifecycle.sh` — passed. 
- Ran repository static sanity checks: `./tests/check_layout_project_load_cache_reset.sh`, `./tests/check_perastage_tree_modules.sh`, and `./tests/check_no_configmanager_get_in_gui.sh` — all passed. 
- Ran `git diff --check` to verify no trailing whitespace or similar issues — passed. 
- Attempted to configure and build with `cmake --preset wsl-x64-debug && cmake --build --preset wsl-debug-build --target Perastage` inside this container but configuration failed due to missing wxWidgets development files (`wxWidgets_LIBRARIES` / `wxWidgets_INCLUDE_DIRS`), so a full binary build+runtime verification was not performed here. 

Files changed (key): `gui/layoutviewerpanel.h`, `gui/layoutviewerpanel.cpp`, `gui/mainwindow.cpp`, `gui/mainwindow_layout.cpp`, `tests/check_layout_viewer_fit_lifecycle.sh`, `tests/CMakeLists.txt`, and `docs/release-notes-draft.md`.

Remaining limitation: this PR does not change OpenGL/offscreen rendering, EGL/Wayland handling, texture uploads, or the diagnostics for the Linux white/black preview issue (#1778); those remain separate investigations if rendering failures persist.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5dca7207c08324ac747fe9a3acc67f)