### PR TITLE
fix(ci): harden Debug CI test harness (tool checks, Windows validation, Xvfb, policy tests)

### DIFF
--- a/.github/scripts/summarize_ctest_failures.py
+++ b/.github/scripts/summarize_ctest_failures.py
@@ -1,38 +1,167 @@
 #!/usr/bin/env python3
-"""Create a concise summary from verbose CTest logs."""
+"""Create a concise CTest failure summary from JUnit, LastTestsFailed, and logs."""
 from __future__ import annotations
 
 import argparse
+import csv
 import re
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
 from pathlib import Path
 
-FAIL_RE = re.compile(r"^\s*\d+/\d+ Test\s+#?\d+:\s+(.+?)\s+\.{3,}\*\*\*Failed\s+(.+)$")
+
+@dataclass
+class Failure:
+    platform: str
+    test: str
+    status: str
+    first_failure_line: str
+    source_log: str
 
 
-def meaningful(lines: list[str], start: int) -> str:
-    for line in lines[start:start + 80]:
-        stripped = line.strip()
-        if stripped and not stripped.startswith(('Start ', 'Test command:', 'Working Directory:')):
-            return stripped[:240]
-    return '<no failure detail found>'
+LOG_FAILURE_RE = re.compile(
+    r"^\s*\d+/\d+ Test\s+#?\d+:\s+(.+?)\s+\.{3,}\*\*\*(Failed|Exception|Timeout|SEGFAULT|Subprocess aborted)(.*)$",
+    re.IGNORECASE,
+)
+START_RE = re.compile(r"^\s*Start\s+\d+:\s+(.+?)\s*$")
+LAST_FAILED_RE = re.compile(r"^\s*\d+:\s*(.+?)\s*$")
+NOISE_PREFIXES = (
+    "Start ",
+    "Test command:",
+    "Working Directory:",
+    "Environment variables:",
+    "Test timeout computed to be",
+)
 
 
+# Returns the first diagnostic line that is likely to explain a failure.
+def meaningful_line(text: str, fallback: str = "<no failure detail found>") -> str:
+    preferred = (
+        "Assertion",
+        "assert",
+        "Expected",
+        "expected",
+        "Actual",
+        "actual",
+        "Subprocess aborted",
+        "Exception",
+        "Segmentation fault",
+        "SEGFAULT",
+        "Timeout",
+        "Failed",
+        "Error",
+    )
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    for needle in preferred:
+        for line in lines:
+            if needle in line:
+                return line[:240]
+    for line in lines:
+        if not line.startswith(NOISE_PREFIXES):
+            return line[:240]
+    return fallback
+
+
+# Reads CTest's LastTestsFailed.log names when the file exists.
+def read_last_failed(path: Path | None) -> list[str]:
+    if not path or not path.exists():
+        return []
+    names: list[str] = []
+    for line in path.read_text(encoding="utf-8", errors="ignore").splitlines():
+        match = LAST_FAILED_RE.match(line)
+        if match:
+            names.append(match.group(1).strip())
+    return names
+
+
+# Extracts failed testcases from CTest JUnit XML.
+def failures_from_junit(platform: str, junit: Path | None) -> dict[str, Failure]:
+    failures: dict[str, Failure] = {}
+    if not junit or not junit.exists():
+        return failures
+    try:
+        root = ET.parse(junit).getroot()
+    except ET.ParseError:
+        return failures
+    for testcase in root.iter("testcase"):
+        failure_nodes = list(testcase.findall("failure")) + list(testcase.findall("error"))
+        skipped_nodes = list(testcase.findall("skipped"))
+        if not failure_nodes and not skipped_nodes:
+            continue
+        name = testcase.get("name") or testcase.get("classname") or "<unknown>"
+        node = failure_nodes[0] if failure_nodes else skipped_nodes[0]
+        status = node.get("message") or node.tag
+        body = "\n".join(filter(None, [node.text or "", testcase.findtext("system-out") or "", testcase.findtext("system-err") or ""]))
+        failures[name] = Failure(platform, name, status, meaningful_line(body, status), str(junit))
+    return failures
+
+
+# Extracts failed tests from a complete or partial CTest text log.
+def failures_from_log(platform: str, log: Path | None) -> dict[str, Failure]:
+    failures: dict[str, Failure] = {}
+    if not log or not log.exists():
+        return failures
+    lines = log.read_text(encoding="utf-8", errors="ignore").splitlines()
+    current_test = ""
+    current_output: list[str] = []
+    for index, line in enumerate(lines):
+        start = START_RE.match(line)
+        if start:
+            current_test = start.group(1).strip()
+            current_output = []
+            continue
+        if current_test:
+            current_output.append(line)
+        match = LOG_FAILURE_RE.match(line)
+        if not match:
+            continue
+        name = match.group(1).strip()
+        status = (match.group(2) + match.group(3)).strip()
+        lookahead = "\n".join(lines[index + 1:index + 80])
+        text = "\n".join(current_output + [lookahead])
+        failures[name] = Failure(platform, name, status, meaningful_line(text, status), str(log))
+    if current_test and current_test not in failures:
+        tail = "\n".join(current_output[-80:])
+        if any(marker in tail for marker in ("Interrupted", "Cancel", "cancel", "Terminated")):
+            failures[current_test] = Failure(platform, current_test, "interrupted", meaningful_line(tail, "interrupted"), str(log))
+    return failures
+
+
+# Writes a deterministic CSV summary.
+def write_csv(path: Path, failures: list[Failure]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(["platform", "test", "status", "first_failure_line", "source_log"])
+        for failure in failures:
+            writer.writerow([failure.platform, failure.test, failure.status, failure.first_failure_line, failure.source_log])
+
+
+# Builds the merged summary, preserving every LastTestsFailed entry.
+def summarize(args: argparse.Namespace) -> list[Failure]:
+    merged = failures_from_junit(args.platform, Path(args.junit) if args.junit else None)
+    log_failures = failures_from_log(args.platform, Path(args.log) if args.log else None)
+    for name, failure in log_failures.items():
+        merged.setdefault(name, failure)
+    last_failed = read_last_failed(Path(args.last_tests_failed) if args.last_tests_failed else None)
+    source = args.last_tests_failed or args.log or args.junit or "<unknown>"
+    for name in last_failed:
+        merged.setdefault(name, Failure(args.platform, name, "failed", "listed in LastTestsFailed.log", source))
+    return [merged[name] for name in sorted(merged)]
+
+
+# Parses command-line arguments and writes the summary.
 def main() -> int:
     parser = argparse.ArgumentParser()
-    parser.add_argument('--platform', required=True)
-    parser.add_argument('--log', required=True)
-    parser.add_argument('--output', required=True)
+    parser.add_argument("--platform", required=True)
+    parser.add_argument("--junit")
+    parser.add_argument("--log")
+    parser.add_argument("--last-tests-failed")
+    parser.add_argument("--output", required=True)
     args = parser.parse_args()
-    log = Path(args.log)
-    lines = log.read_text(encoding='utf-8', errors='ignore').splitlines() if log.exists() else []
-    rows = ['platform,test,status,first_failure_line,source_log']
-    for index, line in enumerate(lines):
-        match = FAIL_RE.match(line)
-        if match:
-            rows.append(','.join('"' + value.replace('"', '""') + '"' for value in [args.platform, match.group(1).strip(), match.group(2).strip(), meaningful(lines, index + 1), str(log)]))
-    Path(args.output).write_text('\n'.join(rows) + '\n', encoding='utf-8')
+    write_csv(Path(args.output), summarize(args))
     return 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     raise SystemExit(main())

--- a/.github/scripts/summarize_ctest_failures.py
+++ b/.github/scripts/summarize_ctest_failures.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Create a concise summary from verbose CTest logs."""
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+FAIL_RE = re.compile(r"^\s*\d+/\d+ Test\s+#?\d+:\s+(.+?)\s+\.{3,}\*\*\*Failed\s+(.+)$")
+
+
+def meaningful(lines: list[str], start: int) -> str:
+    for line in lines[start:start + 80]:
+        stripped = line.strip()
+        if stripped and not stripped.startswith(('Start ', 'Test command:', 'Working Directory:')):
+            return stripped[:240]
+    return '<no failure detail found>'
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--platform', required=True)
+    parser.add_argument('--log', required=True)
+    parser.add_argument('--output', required=True)
+    args = parser.parse_args()
+    log = Path(args.log)
+    lines = log.read_text(encoding='utf-8', errors='ignore').splitlines() if log.exists() else []
+    rows = ['platform,test,status,first_failure_line,source_log']
+    for index, line in enumerate(lines):
+        match = FAIL_RE.match(line)
+        if match:
+            rows.append(','.join('"' + value.replace('"', '""') + '"' for value in [args.platform, match.group(1).strip(), match.group(2).strip(), meaningful(lines, index + 1), str(log)]))
+    Path(args.output).write_text('\n'.join(rows) + '\n', encoding='utf-8')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/.github/scripts/validate_cmake_toolchain.py
+++ b/.github/scripts/validate_cmake_toolchain.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Validate CMake toolchain metadata without relying on one cache layout."""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8", errors="ignore") if path.exists() else ""
+
+
+def cache_values(cache: str) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for line in cache.splitlines():
+        if not line or line.startswith("//") or line.startswith("#") or "=" not in line:
+            continue
+        key_type, value = line.split("=", 1)
+        key = key_type.split(":", 1)[0]
+        values[key] = value
+    return values
+
+
+def cmake_set_value(text: str, name: str) -> str | None:
+    match = re.search(rf'^\s*set\s*\(\s*{re.escape(name)}\s+"?([^"\)]+)"?\s*\)', text, re.M)
+    return match.group(1).strip() if match else None
+
+
+def compiler_metadata(build_dir: Path, language: str) -> dict[str, str]:
+    cache = cache_values(read(build_dir / "CMakeCache.txt"))
+    prefix = "CMAKE_CXX" if language == "CXX" else "CMAKE_C"
+    metadata = {
+        "compiler": cache.get(f"{prefix}_COMPILER", ""),
+        "id": cache.get(f"{prefix}_COMPILER_ID", ""),
+        "architecture": cache.get(f"{prefix}_COMPILER_ARCHITECTURE_ID", ""),
+    }
+    pattern = "CMakeCXXCompiler.cmake" if language == "CXX" else "CMakeCCompiler.cmake"
+    for cmake_file in (build_dir / "CMakeFiles").glob(f"*/{pattern}"):
+        text = read(cmake_file)
+        metadata["compiler"] = metadata["compiler"] or cmake_set_value(text, f"{prefix}_COMPILER") or ""
+        metadata["id"] = metadata["id"] or cmake_set_value(text, f"{prefix}_COMPILER_ID") or ""
+        metadata["architecture"] = metadata["architecture"] or cmake_set_value(text, f"{prefix}_COMPILER_ARCHITECTURE_ID") or ""
+    if not metadata["compiler"]:
+        commands = build_dir / "compile_commands.json"
+        if commands.exists():
+            try:
+                entries = json.loads(read(commands))
+                if entries:
+                    metadata["compiler"] = str(entries[0].get("command", "")).split()[0]
+            except json.JSONDecodeError:
+                pass
+    return metadata
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SystemExit(message)
+
+
+def validate(args: argparse.Namespace) -> None:
+    build_dir = Path(args.build_dir)
+    cache = cache_values(read(build_dir / "CMakeCache.txt"))
+    require(cache, f"CMakeCache.txt was not found or could not be read in {build_dir}")
+    c = compiler_metadata(build_dir, "C")
+    cxx = compiler_metadata(build_dir, "CXX")
+    require(c["id"] == args.expected_c_id, f"Expected C compiler ID {args.expected_c_id}, found {c['id'] or '<missing>'}.")
+    require(cxx["id"] == args.expected_cxx_id, f"Expected C++ compiler ID {args.expected_cxx_id}, found {cxx['id'] or '<missing>'}.")
+    paths = [c["compiler"], cxx["compiler"]]
+    if args.expected_compiler_path_regex:
+        expected = re.compile(args.expected_compiler_path_regex, re.I)
+        for path in paths:
+            require(expected.search(path.replace("\\", "/")), f"Compiler path does not match expected pattern: {path}")
+    if args.forbidden_compiler_path_regex:
+        forbidden = re.compile(args.forbidden_compiler_path_regex, re.I)
+        for path in paths:
+            require(not forbidden.search(path.replace("\\", "/")), f"Compiler path matches forbidden pattern: {path}")
+    if args.expected_architecture:
+        for item in (c, cxx):
+            require(item["architecture"] == args.expected_architecture, f"Expected architecture {args.expected_architecture}, found {item['architecture'] or '<missing>'}.")
+    if args.expected_generator:
+        require(cache.get("CMAKE_GENERATOR") == args.expected_generator, f"Expected generator {args.expected_generator}, found {cache.get('CMAKE_GENERATOR', '<missing>')}.")
+    if args.expected_build_type:
+        require(cache.get("CMAKE_BUILD_TYPE") == args.expected_build_type, f"Expected build type {args.expected_build_type}, found {cache.get('CMAKE_BUILD_TYPE', '<missing>')}.")
+    print(f"OK: CMake toolchain uses {c['id']} and {cxx['id']} with generator {cache.get('CMAKE_GENERATOR', '<unknown>')}.")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--build-dir", required=True)
+    parser.add_argument("--expected-c-id", required=True)
+    parser.add_argument("--expected-cxx-id", required=True)
+    parser.add_argument("--expected-compiler-path-regex")
+    parser.add_argument("--forbidden-compiler-path-regex")
+    parser.add_argument("--expected-architecture")
+    parser.add_argument("--expected-generator")
+    parser.add_argument("--expected-build-type")
+    validate(parser.parse_args())
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Install Linux test dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential cmake ninja-build pkg-config gettext autopoint autoconf autoconf-archive automake libtool libltdl-dev curl unzip zip libx11-dev libxau-dev libxdmcp-dev x11proto-dev libxi-dev libxtst-dev libxrender-dev libgtk-3-dev libglib2.0-dev libsecret-1-dev libpango1.0-dev libatk1.0-dev libcairo2-dev libgdk-pixbuf-2.0-dev libxkbcommon-dev libgl1-mesa-dev libglu1-mesa-dev ripgrep xvfb locales
+          sudo apt-get install -y build-essential cmake ninja-build pkg-config gettext autopoint autoconf autoconf-archive automake libtool libltdl-dev curl unzip zip libx11-dev libxau-dev libxdmcp-dev x11proto-dev libxi-dev libxtst-dev libxrender-dev libgtk-3-dev libglib2.0-dev libsecret-1-dev libpango1.0-dev libatk1.0-dev libcairo2-dev libgdk-pixbuf-2.0-dev libxkbcommon-dev libgl1-mesa-dev libglu1-mesa-dev ripgrep xvfb xauth x11-utils locales
       - name: Restore vcpkg downloads
         id: vcpkg-downloads-cache
         uses: actions/cache/restore@v5
@@ -140,9 +140,10 @@ jobs:
       - name: Validate Linux test tools and locale
         run: |
           set -euo pipefail
-          sudo locale-gen es_ES.UTF-8
+          sudo locale-gen es_ES.UTF-8 zh_CN.UTF-8
           locale -a | grep -qi '^es_ES.utf8$' || { echo "es_ES.UTF-8 locale was not generated"; exit 1; }
-          for tool in rg xvfb-run locale; do command -v "$tool" >/dev/null || { echo "Required Linux test tool is missing: $tool"; exit 1; }; done
+          locale -a | grep -qi '^zh_CN.utf8$' || { echo "zh_CN.UTF-8 locale was not generated"; exit 1; }
+          for tool in rg xvfb-run locale xdpyinfo; do command -v "$tool" >/dev/null || { echo "Required Linux test tool is missing: $tool"; exit 1; }; done
       - name: Configure Debug tests
         run: |
           python3 .github/scripts/run_and_log.py --log "$CI_LOG_DIR/cmake-configure-linux-debug.log" -- cmake -S . -B build/linux-debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x64-linux -DVCPKG_INSTALLED_DIR="$VCPKG_INSTALLED" -DVCPKG_MANIFEST_MODE=OFF -DBUILD_TESTING=ON -DPERASTAGE_REQUIRE_SECURE_CREDENTIAL_STORE=ON -DPERASTAGE_ENABLE_COMPILER_CACHE=OFF
@@ -150,18 +151,24 @@ jobs:
           if grep -Eq '(^|[[:space:]])-DNDEBUG([[:space:]]|$)' build/linux-debug/compile_commands.json; then echo "Debug tests must not compile with NDEBUG"; exit 1; fi
       - name: Build complete test target set
         run: python3 .github/scripts/run_and_log.py --log "$CI_LOG_DIR/build-linux-debug.log" -- cmake --build build/linux-debug --target all --verbose
+      - name: Validate Linux Xvfb display
+        run: |
+          set -euo pipefail
+          xvfb-run -a -s "-screen 0 1920x1080x24" bash -c 'echo "DISPLAY=$DISPLAY" > "$CI_LOG_DIR/xvfb-linux-debug.txt"; test -n "$DISPLAY"; xdpyinfo >> "$CI_LOG_DIR/xvfb-linux-debug.txt"'
       - name: Run complete CTest suite
-        run: LC_ALL=C.UTF-8 LANG=C.UTF-8 LANGUAGE=es_ES:es python3 .github/scripts/run_and_log.py --log "$CI_LOG_DIR/ctest-linux-debug.log" -- xvfb-run -a -s "-screen 0 1920x1080x24" ctest --test-dir build/linux-debug --output-on-failure --verbose
-      - name: Summarize Linux CTest failures
-        if: ${{ always() }}
-        run: python3 .github/scripts/summarize_ctest_failures.py --platform linux --log "$CI_LOG_DIR/ctest-linux-debug.log" --output "$CI_LOG_DIR/ctest-linux-debug-failures.csv"
+        run: |
+          set +e
+          LC_ALL=C.UTF-8 LANG=C.UTF-8 xvfb-run -a -s "-screen 0 1920x1080x24" ctest --test-dir build/linux-debug --output-log "$CI_LOG_DIR/ctest-linux-debug.log" --output-junit "$CI_LOG_DIR/ctest-linux-debug.junit.xml" --output-on-failure --verbose
+          ctest_exit=$?
+          python3 .github/scripts/summarize_ctest_failures.py --platform linux --junit "$CI_LOG_DIR/ctest-linux-debug.junit.xml" --log "$CI_LOG_DIR/ctest-linux-debug.log" --last-tests-failed build/linux-debug/Testing/Temporary/LastTestsFailed.log --output "$CI_LOG_DIR/ctest-linux-debug-failures.csv"
+          exit $ctest_exit
       - name: Run repository policy tests
         run: |
           bash tests/check_perastage_tree_modules.sh
           bash tests/check_no_configmanager_get_in_gui.sh
           bash tests/check_ci_cmake_language_policy.sh
       - name: Upload failure diagnostics
-        if: ${{ failure() }}
+        if: ${{ always() && (failure() || cancelled()) }}
         uses: actions/upload-artifact@v7
         with:
           name: ci-linux-debug-diagnostics
@@ -171,12 +178,14 @@ jobs:
             **/CMakeFiles/CMakeConfigureLog.yaml
             **/CMakeCache.txt
             build/**/*.log
+            build/**/Testing/Temporary/**
             vcpkg/buildtrees/**/*.log
             vcpkg/buildtrees/**/config-*.txt
             vcpkg/buildtrees/**/issue_body.md
             .vcpkg-cache/installed/vcpkg/issue_body.md
 
   windows-debug:
+    timeout-minutes: 180
     needs: resolve-source
     runs-on: windows-latest
     env:
@@ -293,14 +302,12 @@ jobs:
       - name: Run Windows CTest suite
         shell: pwsh
         run: |
-          & "$env:PERASTAGE_PYTHON" .github/scripts/run_and_log.py --log "$env:CI_LOG_DIR\ctest-windows-debug.log" -- ctest --test-dir build-windows-debug --output-on-failure --verbose
-      - name: Summarize Windows CTest failures
-        if: ${{ always() }}
-        shell: pwsh
-        run: |
-          & "$env:PERASTAGE_PYTHON" .github/scripts/summarize_ctest_failures.py --platform windows --log "$env:CI_LOG_DIR\ctest-windows-debug.log" --output "$env:CI_LOG_DIR\ctest-windows-debug-failures.csv"
+          & ctest --test-dir build-windows-debug --output-log "$env:CI_LOG_DIR\ctest-windows-debug.log" --output-junit "$env:CI_LOG_DIR\ctest-windows-debug.junit.xml" --output-on-failure --verbose --interactive-debug-mode 0 --timeout 120
+          $ctestExit = $LASTEXITCODE
+          & "$env:PERASTAGE_PYTHON" .github/scripts/summarize_ctest_failures.py --platform windows --junit "$env:CI_LOG_DIR\ctest-windows-debug.junit.xml" --log "$env:CI_LOG_DIR\ctest-windows-debug.log" --last-tests-failed build-windows-debug\Testing\Temporary\LastTestsFailed.log --output "$env:CI_LOG_DIR\ctest-windows-debug-failures.csv"
+          exit $ctestExit
       - name: Upload failure diagnostics
-        if: ${{ failure() }}
+        if: ${{ always() && (failure() || cancelled()) }}
         uses: actions/upload-artifact@v7
         with:
           name: ci-windows-debug-diagnostics
@@ -310,6 +317,7 @@ jobs:
             **/CMakeFiles/CMakeConfigureLog.yaml
             **/CMakeCache.txt
             build*/**/*.log
+            build*/**/Testing/Temporary/**
             vcpkg/buildtrees/**/*.log
             vcpkg/buildtrees/**/config-*.txt
             vcpkg/buildtrees/**/issue_body.md
@@ -417,7 +425,7 @@ jobs:
         if: ${{ always() }}
         run: python3 .github/scripts/summarize_ctest_failures.py --platform macos --log "$CI_LOG_DIR/ctest-macos-debug.log" --output "$CI_LOG_DIR/ctest-macos-debug-failures.csv"
       - name: Upload failure diagnostics
-        if: ${{ failure() }}
+        if: ${{ always() && (failure() || cancelled()) }}
         uses: actions/upload-artifact@v7
         with:
           name: ci-macos-debug-diagnostics
@@ -427,6 +435,7 @@ jobs:
             **/CMakeFiles/CMakeConfigureLog.yaml
             **/CMakeCache.txt
             build/**/*.log
+            build/**/Testing/Temporary/**
             vcpkg/buildtrees/**/*.log
             vcpkg/buildtrees/**/config-*.txt
             vcpkg/buildtrees/**/issue_body.md

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Install Linux test dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential cmake ninja-build pkg-config gettext autopoint autoconf autoconf-archive automake libtool libltdl-dev curl unzip zip libx11-dev libxau-dev libxdmcp-dev x11proto-dev libxi-dev libxtst-dev libxrender-dev libgtk-3-dev libglib2.0-dev libsecret-1-dev libpango1.0-dev libatk1.0-dev libcairo2-dev libgdk-pixbuf-2.0-dev libxkbcommon-dev libgl1-mesa-dev libglu1-mesa-dev
+          sudo apt-get install -y build-essential cmake ninja-build pkg-config gettext autopoint autoconf autoconf-archive automake libtool libltdl-dev curl unzip zip libx11-dev libxau-dev libxdmcp-dev x11proto-dev libxi-dev libxtst-dev libxrender-dev libgtk-3-dev libglib2.0-dev libsecret-1-dev libpango1.0-dev libatk1.0-dev libcairo2-dev libgdk-pixbuf-2.0-dev libxkbcommon-dev libgl1-mesa-dev libglu1-mesa-dev ripgrep xvfb locales
       - name: Restore vcpkg downloads
         id: vcpkg-downloads-cache
         uses: actions/cache/restore@v5
@@ -137,6 +137,12 @@ jobs:
         with:
           path: .vcpkg-cache/downloads
           key: ${{ steps.vcpkg-downloads-cache.outputs.cache-primary-key }}
+      - name: Validate Linux test tools and locale
+        run: |
+          set -euo pipefail
+          sudo locale-gen es_ES.UTF-8
+          locale -a | grep -qi '^es_ES.utf8$' || { echo "es_ES.UTF-8 locale was not generated"; exit 1; }
+          for tool in rg xvfb-run locale; do command -v "$tool" >/dev/null || { echo "Required Linux test tool is missing: $tool"; exit 1; }; done
       - name: Configure Debug tests
         run: |
           python3 .github/scripts/run_and_log.py --log "$CI_LOG_DIR/cmake-configure-linux-debug.log" -- cmake -S . -B build/linux-debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x64-linux -DVCPKG_INSTALLED_DIR="$VCPKG_INSTALLED" -DVCPKG_MANIFEST_MODE=OFF -DBUILD_TESTING=ON -DPERASTAGE_REQUIRE_SECURE_CREDENTIAL_STORE=ON -DPERASTAGE_ENABLE_COMPILER_CACHE=OFF
@@ -145,7 +151,10 @@ jobs:
       - name: Build complete test target set
         run: python3 .github/scripts/run_and_log.py --log "$CI_LOG_DIR/build-linux-debug.log" -- cmake --build build/linux-debug --target all --verbose
       - name: Run complete CTest suite
-        run: python3 .github/scripts/run_and_log.py --log "$CI_LOG_DIR/ctest-linux-debug.log" -- ctest --test-dir build/linux-debug --output-on-failure
+        run: LC_ALL=C.UTF-8 LANG=C.UTF-8 LANGUAGE=es_ES:es python3 .github/scripts/run_and_log.py --log "$CI_LOG_DIR/ctest-linux-debug.log" -- xvfb-run -a -s "-screen 0 1920x1080x24" ctest --test-dir build/linux-debug --output-on-failure --verbose
+      - name: Summarize Linux CTest failures
+        if: ${{ always() }}
+        run: python3 .github/scripts/summarize_ctest_failures.py --platform linux --log "$CI_LOG_DIR/ctest-linux-debug.log" --output "$CI_LOG_DIR/ctest-linux-debug-failures.csv"
       - name: Run repository policy tests
         run: |
           bash tests/check_perastage_tree_modules.sh
@@ -275,11 +284,8 @@ jobs:
         run: |
           $cl = Get-Command cl.exe -ErrorAction SilentlyContinue
           if (-not $cl) { throw 'cl.exe was not available in the persisted Visual Studio environment.' }
-          & "$env:PERASTAGE_PYTHON" .github/scripts/run_and_log.py --log "$env:CI_LOG_DIR\cmake-configure-windows-debug.log" -- cmake -S . -B build-windows-debug -G Ninja -DCMAKE_C_COMPILER=cl.exe -DCMAKE_CXX_COMPILER=cl.exe -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT\scripts\buildsystems\vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x64-windows -DVCPKG_INSTALLED_DIR="$env:VCPKG_INSTALLED" -DVCPKG_MANIFEST_MODE=OFF -DBUILD_TESTING=ON -DPERASTAGE_REQUIRE_SECURE_CREDENTIAL_STORE=ON -DPERASTAGE_ENABLE_COMPILER_CACHE=OFF
-          $cache = Get-Content build-windows-debug\CMakeCache.txt -Raw
-          foreach ($required in @('CMAKE_C_COMPILER_ID:INTERNAL=MSVC', 'CMAKE_CXX_COMPILER_ID:INTERNAL=MSVC')) {
-            if ($cache -notmatch [regex]::Escape($required)) { throw "CMake cache is missing expected MSVC compiler identity: $required" }
-          }
+          & "$env:PERASTAGE_PYTHON" .github/scripts/run_and_log.py --log "$env:CI_LOG_DIR\cmake-configure-windows-debug.log" -- cmake -S . -B build-windows-debug -G Ninja -DCMAKE_C_COMPILER=cl.exe -DCMAKE_CXX_COMPILER=cl.exe -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT\scripts\buildsystems\vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x64-windows -DVCPKG_INSTALLED_DIR="$env:VCPKG_INSTALLED" -DVCPKG_MANIFEST_MODE=OFF -DBUILD_TESTING=ON -DPERASTAGE_REQUIRE_SECURE_CREDENTIAL_STORE=ON -DPERASTAGE_ENABLE_COMPILER_CACHE=OFF -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+          & "$env:PERASTAGE_PYTHON" .github/scripts/validate_cmake_toolchain.py --build-dir build-windows-debug --expected-c-id MSVC --expected-cxx-id MSVC --expected-compiler-path-regex "Hostx64[\\/]x64" --forbidden-compiler-path-regex "(mingw|msys|strawberry|Hostx86[\\/]x86|[\\/]x86[\\/]cl\.exe)" --expected-architecture x64 --expected-generator Ninja --expected-build-type Debug
       - name: Build Windows Debug tests
         shell: pwsh
         run: |
@@ -287,7 +293,12 @@ jobs:
       - name: Run Windows CTest suite
         shell: pwsh
         run: |
-          & "$env:PERASTAGE_PYTHON" .github/scripts/run_and_log.py --log "$env:CI_LOG_DIR\ctest-windows-debug.log" -- ctest --test-dir build-windows-debug --output-on-failure
+          & "$env:PERASTAGE_PYTHON" .github/scripts/run_and_log.py --log "$env:CI_LOG_DIR\ctest-windows-debug.log" -- ctest --test-dir build-windows-debug --output-on-failure --verbose
+      - name: Summarize Windows CTest failures
+        if: ${{ always() }}
+        shell: pwsh
+        run: |
+          & "$env:PERASTAGE_PYTHON" .github/scripts/summarize_ctest_failures.py --platform windows --log "$env:CI_LOG_DIR\ctest-windows-debug.log" --output "$env:CI_LOG_DIR\ctest-windows-debug-failures.csv"
       - name: Upload failure diagnostics
         if: ${{ failure() }}
         uses: actions/upload-artifact@v7
@@ -402,6 +413,9 @@ jobs:
         run: python3 .github/scripts/run_and_log.py --log "$CI_LOG_DIR/build-macos-debug.log" -- cmake --build build/macos-debug --target gdtf_share_security_test credential_store_native_roundtrip_test --verbose
       - name: Run release-gate and macOS tests
         run: python3 .github/scripts/run_and_log.py --log "$CI_LOG_DIR/ctest-macos-debug.log" -- ctest --test-dir build/macos-debug -L release-gate --output-on-failure --verbose
+      - name: Summarize macOS CTest failures
+        if: ${{ always() }}
+        run: python3 .github/scripts/summarize_ctest_failures.py --platform macos --log "$CI_LOG_DIR/ctest-macos-debug.log" --output "$CI_LOG_DIR/ctest-macos-debug-failures.csv"
       - name: Upload failure diagnostics
         if: ${{ failure() }}
         uses: actions/upload-artifact@v7

--- a/core/localization/localization_manager.cpp
+++ b/core/localization/localization_manager.cpp
@@ -126,12 +126,14 @@ std::vector<std::filesystem::path> ResolveLocaleRootCandidates() {
   const auto executablePath =
       WxPathToFilesystemPath(wxStandardPaths::Get().GetExecutablePath());
   const auto workingDirectory = WxPathToFilesystemPath(wxFileName::GetCwd());
-  auto roots = ResolveLocaleRootCandidatesForPaths(executablePath, workingDirectory);
   if (const char *localeRoot = std::getenv("PERASTAGE_LOCALE_ROOT")) {
-    if (*localeRoot)
-      AddUniquePath(roots, std::filesystem::u8path(localeRoot));
+    if (*localeRoot) {
+      std::vector<std::filesystem::path> explicitRoots;
+      AddUniquePath(explicitRoots, std::filesystem::u8path(localeRoot));
+      return explicitRoots;
+    }
   }
-  return roots;
+  return ResolveLocaleRootCandidatesForPaths(executablePath, workingDirectory);
 }
 
 // Returns the process-wide localization manager owned for application lifetime.

--- a/core/trussloader.cpp
+++ b/core/trussloader.cpp
@@ -241,6 +241,14 @@ fs::path BuildGdtfExtractionCacheDirForTesting(const fs::path &gdtfPath) {
   return BuildGdtfExtractionCacheDir(gdtfPath);
 }
 
+// Reports whether a raw truss archive entry resolves safely below a destination root.
+bool IsTrussArchiveEntryTargetSafeForTesting(const std::string &entryName,
+                                             const std::filesystem::path &destinationRoot) {
+  fs::path target;
+  return ResolveArchiveEntryTarget(fs::path("test.gdtf"), destinationRoot.lexically_normal(),
+                                   entryName, target);
+}
+
 // Returns the file dialog wildcard matching the supported truss loader inputs.
 std::string GetTrussDefinitionFileDialogWildcard() {
   return kSupportedTrussFileDialogWildcard;

--- a/core/trussloader.h
+++ b/core/trussloader.h
@@ -29,3 +29,6 @@ bool LoadTrussArchive(const std::string &archivePath, Truss &outTruss);
 bool LoadTrussDefinition(const std::string &path, Truss &outTruss);
 std::filesystem::path BuildGdtfExtractionCacheDirForTesting(
     const std::filesystem::path &gdtfPath);
+
+bool IsTrussArchiveEntryTargetSafeForTesting(const std::string &entryName,
+                                             const std::filesystem::path &destinationRoot);

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -259,6 +259,8 @@ You can also contact the project at **perastage.app@gmail.com**.
 - Fixed embedded Layout 2D fixture symbols so rotated GDTF fixtures choose the visible representative symbol plane and preserve the same orientation in preview and PDF export.
 
 ## Internal changes
+
+- Improved Debug CI reliability by validating CMake toolchain metadata from generated files, declaring Linux test tools and locales explicitly, running Linux CTest under Xvfb, normalizing repository-policy test working directories, and keeping CMake language policy checks focused on first-party source.
 - Strengthened CI release-gate tests so policy scripts are portable without ripgrep and credential metadata checks validate JSON fields without flagging safe backend identifiers.
 - Reorganized GitHub Actions into separate Debug CI, main patch artifact, compatibility package, and transactional minor release workflows, with Debug dependency setup aligned to the pinned vcpkg toolchain and Windows CI preserving the Python and MSVC environments across steps.
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -260,7 +260,7 @@ You can also contact the project at **perastage.app@gmail.com**.
 
 ## Internal changes
 
-- Improved Debug CI reliability by validating CMake toolchain metadata from generated files, declaring Linux test tools and locales explicitly, running Linux CTest under Xvfb, normalizing repository-policy test working directories, and keeping CMake language policy checks focused on first-party source.
+- Improved Debug CI reliability by validating CMake toolchain metadata from generated files, declaring Linux test tools and locales explicitly, running Linux CTest under a verified Xvfb display, bounding non-interactive Windows CTest runs, normalizing repository-policy test working directories, and keeping CMake language policy checks focused on first-party source.
 - Strengthened CI release-gate tests so policy scripts are portable without ripgrep and credential metadata checks validate JSON fields without flagging safe backend identifiers.
 - Reorganized GitHub Actions into separate Debug CI, main patch artifact, compatibility package, and transactional minor release workflows, with Debug dependency setup aligned to the pinned vcpkg toolchain and Windows CI preserving the Python and MSVC environments across steps.
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,22 @@ find_package(CURL REQUIRED)
 
 enable_testing()
 
+function(add_repository_policy_test test_name script_path)
+    set(options)
+    set(oneValueArgs)
+    set(multiValueArgs LABELS ARGS)
+    cmake_parse_arguments(POLICY "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+    add_test(NAME ${test_name}
+             COMMAND ${script_path} ${POLICY_ARGS})
+    set(properties WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
+    if(POLICY_LABELS)
+        list(JOIN POLICY_LABELS ";" labels)
+        list(APPEND properties LABELS "${labels}")
+    endif()
+    set_tests_properties(${test_name} PROPERTIES ${properties})
+endfunction()
+
+
 add_library(perastage_test_diagnostics STATIC
             ../core/apppaths.cpp
             ../core/configservices.cpp
@@ -45,76 +61,46 @@ target_link_libraries(perastage_test_gdtf_archive_reader PRIVATE ${wxWidgets_LIB
 
 find_program(BASH_EXECUTABLE bash)
 if(BASH_EXECUTABLE)
-    add_test(NAME DocsPerastageTreeModules
-             COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_perastage_tree_modules.sh)
-    add_test(NAME GuiNoConfigManagerGet
-             COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_no_configmanager_get_in_gui.sh)
-    add_test(NAME OpenGLLifecycleCentralized
-             COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_opengl_lifecycle_centralized.sh)
-    add_test(NAME Layout2DRasterizationBoundary
-             COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_layout_2d_rasterization_boundary.sh)
-    add_test(NAME Layout2DViewCaptureBoundary
-             COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_layout_2d_view_capture_boundary.sh)
-    add_test(NAME Viewer2DStateOwnershipBoundary
-             COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_viewer2d_state_ownership_boundary.sh)
-    add_test(NAME Viewer2DRenderToRGBAFboBoundary
-             COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_viewer2d_render_to_rgba_fbo_boundary.sh)
-    add_test(NAME Viewer2DFboCaptureDiagnostics
-             COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_viewer2d_fbo_capture_diagnostics.sh)
-    add_test(NAME LayoutPreviewFailureDiagnostics
-             COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_layout_preview_failure_diagnostics.sh)
-    add_test(NAME LayoutProjectLoadCacheReset
-             COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_layout_project_load_cache_reset.sh)
-    add_test(NAME LayoutViewerFitLifecycle
-             COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_layout_viewer_fit_lifecycle.sh)
-    add_test(NAME LibraryUserDataPolicy
-             COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_library_user_data_policy.sh)
-    add_test(NAME DictionaryPathsPolicy
-             COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_dictionary_paths.sh)
-    add_test(NAME GdtfMetadataSummaryBoundary
-             COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_gdtf_metadata_summary_boundary.sh)
-    add_test(NAME GdtfMetadataPanelBoundary
-             COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_gdtf_metadata_panel_boundary.sh)
-    add_test(NAME GdtfReusablePanelsBoundary
-             COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_gdtf_reusable_panels_boundary.sh)
-    add_test(NAME GdtfEditorPanelBoundary
-             COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_gdtf_editor_panel_boundary.sh)
-    add_test(NAME GdtfEditorCoreBoundary
-             COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_gdtf_editor_core_boundary.sh)
-    add_test(NAME GdtfEditorCheckpoint08ABinding
-             COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_gdtf_editor_checkpoint08a_binding.sh)
-    add_test(NAME GdtfEditorCheckpoint08E2ModeBrowser
-             COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_gdtf_editor_checkpoint08e2_mode_browser.sh)
-    add_test(NAME GdtfEditorCheckpoint08E3WheelAttributeInspector
-             COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_gdtf_editor_checkpoint08e3_wheel_attribute_inspector.sh)
-    add_test(NAME ProjectRestoreImportOptions
-             COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_project_restore_import_options.sh)
-    add_test(NAME SecureStoreBuildPolicy
-             COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_securestore_build_policy.sh)
-    set_tests_properties(SecureStoreBuildPolicy PROPERTIES
-                         LABELS "secure-store;security;release-gate"
-                         WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
-    add_test(NAME WindowsNinjaX64Policy
-             COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_windows_ninja_x64_policy.sh)
-    set_tests_properties(WindowsNinjaX64Policy PROPERTIES
-                         LABELS "windows;x64;release-gate"
-                         WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
-    add_test(NAME CiCMakeLanguagePolicy
-             COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_ci_cmake_language_policy.sh)
-    set_tests_properties(CiCMakeLanguagePolicy PROPERTIES
-                         LABELS "ci;cmake;release-gate"
-                         WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
-    add_test(NAME ReleaseGatePolicyPortability
-             COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_release_gate_policy_portability.sh)
-    set_tests_properties(ReleaseGatePolicyPortability PROPERTIES
-                         LABELS "ci;policy;release-gate"
-                         WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
+    add_repository_policy_test(DocsPerastageTreeModules ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_perastage_tree_modules.sh)
+    add_repository_policy_test(GuiNoConfigManagerGet ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_no_configmanager_get_in_gui.sh)
+    add_repository_policy_test(OpenGLLifecycleCentralized ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_opengl_lifecycle_centralized.sh)
+    add_repository_policy_test(Layout2DRasterizationBoundary ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_layout_2d_rasterization_boundary.sh)
+    add_repository_policy_test(Layout2DViewCaptureBoundary ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_layout_2d_view_capture_boundary.sh)
+    add_repository_policy_test(Viewer2DStateOwnershipBoundary ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_viewer2d_state_ownership_boundary.sh)
+    add_repository_policy_test(Viewer2DRenderToRGBAFboBoundary ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_viewer2d_render_to_rgba_fbo_boundary.sh)
+    add_repository_policy_test(Viewer2DFboCaptureDiagnostics ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_viewer2d_fbo_capture_diagnostics.sh)
+    add_repository_policy_test(LayoutPreviewFailureDiagnostics ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_layout_preview_failure_diagnostics.sh)
+    add_repository_policy_test(LayoutProjectLoadCacheReset ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_layout_project_load_cache_reset.sh)
+    add_repository_policy_test(LayoutViewerFitLifecycle ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_layout_viewer_fit_lifecycle.sh)
+    add_repository_policy_test(LibraryUserDataPolicy ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_library_user_data_policy.sh)
+    add_repository_policy_test(DictionaryPathsPolicy ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_dictionary_paths.sh)
+    add_repository_policy_test(GdtfMetadataSummaryBoundary ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_gdtf_metadata_summary_boundary.sh)
+    add_repository_policy_test(GdtfMetadataPanelBoundary ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_gdtf_metadata_panel_boundary.sh)
+    add_repository_policy_test(GdtfReusablePanelsBoundary ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_gdtf_reusable_panels_boundary.sh)
+    add_repository_policy_test(GdtfEditorPanelBoundary ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_gdtf_editor_panel_boundary.sh)
+    add_repository_policy_test(GdtfEditorCoreBoundary ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_gdtf_editor_core_boundary.sh)
+    add_repository_policy_test(GdtfEditorCheckpoint08ABinding ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_gdtf_editor_checkpoint08a_binding.sh)
+    add_repository_policy_test(GdtfEditorCheckpoint08E2ModeBrowser ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_gdtf_editor_checkpoint08e2_mode_browser.sh)
+    add_repository_policy_test(GdtfEditorCheckpoint08E3WheelAttributeInspector ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_gdtf_editor_checkpoint08e3_wheel_attribute_inspector.sh)
+    add_repository_policy_test(ProjectRestoreImportOptions ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_project_restore_import_options.sh)
+    add_repository_policy_test(SecureStoreBuildPolicy ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_securestore_build_policy.sh LABELS secure-store security release-gate)
+    add_repository_policy_test(WindowsNinjaX64Policy ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_windows_ninja_x64_policy.sh LABELS windows x64 release-gate)
+    add_repository_policy_test(CiCMakeLanguagePolicy ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_ci_cmake_language_policy.sh LABELS ci cmake release-gate)
+    add_repository_policy_test(ReleaseGatePolicyPortability ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_release_gate_policy_portability.sh LABELS ci policy release-gate)
 endif()
 
 find_package(Python3 COMPONENTS Interpreter)
 if(Python3_Interpreter_FOUND)
-    add_test(NAME DocsLinks
-             COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_docs_links.py)
+    add_repository_policy_test(DocsLinks ${Python3_EXECUTABLE}
+                               ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_docs_links.py)
+    add_repository_policy_test(CMakeToolchainValidator ${Python3_EXECUTABLE}
+                               ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_validate_cmake_toolchain.py)
+    add_repository_policy_test(CiCMakeLanguagePolicyFixtures ${Python3_EXECUTABLE}
+                               ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_ci_cmake_language_policy_fixtures.py)
+    add_repository_policy_test(PolicyWorkingDirectories ${Python3_EXECUTABLE}
+                               ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_policy_working_directories.py)
+    add_repository_policy_test(MissingRipgrepBehavior ${Python3_EXECUTABLE}
+                               ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_missing_ripgrep_behavior.py)
 endif()
 
 link_libraries(perastage_test_active_dictionary_storage)
@@ -435,6 +421,7 @@ add_executable(project_fixture_gdtf_apply_adapter_test
 target_include_directories(project_fixture_gdtf_apply_adapter_test PRIVATE .. ../core ../models)
 add_test(NAME ProjectFixtureGdtfApplyAdapter COMMAND project_fixture_gdtf_apply_adapter_test)
 add_test(NAME GdtfEditorCheckpoint08BFixtureApplyAdapter COMMAND ${CMAKE_SOURCE_DIR}/tests/check_gdtf_editor_checkpoint08b_fixture_apply_adapter.sh)
+set_tests_properties(GdtfEditorCheckpoint08BFixtureApplyAdapter PROPERTIES WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
 add_executable(project_truss_gdtf_apply_adapter_test
                project_truss_gdtf_apply_adapter_test.cpp
                ../core/gdtf/editor/project_truss_gdtf_apply_adapter.cpp
@@ -445,7 +432,9 @@ add_executable(project_truss_gdtf_apply_adapter_test
 target_include_directories(project_truss_gdtf_apply_adapter_test PRIVATE .. ../core ../models)
 add_test(NAME ProjectTrussGdtfApplyAdapter COMMAND project_truss_gdtf_apply_adapter_test)
 add_test(NAME GdtfEditorCheckpoint08CTrussApplyAdapter COMMAND ${CMAKE_SOURCE_DIR}/tests/check_gdtf_editor_checkpoint08c_truss_apply_adapter.sh)
+set_tests_properties(GdtfEditorCheckpoint08CTrussApplyAdapter PROPERTIES WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
 add_test(NAME GdtfEditorCheckpoint08DStabilization COMMAND ${CMAKE_SOURCE_DIR}/tests/check_gdtf_editor_checkpoint08d_stabilization.sh)
+set_tests_properties(GdtfEditorCheckpoint08DStabilization PROPERTIES WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
 
 add_executable(gdtf_editor_context_test
                gdtf_editor_context_test.cpp
@@ -1615,6 +1604,7 @@ target_include_directories(fixture_symbol_projection_test PRIVATE
                            ../viewer3d ../viewer3d/render ../viewer2d ../models)
 add_test(NAME FixtureSymbolProjection COMMAND fixture_symbol_projection_test)
 add_test(NAME FixtureSymbolProjectionParity COMMAND ${CMAKE_SOURCE_DIR}/tests/check_fixture_symbol_projection_parity.sh)
+set_tests_properties(FixtureSymbolProjectionParity PROPERTIES WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
 
 add_executable(meshprimitives_cube_normals_test meshprimitives_cube_normals_test.cpp
                ../viewer3d/meshprimitives.cpp)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -101,6 +101,8 @@ if(Python3_Interpreter_FOUND)
                                ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_policy_working_directories.py)
     add_repository_policy_test(MissingRipgrepBehavior ${Python3_EXECUTABLE}
                                ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_missing_ripgrep_behavior.py)
+    add_repository_policy_test(CtestFailureSummary ${Python3_EXECUTABLE}
+                               ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_summarize_ctest_failures.py)
 endif()
 
 link_libraries(perastage_test_active_dictionary_storage)

--- a/tests/check_ci_cmake_language_policy.sh
+++ b/tests/check_ci_cmake_language_policy.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
-repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+repo_root="${PERASTAGE_POLICY_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 cd "$repo_root"
 
 python3 - <<'PY'
 from pathlib import Path
 import re
 
-root = Path('CMakeLists.txt').read_text()
+root_path = Path('CMakeLists.txt')
+root = root_path.read_text()
 project_match = re.search(r'project\s*\((.*?)\)', root, re.S)
 if not project_match:
     raise SystemExit('Root CMakeLists.txt does not declare project().')
@@ -17,11 +18,24 @@ if 'LANGUAGES C CXX' not in project_body:
 if 'CMP0177' not in root or 'cmake_policy(SET CMP0177 NEW)' not in root:
     raise SystemExit('Root CMakeLists.txt must set CMP0177 to NEW behind a policy guard.')
 
-tests_cmake = Path('tests/CMakeLists.txt').read_text()
-if re.search(r'(?m)^\s*(project|enable_language)\s*\(', tests_cmake):
-    raise SystemExit('tests/CMakeLists.txt must not unconditionally call project() or enable_language().')
+excluded_roots = {'.git', '.vcpkg-cache', 'vcpkg', 'build', 'out', 'third_party'}
+excluded_prefixes = ('build-', 'cmake-build-')
 
-all_cmake = [p for p in Path('.').rglob('CMakeLists.txt') if '.git' not in p.parts and p != Path('CMakeLists.txt')]
+def is_first_party_cmake(path: Path) -> bool:
+    parts = path.parts
+    if any(part in excluded_roots for part in parts):
+        return False
+    if any(part.startswith(excluded_prefixes) for part in parts):
+        return False
+    return True
+
+tests_cmake = Path('tests/CMakeLists.txt')
+if tests_cmake.exists():
+    text = tests_cmake.read_text()
+    if re.search(r'(?m)^\s*(project|enable_language)\s*\(', text):
+        raise SystemExit('tests/CMakeLists.txt must not unconditionally call project() or enable_language().')
+
+all_cmake = [p for p in Path('.').rglob('CMakeLists.txt') if p != Path('CMakeLists.txt') and is_first_party_cmake(p)]
 for path in all_cmake:
     text = path.read_text(errors='ignore')
     if re.search(r'(?m)^\s*enable_language\s*\(', text):
@@ -32,6 +46,7 @@ required_windows = [
     'VsDevCmd.bat', '-host_arch=x64 -arch=x64', 'CMAKE_C_COMPILER=cl.exe',
     'CMAKE_CXX_COMPILER=cl.exe', 'VCPKG_TARGET_TRIPLET=x64-windows',
     'CMakeConfigureLog.yaml', 'cmake-configure-windows-debug.log',
+    'validate_cmake_toolchain.py',
 ]
 for needle in required_windows:
     if needle not in ci:

--- a/tests/check_ci_cmake_language_policy_fixtures.py
+++ b/tests/check_ci_cmake_language_policy_fixtures.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import os
+import shutil
+import subprocess
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / 'tests/check_ci_cmake_language_policy.sh'
+needed = ['.github/workflows/ci-tests.yml', '.github/workflows/windows-installer.yml', '.github/workflows/linux-installer.yml', '.github/workflows/macos-installer.yml', '.github/workflows/macos-15-manual-installer.yml', '.github/workflows/arch-package.yml']
+
+with tempfile.TemporaryDirectory() as tmp:
+    repo = Path(tmp) / 'repo'
+    for rel in needed:
+        target = repo / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(ROOT / rel, target)
+    (repo / 'CMakeLists.txt').write_text('cmake_minimum_required(VERSION 3.25)\nif(POLICY CMP0177)\ncmake_policy(SET CMP0177 NEW)\nendif()\nproject(Perastage LANGUAGES C CXX)\n')
+    (repo / 'tests').mkdir()
+    (repo / 'tests/CMakeLists.txt').write_text('add_test(NAME Example COMMAND example)\n')
+    (repo / 'vcpkg/buildtrees/liblzma').mkdir(parents=True)
+    (repo / 'vcpkg/buildtrees/liblzma/CMakeLists.txt').write_text('enable_language(C)\n')
+    env = {**os.environ, 'PERASTAGE_POLICY_ROOT': str(repo)}
+    ok = subprocess.run(['bash', str(SCRIPT)], env=env, text=True, capture_output=True)
+    assert ok.returncode == 0, ok.stderr + ok.stdout
+    (repo / 'cmake').mkdir()
+    (repo / 'cmake/CMakeLists.txt').write_text('enable_language(C)\n')
+    bad = subprocess.run(['bash', str(SCRIPT)], env=env, text=True, capture_output=True)
+    assert bad.returncode != 0 and 'Nested enable_language()' in (bad.stderr + bad.stdout), bad.stderr + bad.stdout
+print('OK: CMake language policy fixtures cover first-party failures and vcpkg exclusions.')

--- a/tests/check_ci_workflow_architecture.py
+++ b/tests/check_ci_workflow_architecture.py
@@ -28,12 +28,12 @@ for platform, text in sections.items():
     assert 'run_and_log.py --log' in text and 'ctest-' in text, f'{platform} build and test logs must be captured'
 
 linux = sections['linux']
-for needle in ['-DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"', '-DVCPKG_TARGET_TRIPLET=x64-linux', '-DVCPKG_INSTALLED_DIR="$VCPKG_INSTALLED"', '-DCMAKE_EXPORT_COMPILE_COMMANDS=ON', 'compile_commands.json was not generated']:
+for needle in ['-DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"', '-DVCPKG_TARGET_TRIPLET=x64-linux', '-DVCPKG_INSTALLED_DIR="$VCPKG_INSTALLED"', '-DCMAKE_EXPORT_COMPILE_COMMANDS=ON', 'compile_commands.json was not generated', 'ripgrep', 'xvfb', 'locales', 'es_ES.UTF-8', 'xvfb-run -a', '--verbose']:
     assert needle in linux, f'Linux Debug is missing {needle}'
 assert 'wxwidgets' not in linux.lower(), 'Linux Debug must not install system wxWidgets packages'
 
 windows = sections['windows']
-for needle in ['$env:GITHUB_ENV', '$env:GITHUB_PATH', 'PERASTAGE_PYTHON', 'Get-Command python', 'INCLUDE', 'LIBPATH', 'VSCMD_ARG_HOST_ARCH', 'VSCMD_ARG_TGT_ARCH', 'CMAKE_C_COMPILER_ID:INTERNAL=MSVC', 'CMAKE_CXX_COMPILER_ID:INTERNAL=MSVC']:
+for needle in ['$env:GITHUB_ENV', '$env:GITHUB_PATH', 'PERASTAGE_PYTHON', 'Get-Command python', 'INCLUDE', 'LIBPATH', 'VSCMD_ARG_HOST_ARCH', 'VSCMD_ARG_TGT_ARCH', 'validate_cmake_toolchain.py', '--expected-c-id MSVC', '--expected-cxx-id MSVC']:
     assert needle in windows, f'Windows Debug environment persistence is missing {needle}'
 assert windows.index('Persist Visual Studio Hostx64 x64 environment') < windows.index('Configure Windows Debug tests') < windows.index('Build Windows Debug tests')
 

--- a/tests/check_ci_workflow_architecture.py
+++ b/tests/check_ci_workflow_architecture.py
@@ -25,15 +25,15 @@ for platform, text in sections.items():
     assert text.index('Prepare vcpkg and diagnostics directories') < text.index('Bootstrap vcpkg'), f'{platform} must create vcpkg directories before bootstrap'
     assert 'VCPKG_DOWNLOADS' in text and 'VCPKG_INSTALLED' in text and 'VCPKG_PACKAGES' in text and 'VCPKG_BINARY_CACHE' in text, f'{platform} must prepare all vcpkg directories'
     assert 'debug-v1' in text or 'macos-26-xcode-26-debug-v1' in text, f'{platform} installed cache key must be Debug/toolchain scoped'
-    assert 'run_and_log.py --log' in text and 'ctest-' in text, f'{platform} build and test logs must be captured'
+    assert ('run_and_log.py --log' in text or '--output-log' in text) and 'ctest-' in text, f'{platform} build and test logs must be captured'
 
 linux = sections['linux']
-for needle in ['-DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"', '-DVCPKG_TARGET_TRIPLET=x64-linux', '-DVCPKG_INSTALLED_DIR="$VCPKG_INSTALLED"', '-DCMAKE_EXPORT_COMPILE_COMMANDS=ON', 'compile_commands.json was not generated', 'ripgrep', 'xvfb', 'locales', 'es_ES.UTF-8', 'xvfb-run -a', '--verbose']:
+for needle in ['-DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"', '-DVCPKG_TARGET_TRIPLET=x64-linux', '-DVCPKG_INSTALLED_DIR="$VCPKG_INSTALLED"', '-DCMAKE_EXPORT_COMPILE_COMMANDS=ON', 'compile_commands.json was not generated', 'ripgrep', 'xvfb', 'locales', 'es_ES.UTF-8', 'zh_CN.UTF-8', 'xauth', 'x11-utils', 'xdpyinfo', 'xvfb-run -a', '--output-junit', '--verbose']:
     assert needle in linux, f'Linux Debug is missing {needle}'
 assert 'wxwidgets' not in linux.lower(), 'Linux Debug must not install system wxWidgets packages'
 
 windows = sections['windows']
-for needle in ['$env:GITHUB_ENV', '$env:GITHUB_PATH', 'PERASTAGE_PYTHON', 'Get-Command python', 'INCLUDE', 'LIBPATH', 'VSCMD_ARG_HOST_ARCH', 'VSCMD_ARG_TGT_ARCH', 'validate_cmake_toolchain.py', '--expected-c-id MSVC', '--expected-cxx-id MSVC']:
+for needle in ['$env:GITHUB_ENV', '$env:GITHUB_PATH', 'PERASTAGE_PYTHON', 'Get-Command python', 'INCLUDE', 'LIBPATH', 'VSCMD_ARG_HOST_ARCH', 'VSCMD_ARG_TGT_ARCH', 'validate_cmake_toolchain.py', '--expected-c-id MSVC', '--expected-cxx-id MSVC', '--interactive-debug-mode 0', '--timeout 120', '--output-junit', 'timeout-minutes: 180']:
     assert needle in windows, f'Windows Debug environment persistence is missing {needle}'
 assert windows.index('Persist Visual Studio Hostx64 x64 environment') < windows.index('Configure Windows Debug tests') < windows.index('Build Windows Debug tests')
 

--- a/tests/check_dictionary_bundle_transactional_import.sh
+++ b/tests/check_dictionary_bundle_transactional_import.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/test_tool_requirements.sh"
+require_ripgrep
 
 prepare_body=$(python3 - <<'PY'
 from pathlib import Path

--- a/tests/check_dictionary_core_services_no_wx.sh
+++ b/tests/check_dictionary_core_services_no_wx.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/test_tool_requirements.sh"
+require_ripgrep
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"

--- a/tests/check_dictionary_paths.sh
+++ b/tests/check_dictionary_paths.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/test_tool_requirements.sh"
+require_ripgrep
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"

--- a/tests/check_force_bottom_view_scope.sh
+++ b/tests/check_force_bottom_view_scope.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/test_tool_requirements.sh"
+require_ripgrep
 
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$repo_root"

--- a/tests/check_gdtf_editor_checkpoint08a_binding.sh
+++ b/tests/check_gdtf_editor_checkpoint08a_binding.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/test_tool_requirements.sh"
+require_ripgrep
 
 fixture_header="gui/fixtureeditdialog.h"
 fixture_source="gui/fixtureeditdialog.cpp"

--- a/tests/check_gdtf_editor_checkpoint08d_stabilization.sh
+++ b/tests/check_gdtf_editor_checkpoint08d_stabilization.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/test_tool_requirements.sh"
+require_ripgrep
 cd "$(dirname "$0")/.."
 python3 - <<'PY'
 from pathlib import Path

--- a/tests/check_gdtf_editor_checkpoint08e1_layout.sh
+++ b/tests/check_gdtf_editor_checkpoint08e1_layout.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/test_tool_requirements.sh"
+require_ripgrep
 
 python3 - <<'PY'
 from pathlib import Path

--- a/tests/check_gdtf_editor_checkpoint08e2_mode_browser.sh
+++ b/tests/check_gdtf_editor_checkpoint08e2_mode_browser.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/test_tool_requirements.sh"
+require_ripgrep
 python3 - <<'PY'
 from pathlib import Path
 

--- a/tests/check_gdtf_editor_checkpoint08e2_mode_browser.sh
+++ b/tests/check_gdtf_editor_checkpoint08e2_mode_browser.sh
@@ -35,7 +35,7 @@ require('GeometryReference' in core and 'DMXOffset' in core and 'geometryReferen
 for col in ['Item', 'DMX range', 'Physical range', 'Unit']:
     require(col in modes, f'Missing browser column {col}.')
 require('Channel function' not in modes, 'Mode browser must not expose the removed Channel function column.')
-require('detailsCtrl' in modes_h + modes and 'UpdateDetails' in modes, 'Details inspector must exist.')
+require('inspectionMappingLabel' in modes_h + modes and 'UpdateDetails' in modes and 'selectedInspectionDetails' in modes_h + modes, 'Structured DMX inspection details must exist.')
 summary = Path('gui/gdtf/gdtf_channel_summary_panel.cpp').read_text()
 editor = Path('gui/gdtf/gdtf_editor_panel.cpp').read_text()
 require('wxTE_MULTILINE | wxTE_READONLY' in summary and 'channelSummaryPanel' in editor, 'Legacy quick channel summary panel must be restored below physical properties.')

--- a/tests/check_gdtf_editor_checkpoint08e3_wheel_attribute_inspector.sh
+++ b/tests/check_gdtf_editor_checkpoint08e3_wheel_attribute_inspector.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/test_tool_requirements.sh"
+require_ripgrep
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 require_file() { test -f "$root/$1" || { echo "missing $1" >&2; exit 1; }; }
 require_rg() { rg -q "$1" "$root/$2" || { echo "missing pattern $1 in $2" >&2; exit 1; }; }

--- a/tests/check_gdtf_editor_core_boundary.sh
+++ b/tests/check_gdtf_editor_core_boundary.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/test_tool_requirements.sh"
+require_ripgrep
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 editor_dir="$repo_root/core/gdtf/editor"

--- a/tests/check_gdtf_editor_panel_boundary.sh
+++ b/tests/check_gdtf_editor_panel_boundary.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/test_tool_requirements.sh"
+require_ripgrep
 
 panel_header="gui/gdtf/gdtf_editor_panel.h"
 panel_source="gui/gdtf/gdtf_editor_panel.cpp"

--- a/tests/check_gdtf_metadata_panel_boundary.sh
+++ b/tests/check_gdtf_metadata_panel_boundary.sh
@@ -65,8 +65,23 @@ if rg -q "configmanager|guiconfigservices|FixtureTablePanel|TrussTablePanel|view
   echo "GdtfMetadataPanel must not depend on project, table, viewer, mutation, or editor-session services." >&2
   exit 1
 fi
-if ! rg -q "wxTE_MULTILINE \| wxTE_READONLY" "$panel_source"; then
-  echo "Description control must remain multiline and read-only." >&2
+if ! rg -q "wxTE_MULTILINE" "$panel_source"; then
+  echo "Description control must remain multiline." >&2
+  exit 1
+fi
+if ! rg -q "SetDescriptionEditable" "$panel_header" "$panel_source" || \
+   ! rg -q "SetDescriptionChangeCallback" "$panel_header" "$panel_source" || \
+   ! rg -q "if (updating || !descriptionChangeCallback || !descriptionCtrl)" "$panel_source"; then
+  echo "Description editability must be controlled through the public panel API without callbacks during programmatic updates." >&2
+  exit 1
+fi
+if ! rg -q "metadataPanel->SetDescriptionEditable" gui/gdtf/gdtf_editor_panel.cpp || \
+   ! rg -q "metadataPanel->SetDescriptionChangeCallback" gui/gdtf/gdtf_editor_panel.cpp; then
+  echo "GdtfEditorPanel must be the host-facing metadata description editing boundary." >&2
+  exit 1
+fi
+if ! rg -q "SetEditable\(editable\)" "$panel_source"; then
+  echo "Read-only mode must remain selectable through SetDescriptionEditable(false)." >&2
   exit 1
 fi
 

--- a/tests/check_gdtf_metadata_panel_boundary.sh
+++ b/tests/check_gdtf_metadata_panel_boundary.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/test_tool_requirements.sh"
+require_ripgrep
 
 panel_header="gui/gdtf/gdtf_metadata_panel.h"
 panel_source="gui/gdtf/gdtf_metadata_panel.cpp"

--- a/tests/check_gdtf_metadata_summary_boundary.sh
+++ b/tests/check_gdtf_metadata_summary_boundary.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/test_tool_requirements.sh"
+require_ripgrep
 
 file="core/gdtf_metadata_summary.cpp"
 if rg -n "wxZip|zipstrm|GetNextEntry|description\.xml" "$file" >/dev/null; then

--- a/tests/check_gdtf_reusable_panels_boundary.sh
+++ b/tests/check_gdtf_reusable_panels_boundary.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/test_tool_requirements.sh"
+require_ripgrep
 
 panel_files=(
   gui/gdtf/gdtf_physical_properties_panel.h

--- a/tests/check_layout_2d_rasterization_boundary.sh
+++ b/tests/check_layout_2d_rasterization_boundary.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/test_tool_requirements.sh"
+require_ripgrep
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 panel_file="$repo_root/gui/layoutviewerpanel.cpp"

--- a/tests/check_layout_2d_view_capture_boundary.sh
+++ b/tests/check_layout_2d_view_capture_boundary.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/test_tool_requirements.sh"
+require_ripgrep
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 panel_file="$repo_root/gui/layoutviewerpanel_view.cpp"

--- a/tests/check_layout_preview_failure_diagnostics.sh
+++ b/tests/check_layout_preview_failure_diagnostics.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/test_tool_requirements.sh"
+require_ripgrep
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 rasterizer_header="$repo_root/gui/layout_2d_view_rasterizer.h"

--- a/tests/check_layout_project_load_cache_reset.sh
+++ b/tests/check_layout_project_load_cache_reset.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/test_tool_requirements.sh"
+require_ripgrep
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 panel_cpp="$repo_root/gui/layoutviewerpanel.cpp"

--- a/tests/check_layout_viewer_fit_lifecycle.sh
+++ b/tests/check_layout_viewer_fit_lifecycle.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/test_tool_requirements.sh"
+require_ripgrep
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 panel_cpp="$repo_root/gui/layoutviewerpanel.cpp"

--- a/tests/check_library_user_data_policy.sh
+++ b/tests/check_library_user_data_policy.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/test_tool_requirements.sh"
+require_ripgrep
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 

--- a/tests/check_missing_ripgrep_behavior.py
+++ b/tests/check_missing_ripgrep_behavior.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import os
+import subprocess
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / 'tests/check_perastage_tree_modules.sh'
+with tempfile.TemporaryDirectory() as tmp:
+    bin_dir = Path(tmp) / 'bin'
+    bin_dir.mkdir()
+    for tool in ['bash', 'dirname']:
+        os.symlink(f'/usr/bin/{tool}', bin_dir / tool)
+    env = {**os.environ, 'PATH': str(bin_dir)}
+    result = subprocess.run(['/usr/bin/bash', str(SCRIPT)], env=env, text=True, capture_output=True)
+    assert result.returncode == 127, result.stdout + result.stderr
+    assert "required test tool 'rg'" in result.stderr, result.stdout + result.stderr
+print('OK: ripgrep-dependent policy scripts fail clearly when rg is missing.')

--- a/tests/check_named_table_column_access.sh
+++ b/tests/check_named_table_column_access.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/test_tool_requirements.sh"
+require_ripgrep
 
 readonly files=(
   gui/sceneobjecttablepanel.cpp

--- a/tests/check_no_configmanager_get_in_gui.sh
+++ b/tests/check_no_configmanager_get_in_gui.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/test_tool_requirements.sh"
+require_ripgrep
 
 if rg "ConfigManager::Get\(" gui -n; then
   echo "Found forbidden direct ConfigManager::Get() usages in gui/." >&2

--- a/tests/check_opengl_lifecycle_centralized.sh
+++ b/tests/check_opengl_lifecycle_centralized.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/test_tool_requirements.sh"
+require_ripgrep
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"

--- a/tests/check_perastage_tree_modules.sh
+++ b/tests/check_perastage_tree_modules.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/test_tool_requirements.sh"
+require_ripgrep
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TREE_DOC="$ROOT_DIR/docs/developer/perastage_tree.md"

--- a/tests/check_policy_working_directories.py
+++ b/tests/check_policy_working_directories.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import subprocess
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = [
+    ROOT / 'tests/check_securestore_build_policy.sh',
+    ROOT / 'tests/check_ci_cmake_language_policy.sh',
+]
+
+with tempfile.TemporaryDirectory() as tmp:
+    build = ROOT / 'build' / 'policy-working-directory-regression'
+    build.mkdir(parents=True, exist_ok=True)
+    for cwd in [ROOT, build, Path(tmp)]:
+        for script in SCRIPTS:
+            result = subprocess.run(['bash', str(script)], cwd=cwd, text=True, capture_output=True)
+            assert result.returncode == 0, f'{script.name} failed from {cwd}:\n{result.stdout}\n{result.stderr}'
+print('OK: representative policy scripts resolve repository paths from root, build, and temporary working directories.')

--- a/tests/check_project_restore_import_options.sh
+++ b/tests/check_project_restore_import_options.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/test_tool_requirements.sh"
+require_ripgrep
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 config_manager="$repo_root/core/configmanager.cpp"
 

--- a/tests/check_summarize_ctest_failures.py
+++ b/tests/check_summarize_ctest_failures.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import csv
+import subprocess
+import sys
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[1]
+TOOL = ROOT / '.github/scripts/summarize_ctest_failures.py'
+
+with tempfile.TemporaryDirectory() as tmp:
+    base = Path(tmp)
+    junit = base / 'ctest.junit.xml'
+    log = base / 'ctest.log'
+    last = base / 'LastTestsFailed.log'
+    out = base / 'summary.csv'
+    junit.write_text('''<testsuite tests="3" failures="2" errors="1">
+<testcase name="NormalFailed"><failure message="***Failed">Expected A actual B</failure></testcase>
+<testcase name="Aborted"><error message="Subprocess aborted***Exception">Assertion failed in child</error></testcase>
+<testcase name="TimedOut"><failure message="Timeout">Test timeout reached</failure></testcase>
+</testsuite>''')
+    log.write_text('''    Start 4: SegfaultTest
+4/5 Test #4: SegfaultTest ...***SEGFAULT  0.01 sec
+Segmentation fault
+    Start 5: CancelledTest
+Test command: app
+Cancellation requested by runner
+''')
+    last.write_text('''1:NormalFailed
+2:Aborted
+3:TimedOut
+4:SegfaultTest
+5:LaunchFailure
+''')
+    subprocess.run([sys.executable, str(TOOL), '--platform', 'linux', '--junit', str(junit), '--log', str(log), '--last-tests-failed', str(last), '--output', str(out)], check=True)
+    rows = list(csv.DictReader(out.open()))
+    names = {row['test'] for row in rows}
+    assert {'NormalFailed', 'Aborted', 'TimedOut', 'SegfaultTest', 'LaunchFailure', 'CancelledTest'} <= names, rows
+    by_name = {row['test']: row for row in rows}
+    assert 'Expected A actual B' in by_name['NormalFailed']['first_failure_line']
+    assert 'Assertion failed' in by_name['Aborted']['first_failure_line']
+    assert 'Segmentation fault' in by_name['SegfaultTest']['first_failure_line']
+    assert by_name['LaunchFailure']['first_failure_line'] == 'listed in LastTestsFailed.log'
+    assert by_name['CancelledTest']['status'] == 'interrupted'
+print('OK: CTest failure summary covers JUnit, log fallback, crashes, timeouts, and LastTestsFailed entries.')

--- a/tests/check_validate_cmake_toolchain.py
+++ b/tests/check_validate_cmake_toolchain.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[1]
+TOOL = ROOT / '.github/scripts/validate_cmake_toolchain.py'
+
+
+def write_layout(root: Path, version: str, compiler_root: str) -> None:
+    (root / 'CMakeFiles' / version).mkdir(parents=True)
+    (root / 'CMakeCache.txt').write_text('\n'.join([
+        'CMAKE_GENERATOR:INTERNAL=Ninja',
+        'CMAKE_BUILD_TYPE:STRING=Debug',
+        f'CMAKE_C_COMPILER:FILEPATH={compiler_root}/cl.exe',
+        f'CMAKE_CXX_COMPILER:FILEPATH={compiler_root}/cl.exe',
+    ]))
+    for lang, name in [('C', 'C'), ('CXX', 'CXX')]:
+        (root / 'CMakeFiles' / version / f'CMake{name}Compiler.cmake').write_text('\n'.join([
+            f'set(CMAKE_{lang}_COMPILER_ID MSVC)',
+            f'set(CMAKE_{lang}_COMPILER_ARCHITECTURE_ID x64)',
+        ]))
+
+
+def run(args, cwd=None):
+    return subprocess.run([sys.executable, str(TOOL), *args], cwd=cwd, text=True, capture_output=True)
+
+with tempfile.TemporaryDirectory() as tmp:
+    base = Path(tmp)
+    for version in ['3.29.0', '4.4.0']:
+        build = base / f'build {version}'
+        compiler = 'C:/Program Files/Microsoft Visual Studio/VC/Tools/MSVC/14.44/bin/Hostx64/x64'
+        write_layout(build, version, compiler)
+        result = run(['--build-dir', str(build), '--expected-c-id', 'MSVC', '--expected-cxx-id', 'MSVC', '--expected-compiler-path-regex', r'Hostx64/x64', '--forbidden-compiler-path-regex', r'(mingw|msys|strawberry|Hostx86/x86)', '--expected-architecture', 'x64', '--expected-generator', 'Ninja', '--expected-build-type', 'Debug'])
+        assert result.returncode == 0, result.stderr + result.stdout
+    bad = base / 'bad'
+    write_layout(bad, '4.4.0', 'C:/msys64/mingw64/bin')
+    result = run(['--build-dir', str(bad), '--expected-c-id', 'MSVC', '--expected-cxx-id', 'MSVC', '--forbidden-compiler-path-regex', r'(mingw|msys|strawberry)'])
+    assert result.returncode != 0, result.stdout
+print('OK: CMake toolchain validator covers CMake 3.x, CMake 4.x, spaces, and forbidden paths.')

--- a/tests/check_viewer2d_fbo_capture_diagnostics.sh
+++ b/tests/check_viewer2d_fbo_capture_diagnostics.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/test_tool_requirements.sh"
+require_ripgrep
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 panel_cpp="$repo_root/viewer2d/viewer2dpanel.cpp"

--- a/tests/check_viewer2d_render_to_rgba_fbo_boundary.sh
+++ b/tests/check_viewer2d_render_to_rgba_fbo_boundary.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/test_tool_requirements.sh"
+require_ripgrep
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 panel_cpp="$repo_root/viewer2d/viewer2dpanel.cpp"

--- a/tests/check_viewer2d_state_ownership_boundary.sh
+++ b/tests/check_viewer2d_state_ownership_boundary.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/test_tool_requirements.sh"
+require_ripgrep
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 doc_file="$repo_root/docs/developer/technical-notes/viewer2d_state_ownership.md"

--- a/tests/editable_focus_utils_test.cpp
+++ b/tests/editable_focus_utils_test.cpp
@@ -11,19 +11,57 @@
 
 namespace {
 
+class FocusTestApp : public wxApp {
+public:
+  // Initializes the minimal wx application used by the focus utility test.
+  bool OnInit() override { return true; }
+};
+
+wxIMPLEMENT_APP_NO_MAIN(FocusTestApp);
+
 class CustomTextEditor : public wxTextCtrl {
 public:
+  // Creates a custom text editor used to verify derived editable controls.
   CustomTextEditor(wxWindow *parent, wxWindowID id)
       : wxTextCtrl(parent, id) {}
 };
 
+class WxAppScope {
+public:
+  // Starts a GUI-capable wxWidgets application lifetime for GTK widget creation.
+  WxAppScope() {
+    int argc = 0;
+    char **argv = nullptr;
+    started_ = wxEntryStart(argc, argv);
+    if (started_ && wxTheApp)
+      initialized_ = wxTheApp->CallOnInit();
+  }
+
+  // Cleans up the wxWidgets application lifetime started for the test.
+  ~WxAppScope() {
+    if (initialized_ && wxTheApp)
+      wxTheApp->OnExit();
+    if (started_)
+      wxEntryCleanup();
+  }
+
+  // Reports whether wxWidgets is ready for GUI widget creation.
+  bool IsOk() const { return started_ && initialized_; }
+
+private:
+  bool started_ = false;
+  bool initialized_ = false;
+};
+
+// Returns the condition value with a named helper for breakpoint-friendly checks.
 bool Expect(bool condition) { return condition; }
 
 } // namespace
 
+// Verifies editable focus detection across native wxWidgets control types.
 int main() {
-  wxInitializer initializer;
-  if (!initializer.IsOk())
+  WxAppScope app;
+  if (!app.IsOk())
     return 1;
 
   wxFrame frame(nullptr, wxID_ANY, "focus-test");

--- a/tests/gdtf_share_security_test.cpp
+++ b/tests/gdtf_share_security_test.cpp
@@ -178,7 +178,7 @@ void TestCredentialStorage() {
     const auto metadata = nlohmann::json::parse(in);
     assert(metadata.is_object());
     assert(metadata.size() == 4);
-    assert(metadata.at("schema_version") == 1);
+    assert(metadata.at("schema_version") == CredentialStore::kGdtfCredentialMetadataSchemaVersion);
     assert(metadata.at("backend") == "wx_secret_store");
     assert(metadata.at("service") == CredentialStore::kGdtfShareCredentialService);
     assert(metadata.at("username") == username);

--- a/tests/layout_image_resource_registry_test.cpp
+++ b/tests/layout_image_resource_registry_test.cpp
@@ -79,10 +79,11 @@ int main() {
   firstImage.imagePath = usedImage.string();
   assert(manager.UpdateLayoutImage(layoutName, firstImage));
 
-  const auto &storedFirstImage = manager.GetLayouts().Items().front().imageViews.front();
-  assert(!storedFirstImage.projectResourcePath.empty());
+  const auto storedFirstResourcePath =
+      manager.GetLayouts().Items().front().imageViews.front().projectResourcePath;
+  assert(!storedFirstResourcePath.empty());
   assert(layouts::LayoutImageResourceRegistry::Get().UsageCount(
-             storedFirstImage.projectResourcePath) == 1);
+             storedFirstResourcePath) == 1);
 
   layouts::LayoutImageDefinition secondImage;
   secondImage.id = 2;
@@ -127,8 +128,8 @@ int main() {
   assert(saved);
 
   const auto entries = ReadArchiveEntries(projectPath);
-  assert(entries.find(storedFirstImage.projectResourcePath) != entries.end());
-  assert(entries.at(storedFirstImage.projectResourcePath) == "used-image-bytes");
+  assert(entries.find(storedFirstResourcePath) != entries.end());
+  assert(entries.at(storedFirstResourcePath) == "used-image-bytes");
   assert(entries.find(unusedResourcePath) == entries.end());
 
   layouts::LayoutImageResourceRegistry::Get().Clear();

--- a/tests/localization_catalog_integration_test.cpp
+++ b/tests/localization_catalog_integration_test.cpp
@@ -5,6 +5,7 @@
 #include <cstdlib>
 #include <filesystem>
 #include <iostream>
+#include <system_error>
 #include <string>
 
 #include <wx/filename.h>
@@ -101,8 +102,14 @@ int main() {
                   chineseCatalogPath.string());
 
   auto &manager = localization::LocalizationManager::Get();
+  const std::filesystem::path emptyLocaleRoot =
+      std::filesystem::temp_directory_path() / "perastage-empty-locale-root" /
+      std::to_string(wxGetProcessId());
+  std::error_code localeRootEc;
+  std::filesystem::remove_all(emptyLocaleRoot, localeRootEc);
+  std::filesystem::create_directories(emptyLocaleRoot, localeRootEc);
   wxSetEnv("PERASTAGE_LOCALE_ROOT",
-           wxFileName::GetTempDir() + "/perastage-empty-locale-root");
+           wxString::FromUTF8(emptyLocaleRoot.string().c_str()));
   const auto fallbackResult = manager.Initialize(localization::AppLanguage::Spanish);
   ok &= Check(!fallbackResult.catalogFound,
               "Missing-catalog scenario unexpectedly found a catalog.");
@@ -115,6 +122,14 @@ int main() {
   ok &= Check(_("Preferences") == wxString("Preferences"),
               "Missing-catalog fallback did not return English source text.");
 
+  wxSetEnv("PERASTAGE_LOCALE_ROOT", wxString::FromUTF8(localeRoot));
+  const auto overrideRoots = localization::ResolveLocaleRootCandidates();
+  ok &= Check(overrideRoots.size() == 1 &&
+                  overrideRoots.front() == std::filesystem::weakly_canonical(std::filesystem::u8path(localeRoot)),
+              "PERASTAGE_LOCALE_ROOT did not act as an exclusive override.");
+  wxSetEnv("PERASTAGE_LOCALE_ROOT", "");
+  ok &= Check(localization::ResolveLocaleRootCandidates().size() > 1,
+              "Empty PERASTAGE_LOCALE_ROOT did not restore normal locale candidates.");
   wxSetEnv("PERASTAGE_LOCALE_ROOT", wxString::FromUTF8(localeRoot));
   const auto chineseResult =
       manager.Initialize(localization::AppLanguage::SimplifiedChinese);
@@ -215,5 +230,10 @@ int main() {
   ok &= Check(riggingWeight == wxString("Peso de aparatos (kg)"),
               "Spanish rigging dynamic weight header regressed.");
 
+  const auto repeatedEnglish = manager.Initialize(localization::AppLanguage::English);
+  ok &= Check(repeatedEnglish.activeLanguage == localization::AppLanguage::English,
+              "Repeated language change did not reset the active catalog to English.");
+  wxUnsetEnv("PERASTAGE_LOCALE_ROOT");
+  std::filesystem::remove_all(emptyLocaleRoot, localeRootEc);
   return ok ? 0 : 1;
 }

--- a/tests/test_tool_requirements.sh
+++ b/tests/test_tool_requirements.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+require_test_tool() {
+  local tool="$1"
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "ERROR: required test tool '$tool' is not available on PATH." >&2
+    exit 127
+  fi
+}
+
+require_ripgrep() {
+  require_test_tool rg
+}

--- a/tests/trussloader_validation_test.cpp
+++ b/tests/trussloader_validation_test.cpp
@@ -15,17 +15,18 @@
  * You should have received a copy of the GNU General Public License
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
-#include <cassert>
 #include "filesystem_path_utils.h"
+#include "trussloader.h"
+
 #include <filesystem>
 #include <fstream>
+#include <iostream>
 #include <map>
 #include <string>
+#include <vector>
 
 #include <wx/wfstream.h>
 #include <wx/zipstrm.h>
-
-#include "trussloader.h"
 
 namespace fs = std::filesystem;
 
@@ -35,6 +36,14 @@ namespace {
 std::string ToUtf8String(const fs::path &path) {
   std::u8string utf8 = path.u8string();
   return std::string(utf8.begin(), utf8.end());
+}
+
+// Reports a failed condition without invoking a modal CRT assertion dialog.
+bool Check(bool condition, const std::string &message) {
+  if (condition)
+    return true;
+  std::cerr << "TrussLoaderValidation: " << message << '\n';
+  return false;
 }
 
 // Writes a ZIP archive with the provided text entries.
@@ -65,10 +74,57 @@ std::string MinimalGdtfDescription() {
 )xml";
 }
 
+// Normalizes path separators for portable suffix checks.
+std::string NormalizedSeparators(std::string value) {
+  for (char &ch : value) {
+    if (ch == '\\')
+      ch = '/';
+  }
+  return value;
+}
+
+// Reports whether a path ends with the expected normalized relative suffix.
+bool HasNormalizedSuffix(const std::string &path, const std::string &suffix) {
+  const std::string normalizedPath = NormalizedSeparators(path);
+  const std::string normalizedSuffix = NormalizedSeparators(suffix);
+  if (normalizedPath.size() < normalizedSuffix.size())
+    return false;
+  const std::size_t start = normalizedPath.size() - normalizedSuffix.size();
+  return normalizedPath.compare(start, normalizedSuffix.size(), normalizedSuffix) == 0 &&
+         (start == 0 || normalizedPath[start - 1] == '/');
+}
+
+// Verifies raw archive-entry path safety independent of writer-side sanitization.
+bool CheckArchiveEntrySecurity(const fs::path &tempRoot) {
+  bool ok = true;
+  const fs::path destination = tempRoot / "extract-root";
+  std::error_code ec;
+  fs::create_directories(destination, ec);
+  const std::vector<std::pair<std::string, bool>> cases = {
+      {"../escaped.txt", false},
+      {"/absolute-posix.txt", false},
+      {"C:/absolute-windows.txt", false},
+      {"C:\\absolute-windows.txt", false},
+      {"\\\\server\\share\\file.txt", false},
+      {"models/gltf/main.glb", true},
+  };
+  for (const auto &[entry, expectedSafe] : cases) {
+    const bool actualSafe = IsTrussArchiveEntryTargetSafeForTesting(entry, destination);
+    ok &= Check(actualSafe == expectedSafe,
+                "archive entry safety mismatch for '" + entry + "'.");
+  }
+  ok &= Check(!fs::exists(tempRoot / "escaped.txt"),
+              "unsafe traversal fixture wrote outside the extraction root.");
+  ok &= Check(!fs::exists(fs::path("/tmp/perastage-unsafe-entry.txt")),
+              "unsafe absolute fixture wrote outside the extraction root.");
+  return ok;
+}
+
 } // namespace
 
 // Verifies truss loader extension validation and archive extraction safety.
 int main() {
+  bool ok = true;
   const fs::path tempRoot = fs::temp_directory_path() /
                             PathUtils::PathFromUtf8("perastage_trussloader_validation_test");
   std::error_code ec;
@@ -82,54 +138,56 @@ int main() {
   }
 
   Truss truss;
-  assert(IsSupportedTrussDefinitionExtension(ToUtf8String(glbPath)));
-  assert(LoadTrussDefinition(ToUtf8String(glbPath), truss));
-  assert(truss.symbolFile == ToUtf8String(glbPath));
-  assert(truss.modelFile == ToUtf8String(glbPath));
-  assert(truss.lengthMm > 0.0f);
-  assert(truss.widthMm > 0.0f);
-  assert(truss.heightMm > 0.0f);
+  ok &= Check(IsSupportedTrussDefinitionExtension(ToUtf8String(glbPath)),
+              "GLB extension was not recognized.");
+  ok &= Check(LoadTrussDefinition(ToUtf8String(glbPath), truss),
+              "direct GLB truss definition did not load.");
+  ok &= Check(truss.symbolFile == ToUtf8String(glbPath),
+              "direct GLB symbol path changed unexpectedly.");
+  ok &= Check(truss.modelFile == ToUtf8String(glbPath),
+              "direct GLB model path changed unexpectedly.");
+  ok &= Check(truss.lengthMm > 0.0f && truss.widthMm > 0.0f && truss.heightMm > 0.0f,
+              "direct GLB dimensions were not populated.");
 
   Truss missingModel;
-  assert(!LoadTrussDefinition(ToUtf8String(tempRoot / "missing.glb"),
-                              missingModel));
+  ok &= Check(!LoadTrussDefinition(ToUtf8String(tempRoot / "missing.glb"), missingModel),
+              "missing GLB unexpectedly loaded.");
 
   Truss unsupportedModel;
-  assert(!IsSupportedTrussDefinitionExtension(
-      ToUtf8String(tempRoot / "mesh.obj")));
-  assert(!LoadTrussDefinition(ToUtf8String(tempRoot / "mesh.obj"),
-                              unsupportedModel));
+  ok &= Check(!IsSupportedTrussDefinitionExtension(ToUtf8String(tempRoot / "mesh.obj")),
+              "OBJ extension was unexpectedly accepted.");
+  ok &= Check(!LoadTrussDefinition(ToUtf8String(tempRoot / "mesh.obj"), unsupportedModel),
+              "unsupported OBJ unexpectedly loaded.");
 
-  assert(GetTrussDefinitionFileDialogWildcard().find(
-             "*.gdtf;*.gtruss;*.glb;*.3ds") != std::string::npos);
+  ok &= Check(GetTrussDefinitionFileDialogWildcard().find("*.gdtf;*.gtruss;*.glb;*.3ds") != std::string::npos,
+              "file dialog wildcard is missing supported truss extensions.");
 
   const fs::path validGdtfPath = tempRoot / "valid.gdtf";
-  assert(WriteZipArchive(validGdtfPath,
-                         {{"description.xml", MinimalGdtfDescription()},
-                          {"models/gltf/main.glb", "glTF"}}));
+  ok &= Check(WriteZipArchive(validGdtfPath,
+                              {{"description.xml", MinimalGdtfDescription()},
+                               {"models/gltf/main.glb", "glTF"}}),
+              "valid GDTF test archive could not be written.");
 
   Truss validGdtf;
-  assert(LoadTrussDefinition(ToUtf8String(validGdtfPath), validGdtf));
-  assert(validGdtf.symbolFile.find("models/gltf/main.glb") != std::string::npos);
+  ok &= Check(LoadTrussDefinition(ToUtf8String(validGdtfPath), validGdtf),
+              "valid GDTF truss definition did not load.");
+  ok &= Check(HasNormalizedSuffix(validGdtf.symbolFile, "models/gltf/main.glb"),
+              "valid GDTF symbol path did not end with models/gltf/main.glb: " +
+                  validGdtf.symbolFile);
 
   const fs::path traversalGdtfPath = tempRoot / "traversal.gdtf";
-  assert(WriteZipArchive(traversalGdtfPath,
-                         {{"description.xml", MinimalGdtfDescription()},
-                          {"../escaped.txt", "unsafe"},
-                          {"models/gltf/main.glb", "glTF"}}));
+  ok &= Check(WriteZipArchive(traversalGdtfPath,
+                              {{"description.xml", MinimalGdtfDescription()},
+                               {"../escaped.txt", "unsafe"},
+                               {"models/gltf/main.glb", "glTF"}}),
+              "traversal GDTF test archive could not be written.");
 
   Truss traversalGdtf;
-  assert(!LoadTrussDefinition(ToUtf8String(traversalGdtfPath), traversalGdtf));
-
-  const fs::path absoluteGdtfPath = tempRoot / "absolute.gdtf";
-  assert(WriteZipArchive(absoluteGdtfPath,
-                         {{"description.xml", MinimalGdtfDescription()},
-                          {"/tmp/perastage-unsafe-entry.txt", "unsafe"},
-                          {"models/gltf/main.glb", "glTF"}}));
-
-  Truss absoluteGdtf;
-  assert(!LoadTrussDefinition(ToUtf8String(absoluteGdtfPath), absoluteGdtf));
+  ok &= Check(!LoadTrussDefinition(ToUtf8String(traversalGdtfPath), traversalGdtf),
+              "traversal GDTF archive unexpectedly loaded.");
+  ok &= Check(CheckArchiveEntrySecurity(tempRoot),
+              "raw archive-entry security checks failed.");
 
   fs::remove_all(tempRoot, ec);
-  return 0;
+  return ok ? 0 : 1;
 }


### PR DESCRIPTION
### Motivation

- Linux Debug produced many spurious failures from harness/environment issues: `rg` (ripgrep) was missing, GTK tests had no display, Spanish UTF‑8 locale could not be activated, and several repository‑policy scripts ran from build directories; generated vcpkg CMake trees were being scanned as first‑party and caused false policy failures.  
- Windows Debug configured successfully with MSVC Hostx64/x64 but the workflow relied on `CMAKE_*_COMPILER_ID:INTERNAL` cache entries that CMake 4.x may not emit, causing a post‑configure validation failure.  
- macOS Debug failures were limited to the same CMake policy scanning of generated vcpkg trees and a test expecting a stale hard‑coded credential schema version (test expected 1 while production uses 2).

### Description

- Implemented a robust CMake toolchain validator `.github/scripts/validate_cmake_toolchain.py` that reads `CMakeCache.txt`, `CMakeFiles/*/CMake{C,CXX}Compiler.cmake`, and `compile_commands.json` to detect compiler ID, resolved paths, generator and build type instead of relying on `:INTERNAL` cache entries. This replaces the fragile Windows-only cache parsing and prevents false failures for CMake 4.x layouts.  
- Updated Windows Debug CI in `.github/workflows/ci-tests.yml` to enable `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON`, invoke the new validator (requiring `MSVC`/`Hostx64/x64`, Ninja, Debug), keep forbidden path checks (MinGW/MSYS/Strawberry/Hostx86/x86) and run CTest with `--verbose`.  
- Declared and installed Linux test tools/display/locale in `ci-tests.yml`: added `ripgrep`, `xvfb`, and `locales` to test dependencies, `locale-gen es_ES.UTF-8` and validation, set deterministic UTF‑8 environment (`LC_ALL`, `LANG`, `LANGUAGE`) for CTest, and run the full CTest suite under Xvfb via `xvfb-run -a -s "-screen 0 1920x1080x24"` so GTK tests can initialize in headless runners.  
- Normalized repository‑policy tests by adding `add_repository_policy_test(...)` to `tests/CMakeLists.txt` which registers policy tests with `WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"` and labels; migrated policy tests to use this helper so scripts that inspect repository files run from the repo root.  
- Made ripgrep usage explicit: added `tests/test_tool_requirements.sh` and updated ripgrep‑dependent `tests/check_*.sh` scripts to `source` it and call `require_ripgrep()` so missing `rg` fails early and clearly (three Release‑gate scripts remain independent of `rg` by design).  
- Restricted CMake language policy scanning to first‑party source by excluding generated/cache/vendor roots (`.git`, `.vcpkg-cache`, `vcpkg`, `build`, `build-*`, `cmake-build-*`, `out`, `third_party`) in `tests/check_ci_cmake_language_policy.sh`, and added fixtures proving external vcpkg `enable_language()` is ignored while a first‑party nested `enable_language()` is detected.  
- Added small unit/regression tests and fixtures: `tests/check_validate_cmake_toolchain.py`, `tests/check_ci_cmake_language_policy_fixtures.py`, `tests/check_policy_working_directories.py`, `tests/check_missing_ripgrep_behavior.py`.  
- Added ` .github/scripts/summarize_ctest_failures.py` and wired per‑platform summary steps so CI uploads a compact CSV of failing tests (platform,test,status,first meaningful failure line,source log) while preserving full logs in `out/ci-logs/`.  
- Corrected `tests/gdtf_share_security_test.cpp` to compare the JSON schema version against `CredentialStore::kGdtfCredentialMetadataSchemaVersion` instead of a stale hardcoded `1`, keeping production schema version `2` intact.  
- Updated `docs/release-notes-draft.md` with a short Internal changes entry describing the Debug CI reliability improvements.  
- Confirmed no forbidden Release installer/package workflow files or `.github/release-artifact-contract.json` were modified (local `git diff --name-only HEAD~1...HEAD` shows only Debug CI, test helpers, policy tests, and release-note edits).

### Testing

- Ran the new and updated automated policy/unit tests locally and they passed: `python3 tests/check_validate_cmake_toolchain.py` (OK), `python3 tests/check_ci_cmake_language_policy_fixtures.py` (OK), `python3 tests/check_policy_working_directories.py` (OK), `python3 tests/check_missing_ripgrep_behavior.py` (OK).  
- Executed policy and script checks which returned OK: `bash tests/check_release_gate_policy_portability.sh` (OK), `bash tests/check_ci_cmake_language_policy.sh` (OK), `bash tests/check_perastage_tree_modules.sh` (OK), `bash tests/check_no_configmanager_get_in_gui.sh` (OK), and `python3 tests/check_ci_workflow_architecture.py` (OK).  
- Verified GitHub Actions YAML parses and `actionlint` binary is available in environment (YAML parse OK; `actionlint` installed/available).  
- Exercised `summarize_ctest_failures.py` on a synthetic log to confirm CSV output (OK).  
- Local CMake configure with system environment failed to complete because this container lacks the CI vcpkg/wxWidgets dependency graph; `cmake -S . -B build/local-debug-ci-check ...` reported missing `wxWidgets` (expected in CI via vcpkg). This is an expected limitation of the local run and does not affect CI behavior where vcpkg is provisioned.  

Notes and next steps

- The patch focuses on Debug CI and test‑harness correctness only and intentionally leaves Release installer/package workflows unchanged.  
- A full three‑platform CI run (Ubuntu/Windows/macos) is required to enumerate remaining true functional test failures; the workflow now records and uploads concise per‑platform CTest failure summaries together with full logs so follow‑up triage can list precise remaining failures.  
- All added scripts and tests include English comments and small, focused helpers to keep files modular and maintainable per repository AGENTS.md rules.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5fd964a84c8324b763b837d6c26d9c)