### PR TITLE
CI: separate Debug CI, patch artifact builders, compatibility builds, and transactional minor release workflows

### DIFF
--- a/.github/release-artifact-contract.json
+++ b/.github/release-artifact-contract.json
@@ -1,0 +1,21 @@
+{
+  "packages": {
+    "windows": "Perastage_*_Setup.exe",
+    "linux": "Perastage-*-x86_64.AppImage",
+    "macos15": "Perastage-*-macOS15-arm64.dmg",
+    "macos26": "Perastage-*-macOS26-arm64.dmg",
+    "arch": "Perastage-*-arch-x86_64.pkg.tar.zst"
+  },
+  "artifacts": {
+    "windowsPackage": "Perastage-windows-installer",
+    "linuxPackage": "Perastage-linux-appimage",
+    "macos15Package": "Perastage-macos15-dmg",
+    "macos26Package": "Perastage-macos26-dmg",
+    "archPackage": "Perastage-arch-package",
+    "windowsSymbols": "Perastage-windows-symbols",
+    "linuxSymbols": "Perastage-linux-symbols",
+    "macos15Symbols": "Perastage-macos15-symbols",
+    "macos26Symbols": "Perastage-macos26-symbols",
+    "archSymbols": "Perastage-archlinux-symbols"
+  }
+}

--- a/.github/workflows/arch-package.yml
+++ b/.github/workflows/arch-package.yml
@@ -1,7 +1,7 @@
 # Arch Linux package workflow for Perastage.
 # Builds an experimental pacman package without changing the AppImage workflow.
 
-name: Arch Linux Package Build
+name: Arch Linux Release Package
 
 on:
   workflow_call:
@@ -162,20 +162,9 @@ jobs:
           useradd --create-home --shell /bin/bash builder
           chown -R builder:builder "$GITHUB_WORKSPACE"
 
-      - name: Run Arch release-gate tests
-        run: |
-          su builder -c "export VCPKG_ROOT='$VCPKG_ROOT' VCPKG_INSTALLED='$VCPKG_INSTALLED' VCPKG_TARGET_TRIPLET='$VCPKG_TARGET_TRIPLET' CI_LOG_DIR='$CI_LOG_DIR'; cd '$GITHUB_WORKSPACE' && python3 .github/scripts/run_and_log.py --log '$CI_LOG_DIR/cmake-configure-arch-release-gate.log' -- cmake -S . -B build-release-gate -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE='$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake' -DVCPKG_TARGET_TRIPLET='$VCPKG_TARGET_TRIPLET' -DVCPKG_INSTALLED_DIR='$VCPKG_INSTALLED' -DVCPKG_MANIFEST_MODE=OFF -DBUILD_TESTING=ON -DPERASTAGE_REQUIRE_SECURE_CREDENTIAL_STORE=ON"
-          su builder -c "cd '$GITHUB_WORKSPACE' && cmake --build build-release-gate --target gdtf_share_security_test credential_store_native_roundtrip_test"
-          su builder -c "cd '$GITHUB_WORKSPACE' && ctest --test-dir build-release-gate -L release-gate --output-on-failure"
-
       - name: Build Arch package
         run: |
-          su builder -c "export VCPKG_ROOT='$VCPKG_ROOT' VCPKG_INSTALLED='$VCPKG_INSTALLED' VCPKG_TARGET_TRIPLET='$VCPKG_TARGET_TRIPLET' PERASTAGE_REQUIRE_SECURE_CREDENTIAL_STORE=ON; cd '$GITHUB_WORKSPACE/packaging/arch' && makepkg --force --noconfirm --nodeps"
-
-      - name: Validate release-gate policy and package dependency
-        run: |
-          su builder -c "cd '$GITHUB_WORKSPACE' && bash tests/check_securestore_build_policy.sh"
-          grep -q "libsecret" packaging/arch/PKGBUILD
+          su builder -c "export VCPKG_ROOT='$VCPKG_ROOT' VCPKG_INSTALLED='$VCPKG_INSTALLED' VCPKG_TARGET_TRIPLET='$VCPKG_TARGET_TRIPLET' PERASTAGE_REQUIRE_SECURE_CREDENTIAL_STORE=ON PERASTAGE_ENABLE_COMPILER_CACHE=OFF; cd '$GITHUB_WORKSPACE/packaging/arch' && makepkg --force --noconfirm --nodeps"
 
       - name: Collect Arch package
         run: |

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -70,26 +70,82 @@ jobs:
       VCPKG_INSTALLED: ${{ github.workspace }}/.vcpkg-cache/installed
       VCPKG_DOWNLOADS: ${{ github.workspace }}/.vcpkg-cache/downloads
       VCPKG_PACKAGES: ${{ github.workspace }}/.vcpkg-cache/packages
+      VCPKG_BINARY_CACHE: ${{ github.workspace }}/.vcpkg-cache/binary
       VCPKG_BINARY_SOURCES: clear;files,${{ github.workspace }}/.vcpkg-cache/binary,readwrite
       CI_LOG_DIR: ${{ github.workspace }}/out/ci-logs
     steps:
       - uses: actions/checkout@v6
         with:
           ref: ${{ needs.resolve-source.outputs.source_sha }}
-      - name: Prepare diagnostics summary
-        run: mkdir -p "$CI_LOG_DIR" && { uname -a; cmake --version; ninja --version || true; } > "$CI_LOG_DIR/environment.txt"
+      - name: Prepare vcpkg and diagnostics directories
+        run: |
+          mkdir -p "$CI_LOG_DIR" "$VCPKG_DOWNLOADS" "$VCPKG_INSTALLED" "$VCPKG_PACKAGES" "$VCPKG_BINARY_CACHE"
+          { uname -a; cmake --version; ninja --version || true; } > "$CI_LOG_DIR/environment-linux-debug.txt"
+      - name: Read vcpkg baseline
+        id: vcpkg-baseline
+        run: |
+          set -euo pipefail
+          baseline="$(python3 .github/scripts/get_vcpkg_baseline.py vcpkg.json)"
+          echo "baseline=${baseline}" >> "$GITHUB_OUTPUT"
+          echo "VCPKG_BASELINE=${baseline}" >> "$GITHUB_ENV"
       - name: Install Linux test dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential cmake ninja-build pkg-config gettext autopoint autoconf autoconf-archive automake libtool libltdl-dev curl unzip zip libx11-dev libxau-dev libxdmcp-dev x11proto-dev libxi-dev libxtst-dev libxrender-dev libgtk-3-dev libglib2.0-dev libsecret-1-dev libpango1.0-dev libatk1.0-dev libcairo2-dev libgdk-pixbuf-2.0-dev libxkbcommon-dev libgl1-mesa-dev libglu1-mesa-dev
+      - name: Restore vcpkg downloads
+        id: vcpkg-downloads-cache
+        uses: actions/cache/restore@v5
+        with:
+          path: .vcpkg-cache/downloads
+          key: ${{ runner.os }}-${{ runner.arch }}-debug-vcpkg-downloads-${{ steps.vcpkg-baseline.outputs.baseline }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-debug-vcpkg-downloads-${{ steps.vcpkg-baseline.outputs.baseline }}-
+            ${{ runner.os }}-${{ runner.arch }}-vcpkg-downloads-${{ steps.vcpkg-baseline.outputs.baseline }}-
+      - name: Cache vcpkg installed packages and binary archives
+        uses: actions/cache@v5
+        with:
+          path: |
+            .vcpkg-cache/installed
+            .vcpkg-cache/packages
+            .vcpkg-cache/binary
+          key: ${{ runner.os }}-${{ runner.arch }}-debug-v1-${{ steps.vcpkg-baseline.outputs.baseline }}-x64-linux-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', '.github/workflows/ci-tests.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-debug-v1-${{ steps.vcpkg-baseline.outputs.baseline }}-x64-linux-
+      - name: Bootstrap vcpkg
+        run: |
+          set -euo pipefail
+          if [ -d "$VCPKG_ROOT/.git" ]; then
+            git -C "$VCPKG_ROOT" fetch --depth 1 origin "$VCPKG_BASELINE"
+            git -C "$VCPKG_ROOT" checkout --force "$VCPKG_BASELINE"
+          else
+            rm -rf "$VCPKG_ROOT"
+            git clone https://github.com/microsoft/vcpkg.git "$VCPKG_ROOT"
+            git -C "$VCPKG_ROOT" checkout --force "$VCPKG_BASELINE"
+          fi
+          "$VCPKG_ROOT/bootstrap-vcpkg.sh" -disableMetrics
+      - name: Install vcpkg packages
+        run: |
+          python3 .github/scripts/vcpkg_install_retry.py --vcpkg "$VCPKG_ROOT/vcpkg" --triplet x64-linux --manifest-root "$GITHUB_WORKSPACE" \
+            --install-root "$VCPKG_INSTALLED" \
+            --packages-root "$VCPKG_PACKAGES" \
+            --downloads-root "$VCPKG_DOWNLOADS" \
+            --attempts 4 --initial-delay-seconds 30 --max-delay-seconds 120 \
+            --log "$CI_LOG_DIR/vcpkg-install-linux-debug.log"
+      - name: Save vcpkg downloads cache
+        if: ${{ always() && steps.vcpkg-downloads-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v5
+        with:
+          path: .vcpkg-cache/downloads
+          key: ${{ steps.vcpkg-downloads-cache.outputs.cache-primary-key }}
       - name: Configure Debug tests
         run: |
-          python3 .github/scripts/run_and_log.py --log "$CI_LOG_DIR/cmake-configure-linux-debug.log" -- cmake -S . -B build/linux-debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON -DPERASTAGE_REQUIRE_SECURE_CREDENTIAL_STORE=ON -DPERASTAGE_ENABLE_COMPILER_CACHE=OFF
-          if grep -Eq '(^|[[:space:]])-DNDEBUG([[:space:]]|$)' build/linux-debug/compile_commands.json 2>/dev/null; then echo "Debug tests must not compile with NDEBUG"; exit 1; fi
+          python3 .github/scripts/run_and_log.py --log "$CI_LOG_DIR/cmake-configure-linux-debug.log" -- cmake -S . -B build/linux-debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x64-linux -DVCPKG_INSTALLED_DIR="$VCPKG_INSTALLED" -DVCPKG_MANIFEST_MODE=OFF -DBUILD_TESTING=ON -DPERASTAGE_REQUIRE_SECURE_CREDENTIAL_STORE=ON -DPERASTAGE_ENABLE_COMPILER_CACHE=OFF
+          test -f build/linux-debug/compile_commands.json || { echo "Debug compile_commands.json was not generated"; exit 1; }
+          if grep -Eq '(^|[[:space:]])-DNDEBUG([[:space:]]|$)' build/linux-debug/compile_commands.json; then echo "Debug tests must not compile with NDEBUG"; exit 1; fi
       - name: Build complete test target set
-        run: cmake --build build/linux-debug --target all --verbose
+        run: python3 .github/scripts/run_and_log.py --log "$CI_LOG_DIR/build-linux-debug.log" -- cmake --build build/linux-debug --target all --verbose
       - name: Run complete CTest suite
-        run: ctest --test-dir build/linux-debug --output-on-failure
+        run: python3 .github/scripts/run_and_log.py --log "$CI_LOG_DIR/ctest-linux-debug.log" -- ctest --test-dir build/linux-debug --output-on-failure
       - name: Run repository policy tests
         run: |
           bash tests/check_perastage_tree_modules.sh
@@ -107,6 +163,8 @@ jobs:
             **/CMakeCache.txt
             build/**/*.log
             vcpkg/buildtrees/**/*.log
+            vcpkg/buildtrees/**/config-*.txt
+            vcpkg/buildtrees/**/issue_body.md
             .vcpkg-cache/installed/vcpkg/issue_body.md
 
   windows-debug:
@@ -117,56 +175,114 @@ jobs:
       VCPKG_INSTALLED: ${{ github.workspace }}\.vcpkg-cache\installed
       VCPKG_DOWNLOADS: ${{ github.workspace }}\.vcpkg-cache\downloads
       VCPKG_PACKAGES: ${{ github.workspace }}\.vcpkg-cache\packages
+      VCPKG_BINARY_CACHE: ${{ github.workspace }}\.vcpkg-cache\binary
       VCPKG_BINARY_SOURCES: clear;files,${{ github.workspace }}\.vcpkg-cache\binary,readwrite
       CI_LOG_DIR: ${{ github.workspace }}\out\ci-logs
     steps:
       - uses: actions/checkout@v6
         with:
           ref: ${{ needs.resolve-source.outputs.source_sha }}
-      - name: Initialize Visual Studio Hostx64 x64
+      - name: Prepare vcpkg and diagnostics directories
         shell: pwsh
         run: |
-          New-Item -ItemType Directory -Path $env:CI_LOG_DIR -Force | Out-Null
-          $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
-          $vsRoot = (& $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath).Trim()
-          $devCmd = Join-Path $vsRoot 'Common7\Tools\VsDevCmd.bat'
-          cmd.exe /c "`"$devCmd`" -host_arch=x64 -arch=x64 >nul && set" | ForEach-Object { $p=$_.IndexOf('='); if ($p -gt 0) { Set-Item -Path "Env:$($_.Substring(0,$p))" -Value $_.Substring($p+1) } }
-          $cl=(Get-Command cl.exe).Source; if ($cl -match '(?i)mingw|msys|strawberry') { throw "Refusing non-MSVC compiler: $cl" }
-          if ($env:VSCMD_ARG_HOST_ARCH -ne 'x64' -or $env:VSCMD_ARG_TGT_ARCH -ne 'x64') { throw 'Visual Studio is not Hostx64/x64.' }
-          cmake --version | Out-File "$env:CI_LOG_DIR\environment.txt"
+          New-Item -ItemType Directory -Path $env:CI_LOG_DIR,$env:VCPKG_DOWNLOADS,$env:VCPKG_INSTALLED,$env:VCPKG_PACKAGES,$env:VCPKG_BINARY_CACHE -Force | Out-Null
+          cmake --version | Out-File "$env:CI_LOG_DIR\environment-windows-debug.txt"
       - name: Read vcpkg baseline
         id: vcpkg-baseline
         shell: bash
         run: |
+          set -euo pipefail
           baseline="$(python3 .github/scripts/get_vcpkg_baseline.py vcpkg.json)"
           echo "baseline=${baseline}" >> "$GITHUB_OUTPUT"
           echo "VCPKG_BASELINE=${baseline}" >> "$GITHUB_ENV"
+      - name: Restore vcpkg downloads
+        id: vcpkg-downloads-cache
+        uses: actions/cache/restore@v5
+        with:
+          path: .vcpkg-cache/downloads
+          key: ${{ runner.os }}-${{ runner.arch }}-debug-vcpkg-downloads-${{ steps.vcpkg-baseline.outputs.baseline }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-debug-vcpkg-downloads-${{ steps.vcpkg-baseline.outputs.baseline }}-
+            ${{ runner.os }}-${{ runner.arch }}-vcpkg-downloads-${{ steps.vcpkg-baseline.outputs.baseline }}-
+      - name: Cache vcpkg installed packages and binary archives
+        uses: actions/cache@v5
+        with:
+          path: |
+            .vcpkg-cache\installed
+            .vcpkg-cache\packages
+            .vcpkg-cache\binary
+          key: ${{ runner.os }}-${{ runner.arch }}-debug-v1-${{ steps.vcpkg-baseline.outputs.baseline }}-x64-windows-msvc-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', '.github/workflows/ci-tests.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-debug-v1-${{ steps.vcpkg-baseline.outputs.baseline }}-x64-windows-msvc-
       - name: Bootstrap vcpkg
         shell: pwsh
         run: |
-          git clone https://github.com/microsoft/vcpkg.git $env:VCPKG_ROOT
-          git -C $env:VCPKG_ROOT checkout --force $env:VCPKG_BASELINE
+          if (Test-Path "$env:VCPKG_ROOT\.git") {
+            git -C $env:VCPKG_ROOT fetch --depth 1 origin $env:VCPKG_BASELINE
+            git -C $env:VCPKG_ROOT checkout --force $env:VCPKG_BASELINE
+          } else {
+            if (Test-Path $env:VCPKG_ROOT) { Remove-Item $env:VCPKG_ROOT -Recurse -Force }
+            git clone https://github.com/microsoft/vcpkg.git $env:VCPKG_ROOT
+            git -C $env:VCPKG_ROOT checkout --force $env:VCPKG_BASELINE
+          }
           & "$env:VCPKG_ROOT\bootstrap-vcpkg.bat" -disableMetrics
       - name: Install vcpkg packages
         shell: pwsh
         run: |
-          New-Item -ItemType Directory -Path $env:VCPKG_DOWNLOADS,$env:VCPKG_INSTALLED,$env:VCPKG_PACKAGES -Force | Out-Null
           python .github/scripts/vcpkg_install_retry.py --vcpkg "$env:VCPKG_ROOT\vcpkg.exe" --triplet x64-windows --manifest-root "$env:GITHUB_WORKSPACE" `
             --install-root "$env:VCPKG_INSTALLED" `
             --packages-root "$env:VCPKG_PACKAGES" `
             --downloads-root "$env:VCPKG_DOWNLOADS" `
             --attempts 4 --initial-delay-seconds 30 --max-delay-seconds 120 `
-            --log "$env:CI_LOG_DIR\vcpkg-install-x64-windows.log"
+            --log "$env:CI_LOG_DIR\vcpkg-install-windows-debug.log"
+      - name: Save vcpkg downloads cache
+        if: ${{ always() && steps.vcpkg-downloads-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v5
+        with:
+          path: .vcpkg-cache/downloads
+          key: ${{ steps.vcpkg-downloads-cache.outputs.cache-primary-key }}
+      - name: Persist Visual Studio Hostx64 x64 environment
+        shell: pwsh
+        run: |
+          $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
+          $vsRoot = (& $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath).Trim()
+          if ([string]::IsNullOrWhiteSpace($vsRoot)) { throw 'No Visual Studio installation with x64 C++ tools was found.' }
+          $devCmd = Join-Path $vsRoot 'Common7\Tools\VsDevCmd.bat'
+          if (-not (Test-Path $devCmd)) { throw "VsDevCmd.bat was not found at: $devCmd" }
+          $envDump = cmd.exe /c "`"$devCmd`" -host_arch=x64 -arch=x64 >nul && set"
+          $envNames = @('INCLUDE','LIB','LIBPATH','Path','VSCMD_ARG_HOST_ARCH','VSCMD_ARG_TGT_ARCH','WindowsSdkDir','WindowsSDKVersion','VCINSTALLDIR','VCToolsInstallDir')
+          foreach ($line in $envDump) {
+            $separator = $line.IndexOf('=')
+            if ($separator -le 0) { continue }
+            $name = $line.Substring(0, $separator)
+            $value = $line.Substring($separator + 1)
+            Set-Item -Path "Env:$name" -Value $value
+            if ($envNames -contains $name) {
+              if ($name -ieq 'Path') { $value.Split(';') | Where-Object { $_ } | ForEach-Object { $_ | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8 } }
+              else { "$name=$value" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8 }
+            }
+          }
+          $cl = Get-Command cl.exe -ErrorAction SilentlyContinue
+          if (-not $cl) { throw 'cl.exe was not found after initializing the Visual Studio environment.' }
+          $normalizedCl = $cl.Source.Replace('/', '\').ToLowerInvariant()
+          if ($normalizedCl -match 'c:[\\/](mingw64|msys64)|mingw|msys|strawberry') { throw "Refusing non-MSVC compiler: $($cl.Source)" }
+          if ($env:VSCMD_ARG_HOST_ARCH -ne 'x64' -or $env:VSCMD_ARG_TGT_ARCH -ne 'x64') { throw "Visual Studio is not Hostx64/x64: host=$env:VSCMD_ARG_HOST_ARCH target=$env:VSCMD_ARG_TGT_ARCH" }
       - name: Configure Windows Debug tests
         shell: pwsh
         run: |
+          $cl = Get-Command cl.exe -ErrorAction SilentlyContinue
+          if (-not $cl) { throw 'cl.exe was not available in the persisted Visual Studio environment.' }
           python .github/scripts/run_and_log.py --log "$env:CI_LOG_DIR\cmake-configure-windows-debug.log" -- cmake -S . -B build-windows-debug -G Ninja -DCMAKE_C_COMPILER=cl.exe -DCMAKE_CXX_COMPILER=cl.exe -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT\scripts\buildsystems\vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x64-windows -DVCPKG_INSTALLED_DIR="$env:VCPKG_INSTALLED" -DVCPKG_MANIFEST_MODE=OFF -DBUILD_TESTING=ON -DPERASTAGE_REQUIRE_SECURE_CREDENTIAL_STORE=ON -DPERASTAGE_ENABLE_COMPILER_CACHE=OFF
+          $cache = Get-Content build-windows-debug\CMakeCache.txt -Raw
+          foreach ($required in @('CMAKE_C_COMPILER_ID:INTERNAL=MSVC', 'CMAKE_CXX_COMPILER_ID:INTERNAL=MSVC')) {
+            if ($cache -notmatch [regex]::Escape($required)) { throw "CMake cache is missing expected MSVC compiler identity: $required" }
+          }
       - name: Build Windows Debug tests
         shell: pwsh
-        run: cmake --build build-windows-debug --target all --verbose
+        run: python .github/scripts/run_and_log.py --log "$env:CI_LOG_DIR\build-windows-debug.log" -- cmake --build build-windows-debug --target all --verbose
       - name: Run Windows CTest suite
         shell: pwsh
-        run: ctest --test-dir build-windows-debug --output-on-failure
+        run: python .github/scripts/run_and_log.py --log "$env:CI_LOG_DIR\ctest-windows-debug.log" -- ctest --test-dir build-windows-debug --output-on-failure
       - name: Upload failure diagnostics
         if: ${{ failure() }}
         uses: actions/upload-artifact@v7
@@ -179,6 +295,9 @@ jobs:
             **/CMakeCache.txt
             build*/**/*.log
             vcpkg/buildtrees/**/*.log
+            vcpkg/buildtrees/**/config-*.txt
+            vcpkg/buildtrees/**/issue_body.md
+            .vcpkg-cache/installed/vcpkg/issue_body.md
 
   macos-debug:
     needs: resolve-source
@@ -188,43 +307,96 @@ jobs:
       VCPKG_INSTALLED: ${{ github.workspace }}/.vcpkg-cache/installed
       VCPKG_DOWNLOADS: ${{ github.workspace }}/.vcpkg-cache/downloads
       VCPKG_PACKAGES: ${{ github.workspace }}/.vcpkg-cache/packages
+      VCPKG_BINARY_CACHE: ${{ github.workspace }}/.vcpkg-cache/binary
       VCPKG_BINARY_SOURCES: clear;files,${{ github.workspace }}/.vcpkg-cache/binary,readwrite
       CI_LOG_DIR: ${{ github.workspace }}/out/ci-logs
     steps:
       - uses: actions/checkout@v6
         with:
           ref: ${{ needs.resolve-source.outputs.source_sha }}
-      - name: Prepare macOS debug environment
-        run: mkdir -p "$CI_LOG_DIR" && { sw_vers; uname -m; xcodebuild -version; } > "$CI_LOG_DIR/environment.txt"
-      - name: Install macOS test tools
-        run: brew update && brew install autoconf autoconf-archive automake gettext libtool ninja
+      - name: Prepare vcpkg and diagnostics directories
+        run: |
+          mkdir -p "$CI_LOG_DIR" "$VCPKG_DOWNLOADS" "$VCPKG_INSTALLED" "$VCPKG_PACKAGES" "$VCPKG_BINARY_CACHE"
+          { sw_vers; uname -m; xcodebuild -version; xcrun --sdk macosx --show-sdk-path; } > "$CI_LOG_DIR/environment-macos-debug.txt"
       - name: Read vcpkg baseline
         id: vcpkg-baseline
         run: |
+          set -euo pipefail
           baseline="$(python3 .github/scripts/get_vcpkg_baseline.py vcpkg.json)"
           echo "baseline=${baseline}" >> "$GITHUB_OUTPUT"
           echo "VCPKG_BASELINE=${baseline}" >> "$GITHUB_ENV"
+      - name: Install macOS test tools
+        run: brew update && brew install autoconf autoconf-archive automake gettext libtool ninja
+      - name: Restore vcpkg downloads
+        id: vcpkg-downloads-cache
+        uses: actions/cache/restore@v5
+        with:
+          path: .vcpkg-cache/downloads
+          key: macos-26-arm64-debug-vcpkg-downloads-${{ steps.vcpkg-baseline.outputs.baseline }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
+          restore-keys: |
+            macos-26-arm64-debug-vcpkg-downloads-${{ steps.vcpkg-baseline.outputs.baseline }}-
+            ${{ runner.os }}-${{ runner.arch }}-vcpkg-downloads-${{ steps.vcpkg-baseline.outputs.baseline }}-
+      - name: Cache vcpkg installed packages and binary archives
+        uses: actions/cache@v5
+        with:
+          path: |
+            .vcpkg-cache/installed
+            .vcpkg-cache/packages
+            .vcpkg-cache/binary
+          key: macos-26-xcode-26-debug-v1-${{ steps.vcpkg-baseline.outputs.baseline }}-arm64-osx-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', '.github/workflows/ci-tests.yml') }}
+          restore-keys: |
+            macos-26-xcode-26-debug-v1-${{ steps.vcpkg-baseline.outputs.baseline }}-arm64-osx-
       - name: Bootstrap vcpkg
         run: |
-          git clone https://github.com/microsoft/vcpkg.git "$VCPKG_ROOT"
-          git -C "$VCPKG_ROOT" checkout --force "$VCPKG_BASELINE"
+          set -euo pipefail
+          if [ -d "$VCPKG_ROOT/.git" ]; then
+            git -C "$VCPKG_ROOT" fetch --depth 1 origin "$VCPKG_BASELINE"
+            git -C "$VCPKG_ROOT" checkout --force "$VCPKG_BASELINE"
+          else
+            rm -rf "$VCPKG_ROOT"
+            git clone https://github.com/microsoft/vcpkg.git "$VCPKG_ROOT"
+            git -C "$VCPKG_ROOT" checkout --force "$VCPKG_BASELINE"
+          fi
           "$VCPKG_ROOT/bootstrap-vcpkg.sh" -disableMetrics
+      - name: Diagnose restored vcpkg SDK metadata
+        run: |
+          set -euo pipefail
+          current_sdk_path="$(xcrun --sdk macosx --show-sdk-path)"
+          stale_sdk_paths="$(
+            for cache_dir in "$VCPKG_INSTALLED" "$VCPKG_PACKAGES"; do
+              if [ -d "$cache_dir" ]; then
+                grep -R -h -o -E "/Applications/Xcode_[^[:space:]]*/SDKs/MacOSX\.sdk" "$cache_dir" 2>/dev/null || true
+              fi
+            done | sort -u | grep -F -v -x "$current_sdk_path" || true
+          )"
+          if [ -n "$stale_sdk_paths" ]; then
+            echo "Stale macOS SDK path metadata was found in the restored vcpkg cache."
+            echo "Current SDK path: $current_sdk_path"
+            echo "$stale_sdk_paths"
+            exit 1
+          fi
       - name: Install vcpkg packages
         run: |
-          mkdir -p "$VCPKG_DOWNLOADS" "$VCPKG_INSTALLED" "$VCPKG_PACKAGES"
           python3 .github/scripts/vcpkg_install_retry.py --vcpkg "$VCPKG_ROOT/vcpkg" --triplet arm64-osx --manifest-root "$GITHUB_WORKSPACE" \
             --install-root "$VCPKG_INSTALLED" \
             --packages-root "$VCPKG_PACKAGES" \
             --downloads-root "$VCPKG_DOWNLOADS" \
             --attempts 4 --initial-delay-seconds 30 --max-delay-seconds 120 \
-            --log "$CI_LOG_DIR/vcpkg-install-arm64-osx.log"
+            --log "$CI_LOG_DIR/vcpkg-install-macos-debug.log"
+      - name: Save vcpkg downloads cache
+        if: ${{ always() && steps.vcpkg-downloads-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v5
+        with:
+          path: .vcpkg-cache/downloads
+          key: ${{ steps.vcpkg-downloads-cache.outputs.cache-primary-key }}
       - name: Configure macOS Debug tests
         run: |
-          python3 .github/scripts/run_and_log.py --log "$CI_LOG_DIR/cmake-configure-macos-debug.log" -- cmake -S . -B build/macos-debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_OSX_ARCHITECTURES=arm64 -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=arm64-osx -DVCPKG_INSTALLED_DIR="$VCPKG_INSTALLED" -DVCPKG_MANIFEST_MODE=OFF -DBUILD_TESTING=ON -DPERASTAGE_REQUIRE_SECURE_CREDENTIAL_STORE=ON -DPERASTAGE_ENABLE_COMPILER_CACHE=OFF
+          current_sdk_path="$(xcrun --sdk macosx --show-sdk-path)"
+          python3 .github/scripts/run_and_log.py --log "$CI_LOG_DIR/cmake-configure-macos-debug.log" -- cmake -S . -B build/macos-debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_OSX_ARCHITECTURES=arm64 -DCMAKE_OSX_SYSROOT="$current_sdk_path" -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=arm64-osx -DVCPKG_INSTALLED_DIR="$VCPKG_INSTALLED" -DVCPKG_MANIFEST_MODE=OFF -DBUILD_TESTING=ON -DPERASTAGE_REQUIRE_SECURE_CREDENTIAL_STORE=ON -DPERASTAGE_ENABLE_COMPILER_CACHE=OFF
       - name: Build release-gate and macOS tests
-        run: cmake --build build/macos-debug --target gdtf_share_security_test credential_store_native_roundtrip_test --verbose
+        run: python3 .github/scripts/run_and_log.py --log "$CI_LOG_DIR/build-macos-debug.log" -- cmake --build build/macos-debug --target gdtf_share_security_test credential_store_native_roundtrip_test --verbose
       - name: Run release-gate and macOS tests
-        run: ctest --test-dir build/macos-debug -L release-gate --output-on-failure
+        run: python3 .github/scripts/run_and_log.py --log "$CI_LOG_DIR/ctest-macos-debug.log" -- ctest --test-dir build/macos-debug -L release-gate --output-on-failure
       - name: Upload failure diagnostics
         if: ${{ failure() }}
         uses: actions/upload-artifact@v7
@@ -237,3 +409,6 @@ jobs:
             **/CMakeCache.txt
             build/**/*.log
             vcpkg/buildtrees/**/*.log
+            vcpkg/buildtrees/**/config-*.txt
+            vcpkg/buildtrees/**/issue_body.md
+            .vcpkg-cache/installed/vcpkg/issue_body.md

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -186,7 +186,10 @@ jobs:
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Path $env:CI_LOG_DIR,$env:VCPKG_DOWNLOADS,$env:VCPKG_INSTALLED,$env:VCPKG_PACKAGES,$env:VCPKG_BINARY_CACHE -Force | Out-Null
+          $python = (Get-Command python -ErrorAction Stop).Source
+          "PERASTAGE_PYTHON=$python" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
           cmake --version | Out-File "$env:CI_LOG_DIR\environment-windows-debug.txt"
+          & $python --version | Out-File "$env:CI_LOG_DIR\environment-windows-debug.txt" -Append
       - name: Read vcpkg baseline
         id: vcpkg-baseline
         shell: bash
@@ -229,7 +232,7 @@ jobs:
       - name: Install vcpkg packages
         shell: pwsh
         run: |
-          python .github/scripts/vcpkg_install_retry.py --vcpkg "$env:VCPKG_ROOT\vcpkg.exe" --triplet x64-windows --manifest-root "$env:GITHUB_WORKSPACE" `
+          & "$env:PERASTAGE_PYTHON" .github/scripts/vcpkg_install_retry.py --vcpkg "$env:VCPKG_ROOT\vcpkg.exe" --triplet x64-windows --manifest-root "$env:GITHUB_WORKSPACE" `
             --install-root "$env:VCPKG_INSTALLED" `
             --packages-root "$env:VCPKG_PACKAGES" `
             --downloads-root "$env:VCPKG_DOWNLOADS" `
@@ -272,17 +275,19 @@ jobs:
         run: |
           $cl = Get-Command cl.exe -ErrorAction SilentlyContinue
           if (-not $cl) { throw 'cl.exe was not available in the persisted Visual Studio environment.' }
-          python .github/scripts/run_and_log.py --log "$env:CI_LOG_DIR\cmake-configure-windows-debug.log" -- cmake -S . -B build-windows-debug -G Ninja -DCMAKE_C_COMPILER=cl.exe -DCMAKE_CXX_COMPILER=cl.exe -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT\scripts\buildsystems\vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x64-windows -DVCPKG_INSTALLED_DIR="$env:VCPKG_INSTALLED" -DVCPKG_MANIFEST_MODE=OFF -DBUILD_TESTING=ON -DPERASTAGE_REQUIRE_SECURE_CREDENTIAL_STORE=ON -DPERASTAGE_ENABLE_COMPILER_CACHE=OFF
+          & "$env:PERASTAGE_PYTHON" .github/scripts/run_and_log.py --log "$env:CI_LOG_DIR\cmake-configure-windows-debug.log" -- cmake -S . -B build-windows-debug -G Ninja -DCMAKE_C_COMPILER=cl.exe -DCMAKE_CXX_COMPILER=cl.exe -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT\scripts\buildsystems\vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x64-windows -DVCPKG_INSTALLED_DIR="$env:VCPKG_INSTALLED" -DVCPKG_MANIFEST_MODE=OFF -DBUILD_TESTING=ON -DPERASTAGE_REQUIRE_SECURE_CREDENTIAL_STORE=ON -DPERASTAGE_ENABLE_COMPILER_CACHE=OFF
           $cache = Get-Content build-windows-debug\CMakeCache.txt -Raw
           foreach ($required in @('CMAKE_C_COMPILER_ID:INTERNAL=MSVC', 'CMAKE_CXX_COMPILER_ID:INTERNAL=MSVC')) {
             if ($cache -notmatch [regex]::Escape($required)) { throw "CMake cache is missing expected MSVC compiler identity: $required" }
           }
       - name: Build Windows Debug tests
         shell: pwsh
-        run: python .github/scripts/run_and_log.py --log "$env:CI_LOG_DIR\build-windows-debug.log" -- cmake --build build-windows-debug --target all --verbose
+        run: |
+          & "$env:PERASTAGE_PYTHON" .github/scripts/run_and_log.py --log "$env:CI_LOG_DIR\build-windows-debug.log" -- cmake --build build-windows-debug --target all --verbose
       - name: Run Windows CTest suite
         shell: pwsh
-        run: python .github/scripts/run_and_log.py --log "$env:CI_LOG_DIR\ctest-windows-debug.log" -- ctest --test-dir build-windows-debug --output-on-failure
+        run: |
+          & "$env:PERASTAGE_PYTHON" .github/scripts/run_and_log.py --log "$env:CI_LOG_DIR\ctest-windows-debug.log" -- ctest --test-dir build-windows-debug --output-on-failure
       - name: Upload failure diagnostics
         if: ${{ failure() }}
         uses: actions/upload-artifact@v7

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,0 +1,239 @@
+name: CI Debug Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      source_ref:
+        description: Exact branch, tag, or commit to test.
+        required: false
+        type: string
+        default: ""
+      profile:
+        description: Test profile to run.
+        required: false
+        type: choice
+        options:
+          - pr
+          - release
+        default: pr
+  workflow_call:
+    inputs:
+      source_ref:
+        description: Exact branch, tag, or commit to test.
+        required: false
+        type: string
+      profile:
+        description: Test profile to run.
+        required: false
+        type: string
+        default: release
+
+permissions:
+  contents: read
+
+env:
+  PERASTAGE_CI_PROFILE: ${{ inputs.profile || 'pr' }}
+
+concurrency:
+  group: ci-debug-tests-${{ github.event.pull_request.number || inputs.source_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  resolve-source:
+    runs-on: ubuntu-latest
+    outputs:
+      source_sha: ${{ steps.resolve.outputs.source_sha }}
+      source_ref: ${{ steps.resolve.outputs.source_ref }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.source_ref != '' && inputs.source_ref || github.event.pull_request.head.sha || github.ref }}
+          fetch-depth: 0
+      - name: Resolve exact source commit
+        id: resolve
+        run: |
+          set -euo pipefail
+          sha="$(git rev-parse HEAD)"
+          echo "source_sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "source_ref=${{ inputs.source_ref != '' && inputs.source_ref || github.event.pull_request.head.sha || github.ref }}" >> "$GITHUB_OUTPUT"
+          echo "Testing exact commit: $sha" >> "$GITHUB_STEP_SUMMARY"
+
+  linux-debug:
+    needs: resolve-source
+    runs-on: ubuntu-latest
+    env:
+      VCPKG_ROOT: ${{ github.workspace }}/vcpkg
+      VCPKG_INSTALLED: ${{ github.workspace }}/.vcpkg-cache/installed
+      VCPKG_DOWNLOADS: ${{ github.workspace }}/.vcpkg-cache/downloads
+      VCPKG_PACKAGES: ${{ github.workspace }}/.vcpkg-cache/packages
+      VCPKG_BINARY_SOURCES: clear;files,${{ github.workspace }}/.vcpkg-cache/binary,readwrite
+      CI_LOG_DIR: ${{ github.workspace }}/out/ci-logs
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.resolve-source.outputs.source_sha }}
+      - name: Prepare diagnostics summary
+        run: mkdir -p "$CI_LOG_DIR" && { uname -a; cmake --version; ninja --version || true; } > "$CI_LOG_DIR/environment.txt"
+      - name: Install Linux test dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake ninja-build pkg-config gettext autopoint autoconf autoconf-archive automake libtool libltdl-dev curl unzip zip libx11-dev libxau-dev libxdmcp-dev x11proto-dev libxi-dev libxtst-dev libxrender-dev libgtk-3-dev libglib2.0-dev libsecret-1-dev libpango1.0-dev libatk1.0-dev libcairo2-dev libgdk-pixbuf-2.0-dev libxkbcommon-dev libgl1-mesa-dev libglu1-mesa-dev
+      - name: Configure Debug tests
+        run: |
+          python3 .github/scripts/run_and_log.py --log "$CI_LOG_DIR/cmake-configure-linux-debug.log" -- cmake -S . -B build/linux-debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON -DPERASTAGE_REQUIRE_SECURE_CREDENTIAL_STORE=ON -DPERASTAGE_ENABLE_COMPILER_CACHE=OFF
+          if grep -Eq '(^|[[:space:]])-DNDEBUG([[:space:]]|$)' build/linux-debug/compile_commands.json 2>/dev/null; then echo "Debug tests must not compile with NDEBUG"; exit 1; fi
+      - name: Build complete test target set
+        run: cmake --build build/linux-debug --target all --verbose
+      - name: Run complete CTest suite
+        run: ctest --test-dir build/linux-debug --output-on-failure
+      - name: Run repository policy tests
+        run: |
+          bash tests/check_perastage_tree_modules.sh
+          bash tests/check_no_configmanager_get_in_gui.sh
+          bash tests/check_ci_cmake_language_policy.sh
+      - name: Upload failure diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ci-linux-debug-diagnostics
+          if-no-files-found: ignore
+          path: |
+            out/ci-logs/**
+            **/CMakeFiles/CMakeConfigureLog.yaml
+            **/CMakeCache.txt
+            build/**/*.log
+            vcpkg/buildtrees/**/*.log
+            .vcpkg-cache/installed/vcpkg/issue_body.md
+
+  windows-debug:
+    needs: resolve-source
+    runs-on: windows-latest
+    env:
+      VCPKG_ROOT: ${{ github.workspace }}\vcpkg
+      VCPKG_INSTALLED: ${{ github.workspace }}\.vcpkg-cache\installed
+      VCPKG_DOWNLOADS: ${{ github.workspace }}\.vcpkg-cache\downloads
+      VCPKG_PACKAGES: ${{ github.workspace }}\.vcpkg-cache\packages
+      VCPKG_BINARY_SOURCES: clear;files,${{ github.workspace }}\.vcpkg-cache\binary,readwrite
+      CI_LOG_DIR: ${{ github.workspace }}\out\ci-logs
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.resolve-source.outputs.source_sha }}
+      - name: Initialize Visual Studio Hostx64 x64
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Path $env:CI_LOG_DIR -Force | Out-Null
+          $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
+          $vsRoot = (& $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath).Trim()
+          $devCmd = Join-Path $vsRoot 'Common7\Tools\VsDevCmd.bat'
+          cmd.exe /c "`"$devCmd`" -host_arch=x64 -arch=x64 >nul && set" | ForEach-Object { $p=$_.IndexOf('='); if ($p -gt 0) { Set-Item -Path "Env:$($_.Substring(0,$p))" -Value $_.Substring($p+1) } }
+          $cl=(Get-Command cl.exe).Source; if ($cl -match '(?i)mingw|msys|strawberry') { throw "Refusing non-MSVC compiler: $cl" }
+          if ($env:VSCMD_ARG_HOST_ARCH -ne 'x64' -or $env:VSCMD_ARG_TGT_ARCH -ne 'x64') { throw 'Visual Studio is not Hostx64/x64.' }
+          cmake --version | Out-File "$env:CI_LOG_DIR\environment.txt"
+      - name: Read vcpkg baseline
+        id: vcpkg-baseline
+        shell: bash
+        run: |
+          baseline="$(python3 .github/scripts/get_vcpkg_baseline.py vcpkg.json)"
+          echo "baseline=${baseline}" >> "$GITHUB_OUTPUT"
+          echo "VCPKG_BASELINE=${baseline}" >> "$GITHUB_ENV"
+      - name: Bootstrap vcpkg
+        shell: pwsh
+        run: |
+          git clone https://github.com/microsoft/vcpkg.git $env:VCPKG_ROOT
+          git -C $env:VCPKG_ROOT checkout --force $env:VCPKG_BASELINE
+          & "$env:VCPKG_ROOT\bootstrap-vcpkg.bat" -disableMetrics
+      - name: Install vcpkg packages
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Path $env:VCPKG_DOWNLOADS,$env:VCPKG_INSTALLED,$env:VCPKG_PACKAGES -Force | Out-Null
+          python .github/scripts/vcpkg_install_retry.py --vcpkg "$env:VCPKG_ROOT\vcpkg.exe" --triplet x64-windows --manifest-root "$env:GITHUB_WORKSPACE" `
+            --install-root "$env:VCPKG_INSTALLED" `
+            --packages-root "$env:VCPKG_PACKAGES" `
+            --downloads-root "$env:VCPKG_DOWNLOADS" `
+            --attempts 4 --initial-delay-seconds 30 --max-delay-seconds 120 `
+            --log "$env:CI_LOG_DIR\vcpkg-install-x64-windows.log"
+      - name: Configure Windows Debug tests
+        shell: pwsh
+        run: |
+          python .github/scripts/run_and_log.py --log "$env:CI_LOG_DIR\cmake-configure-windows-debug.log" -- cmake -S . -B build-windows-debug -G Ninja -DCMAKE_C_COMPILER=cl.exe -DCMAKE_CXX_COMPILER=cl.exe -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT\scripts\buildsystems\vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x64-windows -DVCPKG_INSTALLED_DIR="$env:VCPKG_INSTALLED" -DVCPKG_MANIFEST_MODE=OFF -DBUILD_TESTING=ON -DPERASTAGE_REQUIRE_SECURE_CREDENTIAL_STORE=ON -DPERASTAGE_ENABLE_COMPILER_CACHE=OFF
+      - name: Build Windows Debug tests
+        shell: pwsh
+        run: cmake --build build-windows-debug --target all --verbose
+      - name: Run Windows CTest suite
+        shell: pwsh
+        run: ctest --test-dir build-windows-debug --output-on-failure
+      - name: Upload failure diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ci-windows-debug-diagnostics
+          if-no-files-found: ignore
+          path: |
+            out/ci-logs/**
+            **/CMakeFiles/CMakeConfigureLog.yaml
+            **/CMakeCache.txt
+            build*/**/*.log
+            vcpkg/buildtrees/**/*.log
+
+  macos-debug:
+    needs: resolve-source
+    runs-on: macos-26
+    env:
+      VCPKG_ROOT: ${{ github.workspace }}/vcpkg
+      VCPKG_INSTALLED: ${{ github.workspace }}/.vcpkg-cache/installed
+      VCPKG_DOWNLOADS: ${{ github.workspace }}/.vcpkg-cache/downloads
+      VCPKG_PACKAGES: ${{ github.workspace }}/.vcpkg-cache/packages
+      VCPKG_BINARY_SOURCES: clear;files,${{ github.workspace }}/.vcpkg-cache/binary,readwrite
+      CI_LOG_DIR: ${{ github.workspace }}/out/ci-logs
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.resolve-source.outputs.source_sha }}
+      - name: Prepare macOS debug environment
+        run: mkdir -p "$CI_LOG_DIR" && { sw_vers; uname -m; xcodebuild -version; } > "$CI_LOG_DIR/environment.txt"
+      - name: Install macOS test tools
+        run: brew update && brew install autoconf autoconf-archive automake gettext libtool ninja
+      - name: Read vcpkg baseline
+        id: vcpkg-baseline
+        run: |
+          baseline="$(python3 .github/scripts/get_vcpkg_baseline.py vcpkg.json)"
+          echo "baseline=${baseline}" >> "$GITHUB_OUTPUT"
+          echo "VCPKG_BASELINE=${baseline}" >> "$GITHUB_ENV"
+      - name: Bootstrap vcpkg
+        run: |
+          git clone https://github.com/microsoft/vcpkg.git "$VCPKG_ROOT"
+          git -C "$VCPKG_ROOT" checkout --force "$VCPKG_BASELINE"
+          "$VCPKG_ROOT/bootstrap-vcpkg.sh" -disableMetrics
+      - name: Install vcpkg packages
+        run: |
+          mkdir -p "$VCPKG_DOWNLOADS" "$VCPKG_INSTALLED" "$VCPKG_PACKAGES"
+          python3 .github/scripts/vcpkg_install_retry.py --vcpkg "$VCPKG_ROOT/vcpkg" --triplet arm64-osx --manifest-root "$GITHUB_WORKSPACE" \
+            --install-root "$VCPKG_INSTALLED" \
+            --packages-root "$VCPKG_PACKAGES" \
+            --downloads-root "$VCPKG_DOWNLOADS" \
+            --attempts 4 --initial-delay-seconds 30 --max-delay-seconds 120 \
+            --log "$CI_LOG_DIR/vcpkg-install-arm64-osx.log"
+      - name: Configure macOS Debug tests
+        run: |
+          python3 .github/scripts/run_and_log.py --log "$CI_LOG_DIR/cmake-configure-macos-debug.log" -- cmake -S . -B build/macos-debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_OSX_ARCHITECTURES=arm64 -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=arm64-osx -DVCPKG_INSTALLED_DIR="$VCPKG_INSTALLED" -DVCPKG_MANIFEST_MODE=OFF -DBUILD_TESTING=ON -DPERASTAGE_REQUIRE_SECURE_CREDENTIAL_STORE=ON -DPERASTAGE_ENABLE_COMPILER_CACHE=OFF
+      - name: Build release-gate and macOS tests
+        run: cmake --build build/macos-debug --target gdtf_share_security_test credential_store_native_roundtrip_test --verbose
+      - name: Run release-gate and macOS tests
+        run: ctest --test-dir build/macos-debug -L release-gate --output-on-failure
+      - name: Upload failure diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ci-macos-debug-diagnostics
+          if-no-files-found: ignore
+          path: |
+            out/ci-logs/**
+            **/CMakeFiles/CMakeConfigureLog.yaml
+            **/CMakeCache.txt
+            build/**/*.log
+            vcpkg/buildtrees/**/*.log

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -401,7 +401,7 @@ jobs:
       - name: Build release-gate and macOS tests
         run: python3 .github/scripts/run_and_log.py --log "$CI_LOG_DIR/build-macos-debug.log" -- cmake --build build/macos-debug --target gdtf_share_security_test credential_store_native_roundtrip_test --verbose
       - name: Run release-gate and macOS tests
-        run: python3 .github/scripts/run_and_log.py --log "$CI_LOG_DIR/ctest-macos-debug.log" -- ctest --test-dir build/macos-debug -L release-gate --output-on-failure
+        run: python3 .github/scripts/run_and_log.py --log "$CI_LOG_DIR/ctest-macos-debug.log" -- ctest --test-dir build/macos-debug -L release-gate --output-on-failure --verbose
       - name: Upload failure diagnostics
         if: ${{ failure() }}
         uses: actions/upload-artifact@v7

--- a/.github/workflows/compatibility-builds.yml
+++ b/.github/workflows/compatibility-builds.yml
@@ -1,0 +1,61 @@
+name: Weekly Compatibility Packages
+
+on:
+  schedule:
+    - cron: '27 3 * * 2'
+  workflow_dispatch:
+    inputs:
+      source_ref:
+        description: Optional exact branch, tag, or commit to build. Defaults to main.
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: compatibility-packages-${{ inputs.source_ref || 'main' }}
+  cancel-in-progress: true
+
+jobs:
+  resolve-source:
+    runs-on: ubuntu-latest
+    outputs:
+      source_sha: ${{ steps.resolve.outputs.source_sha }}
+      version: ${{ steps.resolve.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.source_ref != '' && inputs.source_ref || 'main' }}
+          fetch-depth: 0
+      - id: resolve
+        run: |
+          echo "source_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "version=$(tr -d '[:space:]' < VERSION)" >> "$GITHUB_OUTPUT"
+  macos15-installer:
+    needs: resolve-source
+    uses: ./.github/workflows/macos-15-manual-installer.yml
+    with:
+      source_ref: ${{ needs.resolve-source.outputs.source_sha }}
+  arch-package:
+    needs: resolve-source
+    uses: ./.github/workflows/arch-package.yml
+    with:
+      source_ref: ${{ needs.resolve-source.outputs.source_sha }}
+  summarize:
+    if: ${{ always() }}
+    needs: [resolve-source, macos15-installer, arch-package]
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          # Weekly compatibility packages
+          Source SHA: ${{ needs.resolve-source.outputs.source_sha }}
+          Version: ${{ needs.resolve-source.outputs.version }}
+          macOS 15 package: Perastage-*-macOS15-arm64.dmg (${{ needs.macos15-installer.result }})
+          Arch package: Perastage-*-arch-x86_64.pkg.tar.zst (${{ needs.arch-package.result }})
+          EOF
+          test "${{ needs.macos15-installer.result }}" = success
+          test "${{ needs.arch-package.result }}" = success

--- a/.github/workflows/linux-installer.yml
+++ b/.github/workflows/linux-installer.yml
@@ -1,7 +1,7 @@
 # Linux installer workflow for Perastage
 # Builds, stages, and packages the Linux AppImage using vcpkg and CMake.
 
-name: Linux Ubuntu Installer Build
+name: Linux Ubuntu Release AppImage
 
 on:
   workflow_call:
@@ -157,18 +157,16 @@ jobs:
         run: |
           python3 .github/scripts/run_and_log.py --log "$CI_LOG_DIR/cmake-configure-linux.log" -- \
             cmake --preset wsl-x64-release \
+              -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_CXX_FLAGS_RELEASE="-O3 -DNDEBUG -g" \
               -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" \
               -DVCPKG_TARGET_TRIPLET=x64-linux \
               -DVCPKG_INSTALLED_DIR="$VCPKG_INSTALLED" \
               -DVCPKG_MANIFEST_MODE=OFF \
               -DPERASTAGE_REQUIRE_SECURE_CREDENTIAL_STORE=ON \
-              -DBUILD_TESTING=ON
+              -DPERASTAGE_ENABLE_COMPILER_CACHE=OFF \
+              -DBUILD_TESTING=OFF
 
-      - name: Build and run release-gate tests
-        run: |
-          cmake --build --preset wsl-release-build --target gdtf_share_security_test credential_store_native_roundtrip_test
-          ctest --test-dir build/wsl-x64-release -L release-gate --output-on-failure
 
       - name: Build staged distribution
         run: |

--- a/.github/workflows/macos-15-manual-installer.yml
+++ b/.github/workflows/macos-15-manual-installer.yml
@@ -1,7 +1,7 @@
 # macOS installer workflow for Perastage
 # Builds and stages the macOS 15 Apple Silicon application using vcpkg and CMake.
 
-name: macOS 15 Manual Installer Build
+name: macOS 15 Release DMG
 
 on:
   workflow_call:
@@ -214,12 +214,8 @@ jobs:
               -DVCPKG_INSTALLED_DIR="$VCPKG_INSTALLED" \
               -DVCPKG_MANIFEST_MODE=OFF \
               -DPERASTAGE_REQUIRE_SECURE_CREDENTIAL_STORE=ON \
-              -DBUILD_TESTING=ON
-
-      - name: Build and run release-gate tests
-        run: |
-          cmake --build build --target gdtf_share_security_test credential_store_native_roundtrip_test
-          ctest --test-dir build -L release-gate --output-on-failure
+              -DPERASTAGE_ENABLE_COMPILER_CACHE=OFF \
+              -DBUILD_TESTING=OFF
 
       # ── 10. Build project ───────────────────────────────────────────────────
       - name: Build project

--- a/.github/workflows/macos-installer.yml
+++ b/.github/workflows/macos-installer.yml
@@ -1,7 +1,7 @@
 # macOS installer workflow for Perastage
 # Builds and stages the macOS application using vcpkg and CMake.
 
-name: macOS Installer Build
+name: macOS Current Release DMG
 
 on:
   workflow_call:
@@ -205,12 +205,8 @@ jobs:
               -DVCPKG_INSTALLED_DIR="$VCPKG_INSTALLED" \
               -DVCPKG_MANIFEST_MODE=OFF \
               -DPERASTAGE_REQUIRE_SECURE_CREDENTIAL_STORE=ON \
-              -DBUILD_TESTING=ON
-
-      - name: Build and run release-gate tests
-        run: |
-          cmake --build build --target gdtf_share_security_test credential_store_native_roundtrip_test
-          ctest --test-dir build -L release-gate --output-on-failure
+              -DPERASTAGE_ENABLE_COMPILER_CACHE=OFF \
+              -DBUILD_TESTING=OFF
 
       # ── 10. Build project ───────────────────────────────────────────────────
       - name: Build project

--- a/.github/workflows/main-patch-test-build.yml
+++ b/.github/workflows/main-patch-test-build.yml
@@ -1,6 +1,4 @@
-# Main branch patch version bump and tracked installer validation workflow.
-
-name: Main Patch Version and Test Installer Builds
+name: Main Patch Release Artifacts
 
 on:
   push:
@@ -28,29 +26,24 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       source_ref: ${{ steps.commit.outputs.source_ref }}
-
+      previous_version: ${{ steps.bump.outputs.previous_version }}
+      new_version: ${{ steps.bump.outputs.new_version }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 0
-
       - name: Bump patch version in VERSION
         id: bump
         run: |
           set -euo pipefail
           VERSION_RAW="$(tr -d '[:space:]' < VERSION)"
-          if ! [[ "$VERSION_RAW" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "VERSION must be MAJOR.MINOR.PATCH, got: '$VERSION_RAW'"
-            exit 1
-          fi
+          [[ "$VERSION_RAW" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "Invalid VERSION: $VERSION_RAW"; exit 1; }
           IFS='.' read -r major minor patch <<< "$VERSION_RAW"
           NEW_VERSION="${major}.${minor}.$((patch + 1))"
           printf '%s\n' "$NEW_VERSION" > VERSION
           echo "previous_version=$VERSION_RAW" >> "$GITHUB_OUTPUT"
           echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
-
       - name: Commit and push VERSION bump
         id: commit
         env:
@@ -69,15 +62,39 @@ jobs:
     uses: ./.github/workflows/windows-installer.yml
     with:
       source_ref: ${{ needs.bump-version.outputs.source_ref }}
-
   linux-installer:
     needs: bump-version
     uses: ./.github/workflows/linux-installer.yml
     with:
       source_ref: ${{ needs.bump-version.outputs.source_ref }}
-
   macos-installer:
     needs: bump-version
     uses: ./.github/workflows/macos-installer.yml
     with:
       source_ref: ${{ needs.bump-version.outputs.source_ref }}
+  summarize:
+    if: ${{ always() && needs.bump-version.result == 'success' }}
+    needs: [bump-version, windows-installer, linux-installer, macos-installer]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Write patch artifact summary
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          # Main patch release artifacts
+          Previous version: ${{ needs.bump-version.outputs.previous_version }}
+          Generated patch version: ${{ needs.bump-version.outputs.new_version }}
+          Source commit SHA: ${{ needs.bump-version.outputs.source_ref }}
+
+          Required builders:
+          - Windows Release installer: ${{ needs.windows-installer.result }}
+          - Ubuntu Release AppImage: ${{ needs.linux-installer.result }}
+          - Current macOS Release DMG: ${{ needs.macos-installer.result }}
+
+          Expected artifact names:
+          - Perastage-windows-installer
+          - Perastage-linux-appimage
+          - Perastage-macos26-dmg
+          EOF
+          test "${{ needs.windows-installer.result }}" = success
+          test "${{ needs.linux-installer.result }}" = success
+          test "${{ needs.macos-installer.result }}" = success

--- a/.github/workflows/minor-draft-release.yml
+++ b/.github/workflows/minor-draft-release.yml
@@ -29,328 +29,202 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  prepare-release:
+  resolve-release:
     runs-on: ubuntu-latest
     outputs:
-      new_version: ${{ steps.bump.outputs.new_version }}
-      new_tag: ${{ steps.bump.outputs.new_tag }}
-      release_title: ${{ steps.bump.outputs.release_title }}
-      prerelease: ${{ steps.bump.outputs.prerelease }}
-      dry_run: ${{ steps.bump.outputs.dry_run }}
-
+      base_sha: ${{ steps.meta.outputs.base_sha }}
+      previous_version: ${{ steps.meta.outputs.previous_version }}
+      new_version: ${{ steps.meta.outputs.new_version }}
+      new_tag: ${{ steps.meta.outputs.new_tag }}
+      release_title: ${{ steps.meta.outputs.release_title }}
+      prerelease: ${{ steps.meta.outputs.prerelease }}
+      dry_run: ${{ steps.meta.outputs.dry_run }}
+      temp_ref: ${{ steps.meta.outputs.temp_ref }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 0
-
-      - name: Compute next minor version
-        id: bump
+      - name: Resolve release metadata and validate contracts
+        id: meta
         env:
           RELEASE_TITLE_INPUT: ${{ github.event.inputs.release_title }}
           PRERELEASE_INPUT: ${{ github.event.inputs.prerelease }}
           DRY_RUN_INPUT: ${{ github.event.inputs.dry_run }}
         run: |
           set -euo pipefail
-
-          if [ "${GITHUB_REF}" != "refs/heads/main" ]; then
-            echo "This workflow must run from refs/heads/main, got: ${GITHUB_REF}"
-            exit 1
-          fi
-
-          if [ -n "$(git status --porcelain)" ]; then
-            echo "Working tree must be clean before version bump"
-            exit 1
-          fi
-
+          test -f .github/release-artifact-contract.json
+          python3 -m json.tool .github/release-artifact-contract.json >/dev/null
           VERSION_RAW="$(tr -d '[:space:]' < VERSION)"
-          if ! [[ "$VERSION_RAW" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "VERSION must be MAJOR.MINOR.PATCH, got: '$VERSION_RAW'"
-            exit 1
-          fi
-
+          [[ "$VERSION_RAW" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "Invalid VERSION: $VERSION_RAW"; exit 1; }
           IFS='.' read -r major minor patch <<< "$VERSION_RAW"
-          next_minor=$((minor + 1))
-          NEW_VERSION="${major}.${next_minor}.0"
+          NEW_VERSION="${major}.$((minor + 1)).0"
           NEW_TAG="v${NEW_VERSION}"
+          git ls-remote --exit-code --tags origin "refs/tags/${NEW_TAG}" >/dev/null 2>&1 && { echo "Tag already exists: $NEW_TAG"; exit 1; } || true
+          RELEASE_TITLE="$RELEASE_TITLE_INPUT"; [ -n "$RELEASE_TITLE" ] || RELEASE_TITLE="Perastage ${NEW_TAG}"
+          BASE_SHA="$(git rev-parse HEAD)"
+          TEMP_REF="automation/release-${NEW_TAG}-${GITHUB_RUN_ID}"
+          {
+            echo "base_sha=$BASE_SHA"
+            echo "previous_version=$VERSION_RAW"
+            echo "new_version=$NEW_VERSION"
+            echo "new_tag=$NEW_TAG"
+            echo "release_title=$RELEASE_TITLE"
+            echo "prerelease=$PRERELEASE_INPUT"
+            echo "dry_run=$DRY_RUN_INPUT"
+            echo "temp_ref=$TEMP_REF"
+          } >> "$GITHUB_OUTPUT"
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          # Minor release plan
+          Base SHA: $BASE_SHA
+          Previous version: $VERSION_RAW
+          New version: $NEW_VERSION
+          Tag: $NEW_TAG
+          Dry run: $DRY_RUN_INPUT
+          EOF
 
-          if git rev-parse -q --verify "refs/tags/${NEW_TAG}" >/dev/null; then
-            echo "Tag already exists locally: ${NEW_TAG}"
-            exit 1
-          fi
-          if git ls-remote --exit-code --tags origin "refs/tags/${NEW_TAG}" >/dev/null 2>&1; then
-            echo "Tag already exists on origin: ${NEW_TAG}"
-            exit 1
-          fi
+  dry-run-summary:
+    if: ${{ needs.resolve-release.outputs.dry_run == 'true' }}
+    needs: resolve-release
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "Dry run validated ${{ needs.resolve-release.outputs.new_tag }} from ${{ needs.resolve-release.outputs.base_sha }} without publishing." >> "$GITHUB_STEP_SUMMARY"
 
-          RELEASE_TITLE="${RELEASE_TITLE_INPUT}"
-          if [ -z "$RELEASE_TITLE" ]; then
-            RELEASE_TITLE="Perastage ${NEW_TAG}"
-          fi
+  quality-gate:
+    if: ${{ needs.resolve-release.outputs.dry_run != 'true' }}
+    needs: resolve-release
+    uses: ./.github/workflows/ci-tests.yml
+    with:
+      source_ref: ${{ needs.resolve-release.outputs.base_sha }}
+      profile: release
 
-          printf '%s\n' "$NEW_VERSION" > VERSION
-
-          echo "previous_version=${VERSION_RAW}" >> "$GITHUB_OUTPUT"
-          echo "new_version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
-          echo "new_tag=${NEW_TAG}" >> "$GITHUB_OUTPUT"
-          echo "release_title=${RELEASE_TITLE}" >> "$GITHUB_OUTPUT"
-          echo "prerelease=${PRERELEASE_INPUT}" >> "$GITHUB_OUTPUT"
-          echo "dry_run=${DRY_RUN_INPUT}" >> "$GITHUB_OUTPUT"
-
-      - name: Commit, push, and tag release version
-        if: ${{ steps.bump.outputs.dry_run != 'true' }}
+  stage-release-commit:
+    if: ${{ needs.resolve-release.outputs.dry_run != 'true' }}
+    needs: [resolve-release, quality-gate]
+    runs-on: ubuntu-latest
+    outputs:
+      release_sha: ${{ steps.stage.outputs.release_sha }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.resolve-release.outputs.base_sha }}
+          fetch-depth: 0
+      - name: Create temporary release preparation ref
+        id: stage
         env:
-          NEW_VERSION: ${{ steps.bump.outputs.new_version }}
-          NEW_TAG: ${{ steps.bump.outputs.new_tag }}
+          NEW_VERSION: ${{ needs.resolve-release.outputs.new_version }}
+          NEW_TAG: ${{ needs.resolve-release.outputs.new_tag }}
+          TEMP_REF: ${{ needs.resolve-release.outputs.temp_ref }}
         run: |
           set -euo pipefail
-
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
+          printf '%s\n' "$NEW_VERSION" > VERSION
           git add VERSION
           git commit -m "chore: prepare minor release ${NEW_TAG} [skip version-bump]"
-          git push origin HEAD:main
-
-          git tag -a "${NEW_TAG}" -m "Perastage ${NEW_TAG}"
-          git push origin "${NEW_TAG}"
-
-      - name: Show dry run result
-        if: ${{ steps.bump.outputs.dry_run == 'true' }}
-        run: |
-          echo "Dry run enabled: computed ${NEW_VERSION} and ${NEW_TAG} without changes"
-        env:
-          NEW_VERSION: ${{ steps.bump.outputs.new_version }}
-          NEW_TAG: ${{ steps.bump.outputs.new_tag }}
+          git push origin HEAD:"$TEMP_REF"
+          echo "release_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
   windows-installer:
-    if: ${{ needs.prepare-release.outputs.dry_run != 'true' }}
-    needs: prepare-release
+    needs: stage-release-commit
     uses: ./.github/workflows/windows-installer.yml
     with:
-      source_ref: ${{ needs.prepare-release.outputs.new_tag }}
-
+      source_ref: ${{ needs.stage-release-commit.outputs.release_sha }}
   linux-installer:
-    if: ${{ needs.prepare-release.outputs.dry_run != 'true' }}
-    needs: prepare-release
+    needs: stage-release-commit
     uses: ./.github/workflows/linux-installer.yml
     with:
-      source_ref: ${{ needs.prepare-release.outputs.new_tag }}
-
+      source_ref: ${{ needs.stage-release-commit.outputs.release_sha }}
   macos15-installer:
-    if: ${{ needs.prepare-release.outputs.dry_run != 'true' }}
-    needs: prepare-release
+    needs: stage-release-commit
     uses: ./.github/workflows/macos-15-manual-installer.yml
     with:
-      source_ref: ${{ needs.prepare-release.outputs.new_tag }}
-
+      source_ref: ${{ needs.stage-release-commit.outputs.release_sha }}
   macos-installer:
-    if: ${{ needs.prepare-release.outputs.dry_run != 'true' }}
-    needs: prepare-release
+    needs: stage-release-commit
     uses: ./.github/workflows/macos-installer.yml
     with:
-      source_ref: ${{ needs.prepare-release.outputs.new_tag }}
-
+      source_ref: ${{ needs.stage-release-commit.outputs.release_sha }}
   arch-package:
-    if: ${{ needs.prepare-release.outputs.dry_run != 'true' }}
-    needs: prepare-release
+    needs: stage-release-commit
     uses: ./.github/workflows/arch-package.yml
     with:
-      source_ref: ${{ needs.prepare-release.outputs.new_tag }}
+      source_ref: ${{ needs.stage-release-commit.outputs.release_sha }}
 
-  create-draft-release:
-    if: ${{ needs.prepare-release.outputs.dry_run != 'true' }}
-    needs:
-      - prepare-release
-      - windows-installer
-      - linux-installer
-      - macos15-installer
-      - macos-installer
-      - arch-package
+  validate-release-assets:
+    needs: [resolve-release, stage-release-commit, windows-installer, linux-installer, macos15-installer, macos-installer, arch-package]
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout release tag
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v6
         with:
-          ref: ${{ needs.prepare-release.outputs.new_tag }}
-
-      - name: Download installer artifacts
-        uses: actions/download-artifact@v8
+          ref: ${{ needs.stage-release-commit.outputs.release_sha }}
+      - uses: actions/download-artifact@v8
         with:
           path: release-assets
           pattern: Perastage-*
-
-      - name: Prepare final installer assets and debug symbols
-        id: assets
+      - name: Assemble and validate assets
         env:
-          RELEASE_VERSION: ${{ needs.prepare-release.outputs.new_version }}
-          RELEASE_TAG: ${{ needs.prepare-release.outputs.new_tag }}
+          RELEASE_VERSION: ${{ needs.resolve-release.outputs.new_version }}
         run: |
           set -euo pipefail
+          mkdir -p release-assets/final release-assets/symbols-final
+          single() { mapfile -t m < <(find release-assets -type f -name "$2" | sort -u); [ "${#m[@]}" -eq 1 ] || { echo "$1 count ${#m[@]}"; printf '%s\n' "${m[@]:-}"; exit 1; }; cp "${m[0]}" release-assets/final/; }
+          single Windows 'Perastage_*_Setup.exe'
+          single Linux 'Perastage-*-x86_64.AppImage'
+          single macOS15 'Perastage-*-macOS15-arm64.dmg'
+          single macOS26 'Perastage-*-macOS26-arm64.dmg'
+          single Arch 'Perastage-*-arch-x86_64.pkg.tar.zst'
+          for f in release-assets/final/*; do [[ "$(basename "$f")" == *"$RELEASE_VERSION"* ]] || { echo "Stale asset: $f"; exit 1; }; done
+          find release-assets -path 'release-assets/final' -prune -o -type f \( -name '*.pdb' -o -name 'Perastage.debug' -o -name 'perastage-debug-*.pkg.tar.zst' \) -print > release-assets/symbols-final/symbol-files.txt
+          test -s release-assets/symbols-final/symbol-files.txt
+          (cd release-assets/symbols-final && zip -r "../final/Perastage-$RELEASE_VERSION-Debug-Symbols-Developers-Only.zip" .)
+      - uses: actions/upload-artifact@v7
+        with:
+          name: Perastage-validated-release-assets
+          path: release-assets/final
 
-          FINAL_DIR="release-assets/final"
-          EXTRACT_DIR="release-assets/.extracted-zips"
-          SYMBOLS_FINAL_DIR="release-assets/symbols-final"
-          SYMBOL_ARCHIVE="$FINAL_DIR/Perastage-$RELEASE_VERSION-Debug-Symbols-Developers-Only.zip"
-
-          rm -rf "$FINAL_DIR" "$EXTRACT_DIR" "$SYMBOLS_FINAL_DIR"
-          mkdir -p "$FINAL_DIR" "$EXTRACT_DIR" "$SYMBOLS_FINAL_DIR"
-
-          echo "Downloaded artifact tree (release-assets):"
-          find release-assets -mindepth 1 -maxdepth 4 -print | sort
-
-          mapfile -t ZIP_FILES < <(find release-assets -type f -name '*.zip' | sort)
-          for zip_file in "${ZIP_FILES[@]}"; do
-            zip_base="$(basename "$zip_file" .zip)"
-            target_dir="$EXTRACT_DIR/$zip_base"
-            mkdir -p "$target_dir"
-            unzip -q "$zip_file" -d "$target_dir"
-          done
-
-          collect_single_asset() {
-            local label="$1"
-            local pattern="$2"
-            local -n matches_ref="$3"
-            mapfile -t matches_ref < <(find release-assets "$EXTRACT_DIR" -type f -name "$pattern" | sort -u)
-            if [ "${#matches_ref[@]}" -ne 1 ]; then
-              echo "${label} matches (${#matches_ref[@]}): ${matches_ref[*]:-none}"
-              return 1
-            fi
-          }
-
-          asset_errors=0
-          collect_single_asset "Windows installer" 'Perastage_*_Setup.exe' WIN_MATCHES || asset_errors=1
-          collect_single_asset "Linux AppImage" 'Perastage-*-x86_64.AppImage' LINUX_MATCHES || asset_errors=1
-          collect_single_asset "macOS 15 DMG" 'Perastage-*-macOS15-arm64.dmg' MAC15_MATCHES || asset_errors=1
-          collect_single_asset "macOS 26 DMG" 'Perastage-*-macOS26-arm64.dmg' MAC26_MATCHES || asset_errors=1
-          collect_single_asset "Arch Linux package" 'Perastage-*-arch-x86_64.pkg.tar.zst' ARCH_MATCHES || asset_errors=1
-          if [ "$asset_errors" -ne 0 ]; then
-            echo "Expected exactly one installer/package asset for each platform and symbol artifacts"
-            exit 1
-          fi
-
-          cp "${WIN_MATCHES[0]}" "$FINAL_DIR/"
-          cp "${LINUX_MATCHES[0]}" "$FINAL_DIR/"
-          cp "${MAC15_MATCHES[0]}" "$FINAL_DIR/"
-          cp "${MAC26_MATCHES[0]}" "$FINAL_DIR/"
-          cp "${ARCH_MATCHES[0]}" "$FINAL_DIR/"
-
-          mkdir -p "$SYMBOLS_FINAL_DIR/Windows-x64" "$SYMBOLS_FINAL_DIR/Linux-AppImage-x86_64" "$SYMBOLS_FINAL_DIR/ArchLinux-x86_64" "$SYMBOLS_FINAL_DIR/macOS15-arm64" "$SYMBOLS_FINAL_DIR/macOS26-arm64"
-
-          mapfile -t WINDOWS_PDBS < <(find release-assets/Perastage-windows-symbols -type f -name '*.pdb' | sort)
-          if [ "${#WINDOWS_PDBS[@]}" -lt 1 ]; then
-            echo "Windows symbols artifact must contain at least one PDB file"
-            exit 1
-          fi
-          cp "${WINDOWS_PDBS[@]}" "$SYMBOLS_FINAL_DIR/Windows-x64/"
-
-          collect_single_asset "Linux debug symbols" 'Perastage.debug' LINUX_DEBUG_MATCHES || exit 1
-          cp "${LINUX_DEBUG_MATCHES[0]}" "$SYMBOLS_FINAL_DIR/Linux-AppImage-x86_64/"
-
-          mapfile -t ARCH_DEBUG_MATCHES < <(find release-assets "$EXTRACT_DIR" -type f -name 'perastage-debug-*.pkg.tar.zst' | sort -u)
-          if [ "${#ARCH_DEBUG_MATCHES[@]}" -lt 1 ]; then
-            echo "Arch Linux symbols artifact must contain at least one debug package"
-            exit 1
-          fi
-          cp "${ARCH_DEBUG_MATCHES[@]}" "$SYMBOLS_FINAL_DIR/ArchLinux-x86_64/"
-
-          cp -a "release-assets/Perastage-macos15-symbols/Perastage.dSYM" "$SYMBOLS_FINAL_DIR/macOS15-arm64/"
-          cp -a "release-assets/Perastage-macos26-symbols/Perastage.dSYM" "$SYMBOLS_FINAL_DIR/macOS26-arm64/"
-
-          cat > "$SYMBOLS_FINAL_DIR/README.txt" <<EOF
-          Perastage Debug Symbols
-          =======================
-
-          These files are debugging symbols for crash analysis.
-
-          They are not application resources and are not required to install or run
-          Perastage. Download this archive only when requested by the developer or when
-          performing crash analysis for the exact matching Perastage version.
-
-          Each directory contains symbols for a different release binary. Symbols must
-          only be used with the exact matching version, platform, architecture, and build
-          variant.
-
-          Version: $RELEASE_VERSION
-          Release tag: $RELEASE_TAG
-
-          Directories:
-          - Windows-x64: PDB files for the Windows x64 installer build.
-          - Linux-AppImage-x86_64: Perastage.debug for the Linux AppImage build.
-          - ArchLinux-x86_64: perastage-debug package for the Arch Linux package build.
-          - macOS15-arm64: Perastage.dSYM for the macOS 15 Apple Silicon build.
-          - macOS26-arm64: Perastage.dSYM for the macOS 26 Apple Silicon build.
-
-          The macOS 15 and macOS 26 symbols are different build variants and are not
-          interchangeable. Do not rename or alter files before crash analysis.
-          EOF
-
-          test -s "$SYMBOLS_FINAL_DIR/README.txt"
-          test -n "$(find "$SYMBOLS_FINAL_DIR/Windows-x64" -type f -name '*.pdb' -print -quit)"
-          test -f "$SYMBOLS_FINAL_DIR/Linux-AppImage-x86_64/Perastage.debug"
-          test -n "$(find "$SYMBOLS_FINAL_DIR/ArchLinux-x86_64" -type f -name 'perastage-debug-*.pkg.tar.zst' -print -quit)"
-          test -d "$SYMBOLS_FINAL_DIR/macOS15-arm64/Perastage.dSYM"
-          test -d "$SYMBOLS_FINAL_DIR/macOS26-arm64/Perastage.dSYM"
-
-          (cd "$SYMBOLS_FINAL_DIR" && zip -yr "../final/$(basename "$SYMBOL_ARCHIVE")" .)
-          test -s "$SYMBOL_ARCHIVE"
-
-          if find "$FINAL_DIR" -type f -name '*-symbols.zip' | grep -q .; then
-            echo "Final release assets must not contain separate platform symbol ZIP files"
-            exit 1
-          fi
-
-          echo "Unified debug-symbol archive listing:"
-          unzip -l "$SYMBOL_ARCHIVE"
-
-          WIN_ASSET="$FINAL_DIR/$(basename "${WIN_MATCHES[0]}")"
-          LINUX_ASSET="$FINAL_DIR/$(basename "${LINUX_MATCHES[0]}")"
-          MAC15_ASSET="$FINAL_DIR/$(basename "${MAC15_MATCHES[0]}")"
-          MAC26_ASSET="$FINAL_DIR/$(basename "${MAC26_MATCHES[0]}")"
-          ARCH_INSTALLER_ASSET="$FINAL_DIR/$(basename "${ARCH_MATCHES[0]}")"
-
-          echo "Final release assets (release-assets/final):"
-          find "$FINAL_DIR" -mindepth 1 -maxdepth 1 -type f -print | sort
-
-          echo "win_asset=$WIN_ASSET" >> "$GITHUB_OUTPUT"
-          echo "linux_asset=$LINUX_ASSET" >> "$GITHUB_OUTPUT"
-          echo "mac15_asset=$MAC15_ASSET" >> "$GITHUB_OUTPUT"
-          echo "mac26_asset=$MAC26_ASSET" >> "$GITHUB_OUTPUT"
-          echo "arch_installer_asset=$ARCH_INSTALLER_ASSET" >> "$GITHUB_OUTPUT"
-          echo "symbol_archive=$SYMBOL_ARCHIVE" >> "$GITHUB_OUTPUT"
-
-      - name: Create draft release with curated notes
+  publish-release:
+    needs: [resolve-release, stage-release-commit, validate-release-assets]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.stage-release-commit.outputs.release_sha }}
+          fetch-depth: 0
+      - uses: actions/download-artifact@v8
+        with:
+          name: Perastage-validated-release-assets
+          path: release-assets/final
+      - name: Publish main, tag, and draft release after validation
         env:
           GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-          TAG_NAME: ${{ needs.prepare-release.outputs.new_tag }}
-          RELEASE_TITLE: ${{ needs.prepare-release.outputs.release_title }}
-          PRERELEASE: ${{ needs.prepare-release.outputs.prerelease }}
-          WIN_ASSET: ${{ steps.assets.outputs.win_asset }}
-          LINUX_ASSET: ${{ steps.assets.outputs.linux_asset }}
-          MAC15_ASSET: ${{ steps.assets.outputs.mac15_asset }}
-          MAC26_ASSET: ${{ steps.assets.outputs.mac26_asset }}
-          ARCH_INSTALLER_ASSET: ${{ steps.assets.outputs.arch_installer_asset }}
-          SYMBOL_ARCHIVE: ${{ steps.assets.outputs.symbol_archive }}
+          BASE_SHA: ${{ needs.resolve-release.outputs.base_sha }}
+          RELEASE_SHA: ${{ needs.stage-release-commit.outputs.release_sha }}
+          NEW_TAG: ${{ needs.resolve-release.outputs.new_tag }}
+          TEMP_REF: ${{ needs.resolve-release.outputs.temp_ref }}
+          RELEASE_TITLE: ${{ needs.resolve-release.outputs.release_title }}
+          PRERELEASE: ${{ needs.resolve-release.outputs.prerelease }}
         run: |
           set -euo pipefail
-
-          RELEASE_NOTES_FILE="docs/release-notes-draft.md"
-
-          echo "Creating draft release in $GH_REPO"
-
-          cmd=(gh release create "$TAG_NAME" "$WIN_ASSET" "$LINUX_ASSET" "$MAC15_ASSET" "$MAC26_ASSET" "$ARCH_INSTALLER_ASSET" "$SYMBOL_ARCHIVE" --draft --title "$RELEASE_TITLE")
-          if [ -s "$RELEASE_NOTES_FILE" ]; then
-            echo "Using curated release notes from $RELEASE_NOTES_FILE"
-            cmd+=(--notes-file "$RELEASE_NOTES_FILE")
-          else
-            echo "Curated release notes draft is missing or empty; falling back to GitHub generated notes"
-            cmd+=(--generate-notes)
-          fi
-          if [ "$PRERELEASE" = "true" ]; then
-            cmd+=(--prerelease)
-          fi
-
+          git fetch origin main --tags
+          CURRENT_MAIN="$(git rev-parse origin/main)"
+          [ "$CURRENT_MAIN" = "$BASE_SHA" ] || { echo "main moved from $BASE_SHA to $CURRENT_MAIN; rerun the release."; exit 1; }
+          git push origin "$RELEASE_SHA":main
+          git tag -a "$NEW_TAG" "$RELEASE_SHA" -m "Perastage $NEW_TAG"
+          git push origin "$NEW_TAG"
+          cmd=(gh release create "$NEW_TAG" release-assets/final/* --draft --title "$RELEASE_TITLE")
+          [ -s docs/release-notes-draft.md ] && cmd+=(--notes-file docs/release-notes-draft.md) || cmd+=(--generate-notes)
+          [ "$PRERELEASE" = true ] && cmd+=(--prerelease)
           "${cmd[@]}"
+          git push origin --delete "$TEMP_REF"
+
+  cleanup-temp-ref:
+    if: ${{ always() && needs.resolve-release.outputs.dry_run != 'true' }}
+    needs: [resolve-release, publish-release]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete temporary release ref if it remains
+        env:
+          TEMP_REF: ${{ needs.resolve-release.outputs.temp_ref }}
+        run: git push origin --delete "$TEMP_REF" || true

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -1,7 +1,7 @@
 # Windows installer workflow for Perastage
 # Builds, stages and packages the Windows installer with Inno Setup.
 
-name: Windows Installer Build
+name: Windows Release Installer
 
 on:
   workflow_call:
@@ -154,7 +154,9 @@ jobs:
               -DVCPKG_TARGET_TRIPLET=x64-windows `
               -DVCPKG_INSTALLED_DIR="$env:VCPKG_INSTALLED" `
               -DVCPKG_MANIFEST_MODE=OFF `
-              -DPERASTAGE_REQUIRE_SECURE_CREDENTIAL_STORE=ON
+              -DPERASTAGE_REQUIRE_SECURE_CREDENTIAL_STORE=ON `
+              -DPERASTAGE_ENABLE_COMPILER_CACHE=OFF `
+              -DBUILD_TESTING=OFF
 
       # ── 6. Build ────────────────────────────────────────────────────────────
       - name: Build project
@@ -255,160 +257,6 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: windows-release-installer-diagnostics
-          if-no-files-found: ignore
-          path: |
-            out/ci-logs/**
-            **/CMakeFiles/CMakeConfigureLog.yaml
-            **/CMakeCache.txt
-            **/CMakeFiles/CMakeOutput.log
-            **/CMakeFiles/CMakeError.log
-            build/**/*.log
-            build-*/**/*.log
-            vcpkg/buildtrees/**/*.log
-            vcpkg/buildtrees/**/config-*.txt
-            vcpkg/buildtrees/**/issue_body.md
-            .vcpkg-cache/installed/vcpkg/issue_body.md
-
-
-  test-windows-secure-store:
-    needs: build-windows-installer
-    runs-on: windows-latest
-
-    env:
-      VCPKG_ROOT:         ${{ github.workspace }}\vcpkg
-      VCPKG_INSTALLED:    ${{ github.workspace }}\.vcpkg-cache\installed
-      VCPKG_DOWNLOADS:    ${{ github.workspace }}\.vcpkg-cache\downloads
-      VCPKG_CACHE_SCHEMA: securestore-v2
-      VCPKG_PACKAGES:     ${{ github.workspace }}\.vcpkg-cache\packages
-      VCPKG_BINARY_CACHE: ${{ github.workspace }}\.vcpkg-cache\binary
-      CI_LOG_DIR: ${{ github.workspace }}\out\ci-logs
-      VCPKG_BINARY_SOURCES: clear;files,${{ github.workspace }}\.vcpkg-cache\binary,readwrite
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ inputs.source_ref != '' && inputs.source_ref || github.ref }}
-
-      - name: Prepare CI log directory
-        shell: bash
-        run: mkdir -p "$CI_LOG_DIR"
-
-      - name: Read vcpkg baseline
-        id: vcpkg-baseline
-        shell: bash
-        run: |
-          set -euo pipefail
-          baseline="$(python3 .github/scripts/get_vcpkg_baseline.py vcpkg.json)"
-          echo "baseline=${baseline}" >> "$GITHUB_OUTPUT"
-          echo "VCPKG_BASELINE=${baseline}" >> "$GITHUB_ENV"
-
-      - name: Restore vcpkg downloads
-        id: vcpkg-downloads-cache
-        uses: actions/cache/restore@v5
-        with:
-          path: |
-            .vcpkg-cache/downloads
-          key: ${{ runner.os }}-${{ runner.arch }}-vcpkg-downloads-${{ steps.vcpkg-baseline.outputs.baseline }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-vcpkg-downloads-${{ steps.vcpkg-baseline.outputs.baseline }}-
-            ${{ runner.os }}-${{ runner.arch }}-vcpkg-downloads-
-
-      - name: Cache vcpkg installed packages and binary archives
-        uses: actions/cache@v5
-        with:
-          path: |
-            .vcpkg-cache\installed
-            .vcpkg-cache\packages
-            .vcpkg-cache\binary
-          key: ${{ runner.os }}-${{ runner.arch }}-vcpkg-securestore-v2-${{ steps.vcpkg-baseline.outputs.baseline }}-x64-windows-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', '.github/workflows/windows-installer.yml') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-vcpkg-securestore-v2-${{ steps.vcpkg-baseline.outputs.baseline }}-x64-windows-
-
-      - name: Bootstrap vcpkg
-        shell: pwsh
-        run: |
-          if (Test-Path "$env:VCPKG_ROOT\.git") {
-            git -C $env:VCPKG_ROOT fetch --depth 1 origin $env:VCPKG_BASELINE
-            git -C $env:VCPKG_ROOT checkout --detach $env:VCPKG_BASELINE
-          } else {
-            if (Test-Path $env:VCPKG_ROOT) { Remove-Item $env:VCPKG_ROOT -Recurse -Force }
-            git clone https://github.com/microsoft/vcpkg.git $env:VCPKG_ROOT
-            git -C $env:VCPKG_ROOT checkout --detach $env:VCPKG_BASELINE
-          }
-          & "$env:VCPKG_ROOT\bootstrap-vcpkg.bat" -disableMetrics
-
-      - name: Install vcpkg packages
-        shell: pwsh
-        run: |
-          New-Item -ItemType Directory -Path $env:VCPKG_DOWNLOADS,$env:VCPKG_INSTALLED,$env:VCPKG_PACKAGES -Force | Out-Null
-          python .github/scripts/vcpkg_install_retry.py --vcpkg "$env:VCPKG_ROOT\vcpkg.exe" --triplet x64-windows --manifest-root "$env:GITHUB_WORKSPACE" `
-            --install-root "$env:VCPKG_INSTALLED" `
-            --packages-root "$env:VCPKG_PACKAGES" `
-            --downloads-root "$env:VCPKG_DOWNLOADS" `
-            --attempts 4 --initial-delay-seconds 30 --max-delay-seconds 120 `
-            --log "$env:CI_LOG_DIR\vcpkg-install-x64-windows.log"
-
-      - name: Save vcpkg downloads cache
-        if: ${{ always() && steps.vcpkg-downloads-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@v5
-        with:
-          path: .vcpkg-cache/downloads
-          key: ${{ steps.vcpkg-downloads-cache.outputs.cache-primary-key }}
-
-      - name: Configure focused security tests
-        shell: pwsh
-        run: |
-          $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
-          if (-not (Test-Path $vswhere)) { throw "vswhere.exe was not found at: $vswhere" }
-          $vsRoot = (& $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath).Trim()
-          if ([string]::IsNullOrWhiteSpace($vsRoot)) { throw 'No Visual Studio installation with x64 C++ tools was found.' }
-          $devCmd = Join-Path $vsRoot 'Common7\Tools\VsDevCmd.bat'
-          if (-not (Test-Path $devCmd)) { throw "VsDevCmd.bat was not found at: $devCmd" }
-          cmd.exe /c "`"$devCmd`" -host_arch=x64 -arch=x64 >nul && set" | ForEach-Object {
-            $separator = $_.IndexOf('=')
-            if ($separator -gt 0) { Set-Item -Path "Env:$($_.Substring(0, $separator))" -Value $_.Substring($separator + 1) }
-          }
-          $cl = Get-Command cl.exe -ErrorAction SilentlyContinue
-          if (-not $cl) { throw 'cl.exe was not found after initializing the Visual Studio x64 developer environment.' }
-          $normalizedCl = $cl.Source.Replace('/', '\').ToLowerInvariant()
-          if ($normalizedCl -match 'c:[\\/](mingw64|msys64)') { throw "Refusing to configure x64-windows with MinGW/MSYS compiler: $($cl.Source)" }
-          if (-not $normalizedCl.Contains('hostx64\x64')) { throw "cl.exe is not the preferred Hostx64\x64 tool: $($cl.Source)" }
-          if ($env:VSCMD_ARG_HOST_ARCH -ne 'x64' -or $env:VSCMD_ARG_TGT_ARCH -ne 'x64') { throw "Visual Studio environment is not host x64/target x64: host=$env:VSCMD_ARG_HOST_ARCH target=$env:VSCMD_ARG_TGT_ARCH" }
-
-          python .github/scripts/run_and_log.py --log "$env:CI_LOG_DIR\cmake-configure-windows-security.log" -- `
-            cmake -S . -B build-security -G Ninja `
-              -DCMAKE_C_COMPILER=cl.exe `
-              -DCMAKE_CXX_COMPILER=cl.exe `
-              -DCMAKE_BUILD_TYPE=Debug `
-              -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT\scripts\buildsystems\vcpkg.cmake" `
-              -DVCPKG_TARGET_TRIPLET=x64-windows `
-              -DVCPKG_INSTALLED_DIR="$env:VCPKG_INSTALLED" `
-              -DVCPKG_MANIFEST_MODE=OFF `
-              -DBUILD_TESTING=ON `
-              -DPERASTAGE_REQUIRE_SECURE_CREDENTIAL_STORE=ON
-
-          $cache = Get-Content build-security\CMakeCache.txt -Raw
-          foreach ($required in @('CMAKE_C_COMPILER_ID:INTERNAL=MSVC', 'CMAKE_CXX_COMPILER_ID:INTERNAL=MSVC')) {
-            if ($cache -notmatch [regex]::Escape($required)) { throw "CMake cache is missing expected MSVC compiler identity: $required" }
-          }
-          if ($cache -match '(?i)c:[\\/](mingw64|msys64)|mingw|gnu') { throw 'CMake cache contains MinGW/GNU compiler markers for x64-windows.' }
-
-      - name: Build focused security tests
-        shell: pwsh
-        run: |
-          cmake --build build-security --target gdtf_share_security_test credential_store_native_roundtrip_test
-
-      - name: Run release-gate tests
-        shell: pwsh
-        run: |
-          ctest --test-dir build-security -L release-gate --output-on-failure
-
-      - name: Upload final CI diagnostics
-        if: ${{ failure() }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: windows-secure-store-diagnostics
           if-no-files-found: ignore
           path: |
             out/ci-logs/**

--- a/docs/developer/github_actions_workflows.md
+++ b/docs/developer/github_actions_workflows.md
@@ -1,0 +1,83 @@
+# GitHub Actions workflow architecture
+
+Perastage uses separate workflows for validation, automatic test artifacts, compatibility packages, and formal releases. The separation keeps Debug test coverage out of Release package builders and prevents release publication before every package and asset check has succeeded.
+
+## Pull requests
+
+Pull requests targeting `main` run `CI Debug Tests` from `.github/workflows/ci-tests.yml`.
+
+- The workflow resolves the requested ref to one exact commit SHA and every Debug job checks out that SHA.
+- Linux Debug builds the complete test target set, runs the complete CTest suite, and runs repository policy tests.
+- Windows Debug initializes Visual Studio Hostx64/x64 explicitly, uses Ninja with MSVC and the `x64-windows` vcpkg triplet, and rejects MinGW, MSYS, or Strawberry toolchain selection.
+- Current macOS Debug uses the explicit current macOS runner, Ninja, arm64, and release-gate secure-store tests.
+- Debug jobs configure with `BUILD_TESTING=ON` and do not define `NDEBUG`, because several tests rely on `assert()`.
+- The workflow uploads diagnostics only on failure. Diagnostics include command logs, CMake configure logs, `CMakeCache.txt`, CTest logs, vcpkg failure logs, and a concise environment summary.
+
+The Debug CI workflow does not upload installers, AppImages, DMGs, or platform packages.
+
+## Merges into main
+
+`Main Patch Release Artifacts` in `.github/workflows/main-patch-test-build.yml` runs after accepted non-bot pushes to `main` and can also be started manually.
+
+The workflow serializes version mutation, increments only the patch component in `VERSION`, commits the bump with `[skip version-bump]`, and passes the exact generated commit SHA to the three primary Release builders:
+
+- Windows Release installer.
+- Ubuntu Release AppImage.
+- Current macOS Release DMG.
+
+It does not rerun Debug CI, and it does not build macOS 15 or Arch Linux compatibility packages. These artifacts are intended for manual testing and continuous verification of current hosted packaging runners. Automatic patch artifacts use GitHub Actions artifact retention and are not permanent release assets.
+
+## Weekly and manual compatibility packages
+
+`Weekly Compatibility Packages` in `.github/workflows/compatibility-builds.yml` runs weekly at `03:27 UTC` on Tuesday and supports `workflow_dispatch` with an optional `source_ref`.
+
+The workflow resolves `source_ref` or `main` to one exact SHA, does not modify `VERSION`, and builds only the secondary compatibility packages:
+
+- macOS 15 arm64 Release DMG.
+- Arch Linux x64 Release package.
+
+A newer compatibility run for the same ref cancels an older in-progress compatibility run. The individual macOS 15 and Arch builder workflows remain manually runnable when a maintainer needs to reproduce one package.
+
+## Minor draft releases
+
+`Minor Draft Release` in `.github/workflows/minor-draft-release.yml` is manual. It keeps the existing release title, prerelease, and dry-run inputs.
+
+The release pipeline is staged:
+
+1. Resolve current `main` to an exact base SHA, validate `VERSION`, compute the next `MAJOR.MINOR.0` version and tag, verify the tag does not already exist, and validate the artifact contract.
+2. Run the reusable `CI Debug Tests` quality gate against the exact base SHA.
+3. Create a temporary automation ref based on the validated base SHA and commit only the `VERSION` update there.
+4. Build all five Release packages from the staged release commit SHA: Windows, Ubuntu AppImage, macOS 15, current macOS, and Arch Linux.
+5. Download and validate all package and symbol artifacts, reject duplicates or stale filenames, and create the final validated release-assets artifact.
+6. Publish only after validation succeeds by verifying `origin/main` still equals the base SHA, fast-forwarding `main` to the staged release commit, creating the annotated tag at that commit, and creating a draft GitHub Release with the validated assets.
+
+If `main` changes while packages are building, publication fails clearly before the tag or draft release is created. The maintainer should rerun the workflow from the updated `main`. Temporary automation refs are deleted after success and by the cleanup job after failure.
+
+Dry runs are inexpensive: they compute and report the version, tag, title, and artifact contract status without pushing a branch, committing, tagging, building packages, or creating a release.
+
+## Stable artifact contract
+
+The package filename patterns are centralized in `.github/release-artifact-contract.json` and validated by `tests/check_ci_workflow_architecture.py`.
+
+Stable package patterns:
+
+- `Perastage_*_Setup.exe`
+- `Perastage-*-x86_64.AppImage`
+- `Perastage-*-macOS15-arm64.dmg`
+- `Perastage-*-macOS26-arm64.dmg`
+- `Perastage-*-arch-x86_64.pkg.tar.zst`
+
+Stable artifact names:
+
+- `Perastage-windows-installer`
+- `Perastage-linux-appimage`
+- `Perastage-macos15-dmg`
+- `Perastage-macos26-dmg`
+- `Perastage-arch-package`
+- `Perastage-windows-symbols`
+- `Perastage-linux-symbols`
+- `Perastage-macos15-symbols`
+- `Perastage-macos26-symbols`
+- `Perastage-archlinux-symbols`
+
+Builder workflows must preserve the package filenames and symbol artifact structures unless the producer and collector contract is updated and tested in the same change.

--- a/docs/developer/index.md
+++ b/docs/developer/index.md
@@ -13,3 +13,4 @@ This section collects maintainer-facing build, architecture, packaging, policy, 
 - [GDTF Mutation Policy](gdtf_mutation_policy.md)
 - [GUI Shortcut Architecture](gui_shortcut_architecture.md)
 - [Technical Notes](technical-notes/index.md)
+- [GitHub Actions workflow architecture](github_actions_workflows.md)

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -258,6 +258,7 @@ You can also contact the project at **perastage.app@gmail.com**.
 - Fixed embedded Layout 2D fixture symbols so rotated GDTF fixtures choose the visible representative symbol plane and preserve the same orientation in preview and PDF export.
 
 ## Internal changes
+- Strengthened CI release-gate tests so policy scripts are portable without ripgrep and credential metadata checks validate JSON fields without flagging safe backend identifiers.
 - Reorganized GitHub Actions into separate Debug CI, main patch artifact, compatibility package, and transactional minor release workflows, with Debug dependency setup aligned to the pinned vcpkg toolchain and Windows CI preserving the Python and MSVC environments across steps.
 
 - Hardened installer CI configuration so test-enabled builds configure C and C++ from the project root, Windows secure-store Ninja jobs use the MSVC x64 toolchain, and final failure diagnostics include modern CMake configure logs.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -258,6 +258,7 @@ You can also contact the project at **perastage.app@gmail.com**.
 - Fixed embedded Layout 2D fixture symbols so rotated GDTF fixtures choose the visible representative symbol plane and preserve the same orientation in preview and PDF export.
 
 ## Internal changes
+- Reorganized GitHub Actions into separate Debug CI, main patch artifact, compatibility package, and transactional minor release workflows.
 
 - Hardened installer CI configuration so test-enabled builds configure C and C++ from the project root, Windows secure-store Ninja jobs use the MSVC x64 toolchain, and final failure diagnostics include modern CMake configure logs.
 - Hardened installer and release CI dependency installation with transient vcpkg retry handling, separated caches, improved failure diagnostics, and Node 24-compatible GitHub Actions.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -258,7 +258,7 @@ You can also contact the project at **perastage.app@gmail.com**.
 - Fixed embedded Layout 2D fixture symbols so rotated GDTF fixtures choose the visible representative symbol plane and preserve the same orientation in preview and PDF export.
 
 ## Internal changes
-- Reorganized GitHub Actions into separate Debug CI, main patch artifact, compatibility package, and transactional minor release workflows, with Debug dependency setup aligned to the pinned vcpkg toolchain.
+- Reorganized GitHub Actions into separate Debug CI, main patch artifact, compatibility package, and transactional minor release workflows, with Debug dependency setup aligned to the pinned vcpkg toolchain and Windows CI preserving the Python and MSVC environments across steps.
 
 - Hardened installer CI configuration so test-enabled builds configure C and C++ from the project root, Windows secure-store Ninja jobs use the MSVC x64 toolchain, and final failure diagnostics include modern CMake configure logs.
 - Hardened installer and release CI dependency installation with transient vcpkg retry handling, separated caches, improved failure diagnostics, and Node 24-compatible GitHub Actions.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -258,7 +258,7 @@ You can also contact the project at **perastage.app@gmail.com**.
 - Fixed embedded Layout 2D fixture symbols so rotated GDTF fixtures choose the visible representative symbol plane and preserve the same orientation in preview and PDF export.
 
 ## Internal changes
-- Reorganized GitHub Actions into separate Debug CI, main patch artifact, compatibility package, and transactional minor release workflows.
+- Reorganized GitHub Actions into separate Debug CI, main patch artifact, compatibility package, and transactional minor release workflows, with Debug dependency setup aligned to the pinned vcpkg toolchain.
 
 - Hardened installer CI configuration so test-enabled builds configure C and C++ from the project root, Windows secure-store Ninja jobs use the MSVC x64 toolchain, and final failure diagnostics include modern CMake configure logs.
 - Hardened installer and release CI dependency installation with transient vcpkg retry handling, separated caches, improved failure diagnostics, and Node 24-compatible GitHub Actions.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -91,13 +91,24 @@ if(BASH_EXECUTABLE)
              COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_project_restore_import_options.sh)
     add_test(NAME SecureStoreBuildPolicy
              COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_securestore_build_policy.sh)
-    set_tests_properties(SecureStoreBuildPolicy PROPERTIES LABELS "secure-store;security;release-gate")
+    set_tests_properties(SecureStoreBuildPolicy PROPERTIES
+                         LABELS "secure-store;security;release-gate"
+                         WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
     add_test(NAME WindowsNinjaX64Policy
              COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_windows_ninja_x64_policy.sh)
-    set_tests_properties(WindowsNinjaX64Policy PROPERTIES LABELS "windows;x64;release-gate")
+    set_tests_properties(WindowsNinjaX64Policy PROPERTIES
+                         LABELS "windows;x64;release-gate"
+                         WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
     add_test(NAME CiCMakeLanguagePolicy
              COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_ci_cmake_language_policy.sh)
-    set_tests_properties(CiCMakeLanguagePolicy PROPERTIES LABELS "ci;cmake;release-gate")
+    set_tests_properties(CiCMakeLanguagePolicy PROPERTIES
+                         LABELS "ci;cmake;release-gate"
+                         WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
+    add_test(NAME ReleaseGatePolicyPortability
+             COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_release_gate_policy_portability.sh)
+    set_tests_properties(ReleaseGatePolicyPortability PROPERTIES
+                         LABELS "ci;policy;release-gate"
+                         WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
 endif()
 
 find_package(Python3 COMPONENTS Interpreter)

--- a/tests/check_ci_cmake_language_policy.sh
+++ b/tests/check_ci_cmake_language_policy.sh
@@ -25,16 +25,15 @@ for path in all_cmake:
     if re.search(r'(?m)^\s*enable_language\s*\(', text):
         raise SystemExit(f'Nested enable_language() is not allowed: {path}')
 
-windows = Path('.github/workflows/windows-installer.yml').read_text()
+ci = Path('.github/workflows/ci-tests.yml').read_text()
 required_windows = [
     'VsDevCmd.bat', '-host_arch=x64 -arch=x64', 'CMAKE_C_COMPILER=cl.exe',
-    'CMAKE_CXX_COMPILER=cl.exe', 'CMAKE_C_COMPILER_ID:INTERNAL=MSVC',
-    'CMAKE_CXX_COMPILER_ID:INTERNAL=MSVC', 'c:[\\\\/](mingw64|msys64)',
-    'CMakeConfigureLog.yaml', 'cmake-configure-windows-security.log',
+    'CMAKE_CXX_COMPILER=cl.exe', 'VCPKG_TARGET_TRIPLET=x64-windows',
+    'CMakeConfigureLog.yaml', 'cmake-configure-windows-debug.log',
 ]
 for needle in required_windows:
-    if needle not in windows:
-        raise SystemExit(f'Windows secure-store workflow is missing policy marker: {needle}')
+    if needle not in ci:
+        raise SystemExit(f'Windows Debug CI is missing policy marker: {needle}')
 
 workflow_paths = [
     Path('.github/workflows/windows-installer.yml'), Path('.github/workflows/linux-installer.yml'),
@@ -52,19 +51,16 @@ for path in workflow_paths:
     final_upload = text.rfind('Upload final CI diagnostics')
     last_operation = max(text.rfind('cmake '), text.rfind('ctest '), text.rfind('makepkg'), text.rfind('appimagetool'), text.rfind('ISCC'))
     if final_upload < last_operation:
-        raise SystemExit(f'{path} final diagnostic upload must be after build/package/test operations.')
+        raise SystemExit(f'{path} final diagnostic upload must be after build/package operations.')
+    if '-DBUILD_TESTING=ON' in text or 'release-gate' in text:
+        raise SystemExit(f'{path} must be a Release-only package builder without release-gate tests.')
+    if 'PERASTAGE_ENABLE_COMPILER_CACHE=OFF' not in text:
+        raise SystemExit(f'{path} must disable uncontrolled compiler-cache discovery.')
+    if path.name != 'arch-package.yml' and '-DBUILD_TESTING=OFF' not in text:
+        raise SystemExit(f'{path} must configure with BUILD_TESTING=OFF.')
 
-release_gate_configs = {
-    '.github/workflows/linux-installer.yml': 'cmake-configure-linux.log',
-    '.github/workflows/macos-installer.yml': 'cmake-configure-macos26.log',
-    '.github/workflows/macos-15-manual-installer.yml': 'cmake-configure-macos15.log',
-    '.github/workflows/arch-package.yml': 'cmake-configure-arch-release-gate.log',
-    '.github/workflows/windows-installer.yml': 'cmake-configure-windows-security.log',
-}
-for path, log_name in release_gate_configs.items():
-    text = Path(path).read_text()
-    if log_name not in text or '-DBUILD_TESTING=ON' not in text:
-        raise SystemExit(f'{path} must keep BUILD_TESTING=ON and configure logging for release-gate paths.')
+if 'CMAKE_BUILD_TYPE=Debug' not in ci or '-DBUILD_TESTING=ON' not in ci or 'must not compile with NDEBUG' not in ci:
+    raise SystemExit('ci-tests.yml must be the Debug test owner and must protect assert-based tests.')
 
 print('OK: CI CMake language, compiler, diagnostics, and release-gate policies are enforced.')
 PY

--- a/tests/check_ci_cmake_language_policy.sh
+++ b/tests/check_ci_cmake_language_policy.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
 
 python3 - <<'PY'
 from pathlib import Path

--- a/tests/check_ci_workflow_architecture.py
+++ b/tests/check_ci_workflow_architecture.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import json
+import re
+import sys
+
+import subprocess
+
+WORKFLOWS = Path('.github/workflows')
+for workflow in WORKFLOWS.glob('*.yml'):
+    subprocess.run(['ruby', '-e', "require 'yaml'; YAML.load_file(ARGV[0])", str(workflow)], check=True)
+
+ci = (WORKFLOWS / 'ci-tests.yml').read_text()
+for needle in ['name: CI Debug Tests', 'pull_request:', 'workflow_call:', 'CMAKE_BUILD_TYPE=Debug', '-DBUILD_TESTING=ON', 'cancel-in-progress: true', '-host_arch=x64 -arch=x64', 'VCPKG_TARGET_TRIPLET=x64-windows']:
+    assert needle in ci, f'ci-tests.yml is missing {needle}'
+assert '-DNDEBUG' in ci and 'must not compile with NDEBUG' in ci
+assert 'Refusing non-MSVC compiler' in ci and '(?i)mingw|msys|strawberry' in ci, 'Windows Debug CI must reject MinGW, MSYS, and Strawberry tools'
+
+builders = ['windows-installer.yml','linux-installer.yml','macos-installer.yml','macos-15-manual-installer.yml','arch-package.yml']
+for name in builders:
+    text = (WORKFLOWS / name).read_text()
+    assert 'workflow_call:' in text and 'workflow_dispatch:' in text, f'{name} must remain reusable and manual'
+    assert "ref: ${{ inputs.source_ref != '' && inputs.source_ref || github.ref }}" in text, f'{name} must checkout source_ref'
+    assert 'PERASTAGE_REQUIRE_SECURE_CREDENTIAL_STORE=ON' in text, f'{name} must require secure store'
+    assert 'PERASTAGE_ENABLE_COMPILER_CACHE=OFF' in text, f'{name} must disable uncontrolled compiler cache'
+    assert '-DBUILD_TESTING=ON' not in text, f'{name} must not configure tests'
+    assert 'release-gate' not in text, f'{name} must not run release-gate tests'
+for name in ['linux-installer.yml','macos-installer.yml','macos-15-manual-installer.yml','windows-installer.yml']:
+    text = (WORKFLOWS / name).read_text()
+    assert 'CMAKE_BUILD_TYPE=Release' in text, f'{name} must be Release'
+    assert '-DBUILD_TESTING=OFF' in text, f'{name} must disable tests'
+
+main_patch = (WORKFLOWS / 'main-patch-test-build.yml').read_text()
+assert 'name: Main Patch Release Artifacts' in main_patch
+assert main_patch.count('uses: ./.github/workflows/windows-installer.yml') == 1
+assert main_patch.count('uses: ./.github/workflows/linux-installer.yml') == 1
+assert main_patch.count('uses: ./.github/workflows/macos-installer.yml') == 1
+assert 'macos-15-manual-installer.yml' not in main_patch and 'arch-package.yml' not in main_patch and 'ci-tests.yml' not in main_patch
+
+compat = (WORKFLOWS / 'compatibility-builds.yml').read_text()
+assert 'name: Weekly Compatibility Packages' in compat and 'schedule:' in compat
+assert compat.count('uses: ./.github/workflows/macos-15-manual-installer.yml') == 1
+assert compat.count('uses: ./.github/workflows/arch-package.yml') == 1
+assert 'windows-installer.yml' not in compat and 'linux-installer.yml' not in compat and 'macos-installer.yml' not in compat
+assert 'git commit' not in compat and 'git push origin HEAD:main' not in compat and 'printf' not in compat, 'compatibility workflow must not mutate VERSION'
+
+minor = (WORKFLOWS / 'minor-draft-release.yml').read_text()
+for builder in ['windows-installer.yml','linux-installer.yml','macos-15-manual-installer.yml','macos-installer.yml','arch-package.yml']:
+    assert builder in minor, f'minor release must require {builder}'
+assert 'uses: ./.github/workflows/ci-tests.yml' in minor
+assert 'validate-release-assets' in minor and 'publish-release' in minor
+assert re.search(r'publish-release:[\s\S]+needs: \[resolve-release, stage-release-commit, validate-release-assets\]', minor)
+assert minor.find('git tag -a') > minor.find('validate-release-assets'), 'final tag must be created after asset validation'
+assert 'git push origin "$RELEASE_SHA":main' in minor and 'main moved' in minor
+assert 'git push origin --delete "$TEMP_REF"' in minor
+
+contract = json.loads(Path('.github/release-artifact-contract.json').read_text())
+patterns = contract['packages']
+for pattern in patterns.values():
+    assert pattern in minor, f'collector is missing package pattern {pattern}'
+for artifact in contract['artifacts'].values():
+    found = any(artifact in (WORKFLOWS / name).read_text() for name in builders) or artifact in minor
+    assert found, f'artifact contract name is not produced or consumed: {artifact}'
+
+print('OK: GitHub Actions architecture policies are enforced.')

--- a/tests/check_ci_workflow_architecture.py
+++ b/tests/check_ci_workflow_architecture.py
@@ -2,8 +2,6 @@
 from pathlib import Path
 import json
 import re
-import sys
-
 import subprocess
 
 WORKFLOWS = Path('.github/workflows')
@@ -14,7 +12,34 @@ ci = (WORKFLOWS / 'ci-tests.yml').read_text()
 for needle in ['name: CI Debug Tests', 'pull_request:', 'workflow_call:', 'CMAKE_BUILD_TYPE=Debug', '-DBUILD_TESTING=ON', 'cancel-in-progress: true', '-host_arch=x64 -arch=x64', 'VCPKG_TARGET_TRIPLET=x64-windows']:
     assert needle in ci, f'ci-tests.yml is missing {needle}'
 assert '-DNDEBUG' in ci and 'must not compile with NDEBUG' in ci
-assert 'Refusing non-MSVC compiler' in ci and '(?i)mingw|msys|strawberry' in ci, 'Windows Debug CI must reject MinGW, MSYS, and Strawberry tools'
+assert 'Refusing non-MSVC compiler' in ci and all(token in ci.lower() for token in ['mingw', 'msys', 'strawberry']), 'Windows Debug CI must reject MinGW, MSYS, and Strawberry tools'
+
+sections = {
+    'linux': ci[ci.index('  linux-debug:'):ci.index('\n  windows-debug:')],
+    'windows': ci[ci.index('  windows-debug:'):ci.index('\n  macos-debug:')],
+    'macos': ci[ci.index('  macos-debug:'):],
+}
+for platform, text in sections.items():
+    for needle in ['Read vcpkg baseline', 'get_vcpkg_baseline.py vcpkg.json', 'Restore vcpkg downloads', 'Cache vcpkg installed packages and binary archives', 'Bootstrap vcpkg', 'vcpkg_install_retry.py', '-DVCPKG_MANIFEST_MODE=OFF', '-DBUILD_TESTING=ON', 'PERASTAGE_ENABLE_COMPILER_CACHE=OFF']:
+        assert needle in text, f'{platform} Debug is missing {needle}'
+    assert text.index('Prepare vcpkg and diagnostics directories') < text.index('Bootstrap vcpkg'), f'{platform} must create vcpkg directories before bootstrap'
+    assert 'VCPKG_DOWNLOADS' in text and 'VCPKG_INSTALLED' in text and 'VCPKG_PACKAGES' in text and 'VCPKG_BINARY_CACHE' in text, f'{platform} must prepare all vcpkg directories'
+    assert 'debug-v1' in text or 'macos-26-xcode-26-debug-v1' in text, f'{platform} installed cache key must be Debug/toolchain scoped'
+    assert 'run_and_log.py --log' in text and 'ctest-' in text, f'{platform} build and test logs must be captured'
+
+linux = sections['linux']
+for needle in ['-DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"', '-DVCPKG_TARGET_TRIPLET=x64-linux', '-DVCPKG_INSTALLED_DIR="$VCPKG_INSTALLED"', '-DCMAKE_EXPORT_COMPILE_COMMANDS=ON', 'compile_commands.json was not generated']:
+    assert needle in linux, f'Linux Debug is missing {needle}'
+assert 'wxwidgets' not in linux.lower(), 'Linux Debug must not install system wxWidgets packages'
+
+windows = sections['windows']
+for needle in ['$env:GITHUB_ENV', '$env:GITHUB_PATH', 'INCLUDE', 'LIBPATH', 'VSCMD_ARG_HOST_ARCH', 'VSCMD_ARG_TGT_ARCH', 'CMAKE_C_COMPILER_ID:INTERNAL=MSVC', 'CMAKE_CXX_COMPILER_ID:INTERNAL=MSVC']:
+    assert needle in windows, f'Windows Debug environment persistence is missing {needle}'
+assert windows.index('Persist Visual Studio Hostx64 x64 environment') < windows.index('Configure Windows Debug tests') < windows.index('Build Windows Debug tests')
+
+macos = sections['macos']
+for needle in ['macos-26-xcode-26-debug-v1', 'xcrun --sdk macosx --show-sdk-path', '-DCMAKE_OSX_SYSROOT="$current_sdk_path"', 'Stale macOS SDK path metadata']:
+    assert needle in macos, f'macOS Debug is missing {needle}'
 
 builders = ['windows-installer.yml','linux-installer.yml','macos-installer.yml','macos-15-manual-installer.yml','arch-package.yml']
 for name in builders:

--- a/tests/check_ci_workflow_architecture.py
+++ b/tests/check_ci_workflow_architecture.py
@@ -33,7 +33,7 @@ for needle in ['-DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.c
 assert 'wxwidgets' not in linux.lower(), 'Linux Debug must not install system wxWidgets packages'
 
 windows = sections['windows']
-for needle in ['$env:GITHUB_ENV', '$env:GITHUB_PATH', 'INCLUDE', 'LIBPATH', 'VSCMD_ARG_HOST_ARCH', 'VSCMD_ARG_TGT_ARCH', 'CMAKE_C_COMPILER_ID:INTERNAL=MSVC', 'CMAKE_CXX_COMPILER_ID:INTERNAL=MSVC']:
+for needle in ['$env:GITHUB_ENV', '$env:GITHUB_PATH', 'PERASTAGE_PYTHON', 'Get-Command python', 'INCLUDE', 'LIBPATH', 'VSCMD_ARG_HOST_ARCH', 'VSCMD_ARG_TGT_ARCH', 'CMAKE_C_COMPILER_ID:INTERNAL=MSVC', 'CMAKE_CXX_COMPILER_ID:INTERNAL=MSVC']:
     assert needle in windows, f'Windows Debug environment persistence is missing {needle}'
 assert windows.index('Persist Visual Studio Hostx64 x64 environment') < windows.index('Configure Windows Debug tests') < windows.index('Build Windows Debug tests')
 

--- a/tests/check_release_gate_policy_portability.sh
+++ b/tests/check_release_gate_policy_portability.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp_root="$(mktemp -d)"
+trap 'rm -rf "$tmp_root"' EXIT
+
+tmp_bin="$tmp_root/bin"
+mkdir -p "$tmp_bin"
+ln -s /usr/bin/python3 "$tmp_bin/python3"
+ln -s /usr/bin/bash "$tmp_bin/bash"
+ln -s /usr/bin/dirname "$tmp_bin/dirname"
+ln -s /usr/bin/env "$tmp_bin/env"
+
+scripts=(
+  "$repo_root/tests/check_securestore_build_policy.sh"
+  "$repo_root/tests/check_windows_ninja_x64_policy.sh"
+  "$repo_root/tests/check_ci_cmake_language_policy.sh"
+)
+
+for script in "${scripts[@]}"; do
+  (cd "$repo_root" && PATH="$tmp_bin" /usr/bin/bash "$script")
+  (cd "$tmp_root" && PATH="$tmp_bin" /usr/bin/bash "$script")
+done
+
+if PATH="$tmp_bin" command -v rg >/dev/null 2>&1; then
+  echo 'Regression setup error: rg is unexpectedly available on PATH.' >&2
+  exit 1
+fi
+
+echo 'OK: release-gate policy scripts are independent of rg and caller working directory.'

--- a/tests/check_securestore_build_policy.sh
+++ b/tests/check_securestore_build_policy.sh
@@ -34,7 +34,7 @@ rg -q 'PERASTAGE_REQUIRE_SECURE_CREDENTIAL_STORE.*ON|PERASTAGE_REQUIRE_SECURE_CR
   setup_windows.ps1 \
   packaging/arch/PKGBUILD
 rg -q 'bootstrap-vcpkg\.bat' .github/workflows/windows-installer.yml
-rg -q 'checkout --detach' .github/workflows/windows-installer.yml
+rg -q 'checkout --force|checkout --detach' .github/workflows/windows-installer.yml
 rg -q -- '--x-install-root' .github/workflows/windows-installer.yml
 rg -q 'VCPKG_INSTALLED_DIR' .github/workflows/windows-installer.yml
 rg -q 'Initialize-X64MsvcEnvironment' setup_windows.ps1
@@ -48,9 +48,9 @@ rg -q 'VCPKG_MANIFEST_MODE=OFF|VCPKG_MANIFEST_MODE.*OFF' setup_windows.ps1 CMake
 rg -q 'securestore-v2' .github/workflows/windows-installer.yml .github/workflows/linux-installer.yml .github/workflows/arch-package.yml .github/workflows/macos-installer.yml .github/workflows/macos-15-manual-installer.yml
 rg -q '0878b5224d4a4968940ee296a2e7fae2d3b62983' vcpkg.json
 rg -q 'get_vcpkg_baseline.py vcpkg.json' .github/workflows/windows-installer.yml .github/workflows/linux-installer.yml .github/workflows/arch-package.yml .github/workflows/macos-installer.yml .github/workflows/macos-15-manual-installer.yml
-rg -q 'ctest --test-dir .* -L release-gate' .github/workflows/windows-installer.yml .github/workflows/linux-installer.yml .github/workflows/macos-installer.yml .github/workflows/macos-15-manual-installer.yml
-rg -q 'gdtf_share_security_test' .github/workflows/windows-installer.yml tests/CMakeLists.txt
-rg -q 'credential_store_native_roundtrip_test' .github/workflows/windows-installer.yml tests/CMakeLists.txt
+rg -q 'ctest --test-dir .* -L release-gate' .github/workflows/ci-tests.yml
+rg -q 'gdtf_share_security_test' .github/workflows/ci-tests.yml tests/CMakeLists.txt
+rg -q 'credential_store_native_roundtrip_test' .github/workflows/ci-tests.yml tests/CMakeLists.txt
 rg -q 'libsecret-1-dev' .github/workflows/linux-installer.yml
 rg -q "'libsecret'" packaging/arch/PKGBUILD
 rg -q -- '--manifest-root' .github/workflows/macos-installer.yml .github/workflows/macos-15-manual-installer.yml
@@ -74,4 +74,4 @@ for preset in presets['configurePresets']:
         assert arch.get('strategy') == 'external', preset['name']
 PY
 
-echo 'OK: secure-store build, manifest, workflow, and release-gate policies are enforced.'
+echo 'OK: secure-store build, manifest, workflow, and Debug CI and Release builder policies are enforced.'

--- a/tests/check_securestore_build_policy.sh
+++ b/tests/check_securestore_build_policy.sh
@@ -5,8 +5,28 @@ cd "$repo_root"
 
 python3 - <<'PY'
 import json
+import re
 from pathlib import Path
-manifest = json.loads(Path('vcpkg.json').read_text())
+
+ROOT = Path('.')
+
+def read(path):
+    return (ROOT / path).read_text(errors='ignore')
+
+def require(pattern, *paths, flags=0):
+    for path in paths:
+        if re.search(pattern, read(path), flags):
+            return
+    raise SystemExit(f'Missing required pattern {pattern!r} in: {", ".join(paths)}')
+
+def forbid(pattern, *paths, flags=0):
+    for path in paths:
+        text = read(path)
+        match = re.search(pattern, text, flags)
+        if match:
+            raise SystemExit(f'Forbidden pattern {pattern!r} found in {path}: {match.group(0)!r}')
+
+manifest = json.loads(read('vcpkg.json'))
 baseline = manifest.get('builtin-baseline')
 assert baseline == '0878b5224d4a4968940ee296a2e7fae2d3b62983', 'vcpkg.json must pin the expected builtin-baseline'
 deps = manifest['dependencies']
@@ -17,48 +37,34 @@ assert gettext, 'vcpkg.json must declare gettext'
 assert gettext.get('host') is True, 'gettext must be a host dependency'
 assert gettext.get('platform') == 'windows', 'gettext host tools must be Windows-only in the manifest'
 assert 'tools' in gettext.get('features', []), 'gettext must request the tools feature'
-PY
 
-windows_roots=(setup_windows.ps1 .github/workflows/windows-installer.yml docs/developer/build.md docs/user/installation-windows.md docs/user/troubleshooting.md docs/developer/localization.md)
-if rg -n 'vcpkg(?:\.exe)?\s+install\s+"?gettext\[tools\]' "${windows_roots[@]}"; then
-  echo 'Windows setup must not run a package-argument gettext install from the manifest root.' >&2
-  exit 1
-fi
+windows_roots = ['setup_windows.ps1', '.github/workflows/windows-installer.yml', 'docs/developer/build.md', 'docs/user/installation-windows.md', 'docs/user/troubleshooting.md', 'docs/developer/localization.md']
+forbid(r'vcpkg(?:\.exe)?\s+install\s+"?gettext\[tools\]', *windows_roots, flags=re.I)
 
-rg -q 'PERASTAGE_REQUIRE_SECURE_CREDENTIAL_STORE.*ON|PERASTAGE_REQUIRE_SECURE_CREDENTIAL_STORE=ON' \
-  .github/workflows/windows-installer.yml \
-  .github/workflows/linux-installer.yml \
-  .github/workflows/arch-package.yml \
-  .github/workflows/macos-installer.yml \
-  .github/workflows/macos-15-manual-installer.yml \
-  setup_windows.ps1 \
-  packaging/arch/PKGBUILD
-rg -q 'bootstrap-vcpkg\.bat' .github/workflows/windows-installer.yml
-rg -q 'checkout --force|checkout --detach' .github/workflows/windows-installer.yml
-rg -q -- '--x-install-root' .github/workflows/windows-installer.yml
-rg -q 'VCPKG_INSTALLED_DIR' .github/workflows/windows-installer.yml
-rg -q 'Initialize-X64MsvcEnvironment' setup_windows.ps1
-rg -q 'VSCMD_ARG_HOST_ARCH.*x64|hostArch.*x64' setup_windows.ps1
-rg -q 'VSCMD_ARG_TGT_ARCH.*x64|targetArch.*x64' setup_windows.ps1
-rg -q 'for\\s\+x64|for\\s\*x64|for\\s+x64' setup_windows.ps1
-rg -qi 'hostx64.*x64' setup_windows.ps1
-rg -qi 'hostx86.*x86' setup_windows.ps1
-rg -q 'cached compiler Visual Studio root' setup_windows.ps1
-rg -q 'VCPKG_MANIFEST_MODE=OFF|VCPKG_MANIFEST_MODE.*OFF' setup_windows.ps1 CMakePresets.json .github/workflows/windows-installer.yml .github/workflows/linux-installer.yml .github/workflows/arch-package.yml .github/workflows/macos-installer.yml .github/workflows/macos-15-manual-installer.yml
-rg -q 'securestore-v2' .github/workflows/windows-installer.yml .github/workflows/linux-installer.yml .github/workflows/arch-package.yml .github/workflows/macos-installer.yml .github/workflows/macos-15-manual-installer.yml
-rg -q '0878b5224d4a4968940ee296a2e7fae2d3b62983' vcpkg.json
-rg -q 'get_vcpkg_baseline.py vcpkg.json' .github/workflows/windows-installer.yml .github/workflows/linux-installer.yml .github/workflows/arch-package.yml .github/workflows/macos-installer.yml .github/workflows/macos-15-manual-installer.yml
-rg -q 'ctest --test-dir .* -L release-gate' .github/workflows/ci-tests.yml
-rg -q 'gdtf_share_security_test' .github/workflows/ci-tests.yml tests/CMakeLists.txt
-rg -q 'credential_store_native_roundtrip_test' .github/workflows/ci-tests.yml tests/CMakeLists.txt
-rg -q 'libsecret-1-dev' .github/workflows/linux-installer.yml
-rg -q "'libsecret'" packaging/arch/PKGBUILD
-rg -q -- '--manifest-root' .github/workflows/macos-installer.yml .github/workflows/macos-15-manual-installer.yml
+require(r'PERASTAGE_REQUIRE_SECURE_CREDENTIAL_STORE.*ON|PERASTAGE_REQUIRE_SECURE_CREDENTIAL_STORE=ON', '.github/workflows/windows-installer.yml', '.github/workflows/linux-installer.yml', '.github/workflows/arch-package.yml', '.github/workflows/macos-installer.yml', '.github/workflows/macos-15-manual-installer.yml', 'setup_windows.ps1', 'packaging/arch/PKGBUILD')
+require(r'bootstrap-vcpkg\.bat', '.github/workflows/windows-installer.yml')
+require(r'checkout --force|checkout --detach', '.github/workflows/windows-installer.yml')
+require(r'--x-install-root', '.github/workflows/windows-installer.yml')
+require(r'VCPKG_INSTALLED_DIR', '.github/workflows/windows-installer.yml')
+require(r'Initialize-X64MsvcEnvironment', 'setup_windows.ps1')
+require(r'VSCMD_ARG_HOST_ARCH.*x64|hostArch.*x64', 'setup_windows.ps1')
+require(r'VSCMD_ARG_TGT_ARCH.*x64|targetArch.*x64', 'setup_windows.ps1')
+require(r'for\\s\+x64|for\\s\*x64|for\\s\+x64', 'setup_windows.ps1')
+require(r'hostx64.*x64', 'setup_windows.ps1', flags=re.I)
+require(r'hostx86.*x86', 'setup_windows.ps1', flags=re.I)
+require(r'cached compiler Visual Studio root', 'setup_windows.ps1')
+require(r'VCPKG_MANIFEST_MODE=OFF|VCPKG_MANIFEST_MODE.*OFF', 'setup_windows.ps1', 'CMakePresets.json', '.github/workflows/windows-installer.yml', '.github/workflows/linux-installer.yml', '.github/workflows/arch-package.yml', '.github/workflows/macos-installer.yml', '.github/workflows/macos-15-manual-installer.yml')
+require(r'securestore-v2', '.github/workflows/windows-installer.yml', '.github/workflows/linux-installer.yml', '.github/workflows/arch-package.yml', '.github/workflows/macos-installer.yml', '.github/workflows/macos-15-manual-installer.yml')
+require(r'0878b5224d4a4968940ee296a2e7fae2d3b62983', 'vcpkg.json')
+require(r'get_vcpkg_baseline\.py vcpkg\.json', '.github/workflows/windows-installer.yml', '.github/workflows/linux-installer.yml', '.github/workflows/arch-package.yml', '.github/workflows/macos-installer.yml', '.github/workflows/macos-15-manual-installer.yml')
+require(r'ctest --test-dir .* -L release-gate', '.github/workflows/ci-tests.yml')
+require(r'gdtf_share_security_test', '.github/workflows/ci-tests.yml', 'tests/CMakeLists.txt')
+require(r'credential_store_native_roundtrip_test', '.github/workflows/ci-tests.yml', 'tests/CMakeLists.txt')
+require(r'libsecret-1-dev', '.github/workflows/linux-installer.yml')
+require(r"'libsecret'", 'packaging/arch/PKGBUILD')
+require(r'--manifest-root', '.github/workflows/macos-installer.yml', '.github/workflows/macos-15-manual-installer.yml')
 
-python3 - <<'PY'
-import json
-from pathlib import Path
-presets = json.loads(Path('CMakePresets.json').read_text())
+presets = json.loads(read('CMakePresets.json'))
 windows_presets = [preset for preset in presets['configurePresets'] if preset['name'].startswith('win-')]
 assert {preset['name'] for preset in windows_presets} == {'win-x64-debug-ninja', 'win-x64-release-ninja'}
 for preset in presets['configurePresets']:

--- a/tests/check_windows_ninja_x64_policy.sh
+++ b/tests/check_windows_ninja_x64_policy.sh
@@ -5,8 +5,15 @@ cd "$repo_root"
 
 python3 - <<'PY'
 import json
+import re
 from pathlib import Path
-presets = json.loads(Path('CMakePresets.json').read_text())
+
+ROOT = Path('.')
+
+def read(path):
+    return (ROOT / path).read_text(errors='ignore')
+
+presets = json.loads(read('CMakePresets.json'))
 windows_configure = [preset for preset in presets['configurePresets'] if preset['name'].startswith('win-')]
 assert {preset['name'] for preset in windows_configure} == {'win-x64-debug-ninja', 'win-x64-release-ninja'}, windows_configure
 for preset in windows_configure:
@@ -22,18 +29,15 @@ for preset in windows_configure:
     assert 'VCPKG_INSTALLED_DIR' not in cache, name
 windows_build = [preset for preset in presets['buildPresets'] if preset['name'].startswith('win-')]
 assert {preset['configurePreset'] for preset in windows_build} <= {'win-x64-debug-ninja', 'win-x64-release-ninja'}, windows_build
-PY
 
-python3 - <<'PY'
-from pathlib import Path
-script = Path('setup_windows.ps1').read_text()
+script = read('setup_windows.ps1')
 required = [
     "[string]$VcpkgRoot = 'C:\\vcpkg'",
     'VSCMD_ARG_HOST_ARCH',
     'VSCMD_ARG_TGT_ARCH',
     'cl.exe banner does not identify an x64 target',
-    'hostx64\\\\x64',
-    'hostx86\\\\x86',
+    r'hostx64\\x64',
+    r'hostx86\\x86',
     'cached compiler Visual Studio root',
     'VCPKG_MANIFEST_MODE=OFF',
     'VCPKG_MANIFEST_INSTALL=OFF',
@@ -56,20 +60,21 @@ for forbidden in [
 ]:
     assert forbidden not in script, forbidden
 assert "Write-Host 'MSVC compiler architecture: x64'" not in script, 'setup must not print unconditional x64 status'
-PY
 
-if rg -n 'local''-win-'; then
-  echo 'Tracked files must not reference generated local Windows presets.' >&2
-  exit 1
-fi
+ignored_roots = {'.git', 'build', 'out', 'vcpkg', '.vcpkg-cache'}
+for path in ROOT.rglob('*'):
+    if not path.is_file() or ignored_roots.intersection(path.parts) or path == ROOT / 'tests/check_windows_ninja_x64_policy.sh':
+        continue
+    try:
+        text = path.read_text(errors='ignore')
+    except OSError:
+        continue
+    if 'local-win-' in text:
+        raise SystemExit(f'Tracked files must not reference generated local Windows presets: {path}')
 
-python3 - <<'PY_SETUP'
-import re
-from pathlib import Path
-script = Path('setup_windows.ps1').read_text()
 for pattern in [r'&\s+\$[^\n]*vcpkg[^\n]*\s+install\b', r"vcpkg(?:\.exe)?[\"\']?\s+install\b"]:
     match = re.search(pattern, script, re.IGNORECASE)
     assert not match, match.group(0)
-PY_SETUP
+PY
 
 echo 'OK: Windows Ninja presets and setup script enforce classic x64 vcpkg validation policy.'

--- a/tests/gdtf_share_security_test.cpp
+++ b/tests/gdtf_share_security_test.cpp
@@ -9,6 +9,33 @@
 #include <map>
 #include <vector>
 
+// Returns true when any JSON string value equals the provided sentinel.
+bool ContainsJsonStringValue(const nlohmann::json& value, const std::string& sentinel) {
+    if (value.is_string()) return value.get<std::string>() == sentinel;
+    if (value.is_array()) {
+        for (const auto& item : value) { if (ContainsJsonStringValue(item, sentinel)) return true; }
+        return false;
+    }
+    if (value.is_object()) {
+        for (const auto& item : value.items()) { if (ContainsJsonStringValue(item.value(), sentinel)) return true; }
+    }
+    return false;
+}
+
+// Returns true when any JSON object key equals the provided field name.
+bool ContainsJsonObjectKey(const nlohmann::json& value, const std::string& fieldName) {
+    if (value.is_array()) {
+        for (const auto& item : value) { if (ContainsJsonObjectKey(item, fieldName)) return true; }
+        return false;
+    }
+    if (value.is_object()) {
+        for (const auto& item : value.items()) {
+            if (item.key() == fieldName || ContainsJsonObjectKey(item.value(), fieldName)) return true;
+        }
+    }
+    return false;
+}
+
 class FakeBackend final : public CredentialStore::CredentialBackend {
 public:
     bool available = true;
@@ -133,22 +160,31 @@ void TestCredentialStorage() {
     CredentialStore::SetCredentialMetadataPathForTesting((dir / "gdtf_credentials.json").string());
     auto backend = std::make_shared<FakeBackend>();
     CredentialStore::SetCredentialBackendForTesting(backend);
-    CredentialStore::Credentials cred{"user", "secret"};
+    const std::string username = "perastage-test-user";
+    const std::string password = "perastage-test-password-gdtf-share-security-sentinel";
+    CredentialStore::Credentials cred{username, password};
     CredentialStore::Result save = CredentialStore::Save(cred);
     assert(save.Succeeded());
     assert(save.metadataWritten);
     assert(save.secretWritten);
     auto loaded = CredentialStore::LoadDetailed();
-    assert(loaded.credentials && loaded.credentials->password == "secret");
+    assert(loaded.credentials && loaded.credentials->password == password);
     backend->stored.reset();
     auto usernameOnly = CredentialStore::LoadDetailed();
     assert(!usernameOnly.credentials);
-    assert(usernameOnly.usernameHint && *usernameOnly.usernameHint == "user");
+    assert(usernameOnly.usernameHint && *usernameOnly.usernameHint == username);
     backend->stored = cred;
     std::ifstream in(dir / "gdtf_credentials.json");
-    std::string meta((std::istreambuf_iterator<char>(in)), {});
-    assert(meta.find("secret") == std::string::npos);
-    assert(meta.find("password") == std::string::npos);
+    const auto metadata = nlohmann::json::parse(in);
+    assert(metadata.is_object());
+    assert(metadata.size() == 4);
+    assert(metadata.at("schema_version") == 1);
+    assert(metadata.at("backend") == "wx_secret_store");
+    assert(metadata.at("service") == CredentialStore::kGdtfShareCredentialService);
+    assert(metadata.at("username") == username);
+    assert(!ContainsJsonObjectKey(metadata, "password"));
+    assert(!ContainsJsonObjectKey(metadata, "secret"));
+    assert(!ContainsJsonStringValue(metadata, password));
     assert(CredentialStore::ClearDetailed().Succeeded());
     assert(!CredentialStore::LoadDetailed().credentials);
     backend->available = false;
@@ -158,7 +194,7 @@ void TestCredentialStorage() {
     assert(!unavailableSave.secretWritten);
     auto hintOnly = CredentialStore::LoadDetailed();
     assert(!hintOnly.credentials);
-    assert(hintOnly.usernameHint && *hintOnly.usernameHint == "user");
+    assert(hintOnly.usernameHint && *hintOnly.usernameHint == username);
     CredentialStore::SetCredentialBackendForTesting(nullptr);
     CredentialStore::SetCredentialMetadataPathForTesting("");
     fs::remove_all(dir);


### PR DESCRIPTION
### Motivation
- The previous `main` workflow mixed Debug test validation, Release builds, packaging, and publication which blurred responsibilities and risked publishing tags before assets were validated.
- The change splits CI so pull requests run focused Debug validation and only validated Release builders produce artifacts or publish releases, reducing risk and runner cost.
- Preserve existing packaging/symbol filename contracts so release collectors and downstream tooling remain compatible.
- Provide a clear, documented, and test-covered workflow map to make release failure and recovery deterministic and auditable.

### Description
- Added a reusable Debug CI workflow `/.github/workflows/ci-tests.yml` (`name: CI Debug Tests`) which runs on `pull_request`, `workflow_dispatch`, and `workflow_call`, resolves one exact commit SHA, uses a cancellable per-ref concurrency group, and implements Linux/Windows/macOS Debug matrices with `BUILD_TESTING=ON` and `CMAKE_BUILD_TYPE=Debug` while protecting `assert()`-based tests and uploading diagnostics only on failure.
- Converted the platform builders to Release-only responsibilities by updating `/.github/workflows/windows-installer.yml`, `/.github/workflows/linux-installer.yml`, `/.github/workflows/macos-installer.yml`, `/.github/workflows/macos-15-manual-installer.yml`, and `/.github/workflows/arch-package.yml` to require `CMAKE_BUILD_TYPE=Release` (or Release config), set `BUILD_TESTING=OFF`, preserve `PERASTAGE_REQUIRE_SECURE_CREDENTIAL_STORE=ON`, and disable uncontrolled compiler-cache discovery via `-DPERASTAGE_ENABLE_COMPILER_CACHE=OFF`.
- Refactored the automatic main workflow into `/.github/workflows/main-patch-test-build.yml` (`name: Main Patch Release Artifacts`) to keep serialized patch `VERSION` bumps and to call exactly the three Release builders (Windows, Ubuntu AppImage, current macOS) using the generated commit SHA and to publish a concise job summary.
- Added `/.github/workflows/compatibility-builds.yml` (`name: Weekly Compatibility Packages`) to build macOS 15 and Arch packages on schedule or by manual dispatch from a resolved SHA without mutating `VERSION`.
- Reworked `/.github/workflows/minor-draft-release.yml` into a transactional, staged pipeline that: resolves and validates `main` metadata, runs the reusable `CI Debug Tests` quality gate against the base SHA, stages a `VERSION` commit on a temporary automation ref, builds all five Release packages from the staged SHA, validates and assembles artifacts, then fast-forwards `main`, tags, and creates the draft GitHub Release only after full validation; the workflow includes cleanup to delete temporary refs on success/failure.
- Centralized artifact filename/producer names in `.github/release-artifact-contract.json` and added `tests/check_ci_workflow_architecture.py` plus updates to `tests/check_ci_cmake_language_policy.sh` and `tests/check_securestore_build_policy.sh` to validate workflow layering and policy rules.
- Added developer documentation `docs/developer/github_actions_workflows.md`, linked it from `docs/developer/index.md`, and added an `Internal changes` entry in `docs/release-notes-draft.md` describing the refactor.

### Testing
- Ran `python3 tests/check_ci_workflow_architecture.py` to validate YAML parseability, workflow-call/dispatch coverage, artifact contract references, Debug/Release separation, and transactional release ordering, which succeeded.
- Ran `bash tests/check_ci_cmake_language_policy.sh` and `bash tests/check_securestore_build_policy.sh` to verify CMake/preset and secure-store build policies, which succeeded.
- Ran repository consistency checks `bash tests/check_perastage_tree_modules.sh` and `bash tests/check_no_configmanager_get_in_gui.sh` which succeeded.
- Executed `python3 tests/ci/test_vcpkg_install_retry.py` and `actionlint` validation (`/tmp/actionlint/actionlint`) locally; both succeeded and no `actionlint` issues were reported.
- Confirmed `git diff --check` and committed the changes; all automated tests listed above passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e711d2618832488822195afc0c71c)