### PR TITLE
Add truss selection context menus to 2D and 3D viewers

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -10,6 +10,7 @@ Perastage 1.5.0 is a substantial update focused on GDTF and truss editing, multi
 - Added the new **Edit Truss** dialog and significantly expanded the GDTF information available in **Edit Fixture**.
 - Added **Cross-table Actions**, allowing compatible 2D and 3D tools to work across fixtures, trusses, hoists, and scene objects.
 - Added a **Scene Object to Truss** conversion tool.
+- Added 2D and 3D viewer context-menu shortcuts for selecting trusses by model/source file or hang position from the **Trusses** table.
 - Added a **Spanish interface**, selectable from Preferences and applied after restarting Perastage.
 - Improved MVR/GDTF compatibility, 3D picking stability, Unicode handling, crash diagnostics, and release packaging.
 

--- a/docs/user/features.md
+++ b/docs/user/features.md
@@ -118,6 +118,7 @@ Additional safeguards include:
   placement.
 - Add Truss supports quantity, real-world insertion-point coordinates in the active distance units, automatic linear placement from the selected truss bounding-box length, and optional default grouping into one bridge.
 - **Tools → Convert Scene Objects to Truss** converts the selected scene object and every other scene object that uses the same model file into truss objects. The same command is available by right-clicking a scene object in the 2D or 3D viewer.
+- In the 2D and 3D viewers, right-clicking empty viewer space while the **Trusses** table is active opens truss selection shortcuts. Trusses can be selected by hang position or by model; geometry-only trusses without a model are grouped by their shared source file name.
 - Multi-row editing helpers include fills, ranges, interpolation, and relative expressions.
 - **Group** and **Ungroup** in the Edit menu create and remove MVR-compatible GroupObject hierarchy from the active cross-table selection across fixtures, trusses, hoists, and scene objects while preserving world placement and hang-position assignments; after grouping, clicking a member selects the full group across related tables, and the selection highlights and moves/rotates the full group, including nested groups, while hovering a grouped member uses a more yellow primary highlight and a paler related-green highlight on the other group members in the 3D view and related tables using the same row style as table selection.
 - CSV export is available through file/export workflows.

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -516,6 +516,67 @@ void ApplyFixtureSelectionToUi(const std::vector<std::string> &selection,
   }
 }
 
+
+// Returns the display key used to group trusses by model or source file.
+std::string BuildTrussModelSelectionKey(const Truss &truss) {
+  if (!truss.model.empty())
+    return truss.model;
+  std::string fileName = !truss.modelFile.empty() ? truss.modelFile : truss.symbolFile;
+  const size_t slash = fileName.find_last_of("/\\");
+  if (slash != std::string::npos)
+    fileName = fileName.substr(slash + 1);
+  return fileName;
+}
+
+// Builds truss UUIDs filtered by model-or-source-file key for selection workflows.
+std::vector<std::string> BuildTrussSelectionByModelKey(
+    const MvrScene &scene, const std::string &modelKey) {
+  std::vector<std::string> uuids;
+  uuids.reserve(scene.trusses.size());
+  for (const auto &[uuid, truss] : scene.trusses) {
+    if (modelKey.empty() || BuildTrussModelSelectionKey(truss) == modelKey)
+      uuids.push_back(uuid);
+  }
+  return uuids;
+}
+
+// Builds truss UUIDs filtered by position-name mapping criteria.
+std::vector<std::string> BuildTrussSelectionByPosition(
+    const MvrScene &scene, const std::string &positionName,
+    bool selectNoPosition) {
+  std::vector<std::string> uuids;
+  uuids.reserve(scene.trusses.size());
+  for (const auto &[uuid, truss] : scene.trusses) {
+    const bool hasPosition = !truss.positionName.empty();
+    if (selectNoPosition) {
+      if (!hasPosition)
+        uuids.push_back(uuid);
+      continue;
+    }
+    if (positionName.empty() || truss.positionName == positionName)
+      uuids.push_back(uuid);
+  }
+  return uuids;
+}
+
+// Applies a truss selection to scene state, controller highlights, and table UI.
+void ApplyTrussSelectionToUi(const std::vector<std::string> &selection,
+                             Viewer3DController &controller) {
+  ConfigManager &cfg = ConfigManager::Get();
+  if (selection != cfg.GetSelectedTrusses()) {
+    cfg.PushUndoState("truss selection");
+    cfg.SetSelectedTrusses(selection);
+  }
+  controller.SetSelectedUuids(selection);
+  selection::ScopedOrigin selectionOrigin(selection::Origin::Viewer2D);
+  if (TrussTablePanel::Instance()) {
+    if (selection.empty())
+      TrussTablePanel::Instance()->ClearSelection();
+    else
+      TrussTablePanel::Instance()->SelectByUuid(selection, false);
+  }
+}
+
 // Appends missing UUIDs from the added selection while preserving existing order.
 std::vector<std::string> MergeSelectionAdditive(
     std::vector<std::string> selection, const std::vector<std::string> &added) {
@@ -3477,7 +3538,7 @@ void Viewer2DPanel::OnMouseUp(wxMouseEvent &event) {
 }
 
 
-// Opens the fixture filter menu when right-clicking empty fixture-table space.
+// Opens the active table selection menu when right-clicking empty viewer space.
 void Viewer2DPanel::OnRightUp(wxMouseEvent &event) {
   if (m_continuousPlacementActive) {
     CancelContinuousPlacement();
@@ -3519,31 +3580,59 @@ void Viewer2DPanel::OnRightUp(wxMouseEvent &event) {
     return;
   }
 
-  if (!(FixtureTablePanel::Instance() && FixtureTablePanel::Instance()->IsActivePage())) {
-    event.Skip();
-    return;
-  }
-
-  if (m_controller.GetFixtureLabelAt(pickPos.x, pickPos.y, w, h, label,
-                                     pos, &hitUuid, true)) {
+  const bool fixturePageActive =
+      FixtureTablePanel::Instance() && FixtureTablePanel::Instance()->IsActivePage();
+  const bool trussPageActive =
+      TrussTablePanel::Instance() && TrussTablePanel::Instance()->IsActivePage();
+  if (!fixturePageActive && !trussPageActive) {
     event.Skip();
     return;
   }
 
   const auto &scene = ConfigManager::Get().GetScene();
-  if (scene.fixtures.empty())
-    return;
-
   std::set<std::string> typeNames;
   std::set<std::string> positionNames;
   bool hasNoPosition = false;
-  for (const auto &[uuid, fixture] : scene.fixtures) {
-    if (!fixture.typeName.empty())
-      typeNames.insert(fixture.typeName);
-    if (fixture.positionName.empty())
-      hasNoPosition = true;
-    else
-      positionNames.insert(fixture.positionName);
+  wxString allLabel;
+  wxString typeMenuLabel;
+
+  if (fixturePageActive) {
+    if (m_controller.GetFixtureLabelAt(pickPos.x, pickPos.y, w, h, label,
+                                       pos, &hitUuid, true)) {
+      event.Skip();
+      return;
+    }
+    if (scene.fixtures.empty())
+      return;
+    for (const auto &[uuid, fixture] : scene.fixtures) {
+      if (!fixture.typeName.empty())
+        typeNames.insert(fixture.typeName);
+      if (fixture.positionName.empty())
+        hasNoPosition = true;
+      else
+        positionNames.insert(fixture.positionName);
+    }
+    allLabel = "All fixtures";
+    typeMenuLabel = "Select by fixture type";
+  } else {
+    if (m_controller.GetTrussLabelAt(pickPos.x, pickPos.y, w, h, label,
+                                     pos, &hitUuid)) {
+      event.Skip();
+      return;
+    }
+    if (scene.trusses.empty())
+      return;
+    for (const auto &[uuid, truss] : scene.trusses) {
+      const std::string modelKey = BuildTrussModelSelectionKey(truss);
+      if (!modelKey.empty())
+        typeNames.insert(modelKey);
+      if (truss.positionName.empty())
+        hasNoPosition = true;
+      else
+        positionNames.insert(truss.positionName);
+    }
+    allLabel = "All trusses";
+    typeMenuLabel = "Select by model";
   }
 
   wxMenu filterMenu;
@@ -3555,7 +3644,7 @@ void Viewer2DPanel::OnRightUp(wxMouseEvent &event) {
   constexpr int kSelectPositionNoneId = wxID_HIGHEST + 800;
   constexpr int kSelectPositionBaseId = wxID_HIGHEST + 801;
 
-  typeSubmenu->Append(kSelectTypeAllId, "All fixtures");
+  typeSubmenu->Append(kSelectTypeAllId, allLabel);
 
   std::vector<std::string> orderedTypes;
   orderedTypes.reserve(typeNames.size());
@@ -3575,7 +3664,7 @@ void Viewer2DPanel::OnRightUp(wxMouseEvent &event) {
     positionSubmenu->Append(nextPositionId++, wxString::FromUTF8(name));
   }
 
-  filterMenu.AppendSubMenu(typeSubmenu.release(), "Select by fixture type");
+  filterMenu.AppendSubMenu(typeSubmenu.release(), typeMenuLabel);
   filterMenu.AppendSubMenu(positionSubmenu.release(), "Select by position");
 
   const int selectedId =
@@ -3585,7 +3674,11 @@ void Viewer2DPanel::OnRightUp(wxMouseEvent &event) {
     return;
 
   if (selectedId == kSelectTypeAllId) {
-    ApplyFixtureSelectionToUi(BuildFixtureSelectionByType(scene, ""),
+    if (fixturePageActive)
+      ApplyFixtureSelectionToUi(BuildFixtureSelectionByType(scene, ""),
+                                m_controller);
+    else
+      ApplyTrussSelectionToUi(BuildTrussSelectionByModelKey(scene, ""),
                               m_controller);
     RequestRepaint();
     return;
@@ -3594,7 +3687,11 @@ void Viewer2DPanel::OnRightUp(wxMouseEvent &event) {
   if (selectedId >= kSelectTypeBaseId &&
       selectedId < kSelectTypeBaseId + static_cast<int>(orderedTypes.size())) {
     const size_t idx = static_cast<size_t>(selectedId - kSelectTypeBaseId);
-    ApplyFixtureSelectionToUi(BuildFixtureSelectionByType(scene, orderedTypes[idx]),
+    if (fixturePageActive)
+      ApplyFixtureSelectionToUi(BuildFixtureSelectionByType(scene, orderedTypes[idx]),
+                                m_controller);
+    else
+      ApplyTrussSelectionToUi(BuildTrussSelectionByModelKey(scene, orderedTypes[idx]),
                               m_controller);
     RequestRepaint();
     return;
@@ -3602,10 +3699,17 @@ void Viewer2DPanel::OnRightUp(wxMouseEvent &event) {
 
   if (selectedId == kSelectPositionNoneId) {
     if (!hasNoPosition) {
-      ApplyFixtureSelectionToUi({}, m_controller);
+      if (fixturePageActive)
+        ApplyFixtureSelectionToUi({}, m_controller);
+      else
+        ApplyTrussSelectionToUi({}, m_controller);
     } else {
-      ApplyFixtureSelectionToUi(
-          BuildFixtureSelectionByPosition(scene, "", true), m_controller);
+      if (fixturePageActive)
+        ApplyFixtureSelectionToUi(
+            BuildFixtureSelectionByPosition(scene, "", true), m_controller);
+      else
+        ApplyTrussSelectionToUi(
+            BuildTrussSelectionByPosition(scene, "", true), m_controller);
     }
     RequestRepaint();
     return;
@@ -3615,9 +3719,14 @@ void Viewer2DPanel::OnRightUp(wxMouseEvent &event) {
       selectedId <
           kSelectPositionBaseId + static_cast<int>(orderedPositions.size())) {
     const size_t idx = static_cast<size_t>(selectedId - kSelectPositionBaseId);
-    ApplyFixtureSelectionToUi(
-        BuildFixtureSelectionByPosition(scene, orderedPositions[idx], false),
-        m_controller);
+    if (fixturePageActive)
+      ApplyFixtureSelectionToUi(
+          BuildFixtureSelectionByPosition(scene, orderedPositions[idx], false),
+          m_controller);
+    else
+      ApplyTrussSelectionToUi(
+          BuildTrussSelectionByPosition(scene, orderedPositions[idx], false),
+          m_controller);
     RequestRepaint();
     return;
   }

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -2046,6 +2046,72 @@ void Viewer3DPanel::ClearAllObjectSelections(const char* undoLabel)
         SceneObjectTablePanel::Instance()->ClearSelection();
 }
 
+// Returns the display key used to group trusses by model or source file.
+static std::string BuildTrussModelSelectionKey(const Truss& truss)
+{
+    if (!truss.model.empty())
+        return truss.model;
+    std::string fileName = !truss.modelFile.empty() ? truss.modelFile : truss.symbolFile;
+    const size_t slash = fileName.find_last_of("/\\");
+    if (slash != std::string::npos)
+        fileName = fileName.substr(slash + 1);
+    return fileName;
+}
+
+// Builds truss UUIDs filtered by model-or-source-file key for selection workflows.
+static std::vector<std::string> BuildTrussSelectionByModelKey(
+    const MvrScene& scene, const std::string& modelKey)
+{
+    std::vector<std::string> uuids;
+    uuids.reserve(scene.trusses.size());
+    for (const auto& [uuid, truss] : scene.trusses) {
+        if (modelKey.empty() || BuildTrussModelSelectionKey(truss) == modelKey)
+            uuids.push_back(uuid);
+    }
+    return uuids;
+}
+
+// Builds truss UUIDs filtered by position-name mapping criteria.
+static std::vector<std::string> BuildTrussSelectionByPosition(
+    const MvrScene& scene, const std::string& positionName, bool selectNoPosition)
+{
+    std::vector<std::string> uuids;
+    uuids.reserve(scene.trusses.size());
+    for (const auto& [uuid, truss] : scene.trusses) {
+        const bool hasPosition = !truss.positionName.empty();
+        if (selectNoPosition) {
+            if (!hasPosition)
+                uuids.push_back(uuid);
+            continue;
+        }
+        if (positionName.empty() || truss.positionName == positionName)
+            uuids.push_back(uuid);
+    }
+    return uuids;
+}
+
+// Applies a truss selection to scene state, controller highlights, and table UI.
+static void ApplyTrussSelectionToUi(const std::vector<std::string>& selection,
+                             Viewer3DPanel* panel,
+                             Viewer3DController& controller)
+{
+    ConfigManager& cfg = ConfigManager::Get();
+    if (selection != cfg.GetSelectedTrusses()) {
+        cfg.PushUndoState("truss selection");
+        cfg.SetSelectedTrusses(selection);
+    }
+    controller.SetSelectedUuids(selection);
+    selection::ScopedOrigin selectionOrigin(selection::Origin::Viewer3D);
+    if (panel)
+        panel->SetSelectedFixtures(selection);
+    if (TrussTablePanel::Instance()) {
+        if (selection.empty())
+            TrussTablePanel::Instance()->ClearSelection();
+        else
+            TrussTablePanel::Instance()->SelectByUuid(selection, false);
+    }
+}
+
 // Opens the right-click selection and render-style context menu.
 void Viewer3DPanel::OnRightUp(wxMouseEvent& event)
 {
@@ -2066,11 +2132,15 @@ void Viewer3DPanel::OnRightUp(wxMouseEvent& event)
 
     const bool fixturePageActive =
         FixtureTablePanel::Instance() && FixtureTablePanel::Instance()->IsActivePage();
+    const bool trussPageActive =
+        TrussTablePanel::Instance() && TrussTablePanel::Instance()->IsActivePage();
     const auto& scene = ConfigManager::Get().GetScene();
     std::set<std::string> typeNames;
     std::set<std::string> positionNames;
     bool hasNoPosition = false;
     bool showSelectionSubmenus = false;
+    wxString allSelectionLabel;
+    wxString typeSelectionLabel;
     std::string hitSceneObjectUuid;
     if (TryBindGlContextForInteraction("OnRightUp")) {
         const wxPoint pickPos = ToFramebufferPoint(this, event.GetPosition());
@@ -2091,6 +2161,28 @@ void Viewer3DPanel::OnRightUp(wxMouseEvent& event)
                 else
                     positionNames.insert(fixture.positionName);
             }
+            allSelectionLabel = "All fixtures";
+            typeSelectionLabel = "Select by fixture type";
+            showSelectionSubmenus = true;
+        }
+    }
+    if (trussPageActive && !scene.trusses.empty() &&
+        TryBindGlContextForInteraction("OnRightUp")) {
+        std::string hitUuid;
+        const wxPoint pickPos = ToFramebufferPoint(this, event.GetPosition());
+        if (!QueryHoverUuid(m_controller, HoverTargetTable::Trusses, pickPos.x,
+                            pickPos.y, w, h, hitUuid)) {
+            for (const auto& [uuid, truss] : scene.trusses) {
+                const std::string modelKey = BuildTrussModelSelectionKey(truss);
+                if (!modelKey.empty())
+                    typeNames.insert(modelKey);
+                if (truss.positionName.empty())
+                    hasNoPosition = true;
+                else
+                    positionNames.insert(truss.positionName);
+            }
+            allSelectionLabel = "All trusses";
+            typeSelectionLabel = "Select by model";
             showSelectionSubmenus = true;
         }
     }
@@ -2115,7 +2207,7 @@ void Viewer3DPanel::OnRightUp(wxMouseEvent& event)
     constexpr int kExportImagePngId = wxID_HIGHEST + 1208;
     constexpr int kConvertSceneObjectToTrussId = wxID_HIGHEST + 1209;
 
-    typeSubmenu->Append(kSelectTypeAllId, "All fixtures");
+    typeSubmenu->Append(kSelectTypeAllId, allSelectionLabel);
     std::vector<std::string> orderedTypes;
     orderedTypes.reserve(typeNames.size());
     int nextTypeId = kSelectTypeBaseId;
@@ -2175,7 +2267,7 @@ void Viewer3DPanel::OnRightUp(wxMouseEvent& event)
         rootMenu.AppendSeparator();
     }
     if (showSelectionSubmenus) {
-        rootMenu.AppendSubMenu(typeSubmenu.release(), "Select by fixture type");
+        rootMenu.AppendSubMenu(typeSubmenu.release(), typeSelectionLabel);
         rootMenu.AppendSubMenu(positionSubmenu.release(), "Select by position");
         rootMenu.AppendSeparator();
     }
@@ -2238,8 +2330,12 @@ void Viewer3DPanel::OnRightUp(wxMouseEvent& event)
     }
 
     if (selectedId == kSelectTypeAllId) {
-        ApplyFixtureSelectionToUi(BuildFixtureSelectionByType(scene, ""), this,
-                                  m_controller);
+        if (fixturePageActive)
+            ApplyFixtureSelectionToUi(BuildFixtureSelectionByType(scene, ""), this,
+                                      m_controller);
+        else
+            ApplyTrussSelectionToUi(BuildTrussSelectionByModelKey(scene, ""), this,
+                                    m_controller);
         Refresh();
         return;
     }
@@ -2247,18 +2343,29 @@ void Viewer3DPanel::OnRightUp(wxMouseEvent& event)
     if (selectedId >= kSelectTypeBaseId &&
         selectedId < kSelectTypeBaseId + static_cast<int>(orderedTypes.size())) {
         const size_t idx = static_cast<size_t>(selectedId - kSelectTypeBaseId);
-        ApplyFixtureSelectionToUi(BuildFixtureSelectionByType(scene, orderedTypes[idx]), this,
-                                  m_controller);
+        if (fixturePageActive)
+            ApplyFixtureSelectionToUi(BuildFixtureSelectionByType(scene, orderedTypes[idx]), this,
+                                      m_controller);
+        else
+            ApplyTrussSelectionToUi(BuildTrussSelectionByModelKey(scene, orderedTypes[idx]), this,
+                                    m_controller);
         Refresh();
         return;
     }
 
     if (selectedId == kSelectPositionNoneId) {
         if (!hasNoPosition) {
-            ApplyFixtureSelectionToUi({}, this, m_controller);
+            if (fixturePageActive)
+                ApplyFixtureSelectionToUi({}, this, m_controller);
+            else
+                ApplyTrussSelectionToUi({}, this, m_controller);
         } else {
-            ApplyFixtureSelectionToUi(BuildFixtureSelectionByPosition(scene, "", true),
-                                      this, m_controller);
+            if (fixturePageActive)
+                ApplyFixtureSelectionToUi(BuildFixtureSelectionByPosition(scene, "", true),
+                                          this, m_controller);
+            else
+                ApplyTrussSelectionToUi(BuildTrussSelectionByPosition(scene, "", true),
+                                        this, m_controller);
         }
         Refresh();
         return;
@@ -2267,9 +2374,14 @@ void Viewer3DPanel::OnRightUp(wxMouseEvent& event)
     if (selectedId >= kSelectPositionBaseId &&
         selectedId < kSelectPositionBaseId + static_cast<int>(orderedPositions.size())) {
         const size_t idx = static_cast<size_t>(selectedId - kSelectPositionBaseId);
-        ApplyFixtureSelectionToUi(
-            BuildFixtureSelectionByPosition(scene, orderedPositions[idx], false), this,
-            m_controller);
+        if (fixturePageActive)
+            ApplyFixtureSelectionToUi(
+                BuildFixtureSelectionByPosition(scene, orderedPositions[idx], false), this,
+                m_controller);
+        else
+            ApplyTrussSelectionToUi(
+                BuildTrussSelectionByPosition(scene, orderedPositions[idx], false), this,
+                m_controller);
         Refresh();
         return;
     }


### PR DESCRIPTION
### Motivation
- Provide the same convenient right-click selection shortcuts available for Fixtures to the Trusses workflow so users can select trusses by model (or fallback to a shared source filename) or by hang position from the 2D and 3D viewers. 
- Keep viewer behavior consistent with existing fixture menus while preserving existing selection and table-sync semantics. 
- This change touches UI hotspot files (`viewer2dpanel.cpp`, `viewer3dpanel.cpp`) so the next recommended split is to extract the newly added truss-selection helpers (`BuildTrussModelSelectionKey`, `BuildTrussSelectionByModelKey`, `BuildTrussSelectionByPosition`, `ApplyTrussSelectionToUi`) into a small dedicated helper source file to keep hotspot growth manageable. 

### Description
- Added grouping logic to derive a truss selection key using `Model` first and falling back to the source filename for geometry-only trusses via `BuildTrussModelSelectionKey`. 
- Implemented `BuildTrussSelectionByModelKey` and `BuildTrussSelectionByPosition` utilities and `ApplyTrussSelectionToUi` to apply truss selections to config, controller highlights, and the Truss table. 
- Extended `Viewer2DPanel::OnRightUp` and `Viewer3DPanel::OnRightUp` to show an active-table-aware context menu when the Trusses table is active, offering "All trusses", "Select by model" and "Select by position" (and preserved Fixtures behavior when the Fixtures table is active). 
- Updated user documentation and release notes by adding a user-visible entry in `docs/user/features.md` and `docs/release-notes-draft.md`. 

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both succeeded. 
- Ran `git diff --check`, which reported no issues. 
- Attempted a CMake configure/build (`cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug && cmake --build build -j2`), which failed during configuration because the environment is missing `wxWidgets` (dependency not available in CI environment), so a full build could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e6e8c332c8324b2dce7b0689c3664)