### PR TITLE
fix: stabilize cross-platform paths and Debug test fixtures

### DIFF
--- a/.github/scripts/macos_sdk_cache_guard.py
+++ b/.github/scripts/macos_sdk_cache_guard.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Diagnose restored macOS vcpkg SDK metadata and purge stale Debug caches."""
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import shutil
+from pathlib import Path
+
+SDK_PATTERN = re.compile(r"/Applications/[^\s\"'<>]*Xcode[^\s\"'<>]*/[^\s\"'<>]*/SDKs/MacOSX(?:[0-9]+(?:\.[0-9]+)*)?\.sdk")
+
+
+def _resolve_existing(path: Path) -> Path | None:
+    try:
+        if path.exists():
+            return path.resolve()
+    except OSError:
+        return None
+    return None
+
+
+def discover_sdk_paths(roots: list[Path]) -> set[str]:
+    found: set[str] = set()
+    for root in roots:
+        if not root.is_dir():
+            continue
+        for current, dirs, files in os.walk(root):
+            dirs[:] = [d for d in dirs if d not in {".git", "downloads"}]
+            for name in files:
+                path = Path(current) / name
+                try:
+                    text = path.read_text(encoding="utf-8", errors="ignore")
+                except OSError:
+                    continue
+                found.update(SDK_PATTERN.findall(text))
+    return found
+
+
+def classify_sdk_paths(current_sdk: Path, referenced_paths: set[str]) -> tuple[Path, list[str], list[str]]:
+    current_resolved = current_sdk.resolve()
+    equivalent: list[str] = []
+    stale: list[str] = []
+    for value in sorted(referenced_paths):
+        referenced = Path(value)
+        resolved = _resolve_existing(referenced)
+        if resolved is not None and resolved == current_resolved:
+            equivalent.append(value)
+        elif referenced == current_sdk:
+            equivalent.append(value)
+        else:
+            stale.append(value)
+    return current_resolved, equivalent, stale
+
+
+def purge_cache_roots(roots: list[Path]) -> None:
+    for root in roots:
+        if root.exists():
+            shutil.rmtree(root)
+        root.mkdir(parents=True, exist_ok=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--current-sdk", required=True, type=Path)
+    parser.add_argument("--scan-root", action="append", default=[], type=Path)
+    parser.add_argument("--purge-root", action="append", default=[], type=Path)
+    args = parser.parse_args()
+
+    referenced = discover_sdk_paths(args.scan_root)
+    current_resolved, equivalent, stale = classify_sdk_paths(args.current_sdk, referenced)
+    print(f"Current macOS SDK path: {args.current_sdk}")
+    print(f"Current macOS SDK resolved path: {current_resolved}")
+    if equivalent:
+        print("Equivalent restored SDK metadata paths:")
+        for value in equivalent:
+            print(f"  {value}")
+    if not stale:
+        print("No stale macOS SDK metadata found in restored vcpkg caches.")
+        return 0
+    print("Stale macOS SDK metadata found in restored vcpkg caches:")
+    for value in stale:
+        print(f"  {value}")
+    print("Purging ABI-sensitive restored Debug vcpkg caches before reinstall.")
+    purge_cache_roots(args.purge_root)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -208,20 +208,52 @@ jobs:
           "PERASTAGE_PYTHON=$python" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
           cmake --version | Out-File "$env:CI_LOG_DIR\environment-windows-debug.txt"
           & $python --version | Out-File "$env:CI_LOG_DIR\environment-windows-debug.txt" -Append
+      - name: Prepare Windows Debug test tools
+        id: windows-test-tools
+        shell: pwsh
+        run: |
+          $log = "$env:CI_LOG_DIR\windows-test-tools.txt"
+          $rgCommand = Get-Command rg.exe -ErrorAction SilentlyContinue
+          if (-not $rgCommand) {
+            $choco = Get-Command choco.exe -ErrorAction SilentlyContinue
+            if (-not $choco) { throw 'ripgrep is not installed and Chocolatey is unavailable.' }
+            & $choco.Source install ripgrep -y --no-progress
+            if ($LASTEXITCODE -ne 0) { throw 'ripgrep installation failed.' }
+            $env:PATH = [Environment]::GetEnvironmentVariable('PATH', 'Machine') + ';' + [Environment]::GetEnvironmentVariable('PATH', 'User') + ';' + $env:PATH
+            $rgCommand = Get-Command rg.exe -ErrorAction SilentlyContinue
+          }
+          if (-not $rgCommand) { throw 'ripgrep is not installed after Windows Debug test-tool preparation.' }
+          $rgPath = $rgCommand.Source
+          $rgDir = Split-Path -Parent $rgPath
+          $env:PATH = "$rgDir;$env:PATH"
+          $rgDir | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
+          "rg=$rgPath" | Out-File -FilePath $log -Encoding utf8
+          & $rgPath --version | Out-File -FilePath $log -Append -Encoding utf8
+          if ($LASTEXITCODE -ne 0) { throw "ripgrep failed to run from PowerShell: $rgPath" }
+          "PERASTAGE_RG=$rgPath" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
       - name: Resolve Git Bash for Windows tests
         id: git-bash
         shell: pwsh
         run: |
+          $log = "$env:CI_LOG_DIR\git-bash-windows-debug.txt"
           $git = (Get-Command git.exe -ErrorAction Stop).Source
           $gitRoot = Split-Path -Parent (Split-Path -Parent $git)
           $bash = Join-Path $gitRoot 'bin\bash.exe'
+          "git=$git" | Out-File -FilePath $log -Encoding utf8
+          "bash=$bash" | Out-File -FilePath $log -Append -Encoding utf8
+          "rg=$env:PERASTAGE_RG" | Out-File -FilePath $log -Append -Encoding utf8
           if (-not (Test-Path $bash)) { throw "Git Bash was not found at expected path: $bash" }
           $normalized = $bash.Replace('/', '\').ToLowerInvariant()
           if ($normalized -match '\\windowsapps\\bash\.exe$' -or $normalized -match '\\system32\\bash\.exe$') { throw "Refusing WSL bash launcher: $bash" }
           if ($normalized -notmatch '\\git\\.*\\bash\.exe$') { throw "Refusing Bash outside Git for Windows: $bash" }
-          & $bash --version | Out-File "$env:CI_LOG_DIR\git-bash-windows-debug.txt" -Encoding utf8
-          & $bash -lc 'printf "git-bash-ok\n"; command -v rg' | Out-File "$env:CI_LOG_DIR\git-bash-windows-debug.txt" -Append -Encoding utf8
-          if ($LASTEXITCODE -ne 0) { throw 'Git Bash preflight failed.' }
+          & $bash --version | Out-File -FilePath $log -Append -Encoding utf8
+          if ($LASTEXITCODE -ne 0) { throw "Git Bash identity probe failed: $bash" }
+          & $bash --noprofile --norc -c 'printf "git-bash-ok\n"' | Out-File -FilePath $log -Append -Encoding utf8
+          if ($LASTEXITCODE -ne 0) { throw "Git Bash cannot execute a non-login shell: $bash" }
+          & $env:PERASTAGE_RG --version | Out-File -FilePath $log -Append -Encoding utf8
+          if ($LASTEXITCODE -ne 0) { throw "ripgrep failed to run from PowerShell: $env:PERASTAGE_RG" }
+          & $bash --noprofile --norc -c 'command -v rg && rg --version' | Out-File -FilePath $log -Append -Encoding utf8
+          if ($LASTEXITCODE -ne 0) { throw "ripgrep was not inherited by Git Bash: $env:PERASTAGE_RG" }
           "PERASTAGE_GIT_BASH=$bash" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
           "path=$bash" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
       - name: Read vcpkg baseline

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -208,14 +208,29 @@ jobs:
           "PERASTAGE_PYTHON=$python" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
           cmake --version | Out-File "$env:CI_LOG_DIR\environment-windows-debug.txt"
           & $python --version | Out-File "$env:CI_LOG_DIR\environment-windows-debug.txt" -Append
+      - name: Resolve Git Bash for Windows tests
+        id: git-bash
+        shell: pwsh
+        run: |
+          $git = (Get-Command git.exe -ErrorAction Stop).Source
+          $gitRoot = Split-Path -Parent (Split-Path -Parent $git)
+          $bash = Join-Path $gitRoot 'bin\bash.exe'
+          if (-not (Test-Path $bash)) { throw "Git Bash was not found at expected path: $bash" }
+          $normalized = $bash.Replace('/', '\').ToLowerInvariant()
+          if ($normalized -match '\\windowsapps\\bash\.exe$' -or $normalized -match '\\system32\\bash\.exe$') { throw "Refusing WSL bash launcher: $bash" }
+          if ($normalized -notmatch '\\git\\.*\\bash\.exe$') { throw "Refusing Bash outside Git for Windows: $bash" }
+          & $bash --version | Out-File "$env:CI_LOG_DIR\git-bash-windows-debug.txt" -Encoding utf8
+          & $bash -lc 'printf "git-bash-ok\n"; command -v rg' | Out-File "$env:CI_LOG_DIR\git-bash-windows-debug.txt" -Append -Encoding utf8
+          if ($LASTEXITCODE -ne 0) { throw 'Git Bash preflight failed.' }
+          "PERASTAGE_GIT_BASH=$bash" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "path=$bash" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
       - name: Read vcpkg baseline
         id: vcpkg-baseline
-        shell: bash
+        shell: pwsh
         run: |
-          set -euo pipefail
-          baseline="$(python3 .github/scripts/get_vcpkg_baseline.py vcpkg.json)"
-          echo "baseline=${baseline}" >> "$GITHUB_OUTPUT"
-          echo "VCPKG_BASELINE=${baseline}" >> "$GITHUB_ENV"
+          $baseline = (& "$env:PERASTAGE_PYTHON" .github/scripts/get_vcpkg_baseline.py vcpkg.json).Trim()
+          "baseline=$baseline" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "VCPKG_BASELINE=$baseline" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
       - name: Restore vcpkg downloads
         id: vcpkg-downloads-cache
         uses: actions/cache/restore@v5
@@ -293,7 +308,7 @@ jobs:
         run: |
           $cl = Get-Command cl.exe -ErrorAction SilentlyContinue
           if (-not $cl) { throw 'cl.exe was not available in the persisted Visual Studio environment.' }
-          & "$env:PERASTAGE_PYTHON" .github/scripts/run_and_log.py --log "$env:CI_LOG_DIR\cmake-configure-windows-debug.log" -- cmake -S . -B build-windows-debug -G Ninja -DCMAKE_C_COMPILER=cl.exe -DCMAKE_CXX_COMPILER=cl.exe -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT\scripts\buildsystems\vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x64-windows -DVCPKG_INSTALLED_DIR="$env:VCPKG_INSTALLED" -DVCPKG_MANIFEST_MODE=OFF -DBUILD_TESTING=ON -DPERASTAGE_REQUIRE_SECURE_CREDENTIAL_STORE=ON -DPERASTAGE_ENABLE_COMPILER_CACHE=OFF -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+          & "$env:PERASTAGE_PYTHON" .github/scripts/run_and_log.py --log "$env:CI_LOG_DIR\cmake-configure-windows-debug.log" -- cmake -S . -B build-windows-debug -G Ninja -DCMAKE_C_COMPILER=cl.exe -DCMAKE_CXX_COMPILER=cl.exe -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT\scripts\buildsystems\vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x64-windows -DVCPKG_INSTALLED_DIR="$env:VCPKG_INSTALLED" -DVCPKG_MANIFEST_MODE=OFF -DBUILD_TESTING=ON -DPERASTAGE_REQUIRE_SECURE_CREDENTIAL_STORE=ON -DPERASTAGE_ENABLE_COMPILER_CACHE=OFF -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DBASH_EXECUTABLE="$env:PERASTAGE_GIT_BASH"
           & "$env:PERASTAGE_PYTHON" .github/scripts/validate_cmake_toolchain.py --build-dir build-windows-debug --expected-c-id MSVC --expected-cxx-id MSVC --expected-compiler-path-regex "Hostx64[\\/]x64" --forbidden-compiler-path-regex "(mingw|msys|strawberry|Hostx86[\\/]x86|[\\/]x86[\\/]cl\.exe)" --expected-architecture x64 --expected-generator Ninja --expected-build-type Debug
       - name: Build Windows Debug tests
         shell: pwsh

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -349,6 +349,17 @@ jobs:
           baseline="$(python3 .github/scripts/get_vcpkg_baseline.py vcpkg.json)"
           echo "baseline=${baseline}" >> "$GITHUB_OUTPUT"
           echo "VCPKG_BASELINE=${baseline}" >> "$GITHUB_ENV"
+      - name: Resolve macOS SDK cache identity
+        id: macos-sdk
+        run: |
+          set -euo pipefail
+          current_sdk_path="$(xcrun --sdk macosx --show-sdk-path)"
+          current_sdk_realpath="$(python3 -c 'from pathlib import Path; import sys; print(Path(sys.argv[1]).resolve())' "$current_sdk_path")"
+          xcode_version="$(xcodebuild -version | tr '\n' '-' | sed 's/-$//')"
+          sdk_identity="$(printf '%s|%s' "$xcode_version" "$current_sdk_realpath" | shasum -a 256 | awk '{print $1}')"
+          echo "identity=${sdk_identity}" >> "$GITHUB_OUTPUT"
+          echo "MACOS_SDK_PATH=${current_sdk_path}" >> "$GITHUB_ENV"
+          echo "MACOS_SDK_REALPATH=${current_sdk_realpath}" >> "$GITHUB_ENV"
       - name: Install macOS test tools
         run: brew update && brew install autoconf autoconf-archive automake gettext libtool ninja
       - name: Restore vcpkg downloads
@@ -367,9 +378,9 @@ jobs:
             .vcpkg-cache/installed
             .vcpkg-cache/packages
             .vcpkg-cache/binary
-          key: macos-26-xcode-26-debug-v1-${{ steps.vcpkg-baseline.outputs.baseline }}-arm64-osx-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', '.github/workflows/ci-tests.yml') }}
+          key: macos-26-sdk-${{ steps.macos-sdk.outputs.identity }}-debug-v2-${{ steps.vcpkg-baseline.outputs.baseline }}-arm64-osx-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', '.github/workflows/ci-tests.yml') }}
           restore-keys: |
-            macos-26-xcode-26-debug-v1-${{ steps.vcpkg-baseline.outputs.baseline }}-arm64-osx-
+            macos-26-sdk-${{ steps.macos-sdk.outputs.identity }}-debug-v2-${{ steps.vcpkg-baseline.outputs.baseline }}-arm64-osx-
       - name: Bootstrap vcpkg
         run: |
           set -euo pipefail
@@ -385,20 +396,14 @@ jobs:
       - name: Diagnose restored vcpkg SDK metadata
         run: |
           set -euo pipefail
-          current_sdk_path="$(xcrun --sdk macosx --show-sdk-path)"
-          stale_sdk_paths="$(
-            for cache_dir in "$VCPKG_INSTALLED" "$VCPKG_PACKAGES"; do
-              if [ -d "$cache_dir" ]; then
-                grep -R -h -o -E "/Applications/Xcode_[^[:space:]]*/SDKs/MacOSX\.sdk" "$cache_dir" 2>/dev/null || true
-              fi
-            done | sort -u | grep -F -v -x "$current_sdk_path" || true
-          )"
-          if [ -n "$stale_sdk_paths" ]; then
-            echo "Stale macOS SDK path metadata was found in the restored vcpkg cache."
-            echo "Current SDK path: $current_sdk_path"
-            echo "$stale_sdk_paths"
-            exit 1
-          fi
+          python3 .github/scripts/macos_sdk_cache_guard.py \
+            --current-sdk "$MACOS_SDK_PATH" \
+            --scan-root "$VCPKG_INSTALLED" \
+            --scan-root "$VCPKG_PACKAGES" \
+            --scan-root "$VCPKG_BINARY_CACHE" \
+            --purge-root "$VCPKG_INSTALLED" \
+            --purge-root "$VCPKG_PACKAGES" \
+            --purge-root "$VCPKG_BINARY_CACHE"
       - name: Install vcpkg packages
         run: |
           python3 .github/scripts/vcpkg_install_retry.py --vcpkg "$VCPKG_ROOT/vcpkg" --triplet arm64-osx --manifest-root "$GITHUB_WORKSPACE" \

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -82,6 +82,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/ui_render_size.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ui_unit_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/utf8_utils.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/wx_path_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/units/unit_label_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/units/units.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/uuidutils.cpp

--- a/core/gdtf_canonicalizer.cpp
+++ b/core/gdtf_canonicalizer.cpp
@@ -1,3 +1,4 @@
+#include "wx_path_utils.h"
 #include "gdtf_canonicalizer.h"
 
 #include "gdtf_mutation_audit.h"
@@ -73,7 +74,7 @@ bool ReadCurrentZipEntry(wxZipInputStream &zip, std::string &out) {
 // Reads all non-directory entries from a ZIP archive.
 bool ReadZipEntries(const fs::path &path, std::vector<ZipEntryData> &entries,
                     Result &result) {
-  wxFileInputStream input(path.string());
+  wxFileInputStream input(WxPathUtils::WxStringFromFilesystemPath(path));
   if (!input.IsOk()) {
     result.errors.push_back("Could not open GDTF archive: " + path.string());
     return false;
@@ -102,7 +103,7 @@ bool WriteZipEntries(const fs::path &path, std::vector<ZipEntryData> entries,
     return a.name < b.name;
   });
 
-  wxFileOutputStream output(path.string());
+  wxFileOutputStream output(WxPathUtils::WxStringFromFilesystemPath(path));
   if (!output.IsOk()) {
     result.errors.push_back("Could not create canonical GDTF archive: " +
                             path.string());

--- a/core/layer_service.cpp
+++ b/core/layer_service.cpp
@@ -10,6 +10,7 @@
 #include <map>
 #include <optional>
 #include <set>
+#include <vector>
 #include <unordered_map>
 
 namespace layerdomain {
@@ -337,28 +338,56 @@ LayerResult ValidateSceneLayers(const MvrScene &scene) {
   return {};
 }
 
-// Repairs known legacy Windows-1252 layer-name corruption without merging layers.
+// Repairs known legacy Windows-1252 layer-name corruption without merging valid layers.
 LayerResult ReconcileLegacyLayers(MvrScene &scene) {
-  bool repaired = false;
-  std::set<std::string> names;
-  for (auto &[uuid, layer] : scene.layers) {
-    if (!IsValidUtf8(layer.name)) {
-      const auto repairedName = RepairWindows1252AsUtf8(layer.name);
-      if (!repairedName)
-        return {LayerStatus::InvalidUtf8, "Layer name cannot be repaired", uuid};
-      layer.name = *repairedName;
-      repaired = true;
+  struct RepairCandidate {
+    std::string uuid;
+    std::string originalName;
+    std::string repairedName;
+  };
+
+  std::set<std::string> reservedNames;
+  std::vector<RepairCandidate> repairs;
+  for (const auto &[uuid, layer] : scene.layers) {
+    if (IsValidUtf8(layer.name)) {
+      reservedNames.insert(TrimLayerName(layer.name));
+      continue;
     }
-    std::string unique = layer.name;
-    for (int suffix = 2; names.count(unique) > 0; ++suffix)
-      unique = layer.name + " (Recovered " + std::to_string(suffix) + ")";
-    if (unique != layer.name) {
-      RenameObjectLayers(scene, layer.name, unique);
-      layer.name = unique;
-      repaired = true;
-    }
-    names.insert(layer.name);
+    const auto repairedName = RepairWindows1252AsUtf8(layer.name);
+    if (!repairedName)
+      return {LayerStatus::InvalidUtf8, "Layer name cannot be repaired", uuid};
+    repairs.push_back({uuid, layer.name, TrimLayerName(*repairedName)});
   }
+
+  if (repairs.empty())
+    return {LayerStatus::NoChange, "No legacy repairs needed"};
+
+  bool repaired = false;
+  int recoveredSuffix = 2;
+  for (const auto &repair : repairs) {
+    auto layerIt = scene.layers.find(repair.uuid);
+    if (layerIt == scene.layers.end())
+      continue;
+
+    std::string finalName = repair.repairedName;
+    if (finalName.empty())
+      return {LayerStatus::ValidationFailure, "Layer name is empty", repair.uuid};
+    if (reservedNames.count(finalName) > 0) {
+      do {
+        finalName = repair.repairedName + " (Recovered " +
+                    std::to_string(recoveredSuffix++) + ")";
+      } while (reservedNames.count(finalName) > 0);
+    }
+
+    RenameObjectLayers(scene, repair.originalName, finalName);
+    layerIt->second.name = finalName;
+    reservedNames.insert(finalName);
+    repaired = true;
+  }
+
+  const auto validation = ValidateSceneLayers(scene);
+  if (validation.status != LayerStatus::Success)
+    return validation;
   return {repaired ? LayerStatus::Success : LayerStatus::NoChange,
           repaired ? "Legacy layer data repaired" : "No legacy repairs needed"};
 }

--- a/core/layouts/LayoutCollection.cpp
+++ b/core/layouts/LayoutCollection.cpp
@@ -113,14 +113,6 @@ int MinZIndex(const LayoutDefinition &layout) {
   return hasValue ? minZ : 0;
 }
 
-bool IsExplicitBoundaryZChange(const LayoutDefinition &layout, int currentZ,
-                               int requestedZ) {
-  if (requestedZ == currentZ)
-    return false;
-  const int maxZ = MaxZIndex(layout);
-  const int minZ = MinZIndex(layout);
-  return requestedZ > maxZ || requestedZ < minZ;
-}
 } // namespace
 
 LayoutCollection::LayoutCollection() { layouts.push_back(DefaultLayout()); }
@@ -194,10 +186,7 @@ bool LayoutCollection::UpdateLayout2DView(const std::string &name,
       bool replaced = false;
       for (auto &entry : layout.view2dViews) {
         if (entry.id == updatedView.id && updatedView.id > 0) {
-          if (!IsExplicitBoundaryZChange(layout, entry.zIndex,
-                                         updatedView.zIndex)) {
-            updatedView.zIndex = entry.zIndex;
-          }
+          updatedView.zIndex = entry.zIndex;
           entry = updatedView;
           replaced = true;
           break;
@@ -277,10 +266,7 @@ bool LayoutCollection::UpdateLayoutLegend(
       bool replaced = false;
       for (auto &entry : layout.legendViews) {
         if (entry.id == updatedLegend.id && updatedLegend.id > 0) {
-          if (!IsExplicitBoundaryZChange(layout, entry.zIndex,
-                                         updatedLegend.zIndex)) {
-            updatedLegend.zIndex = entry.zIndex;
-          }
+          updatedLegend.zIndex = entry.zIndex;
           entry = updatedLegend;
           replaced = true;
           break;
@@ -316,10 +302,7 @@ bool LayoutCollection::UpdateLayoutEventTable(
       bool replaced = false;
       for (auto &entry : layout.eventTables) {
         if (entry.id == updatedTable.id && updatedTable.id > 0) {
-          if (!IsExplicitBoundaryZChange(layout, entry.zIndex,
-                                         updatedTable.zIndex)) {
-            updatedTable.zIndex = entry.zIndex;
-          }
+          updatedTable.zIndex = entry.zIndex;
           entry = updatedTable;
           replaced = true;
           break;
@@ -355,10 +338,7 @@ bool LayoutCollection::UpdateLayoutText(const std::string &name,
       bool replaced = false;
       for (auto &entry : layout.textViews) {
         if (entry.id == updatedText.id && updatedText.id > 0) {
-          if (!IsExplicitBoundaryZChange(layout, entry.zIndex,
-                                         updatedText.zIndex)) {
-            updatedText.zIndex = entry.zIndex;
-          }
+          updatedText.zIndex = entry.zIndex;
           entry = updatedText;
           replaced = true;
           break;
@@ -394,10 +374,7 @@ bool LayoutCollection::UpdateLayoutImage(const std::string &name,
       bool replaced = false;
       for (auto &entry : layout.imageViews) {
         if (entry.id == updatedImage.id && updatedImage.id > 0) {
-          if (!IsExplicitBoundaryZChange(layout, entry.zIndex,
-                                         updatedImage.zIndex)) {
-            updatedImage.zIndex = entry.zIndex;
-          }
+          updatedImage.zIndex = entry.zIndex;
           entry = updatedImage;
           replaced = true;
           break;

--- a/core/trussloader.cpp
+++ b/core/trussloader.cpp
@@ -18,6 +18,7 @@
 #include "runtime_storage.h"
 #include "trussloader.h"
 #include "filesystem_path_utils.h"
+#include "wx_path_utils.h"
 
 #include "truss_gdtf_builder.h"
 #include "logger.h"
@@ -136,7 +137,7 @@ static bool ResolveArchiveEntryTarget(const fs::path &archivePath,
 
 // Extracts a ZIP-based archive into the requested destination directory.
 static bool ExtractArchive(const fs::path &archivePath, const fs::path &destination) {
-  wxFileInputStream input(archivePath.string());
+  wxFileInputStream input(WxPathUtils::WxStringFromFilesystemPath(archivePath));
   if (!input.IsOk())
     return false;
 
@@ -161,10 +162,12 @@ static bool ExtractArchive(const fs::path &archivePath, const fs::path &destinat
     if (target.empty())
       continue;
     if (entry->IsDir()) {
-      wxFileName::Mkdir(target.string(), wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
+      wxFileName::Mkdir(WxPathUtils::WxStringFromFilesystemPath(target),
+                       wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
       continue;
     }
-    wxFileName::Mkdir(target.parent_path().string(), wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
+    wxFileName::Mkdir(WxPathUtils::WxStringFromFilesystemPath(target.parent_path()),
+                     wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
     std::ofstream out(target, std::ios::binary);
     if (!out.is_open())
       return false;

--- a/core/wx_path_utils.cpp
+++ b/core/wx_path_utils.cpp
@@ -1,0 +1,1 @@
+#include "wx_path_utils.h"

--- a/core/wx_path_utils.h
+++ b/core/wx_path_utils.h
@@ -23,7 +23,7 @@ inline std::filesystem::path FilesystemPathFromWxString(const wxString &value) {
   if (value.empty())
     return std::filesystem::path();
 #if defined(_WIN32)
-  return std::filesystem::path(value.wc_str().data());
+  return std::filesystem::path(value.wc_str());
 #else
   const wxScopedCharBuffer utf8 = value.utf8_str();
   return std::filesystem::path(reinterpret_cast<const char8_t *>(utf8.data()));

--- a/core/wx_path_utils.h
+++ b/core/wx_path_utils.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <filesystem>
+
+#include <wx/string.h>
+
+namespace WxPathUtils {
+
+// Converts a filesystem path to a wxString without using the active narrow code page.
+inline wxString WxStringFromFilesystemPath(const std::filesystem::path &path) {
+  if (path.empty())
+    return wxString();
+#if defined(_WIN32)
+  return wxString(path.native());
+#else
+  const std::u8string utf8 = path.u8string();
+  return wxString::FromUTF8(reinterpret_cast<const char *>(utf8.c_str()));
+#endif
+}
+
+// Converts a wxString path to std::filesystem::path through the native platform encoding.
+inline std::filesystem::path FilesystemPathFromWxString(const wxString &value) {
+  if (value.empty())
+    return std::filesystem::path();
+#if defined(_WIN32)
+  return std::filesystem::path(value.wc_str().data());
+#else
+  const wxScopedCharBuffer utf8 = value.utf8_str();
+  return std::filesystem::path(reinterpret_cast<const char8_t *>(utf8.data()));
+#endif
+}
+
+} // namespace WxPathUtils

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -263,6 +263,8 @@ You can also contact the project at **perastage.app@gmail.com**.
 
 - Added explicit wxWidgets filesystem path conversion utilities for safer Unicode path handling at file API boundaries, including native wide-path conversion on Windows.
 - Made layout z-order updates and legacy layer-name repair deterministic for cross-platform Debug tests.
+- Hardened Windows Debug test execution by forcing Git Bash for shell checks, routing shell tests through one CMake helper, and disabling modal assertion reporting in test executables.
+- Corrected Debug test expectations and lifetimes for Simplified Chinese localization fallback checks and credential metadata cleanup on Windows.
 
 
 - Improved Debug CI reliability by validating CMake toolchain metadata from generated files, declaring Linux test tools and locales explicitly, running Linux CTest under a verified Xvfb display, bounding non-interactive Windows CTest runs, normalizing repository-policy test working directories, and keeping CMake language policy checks focused on first-party source.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -261,7 +261,7 @@ You can also contact the project at **perastage.app@gmail.com**.
 
 ## Internal changes
 
-- Added explicit wxWidgets filesystem path conversion utilities for safer Unicode path handling at file API boundaries.
+- Added explicit wxWidgets filesystem path conversion utilities for safer Unicode path handling at file API boundaries, including native wide-path conversion on Windows.
 - Made layout z-order updates and legacy layer-name repair deterministic for cross-platform Debug tests.
 
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -13,6 +13,7 @@ Perastage 1.5.0 is a substantial update focused on GDTF and truss editing, multi
 - Added 2D and 3D viewer context-menu shortcuts for selecting trusses by model/source file or hang position from the **Trusses** table.
 - Added a **Spanish interface**, selectable from Preferences and applied after restarting Perastage.
 - Improved MVR/GDTF compatibility, 3D picking stability, Unicode handling, crash diagnostics, and release packaging.
+- Improved Debug CI stability by rebuilding stale macOS SDK caches instead of failing on equivalent SDK aliases.
 
 ## New features and improvements
 
@@ -259,6 +260,10 @@ You can also contact the project at **perastage.app@gmail.com**.
 - Fixed embedded Layout 2D fixture symbols so rotated GDTF fixtures choose the visible representative symbol plane and preserve the same orientation in preview and PDF export.
 
 ## Internal changes
+
+- Added explicit wxWidgets filesystem path conversion utilities for safer Unicode path handling at file API boundaries.
+- Made layout z-order updates and legacy layer-name repair deterministic for cross-platform Debug tests.
+
 
 - Improved Debug CI reliability by validating CMake toolchain metadata from generated files, declaring Linux test tools and locales explicitly, running Linux CTest under a verified Xvfb display, bounding non-interactive Windows CTest runs, normalizing repository-policy test working directories, and keeping CMake language policy checks focused on first-party source.
 - Strengthened CI release-gate tests so policy scripts are portable without ripgrep and credential metadata checks validate JSON fields without flagging safe backend identifiers.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -263,7 +263,7 @@ You can also contact the project at **perastage.app@gmail.com**.
 
 - Added explicit wxWidgets filesystem path conversion utilities for safer Unicode path handling at file API boundaries, including native wide-path conversion on Windows.
 - Made layout z-order updates and legacy layer-name repair deterministic for cross-platform Debug tests.
-- Hardened Windows Debug test execution by forcing Git Bash for shell checks, routing shell tests through one CMake helper, and disabling modal assertion reporting in test executables.
+- Hardened Windows Debug test execution by preparing ripgrep separately, forcing Git Bash for shell checks, routing shell tests through one CMake helper, and disabling modal assertion reporting in test executables.
 - Corrected Debug test expectations and lifetimes for Simplified Chinese localization fallback checks and credential metadata cleanup on Windows.
 
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -145,6 +145,8 @@ if(Python3_Interpreter_FOUND)
                                ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_release_workflows_untouched.py)
     add_repository_policy_test(BashTestRegistration ${Python3_EXECUTABLE}
                                ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_bash_test_registration.py)
+    add_repository_policy_test(WindowsDebugToolPreflight ${Python3_EXECUTABLE}
+                               ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_windows_debug_tool_preflight.py)
     add_repository_policy_test(CMakeToolchainValidator ${Python3_EXECUTABLE}
                                ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_validate_cmake_toolchain.py)
     add_repository_policy_test(CiCMakeLanguagePolicyFixtures ${Python3_EXECUTABLE}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -93,6 +93,12 @@ find_package(Python3 COMPONENTS Interpreter)
 if(Python3_Interpreter_FOUND)
     add_repository_policy_test(DocsLinks ${Python3_EXECUTABLE}
                                ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_docs_links.py)
+    add_repository_policy_test(MacosSdkCacheGuard ${Python3_EXECUTABLE}
+                               ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_macos_sdk_cache_guard.py)
+    add_repository_policy_test(WxFilesystemPathBoundaries ${Python3_EXECUTABLE}
+                               ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_wx_filesystem_path_boundaries.py)
+    add_repository_policy_test(ReleaseWorkflowsUntouched ${Python3_EXECUTABLE}
+                               ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_release_workflows_untouched.py)
     add_repository_policy_test(CMakeToolchainValidator ${Python3_EXECUTABLE}
                                ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_validate_cmake_toolchain.py)
     add_repository_policy_test(CiCMakeLanguagePolicyFixtures ${Python3_EXECUTABLE}
@@ -171,6 +177,13 @@ add_executable(dictionary_editor_state_test dictionary_editor_state_test.cpp)
 target_include_directories(dictionary_editor_state_test PRIVATE ../gui)
 add_test(NAME DictionaryEditorState COMMAND dictionary_editor_state_test)
 
+
+add_executable(wx_path_utils_test wx_path_utils_test.cpp
+               ../core/wx_path_utils.cpp)
+target_include_directories(wx_path_utils_test PRIVATE ../core)
+target_link_libraries(wx_path_utils_test PRIVATE ${wxWidgets_LIBRARIES})
+add_test(NAME WxPathUtilsRoundTrip COMMAND wx_path_utils_test)
+
 add_executable(platform_locale_test
                platform_locale_test.cpp
                ../core/platform_locale.cpp)
@@ -188,6 +201,7 @@ add_executable(trussloader_validation_test
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/trussloader.cpp
+               ../core/wx_path_utils.cpp
                ../models/truss.cpp)
 target_include_directories(trussloader_validation_test PRIVATE
                            . ../core ../models ../third_party)
@@ -700,6 +714,7 @@ add_executable(save_load_roundtrip_test save_load_roundtrip_test.cpp
                ../core/utf8_utils.cpp
                ../core/trussdictionary.cpp
                ../core/trussloader.cpp
+               ../core/wx_path_utils.cpp
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/uuidutils.cpp
@@ -740,6 +755,7 @@ add_executable(project_support_userdata_roundtrip_test project_support_userdata_
                ../core/utf8_utils.cpp
                ../core/trussdictionary.cpp
                ../core/trussloader.cpp
+               ../core/wx_path_utils.cpp
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/uuidutils.cpp
@@ -781,6 +797,7 @@ add_executable(truss_path_encoding_regression_test
                ../core/truss_gdtf_builder.cpp
                ../core/trussdictionary.cpp
                ../core/trussloader.cpp
+               ../core/wx_path_utils.cpp
                ../models/truss.cpp)
 target_include_directories(truss_path_encoding_regression_test PRIVATE
                            . ../core ../models ../third_party)
@@ -811,6 +828,7 @@ add_executable(rider_truss_dictionary_normalization_test
                ../core/utf8_utils.cpp
                ../core/trussdictionary.cpp
                ../core/trussloader.cpp
+               ../core/wx_path_utils.cpp
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
@@ -855,6 +873,7 @@ add_executable(mvr_dmx_address_test mvr_dmx_address_test.cpp
                ../core/utf8_utils.cpp
                ../core/trussdictionary.cpp
                ../core/trussloader.cpp
+               ../core/wx_path_utils.cpp
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/uuidutils.cpp
@@ -892,6 +911,7 @@ add_executable(mvr_support_userdata_roundtrip_test mvr_support_userdata_roundtri
                ../core/utf8_utils.cpp
                ../core/trussdictionary.cpp
                ../core/trussloader.cpp
+               ../core/wx_path_utils.cpp
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/uuidutils.cpp
@@ -933,6 +953,7 @@ add_executable(mvr_layer_appearance_userdata_test mvr_layer_appearance_userdata_
                ../core/utf8_utils.cpp
                ../core/trussdictionary.cpp
                ../core/trussloader.cpp
+               ../core/wx_path_utils.cpp
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/uuidutils.cpp
@@ -974,6 +995,7 @@ add_executable(mvr_fixture_category_roundtrip_test mvr_fixture_category_roundtri
                ../core/utf8_utils.cpp
                ../core/trussdictionary.cpp
                ../core/trussloader.cpp
+               ../core/wx_path_utils.cpp
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/uuidutils.cpp
@@ -1014,6 +1036,7 @@ add_executable(mvr_sceneobject_symbol_identity_test mvr_sceneobject_symbol_ident
                ../core/utf8_utils.cpp
                ../core/trussdictionary.cpp
                ../core/trussloader.cpp
+               ../core/wx_path_utils.cpp
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/uuidutils.cpp
@@ -1059,6 +1082,7 @@ add_executable(mvr_truss_roundtrip_structure_test mvr_truss_roundtrip_structure_
                ../core/utf8_utils.cpp
                ../core/trussdictionary.cpp
                ../core/trussloader.cpp
+               ../core/wx_path_utils.cpp
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/uuidutils.cpp
@@ -1099,6 +1123,7 @@ add_executable(mvr_exporter_compliance_test mvr_exporter_compliance_test.cpp
                ../core/utf8_utils.cpp
                ../core/trussdictionary.cpp
                ../core/trussloader.cpp
+               ../core/wx_path_utils.cpp
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/uuidutils.cpp
@@ -1148,6 +1173,7 @@ add_executable(rider_save_roundtrip_test rider_save_roundtrip_test.cpp
                ../core/layer_service.cpp
                ../core/trussdictionary.cpp
                ../core/trussloader.cpp
+               ../core/wx_path_utils.cpp
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
@@ -1711,6 +1737,7 @@ add_executable(symbol_fixture_applier_gdtf_test symbol_fixture_applier_gdtf_test
                ../core/uuidutils.cpp
                ../core/trussdictionary.cpp
                ../core/trussloader.cpp
+               ../core/wx_path_utils.cpp
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
@@ -1754,6 +1781,7 @@ add_executable(mvr_patched_gdtf_export_test mvr_patched_gdtf_export_test.cpp
                ../core/gdtf_mutation_audit.cpp
                ../core/trussdictionary.cpp
                ../core/trussloader.cpp
+               ../core/wx_path_utils.cpp
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/uuidutils.cpp
@@ -1805,6 +1833,7 @@ add_executable(filesystem_identity_test
                build_info_stub.cpp
                ../core/filesystem_path_utils.cpp
                ../core/trussloader.cpp
+               ../core/wx_path_utils.cpp
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/gdtf_mutation_audit.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,13 +8,56 @@ find_package(CURL REQUIRED)
 
 enable_testing()
 
-function(add_repository_policy_test test_name script_path)
+add_library(perastage_test_no_dialog OBJECT windows_no_dialog_runtime.cpp)
+link_libraries($<TARGET_OBJECTS:perastage_test_no_dialog>)
+
+function(validate_bash_executable bash_path)
+    if(NOT bash_path)
+        message(FATAL_ERROR "BASH_EXECUTABLE is required for shell policy tests.")
+    endif()
+    if(WIN32)
+        string(TOLOWER "${bash_path}" bash_path_lower)
+        if(bash_path_lower MATCHES "windowsapps[/\\]bash\\.exe$" OR
+           bash_path_lower MATCHES "system32[/\\]bash\\.exe$")
+            message(FATAL_ERROR "BASH_EXECUTABLE must be Git Bash on Windows, not a WSL launcher: ${bash_path}")
+        endif()
+        if(NOT bash_path_lower MATCHES "[/\\]git[/\\].*[/\\]bash\\.exe$")
+            message(FATAL_ERROR "BASH_EXECUTABLE must come from Git for Windows: ${bash_path}")
+        endif()
+    endif()
+    execute_process(
+        COMMAND "${bash_path}" -lc "printf 'cmake-bash-ok\n'"
+        RESULT_VARIABLE bash_result
+        OUTPUT_VARIABLE bash_output
+        ERROR_VARIABLE bash_error
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(NOT bash_result EQUAL 0 OR NOT bash_output STREQUAL "cmake-bash-ok")
+        message(FATAL_ERROR "BASH_EXECUTABLE could not run a trivial shell script: ${bash_path} output='${bash_output}' error='${bash_error}'")
+    endif()
+endfunction()
+
+function(add_bash_policy_test test_name script_path)
     set(options)
     set(oneValueArgs)
     set(multiValueArgs LABELS ARGS)
     cmake_parse_arguments(POLICY "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
     add_test(NAME ${test_name}
-             COMMAND ${script_path} ${POLICY_ARGS})
+             COMMAND "${BASH_EXECUTABLE}" "${script_path}" ${POLICY_ARGS})
+    set(properties WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
+    if(POLICY_LABELS)
+        list(JOIN POLICY_LABELS ";" labels)
+        list(APPEND properties LABELS "${labels}")
+    endif()
+    set_tests_properties(${test_name} PROPERTIES ${properties})
+endfunction()
+
+function(add_repository_policy_test test_name command_path)
+    set(options)
+    set(oneValueArgs)
+    set(multiValueArgs LABELS ARGS)
+    cmake_parse_arguments(POLICY "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+    add_test(NAME ${test_name}
+             COMMAND "${command_path}" ${POLICY_ARGS})
     set(properties WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
     if(POLICY_LABELS)
         list(JOIN POLICY_LABELS ";" labels)
@@ -61,32 +104,33 @@ target_link_libraries(perastage_test_gdtf_archive_reader PRIVATE ${wxWidgets_LIB
 
 find_program(BASH_EXECUTABLE bash)
 if(BASH_EXECUTABLE)
-    add_repository_policy_test(DocsPerastageTreeModules ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_perastage_tree_modules.sh)
-    add_repository_policy_test(GuiNoConfigManagerGet ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_no_configmanager_get_in_gui.sh)
-    add_repository_policy_test(OpenGLLifecycleCentralized ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_opengl_lifecycle_centralized.sh)
-    add_repository_policy_test(Layout2DRasterizationBoundary ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_layout_2d_rasterization_boundary.sh)
-    add_repository_policy_test(Layout2DViewCaptureBoundary ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_layout_2d_view_capture_boundary.sh)
-    add_repository_policy_test(Viewer2DStateOwnershipBoundary ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_viewer2d_state_ownership_boundary.sh)
-    add_repository_policy_test(Viewer2DRenderToRGBAFboBoundary ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_viewer2d_render_to_rgba_fbo_boundary.sh)
-    add_repository_policy_test(Viewer2DFboCaptureDiagnostics ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_viewer2d_fbo_capture_diagnostics.sh)
-    add_repository_policy_test(LayoutPreviewFailureDiagnostics ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_layout_preview_failure_diagnostics.sh)
-    add_repository_policy_test(LayoutProjectLoadCacheReset ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_layout_project_load_cache_reset.sh)
-    add_repository_policy_test(LayoutViewerFitLifecycle ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_layout_viewer_fit_lifecycle.sh)
-    add_repository_policy_test(LibraryUserDataPolicy ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_library_user_data_policy.sh)
-    add_repository_policy_test(DictionaryPathsPolicy ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_dictionary_paths.sh)
-    add_repository_policy_test(GdtfMetadataSummaryBoundary ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_gdtf_metadata_summary_boundary.sh)
-    add_repository_policy_test(GdtfMetadataPanelBoundary ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_gdtf_metadata_panel_boundary.sh)
-    add_repository_policy_test(GdtfReusablePanelsBoundary ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_gdtf_reusable_panels_boundary.sh)
-    add_repository_policy_test(GdtfEditorPanelBoundary ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_gdtf_editor_panel_boundary.sh)
-    add_repository_policy_test(GdtfEditorCoreBoundary ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_gdtf_editor_core_boundary.sh)
-    add_repository_policy_test(GdtfEditorCheckpoint08ABinding ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_gdtf_editor_checkpoint08a_binding.sh)
-    add_repository_policy_test(GdtfEditorCheckpoint08E2ModeBrowser ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_gdtf_editor_checkpoint08e2_mode_browser.sh)
-    add_repository_policy_test(GdtfEditorCheckpoint08E3WheelAttributeInspector ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_gdtf_editor_checkpoint08e3_wheel_attribute_inspector.sh)
-    add_repository_policy_test(ProjectRestoreImportOptions ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_project_restore_import_options.sh)
-    add_repository_policy_test(SecureStoreBuildPolicy ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_securestore_build_policy.sh LABELS secure-store security release-gate)
-    add_repository_policy_test(WindowsNinjaX64Policy ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_windows_ninja_x64_policy.sh LABELS windows x64 release-gate)
-    add_repository_policy_test(CiCMakeLanguagePolicy ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_ci_cmake_language_policy.sh LABELS ci cmake release-gate)
-    add_repository_policy_test(ReleaseGatePolicyPortability ${BASH_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_release_gate_policy_portability.sh LABELS ci policy release-gate)
+    validate_bash_executable("${BASH_EXECUTABLE}")
+    add_bash_policy_test(DocsPerastageTreeModules ${CMAKE_CURRENT_SOURCE_DIR}/check_perastage_tree_modules.sh)
+    add_bash_policy_test(GuiNoConfigManagerGet ${CMAKE_CURRENT_SOURCE_DIR}/check_no_configmanager_get_in_gui.sh)
+    add_bash_policy_test(OpenGLLifecycleCentralized ${CMAKE_CURRENT_SOURCE_DIR}/check_opengl_lifecycle_centralized.sh)
+    add_bash_policy_test(Layout2DRasterizationBoundary ${CMAKE_CURRENT_SOURCE_DIR}/check_layout_2d_rasterization_boundary.sh)
+    add_bash_policy_test(Layout2DViewCaptureBoundary ${CMAKE_CURRENT_SOURCE_DIR}/check_layout_2d_view_capture_boundary.sh)
+    add_bash_policy_test(Viewer2DStateOwnershipBoundary ${CMAKE_CURRENT_SOURCE_DIR}/check_viewer2d_state_ownership_boundary.sh)
+    add_bash_policy_test(Viewer2DRenderToRGBAFboBoundary ${CMAKE_CURRENT_SOURCE_DIR}/check_viewer2d_render_to_rgba_fbo_boundary.sh)
+    add_bash_policy_test(Viewer2DFboCaptureDiagnostics ${CMAKE_CURRENT_SOURCE_DIR}/check_viewer2d_fbo_capture_diagnostics.sh)
+    add_bash_policy_test(LayoutPreviewFailureDiagnostics ${CMAKE_CURRENT_SOURCE_DIR}/check_layout_preview_failure_diagnostics.sh)
+    add_bash_policy_test(LayoutProjectLoadCacheReset ${CMAKE_CURRENT_SOURCE_DIR}/check_layout_project_load_cache_reset.sh)
+    add_bash_policy_test(LayoutViewerFitLifecycle ${CMAKE_CURRENT_SOURCE_DIR}/check_layout_viewer_fit_lifecycle.sh)
+    add_bash_policy_test(LibraryUserDataPolicy ${CMAKE_CURRENT_SOURCE_DIR}/check_library_user_data_policy.sh)
+    add_bash_policy_test(DictionaryPathsPolicy ${CMAKE_CURRENT_SOURCE_DIR}/check_dictionary_paths.sh)
+    add_bash_policy_test(GdtfMetadataSummaryBoundary ${CMAKE_CURRENT_SOURCE_DIR}/check_gdtf_metadata_summary_boundary.sh)
+    add_bash_policy_test(GdtfMetadataPanelBoundary ${CMAKE_CURRENT_SOURCE_DIR}/check_gdtf_metadata_panel_boundary.sh)
+    add_bash_policy_test(GdtfReusablePanelsBoundary ${CMAKE_CURRENT_SOURCE_DIR}/check_gdtf_reusable_panels_boundary.sh)
+    add_bash_policy_test(GdtfEditorPanelBoundary ${CMAKE_CURRENT_SOURCE_DIR}/check_gdtf_editor_panel_boundary.sh)
+    add_bash_policy_test(GdtfEditorCoreBoundary ${CMAKE_CURRENT_SOURCE_DIR}/check_gdtf_editor_core_boundary.sh)
+    add_bash_policy_test(GdtfEditorCheckpoint08ABinding ${CMAKE_CURRENT_SOURCE_DIR}/check_gdtf_editor_checkpoint08a_binding.sh)
+    add_bash_policy_test(GdtfEditorCheckpoint08E2ModeBrowser ${CMAKE_CURRENT_SOURCE_DIR}/check_gdtf_editor_checkpoint08e2_mode_browser.sh)
+    add_bash_policy_test(GdtfEditorCheckpoint08E3WheelAttributeInspector ${CMAKE_CURRENT_SOURCE_DIR}/check_gdtf_editor_checkpoint08e3_wheel_attribute_inspector.sh)
+    add_bash_policy_test(ProjectRestoreImportOptions ${CMAKE_CURRENT_SOURCE_DIR}/check_project_restore_import_options.sh)
+    add_bash_policy_test(SecureStoreBuildPolicy ${CMAKE_CURRENT_SOURCE_DIR}/check_securestore_build_policy.sh LABELS secure-store security release-gate)
+    add_bash_policy_test(WindowsNinjaX64Policy ${CMAKE_CURRENT_SOURCE_DIR}/check_windows_ninja_x64_policy.sh LABELS windows x64 release-gate)
+    add_bash_policy_test(CiCMakeLanguagePolicy ${CMAKE_CURRENT_SOURCE_DIR}/check_ci_cmake_language_policy.sh LABELS ci cmake release-gate)
+    add_bash_policy_test(ReleaseGatePolicyPortability ${CMAKE_CURRENT_SOURCE_DIR}/check_release_gate_policy_portability.sh LABELS ci policy release-gate)
 endif()
 
 find_package(Python3 COMPONENTS Interpreter)
@@ -99,14 +143,16 @@ if(Python3_Interpreter_FOUND)
                                ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_wx_filesystem_path_boundaries.py)
     add_repository_policy_test(ReleaseWorkflowsUntouched ${Python3_EXECUTABLE}
                                ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_release_workflows_untouched.py)
+    add_repository_policy_test(BashTestRegistration ${Python3_EXECUTABLE}
+                               ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_bash_test_registration.py)
     add_repository_policy_test(CMakeToolchainValidator ${Python3_EXECUTABLE}
                                ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_validate_cmake_toolchain.py)
     add_repository_policy_test(CiCMakeLanguagePolicyFixtures ${Python3_EXECUTABLE}
-                               ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_ci_cmake_language_policy_fixtures.py)
+                               ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_ci_cmake_language_policy_fixtures.py --bash ${BASH_EXECUTABLE})
     add_repository_policy_test(PolicyWorkingDirectories ${Python3_EXECUTABLE}
-                               ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_policy_working_directories.py)
+                               ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_policy_working_directories.py --bash ${BASH_EXECUTABLE})
     add_repository_policy_test(MissingRipgrepBehavior ${Python3_EXECUTABLE}
-                               ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_missing_ripgrep_behavior.py)
+                               ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_missing_ripgrep_behavior.py --bash ${BASH_EXECUTABLE})
     add_repository_policy_test(CtestFailureSummary ${Python3_EXECUTABLE}
                                ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_summarize_ctest_failures.py)
 endif()
@@ -436,7 +482,7 @@ add_executable(project_fixture_gdtf_apply_adapter_test
                ../core/filesystem_path_utils.cpp)
 target_include_directories(project_fixture_gdtf_apply_adapter_test PRIVATE .. ../core ../models)
 add_test(NAME ProjectFixtureGdtfApplyAdapter COMMAND project_fixture_gdtf_apply_adapter_test)
-add_test(NAME GdtfEditorCheckpoint08BFixtureApplyAdapter COMMAND ${CMAKE_SOURCE_DIR}/tests/check_gdtf_editor_checkpoint08b_fixture_apply_adapter.sh)
+add_bash_policy_test(GdtfEditorCheckpoint08BFixtureApplyAdapter ${CMAKE_SOURCE_DIR}/tests/check_gdtf_editor_checkpoint08b_fixture_apply_adapter.sh)
 set_tests_properties(GdtfEditorCheckpoint08BFixtureApplyAdapter PROPERTIES WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
 add_executable(project_truss_gdtf_apply_adapter_test
                project_truss_gdtf_apply_adapter_test.cpp
@@ -447,9 +493,9 @@ add_executable(project_truss_gdtf_apply_adapter_test
                ../core/filesystem_path_utils.cpp)
 target_include_directories(project_truss_gdtf_apply_adapter_test PRIVATE .. ../core ../models)
 add_test(NAME ProjectTrussGdtfApplyAdapter COMMAND project_truss_gdtf_apply_adapter_test)
-add_test(NAME GdtfEditorCheckpoint08CTrussApplyAdapter COMMAND ${CMAKE_SOURCE_DIR}/tests/check_gdtf_editor_checkpoint08c_truss_apply_adapter.sh)
+add_bash_policy_test(GdtfEditorCheckpoint08CTrussApplyAdapter ${CMAKE_SOURCE_DIR}/tests/check_gdtf_editor_checkpoint08c_truss_apply_adapter.sh)
 set_tests_properties(GdtfEditorCheckpoint08CTrussApplyAdapter PROPERTIES WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
-add_test(NAME GdtfEditorCheckpoint08DStabilization COMMAND ${CMAKE_SOURCE_DIR}/tests/check_gdtf_editor_checkpoint08d_stabilization.sh)
+add_bash_policy_test(GdtfEditorCheckpoint08DStabilization ${CMAKE_SOURCE_DIR}/tests/check_gdtf_editor_checkpoint08d_stabilization.sh)
 set_tests_properties(GdtfEditorCheckpoint08DStabilization PROPERTIES WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
 
 add_executable(gdtf_editor_context_test
@@ -1631,7 +1677,7 @@ add_executable(fixture_symbol_projection_test fixture_symbol_projection_test.cpp
 target_include_directories(fixture_symbol_projection_test PRIVATE
                            ../viewer3d ../viewer3d/render ../viewer2d ../models)
 add_test(NAME FixtureSymbolProjection COMMAND fixture_symbol_projection_test)
-add_test(NAME FixtureSymbolProjectionParity COMMAND ${CMAKE_SOURCE_DIR}/tests/check_fixture_symbol_projection_parity.sh)
+add_bash_policy_test(FixtureSymbolProjectionParity ${CMAKE_SOURCE_DIR}/tests/check_fixture_symbol_projection_parity.sh)
 set_tests_properties(FixtureSymbolProjectionParity PROPERTIES WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
 
 add_executable(meshprimitives_cube_normals_test meshprimitives_cube_normals_test.cpp

--- a/tests/check_bash_test_registration.py
+++ b/tests/check_bash_test_registration.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CMAKE = ROOT / "tests/CMakeLists.txt"
+DIRECT_SHELL_TEST = re.compile(r"add_test\s*\([^)]*COMMAND\s+[^)]*\.sh(?:\s|\))", re.DOTALL)
+
+
+def main() -> int:
+    text = CMAKE.read_text(encoding="utf-8")
+    matches = DIRECT_SHELL_TEST.findall(text)
+    if matches:
+        print("Shell CTest registrations must use add_bash_policy_test:")
+        for match in matches:
+            print(match.strip())
+        return 1
+    print("OK: shell CTest registrations use add_bash_policy_test.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/check_ci_cmake_language_policy_fixtures.py
+++ b/tests/check_ci_cmake_language_policy_fixtures.py
@@ -1,11 +1,16 @@
 #!/usr/bin/env python3
 from pathlib import Path
+import argparse
 import os
 import shutil
 import subprocess
 import tempfile
 
 ROOT = Path(__file__).resolve().parents[1]
+parser = argparse.ArgumentParser()
+parser.add_argument('--bash', required=True)
+args = parser.parse_args()
+BASH = args.bash
 SCRIPT = ROOT / 'tests/check_ci_cmake_language_policy.sh'
 needed = ['.github/workflows/ci-tests.yml', '.github/workflows/windows-installer.yml', '.github/workflows/linux-installer.yml', '.github/workflows/macos-installer.yml', '.github/workflows/macos-15-manual-installer.yml', '.github/workflows/arch-package.yml']
 
@@ -21,10 +26,10 @@ with tempfile.TemporaryDirectory() as tmp:
     (repo / 'vcpkg/buildtrees/liblzma').mkdir(parents=True)
     (repo / 'vcpkg/buildtrees/liblzma/CMakeLists.txt').write_text('enable_language(C)\n')
     env = {**os.environ, 'PERASTAGE_POLICY_ROOT': str(repo)}
-    ok = subprocess.run(['bash', str(SCRIPT)], env=env, text=True, capture_output=True)
+    ok = subprocess.run([BASH, str(SCRIPT)], env=env, text=True, capture_output=True)
     assert ok.returncode == 0, ok.stderr + ok.stdout
     (repo / 'cmake').mkdir()
     (repo / 'cmake/CMakeLists.txt').write_text('enable_language(C)\n')
-    bad = subprocess.run(['bash', str(SCRIPT)], env=env, text=True, capture_output=True)
+    bad = subprocess.run([BASH, str(SCRIPT)], env=env, text=True, capture_output=True)
     assert bad.returncode != 0 and 'Nested enable_language()' in (bad.stderr + bad.stdout), bad.stderr + bad.stdout
 print('OK: CMake language policy fixtures cover first-party failures and vcpkg exclusions.')

--- a/tests/check_macos_sdk_cache_guard.py
+++ b/tests/check_macos_sdk_cache_guard.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location("guard", ROOT / ".github/scripts/macos_sdk_cache_guard.py")
+guard = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(guard)
+
+
+def assert_classifies(current: Path, refs: set[str], stale_count: int) -> None:
+    _, _, stale = guard.classify_sdk_paths(current, refs)
+    assert len(stale) == stale_count, stale
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="Perastage SDK Cache ") as tmp:
+        root = Path(tmp)
+        xcode = root / "Applications" / "Xcode 26.app" / "Contents" / "Developer" / "Platforms" / "MacOSX.platform" / "Developer" / "SDKs"
+        xcode.mkdir(parents=True)
+        versioned = xcode / "MacOSX26.5.sdk"
+        versioned.mkdir()
+        alias = xcode / "MacOSX.sdk"
+        alias.symlink_to(versioned, target_is_directory=True)
+        other = xcode / "MacOSX25.4.sdk"
+        other.mkdir()
+
+        assert_classifies(versioned, {str(versioned)}, 0)
+        assert_classifies(versioned, {str(alias)}, 0)
+        assert_classifies(versioned, {str(xcode / "MacOSX24.0.sdk")}, 1)
+        assert_classifies(versioned, {str(other)}, 1)
+        assert_classifies(versioned, {str(alias), str(root / "Applications" / "Xcode With Spaces.app" / "Contents" / "Developer" / "Platforms" / "MacOSX.platform" / "Developer" / "SDKs" / "MacOSX.sdk")}, 1)
+
+        scan = root / "scan"
+        scan.mkdir()
+        metadata_path = "/Applications/Xcode_26.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.5.sdk"
+        (scan / "meta.txt").write_text(f"sdk={metadata_path}\n", encoding="utf-8")
+        assert metadata_path in guard.discover_sdk_paths([scan])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/check_missing_ripgrep_behavior.py
+++ b/tests/check_missing_ripgrep_behavior.py
@@ -1,18 +1,22 @@
 #!/usr/bin/env python3
 from pathlib import Path
+import argparse
 import os
 import subprocess
 import tempfile
 
 ROOT = Path(__file__).resolve().parents[1]
+parser = argparse.ArgumentParser()
+parser.add_argument('--bash', required=True)
+args = parser.parse_args()
+BASH = args.bash
 SCRIPT = ROOT / 'tests/check_perastage_tree_modules.sh'
 with tempfile.TemporaryDirectory() as tmp:
     bin_dir = Path(tmp) / 'bin'
     bin_dir.mkdir()
-    for tool in ['bash', 'dirname']:
-        os.symlink(f'/usr/bin/{tool}', bin_dir / tool)
+    os.symlink('/usr/bin/dirname', bin_dir / 'dirname')
     env = {**os.environ, 'PATH': str(bin_dir)}
-    result = subprocess.run(['/usr/bin/bash', str(SCRIPT)], env=env, text=True, capture_output=True)
+    result = subprocess.run([BASH, str(SCRIPT)], env=env, text=True, capture_output=True)
     assert result.returncode == 127, result.stdout + result.stderr
     assert "required test tool 'rg'" in result.stderr, result.stdout + result.stderr
 print('OK: ripgrep-dependent policy scripts fail clearly when rg is missing.')

--- a/tests/check_policy_working_directories.py
+++ b/tests/check_policy_working_directories.py
@@ -1,9 +1,14 @@
 #!/usr/bin/env python3
 from pathlib import Path
+import argparse
 import subprocess
 import tempfile
 
 ROOT = Path(__file__).resolve().parents[1]
+parser = argparse.ArgumentParser()
+parser.add_argument('--bash', required=True)
+args = parser.parse_args()
+BASH = args.bash
 SCRIPTS = [
     ROOT / 'tests/check_securestore_build_policy.sh',
     ROOT / 'tests/check_ci_cmake_language_policy.sh',
@@ -14,6 +19,6 @@ with tempfile.TemporaryDirectory() as tmp:
     build.mkdir(parents=True, exist_ok=True)
     for cwd in [ROOT, build, Path(tmp)]:
         for script in SCRIPTS:
-            result = subprocess.run(['bash', str(script)], cwd=cwd, text=True, capture_output=True)
+            result = subprocess.run([BASH, str(script)], cwd=cwd, text=True, capture_output=True)
             assert result.returncode == 0, f'{script.name} failed from {cwd}:\n{result.stdout}\n{result.stderr}'
 print('OK: representative policy scripts resolve repository paths from root, build, and temporary working directories.')

--- a/tests/check_release_workflows_untouched.py
+++ b/tests/check_release_workflows_untouched.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import subprocess
+import sys
+
+PROTECTED = [
+    ".github/workflows/windows-installer.yml",
+    ".github/workflows/linux-installer.yml",
+    ".github/workflows/macos-installer.yml",
+    ".github/workflows/macos-15-manual-installer.yml",
+    ".github/workflows/arch-package.yml",
+    ".github/workflows/main-patch-test-build.yml",
+    ".github/workflows/compatibility-builds.yml",
+    ".github/workflows/minor-draft-release.yml",
+    ".github/release-artifact-contract.json",
+]
+
+
+def main() -> int:
+    changed = subprocess.check_output(["git", "diff", "--name-only", "HEAD", "--", *PROTECTED], text=True).splitlines()
+    if changed:
+        print("Protected Release workflow or artifact contract files changed:")
+        for path in changed:
+            print(f"  {path}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/check_windows_debug_tool_preflight.py
+++ b/tests/check_windows_debug_tool_preflight.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github/workflows/ci-tests.yml"
+
+
+def require(text: str, needle: str, message: str) -> bool:
+    if needle in text:
+        return True
+    print(message)
+    return False
+
+
+def main() -> int:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    ok = True
+    ok &= require(text, "Prepare Windows Debug test tools", "Windows Debug must prepare test tools before Bash validation.")
+    ok &= require(text, "Get-Command rg.exe", "Windows Debug must resolve ripgrep in PowerShell.")
+    ok &= require(text, "choco.exe", "Windows Debug must install ripgrep when the hosted runner lacks it.")
+    ok &= require(text, "windows-test-tools.txt", "Windows Debug must log resolved test tools.")
+    ok &= require(text, "--noprofile --norc -c 'printf", "Git Bash execution probe must use a non-login shell.")
+    ok &= require(text, "--noprofile --norc -c 'command -v rg && rg --version'", "Git Bash ripgrep probe must be separate from Bash execution.")
+    ok &= require(text, "-DBASH_EXECUTABLE=\"$env:PERASTAGE_GIT_BASH\"", "Windows CMake configure must receive the validated Git Bash path.")
+    if "bash -lc 'printf \"git-bash-ok" in text or "bash -lc 'printf" in text:
+        print("Windows Debug Git Bash probes must not use login-shell -lc mode.")
+        ok = False
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/check_wx_filesystem_path_boundaries.py
+++ b/tests/check_wx_filesystem_path_boundaries.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PATTERNS = [
+    re.compile(r"wxFile(?:Input|Output)Stream\s+\w+\([^;]*(?:archivePath|target|path)\.string\(\)"),
+    re.compile(r"wxFFileInputStream\s+\w+\([^;]*(?:archivePath|target|path)\.string\(\)"),
+    re.compile(r"wxFileName::Mkdir\([^;]*(?:target|path)\.string\(\)"),
+]
+
+
+def main() -> int:
+    failures: list[str] = []
+    for base in [ROOT / "core", ROOT / "tests"]:
+        for path in base.rglob("*.cpp"):
+            text = path.read_text(encoding="utf-8", errors="ignore")
+            for pattern in PATTERNS:
+                if pattern.search(text):
+                    failures.append(str(path.relative_to(ROOT)))
+                    break
+    if failures:
+        print("wxWidgets filesystem APIs must use WxPathUtils at audited path boundaries:")
+        for failure in failures:
+            print(f"  {failure}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/gdtf_canonicalizer_test.cpp
+++ b/tests/gdtf_canonicalizer_test.cpp
@@ -1,3 +1,4 @@
+#include "wx_path_utils.h"
 #include "gdtf_canonicalizer.h"
 
 #include <cassert>
@@ -54,7 +55,7 @@ std::string MinimalGdtf(const std::string &fixtureTypeInner) {
 
 // Writes a test GDTF archive with description.xml in a nested root folder.
 void WriteNestedDescriptionArchive(const std::filesystem::path &path) {
-  wxFileOutputStream output(path.string());
+  wxFileOutputStream output(WxPathUtils::WxStringFromFilesystemPath(path));
   assert(output.IsOk());
   wxZipOutputStream zip(output);
   auto *entry = new wxZipEntry("Dummy 1ch/description.xml");
@@ -70,7 +71,7 @@ void WriteNestedDescriptionArchive(const std::filesystem::path &path) {
 // Returns whether a ZIP archive contains an entry with the requested name.
 bool ArchiveContainsEntry(const std::filesystem::path &path,
                           const std::string &entryName) {
-  wxFileInputStream input(path.string());
+  wxFileInputStream input(WxPathUtils::WxStringFromFilesystemPath(path));
   assert(input.IsOk());
   wxZipInputStream zip(input);
   std::unique_ptr<wxZipEntry> entry;

--- a/tests/gdtf_dictionary_color_roundtrip_test.cpp
+++ b/tests/gdtf_dictionary_color_roundtrip_test.cpp
@@ -1,6 +1,7 @@
 /*
  * This file is part of Perastage.
  */
+#include "wx_path_utils.h"
 #include "filesystem_path_utils.h"
 #include <cassert>
 #include <filesystem>
@@ -35,7 +36,7 @@ void WriteFile(const std::filesystem::path &path, const std::string &content) {
 
 // Writes a GDTF archive with description.xml stored below a root folder.
 void WriteNestedDescriptionGdtf(const std::filesystem::path &path) {
-  wxFileOutputStream output(path.string());
+  wxFileOutputStream output(WxPathUtils::WxStringFromFilesystemPath(path));
   assert(output.IsOk());
   wxZipOutputStream zip(output);
   auto *entry = new wxZipEntry("Dummy 1ch/description.xml");

--- a/tests/gdtf_fixture_category_test.cpp
+++ b/tests/gdtf_fixture_category_test.cpp
@@ -1,3 +1,4 @@
+#include "wx_path_utils.h"
 #include <cassert>
 #include <filesystem>
 #include <string>
@@ -33,7 +34,7 @@ static std::string WrapDescription(const std::string &name,
 }
 
 static bool WriteGdtf(const fs::path &path, const std::string &descriptionXml) {
-  wxFileOutputStream output(path.string());
+  wxFileOutputStream output(WxPathUtils::WxStringFromFilesystemPath(path));
   if (!output.IsOk())
     return false;
 

--- a/tests/gdtf_metadata_summary_test.cpp
+++ b/tests/gdtf_metadata_summary_test.cpp
@@ -1,3 +1,4 @@
+#include "wx_path_utils.h"
 #include <cassert>
 #include <filesystem>
 #include <string>
@@ -12,7 +13,7 @@ namespace fs = std::filesystem;
 
 // Writes a minimal GDTF archive containing description.xml.
 static bool WriteGdtf(const fs::path &path, const std::string &descriptionXml) {
-  wxFileOutputStream output(path.string());
+  wxFileOutputStream output(WxPathUtils::WxStringFromFilesystemPath(path));
   if (!output.IsOk())
     return false;
 

--- a/tests/gdtf_share_security_test.cpp
+++ b/tests/gdtf_share_security_test.cpp
@@ -6,6 +6,7 @@
 #include <cassert>
 #include <filesystem>
 #include <fstream>
+#include <iostream>
 #include <map>
 #include <vector>
 
@@ -174,18 +175,27 @@ void TestCredentialStorage() {
     assert(!usernameOnly.credentials);
     assert(usernameOnly.usernameHint && *usernameOnly.usernameHint == username);
     backend->stored = cred;
-    std::ifstream in(dir / "gdtf_credentials.json");
-    const auto metadata = nlohmann::json::parse(in);
-    assert(metadata.is_object());
-    assert(metadata.size() == 4);
-    assert(metadata.at("schema_version") == CredentialStore::kGdtfCredentialMetadataSchemaVersion);
-    assert(metadata.at("backend") == "wx_secret_store");
-    assert(metadata.at("service") == CredentialStore::kGdtfShareCredentialService);
-    assert(metadata.at("username") == username);
-    assert(!ContainsJsonObjectKey(metadata, "password"));
-    assert(!ContainsJsonObjectKey(metadata, "secret"));
-    assert(!ContainsJsonStringValue(metadata, password));
-    assert(CredentialStore::ClearDetailed().Succeeded());
+    {
+        std::ifstream in(dir / "gdtf_credentials.json");
+        const auto metadata = nlohmann::json::parse(in);
+        assert(metadata.is_object());
+        assert(metadata.size() == 4);
+        assert(metadata.at("schema_version") == CredentialStore::kGdtfCredentialMetadataSchemaVersion);
+        assert(metadata.at("backend") == "wx_secret_store");
+        assert(metadata.at("service") == CredentialStore::kGdtfShareCredentialService);
+        assert(metadata.at("username") == username);
+        assert(!ContainsJsonObjectKey(metadata, "password"));
+        assert(!ContainsJsonObjectKey(metadata, "secret"));
+        assert(!ContainsJsonStringValue(metadata, password));
+    }
+    const CredentialStore::Result clearResult = CredentialStore::ClearDetailed();
+    if (!clearResult.Succeeded()) {
+        std::cerr << "Credential metadata clear failed: status="
+                  << static_cast<int>(clearResult.status)
+                  << " message=" << clearResult.message << '\n';
+    }
+    assert(clearResult.Succeeded());
+    assert(!fs::exists(dir / "gdtf_credentials.json"));
     assert(!CredentialStore::LoadDetailed().credentials);
     backend->available = false;
     CredentialStore::Result unavailableSave = CredentialStore::Save(cred);

--- a/tests/layer_service_utf8_test.cpp
+++ b/tests/layer_service_utf8_test.cpp
@@ -50,16 +50,21 @@ int main() {
   assert(layerdomain::ValidateSceneLayers(scene).status ==
          layerdomain::LayerStatus::Success);
   assert(scene.layers.at("f806f881-7e6d-538f-bc17-e2a08ec678f1").name ==
-         "rig Iluminación");
-  assert(scene.layers.at("1e4e210c-6fe9-579c-a6f5-e4ba379b368e").name ==
          "rig Iluminación (Recovered 2)");
+  assert(scene.layers.at("1e4e210c-6fe9-579c-a6f5-e4ba379b368e").name ==
+         "rig Iluminación");
 
   const auto entries = layerdomain::EnumerateLayers(scene);
   bool foundSupportLayer = false;
   for (const auto &entry : entries) {
-    if (entry.name == "rig Iluminación")
+    if (entry.name == "rig Iluminación (Recovered 2)")
       foundSupportLayer = true;
   }
   assert(foundSupportLayer);
+
+  const auto second = layerdomain::ReconcileLegacyLayers(scene);
+  assert(second.status == layerdomain::LayerStatus::NoChange);
+  assert(IsValidUtf8("Vídeo"));
+  assert(IsValidUtf8("照明"));
   return 0;
 }

--- a/tests/layout_collection_zorder_test.cpp
+++ b/tests/layout_collection_zorder_test.cpp
@@ -111,6 +111,14 @@ void TestRegularUpdateKeepsExistingZIndex() {
   assert(updated != nullptr);
   assert(updated->view2dViews.size() == 1);
   assert(updated->view2dViews.front().zIndex == 1);
+
+  layouts::LayoutTextDefinition editedText = text;
+  editedText.text = "Updated";
+  editedText.zIndex = 100;
+  assert(collection.UpdateLayoutText("Persist z", editedText));
+  updated = FindLayout(collection, "Persist z");
+  assert(updated != nullptr);
+  assert(updated->textViews.front().zIndex == 5);
 }
 
 } // namespace

--- a/tests/layout_image_resource_registry_test.cpp
+++ b/tests/layout_image_resource_registry_test.cpp
@@ -1,3 +1,4 @@
+#include "wx_path_utils.h"
 #include "LayoutImageResourceRegistry.h"
 #include "LayoutManager.h"
 #include "configmanager.h"
@@ -37,7 +38,7 @@ std::string ReadCurrentZipEntry(wxZipInputStream &zip) {
 // Reads all file entries from a ZIP archive into a name-to-payload map.
 std::map<std::string, std::string> ReadArchiveEntries(const fs::path &archivePath) {
   std::map<std::string, std::string> entries;
-  wxFileInputStream input(archivePath.string());
+  wxFileInputStream input(WxPathUtils::WxStringFromFilesystemPath(archivePath));
   assert(input.IsOk());
   wxZipInputStream zip(input);
   std::unique_ptr<wxZipEntry> entry;

--- a/tests/layout_template_package_service_test.cpp
+++ b/tests/layout_template_package_service_test.cpp
@@ -1,3 +1,4 @@
+#include "wx_path_utils.h"
 #include "LayoutTemplatePackageService.h"
 #include "LayoutTemplateSerializer.h"
 #include "LayoutImageResourceRegistry.h"
@@ -35,7 +36,7 @@ void WriteFile(const fs::path &path, const std::string &bytes) {
 
 // Reads a package into an entry map for package assertions.
 std::map<std::string, std::string> ReadZipEntries(const fs::path &path) {
-  wxFFileInputStream input(path.string());
+  wxFFileInputStream input(WxPathUtils::WxStringFromFilesystemPath(path));
   wxZipInputStream zip(input);
   std::map<std::string, std::string> entries;
   std::unique_ptr<wxZipEntry> entry;

--- a/tests/localization_catalog_integration_test.cpp
+++ b/tests/localization_catalog_integration_test.cpp
@@ -140,8 +140,11 @@ int main() {
   ok &= Check(chineseResult.activeLanguage ==
                   localization::AppLanguage::SimplifiedChinese,
               "Simplified Chinese did not become active after catalog loading.");
-  ok &= Check(_("Preferences") == wxString("Preferences"),
-              "Draft Simplified Chinese catalog should fall back to English source text.");
+  ok &= Check(_("Preferences") == ChineseFixture({0x9996, 0x9009, 0x9879}),
+              "Simplified Chinese catalog did not translate Preferences to 首选项.");
+  ok &= Check(_("Perastage missing localization sentinel") ==
+                  wxString("Perastage missing localization sentinel"),
+              "Missing Simplified Chinese message did not fall back to source text.");
   ok &= Check(ExpectedChineseLanguageName() ==
                   ChineseFixture({0x7B80, 0x4F53, 0x4E2D, 0x6587}),
               "Simplified Chinese native language name code points regressed.");

--- a/tests/rider_truss_dictionary_normalization_test.cpp
+++ b/tests/rider_truss_dictionary_normalization_test.cpp
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
+#include "wx_path_utils.h"
 #include <cassert>
 #include "filesystem_path_utils.h"
 #include <cstdlib>
@@ -53,7 +54,7 @@ bool WriteArchive(const fs::path &archivePath) {
   wxFileName::Mkdir(archivePath.parent_path().string(), wxS_DIR_DEFAULT,
                     wxPATH_MKDIR_FULL);
 
-  wxFileOutputStream output(archivePath.string());
+  wxFileOutputStream output(WxPathUtils::WxStringFromFilesystemPath(archivePath));
   if (!output.IsOk())
     return false;
 

--- a/tests/truss_path_encoding_regression_test.cpp
+++ b/tests/truss_path_encoding_regression_test.cpp
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
+#include "wx_path_utils.h"
 #include <cassert>
 #include "filesystem_path_utils.h"
 #include <cstdlib>
@@ -53,7 +54,7 @@ bool WriteArchive(const fs::path &archivePath) {
   wxFileName::Mkdir(archivePath.parent_path().string(), wxS_DIR_DEFAULT,
                     wxPATH_MKDIR_FULL);
 
-  wxFileOutputStream output(archivePath.string());
+  wxFileOutputStream output(WxPathUtils::WxStringFromFilesystemPath(archivePath));
   if (!output.IsOk())
     return false;
 

--- a/tests/trussloader_validation_test.cpp
+++ b/tests/trussloader_validation_test.cpp
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
+#include "wx_path_utils.h"
 #include "filesystem_path_utils.h"
 #include "trussloader.h"
 
@@ -48,7 +49,7 @@ bool Check(bool condition, const std::string &message) {
 
 // Writes a ZIP archive with the provided text entries.
 bool WriteZipArchive(const fs::path &path, const std::map<std::string, std::string> &entries) {
-  wxFileOutputStream output(path.string());
+  wxFileOutputStream output(WxPathUtils::WxStringFromFilesystemPath(path));
   if (!output.IsOk())
     return false;
 

--- a/tests/windows_no_dialog_runtime.cpp
+++ b/tests/windows_no_dialog_runtime.cpp
@@ -1,0 +1,32 @@
+// Configures Windows test processes to report crashes and assertions to stderr.
+#if defined(_WIN32)
+#include <windows.h>
+
+#if defined(_MSC_VER)
+#include <crtdbg.h>
+#include <cstdlib>
+#endif
+
+namespace {
+
+struct WindowsNoDialogRuntime {
+  // Installs non-modal Windows and CRT failure reporting for test executables.
+  WindowsNoDialogRuntime() {
+    SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX |
+                 SEM_NOOPENFILEERRORBOX);
+#if defined(_MSC_VER)
+    _CrtSetReportMode(_CRT_WARN, _CRTDBG_MODE_FILE);
+    _CrtSetReportFile(_CRT_WARN, _CRTDBG_FILE_STDERR);
+    _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_FILE);
+    _CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
+    _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE);
+    _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
+    _set_abort_behavior(0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
+#endif
+  }
+};
+
+const WindowsNoDialogRuntime kWindowsNoDialogRuntime;
+
+} // namespace
+#endif

--- a/tests/wx_path_utils_test.cpp
+++ b/tests/wx_path_utils_test.cpp
@@ -1,0 +1,21 @@
+#include "wx_path_utils.h"
+
+#include <cassert>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+// Verifies explicit filesystem and wxString path conversion for Unicode paths.
+int main() {
+  const std::vector<std::string> names = {
+      "ascii.gdtf", "path with spaces.gdtf", "Iluminación.gdtf", "照明.gdtf"};
+  for (const auto &name : names) {
+    std::filesystem::path path = std::filesystem::temp_directory_path() / name;
+    const wxString wxPath = WxPathUtils::WxStringFromFilesystemPath(path);
+    const std::filesystem::path roundTrip = WxPathUtils::FilesystemPathFromWxString(wxPath);
+    assert(roundTrip == path);
+  }
+  assert(WxPathUtils::WxStringFromFilesystemPath({}).empty());
+  assert(WxPathUtils::FilesystemPathFromWxString(wxString()).empty());
+  return 0;
+}


### PR DESCRIPTION
### Motivation
- Base `main` inspected locally: `76caf3d74c4c2c5535beab47e26d86b3c23f6bd9`; the change set addresses Debug CI brittleness and cross-platform Unicode/path determinism. 
- Prevent macOS Debug false failures caused by literal SDK-path string comparisons and make restored vcpkg caches recoverable instead of failing the job. 
- Remove ambiguous platform-dependent path conversions passed to wxWidgets and make layout and legacy-layer behavior deterministic across runs and platforms. 
- Add focused policy and unit checks so Debug CI is diagnostic, reproducible, and does not weaken production validation or Release workflows. 

### Description
- macOS SDK guard and CI key: added `.github/scripts/macos_sdk_cache_guard.py` and updated the `macos-debug` section in `.github/workflows/ci-tests.yml` to compute a runtime SDK identity (resolved realpath + Xcode version), accept equivalent symlinked SDK paths, classify stale metadata, and purge only ABI-sensitive restored Debug vcpkg trees (`VCPKG_INSTALLED`, `VCPKG_PACKAGES`, and binary cache) rather than failing the job. 
- wxWidgets path boundary: introduced `core/wx_path_utils.h/.cpp` with `WxStringFromFilesystemPath` and `FilesystemPathFromWxString` (Windows: native wide-string conversion; POSIX: explicit UTF-8 via `u8string`/`utf8_str`), migrated audited call sites that previously passed `path.string()` to wx APIs (GDTF/truss ZIP read/write, `wxFileName::Mkdir`, and affected tests), and added `tests/wx_path_utils_test.cpp` plus a CMake test target. 
- Layout and layer determinism: removed inference-based `IsExplicitBoundaryZChange` usage so all `UpdateLayout*` APIs preserve an element's existing `zIndex` while `Move*` APIs remain the explicit front/back mechanism; refactored `ReconcileLegacyLayers()` to a deterministic multi-phase algorithm that reserves valid UTF-8 names, repairs legacy Windows-1252 names, applies deterministic ` (Recovered N)` suffixes on collision, moves only the repaired layer's object references, validates the result, and is idempotent. 
- Tests and policy checks: added focused tests and policy scripts (`tests/check_macos_sdk_cache_guard.py`, `tests/check_wx_filesystem_path_boundaries.py`, `tests/check_release_workflows_untouched.py`), wired them into `tests/CMakeLists.txt`, and updated `docs/release-notes-draft.md` with brief user-facing notes; test inputs and call sites that needed explicit wx path bridging were migrated rather than accepting weakened validation. 
- Test/fixture classification summary: classified the macOS SDK failure as a CI harness defect; converted multiple failures to production compatibility fixes (wx path boundaries, layout z-order, layer reconciliation); and treated remaining GDTF/MVR fixture work as test-fixture hardening to be expanded in follow-ups. 

### Testing
- Ran the new macOS SDK guard unit test `python3 tests/check_macos_sdk_cache_guard.py` (passed). 
- Ran repository policy checks `python3 tests/check_wx_filesystem_path_boundaries.py` and `python3 tests/check_release_workflows_untouched.py` (both passed) and added them to `tests/CMakeLists.txt`. 
- Ran `python3 -m py_compile` on the new Python scripts and verified `.github/workflows/ci-tests.yml` YAML parsing (`ruby` YAML check) succeeded. 
- Ran repository policy scripts `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh` (both passed). 
- Performed `git diff --check` (no whitespace/patch errors); attempted a local CMake configure for Debug tests but `cmake` configuration could not complete in this container because wxWidgets development libraries are not installed (this is environment-limited and not a regression). 
- Summary status: new unit/policy checks and Python tests passed locally; C++ test build/configure requires the CI images (wxWidgets) to run full Debug CTest on Linux/Windows/macOS in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a607db9048c83248b0929767a83b21e)