### PR TITLE
Differentiate group selection highlights

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -118,6 +118,7 @@ Perastage 1.5.0 is a substantial update focused on GDTF and truss editing, multi
 - Hardened truss selection identity so sorting, replacement, deletion, insertion, reloads, and hover highlights stay attached to persistent scene UUIDs across the Trusses table and both 2D and 3D viewers.
 - Improved generated scene-object, fixture, truss, and support identifiers to use RFC 4122-compatible UUIDs for better MVR interoperability.
 - Fixed Data Views highlight rendering on wxWidgets builds where row-to-item conversion is exposed through the list-store item API.
+- Improved 2D and 3D group-selection highlighting so directly selected items remain bright cyan while other members of the same selected group use a darker blue highlight.
 - Fixed Windows build and linker issues in the Local Axes viewport integration.
 - Fixed a debug-only shutdown warning caused by attempting to make a hidden 2D OpenGL canvas current during cleanup.
 

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -599,6 +599,15 @@ std::vector<std::string> MergeSelectionAdditive(
   return selection;
 }
 
+// Combines all directly selected entity UUID lists into a stable unique sequence.
+std::vector<std::string> BuildDirectSelection(const ConfigManager &cfg) {
+  std::vector<std::string> selection;
+  selection = MergeSelectionAdditive(selection, cfg.GetSelectedFixtures());
+  selection = MergeSelectionAdditive(selection, cfg.GetSelectedTrusses());
+  selection = MergeSelectionAdditive(selection, cfg.GetSelectedSupports());
+  return MergeSelectionAdditive(selection, cfg.GetSelectedSceneObjects());
+}
+
 // Combines all selected entity UUID lists into a stable unique sequence.
 std::vector<std::string> BuildCombinedSelection(const ConfigManager &cfg) {
   const scene_grouping::ObjectSelection selection{
@@ -745,7 +754,8 @@ void Viewer2DPanel::UpdateScene(bool reload) {
     m_controller.Update();
   if (m_enableSelection) {
     ConfigManager &cfg = ConfigManager::Get();
-    m_controller.SetSelectedUuids(BuildCombinedSelection(cfg));
+    m_controller.SetSelectedUuids(BuildCombinedSelection(cfg),
+                                  BuildDirectSelection(cfg));
   }
   InvalidatePickCache();
   RequestRepaint();
@@ -773,10 +783,12 @@ void Viewer2DPanel::SetSelectedUuids(
   const std::vector<std::string> expandedSelection =
       scene_grouping::ExpandSelectionForGroupHighlights(
           ConfigManager::Get().GetScene(), typedSelection);
-  if (expandedSelection == m_lastAppliedSelectionUuids)
+  if (expandedSelection == m_lastAppliedSelectionUuids &&
+      selection == m_lastAppliedPrimarySelectionUuids)
     return;
   m_lastAppliedSelectionUuids = expandedSelection;
-  m_controller.SetSelectedUuids(expandedSelection);
+  m_lastAppliedPrimarySelectionUuids = selection;
+  m_controller.SetSelectedUuids(expandedSelection, selection);
   RequestRepaint();
 }
 
@@ -2182,7 +2194,8 @@ void Viewer2DPanel::ApplyRectangleSelection(const wxPoint &start,
         Viewer2DRenderPanel::Instance()->RefreshLabelControlsFromSelection();
     }
     m_controller.SetSelectedUuids(
-        BuildViewerSelectionForTableSelection(cfg, selection, additive));
+        BuildViewerSelectionForTableSelection(cfg, selection, additive),
+        additive ? BuildDirectSelection(cfg) : selection);
     if (selection.empty())
       FixtureTablePanel::Instance()->ClearSelection();
     else
@@ -2200,7 +2213,8 @@ void Viewer2DPanel::ApplyRectangleSelection(const wxPoint &start,
       cfg.SetSelectedTrusses(selection);
     }
     m_controller.SetSelectedUuids(
-        BuildViewerSelectionForTableSelection(cfg, selection, additive));
+        BuildViewerSelectionForTableSelection(cfg, selection, additive),
+        additive ? BuildDirectSelection(cfg) : selection);
     if (selection.empty())
       TrussTablePanel::Instance()->ClearSelection();
     else
@@ -2217,7 +2231,8 @@ void Viewer2DPanel::ApplyRectangleSelection(const wxPoint &start,
       cfg.SetSelectedSupports(selection);
     }
     m_controller.SetSelectedUuids(
-        BuildViewerSelectionForTableSelection(cfg, selection, additive));
+        BuildViewerSelectionForTableSelection(cfg, selection, additive),
+        additive ? BuildDirectSelection(cfg) : selection);
     if (selection.empty())
       HoistTablePanel::Instance()->ClearSelection();
     else
@@ -2233,7 +2248,8 @@ void Viewer2DPanel::ApplyRectangleSelection(const wxPoint &start,
       cfg.SetSelectedSceneObjects(selection);
     }
     m_controller.SetSelectedUuids(
-        BuildViewerSelectionForTableSelection(cfg, selection, additive));
+        BuildViewerSelectionForTableSelection(cfg, selection, additive),
+        additive ? BuildDirectSelection(cfg) : selection);
     if (selection.empty())
       SceneObjectTablePanel::Instance()->ClearSelection();
     else
@@ -3446,7 +3462,8 @@ void Viewer2DPanel::OnMouseUp(wxMouseEvent &event) {
             Viewer2DRenderPanel::Instance()->RefreshLabelControlsFromSelection();
         }
         m_controller.SetSelectedUuids(
-            BuildViewerSelectionForTableSelection(cfg, selection, additive));
+            BuildViewerSelectionForTableSelection(cfg, selection, additive),
+            additive ? BuildDirectSelection(cfg) : selection);
         FixtureTablePanel::Instance()->SelectByUuid(selection, false);
       } else if (TrussTablePanel::Instance() &&
                  TrussTablePanel::Instance()->IsActivePage()) {
@@ -3467,7 +3484,8 @@ void Viewer2DPanel::OnMouseUp(wxMouseEvent &event) {
           selectionChanged = true;
         }
         m_controller.SetSelectedUuids(
-            BuildViewerSelectionForTableSelection(cfg, selection, additive));
+            BuildViewerSelectionForTableSelection(cfg, selection, additive),
+            additive ? BuildDirectSelection(cfg) : selection);
         TrussTablePanel::Instance()->SelectByUuid(selection, false);
       } else if (HoistTablePanel::Instance() &&
                  HoistTablePanel::Instance()->IsActivePage()) {
@@ -3488,7 +3506,8 @@ void Viewer2DPanel::OnMouseUp(wxMouseEvent &event) {
           selectionChanged = true;
         }
         m_controller.SetSelectedUuids(
-            BuildViewerSelectionForTableSelection(cfg, selection, additive));
+            BuildViewerSelectionForTableSelection(cfg, selection, additive),
+            additive ? BuildDirectSelection(cfg) : selection);
         HoistTablePanel::Instance()->SelectByUuid(selection, false);
       } else if (SceneObjectTablePanel::Instance() &&
                  SceneObjectTablePanel::Instance()->IsActivePage()) {
@@ -3509,7 +3528,8 @@ void Viewer2DPanel::OnMouseUp(wxMouseEvent &event) {
           selectionChanged = true;
         }
         m_controller.SetSelectedUuids(
-            BuildViewerSelectionForTableSelection(cfg, selection, additive));
+            BuildViewerSelectionForTableSelection(cfg, selection, additive),
+            additive ? BuildDirectSelection(cfg) : selection);
         SceneObjectTablePanel::Instance()->SelectByUuid(selection, false);
       }
     } else {

--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -373,6 +373,7 @@ private:
   bool m_enableSelection = true;
   Viewer2DMeasureToolState m_measureToolState;
   std::vector<std::string> m_lastAppliedSelectionUuids;
+  std::vector<std::string> m_lastAppliedPrimarySelectionUuids;
   std::string m_hoverUuid;
   CursorWorldPositionCallback m_cursorWorldPositionCallback;
 

--- a/viewer3d/render/gl_primitive_renderer.cpp
+++ b/viewer3d/render/gl_primitive_renderer.cpp
@@ -22,9 +22,9 @@ constexpr float kPrimaryHighlightR = 0.78f;
 constexpr float kPrimaryHighlightG = 1.0f;
 constexpr float kPrimaryHighlightB = 0.0f;
 
-constexpr float kGroupHighlightR = 0.25f;
-constexpr float kGroupHighlightG = 0.78f;
-constexpr float kGroupHighlightB = 0.55f;
+constexpr float kGroupHighlightR = 0.0f;
+constexpr float kGroupHighlightG = 0.45f;
+constexpr float kGroupHighlightB = 0.85f;
 
 void DrawBoxEdges(float x0, float x1, float y0, float y1, float z0, float z1) {
   glBegin(GL_LINES);

--- a/viewer3d/render/opaque_fixture_pass.cpp
+++ b/viewer3d/render/opaque_fixture_pass.cpp
@@ -802,12 +802,15 @@ void OpaqueFixturePass::Render(
     const bool highlight = !context.idOnlyPass &&
                            !controller.m_highlightUuid.empty() &&
                            uuid == controller.m_highlightUuid;
-    const bool groupHighlight = !context.idOnlyPass &&
-                                controller.m_groupHighlightUuids.find(uuid) !=
-                                    controller.m_groupHighlightUuids.end();
     const bool selected =
-        !context.idOnlyPass && controller.m_selectedUuids.find(uuid) !=
-                                   controller.m_selectedUuids.end();
+        !context.idOnlyPass && controller.m_primarySelectedUuids.find(uuid) !=
+                                   controller.m_primarySelectedUuids.end();
+    const bool groupHighlight =
+        !context.idOnlyPass &&
+        (controller.m_groupHighlightUuids.find(uuid) !=
+             controller.m_groupHighlightUuids.end() ||
+         (controller.m_selectedUuids.find(uuid) != controller.m_selectedUuids.end() &&
+          !selected));
 
     float matrix[16];
     MatrixToArray(f.transform, matrix);

--- a/viewer3d/render/opaque_object_pass.cpp
+++ b/viewer3d/render/opaque_object_pass.cpp
@@ -382,12 +382,15 @@ void OpaqueObjectPass::Render(
     const bool highlight = !context.idOnlyPass &&
                            !controller.m_highlightUuid.empty() &&
                            uuid == controller.m_highlightUuid;
-    const bool groupHighlight = !context.idOnlyPass &&
-                                controller.m_groupHighlightUuids.find(uuid) !=
-                                    controller.m_groupHighlightUuids.end();
     const bool selected =
-        !context.idOnlyPass && controller.m_selectedUuids.find(uuid) !=
-                                   controller.m_selectedUuids.end();
+        !context.idOnlyPass && controller.m_primarySelectedUuids.find(uuid) !=
+                                   controller.m_primarySelectedUuids.end();
+    const bool groupHighlight =
+        !context.idOnlyPass &&
+        (controller.m_groupHighlightUuids.find(uuid) !=
+             controller.m_groupHighlightUuids.end() ||
+         (controller.m_selectedUuids.find(uuid) != controller.m_selectedUuids.end() &&
+          !selected));
 
     float matrix[16];
     MatrixToArray(m.transform, matrix);

--- a/viewer3d/render/opaque_truss_pass.cpp
+++ b/viewer3d/render/opaque_truss_pass.cpp
@@ -122,12 +122,15 @@ void OpaqueTrussPass::Render(
     const bool highlight = !context.idOnlyPass &&
                            !controller.m_highlightUuid.empty() &&
                            uuid == controller.m_highlightUuid;
-    const bool groupHighlight = !context.idOnlyPass &&
-                                controller.m_groupHighlightUuids.find(uuid) !=
-                                    controller.m_groupHighlightUuids.end();
     const bool selected =
-        !context.idOnlyPass && controller.m_selectedUuids.find(uuid) !=
-                                   controller.m_selectedUuids.end();
+        !context.idOnlyPass && controller.m_primarySelectedUuids.find(uuid) !=
+                                   controller.m_primarySelectedUuids.end();
+    const bool groupHighlight =
+        !context.idOnlyPass &&
+        (controller.m_groupHighlightUuids.find(uuid) !=
+             controller.m_groupHighlightUuids.end() ||
+         (controller.m_selectedUuids.find(uuid) != controller.m_selectedUuids.end() &&
+          !selected));
 
     float matrix[16];
     MatrixToArray(t.transform, matrix);

--- a/viewer3d/render/scenerenderer.cpp
+++ b/viewer3d/render/scenerenderer.cpp
@@ -24,9 +24,9 @@ namespace {
 constexpr float kPrimaryHighlightR = 0.78f;
 constexpr float kPrimaryHighlightG = 1.0f;
 constexpr float kPrimaryHighlightB = 0.0f;
-constexpr float kGroupHighlightR = 0.25f;
-constexpr float kGroupHighlightG = 0.78f;
-constexpr float kGroupHighlightB = 0.55f;
+constexpr float kGroupHighlightR = 0.0f;
+constexpr float kGroupHighlightG = 0.45f;
+constexpr float kGroupHighlightB = 0.85f;
 
 struct InkColor {
   float r = 1.0f;

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -128,6 +128,7 @@ struct Viewer3DController::Impl {
   std::string highlightUuid;
   std::unordered_set<std::string> groupHighlightUuids;
   std::unordered_set<std::string> selectedUuids;
+  std::unordered_set<std::string> primarySelectedUuids;
   NVGcontext *vg = nullptr;
   int font = -1;
   int fontBold = -1;
@@ -686,6 +687,7 @@ Viewer3DController::Viewer3DController()
       m_highlightUuid(m_impl->highlightUuid),
       m_groupHighlightUuids(m_impl->groupHighlightUuids),
       m_selectedUuids(m_impl->selectedUuids),
+      m_primarySelectedUuids(m_impl->primarySelectedUuids),
       m_captureCanvas(m_impl->captureCanvas),
       m_captureView(m_impl->captureView),
       m_captureIncludeGrid(m_impl->captureIncludeGrid),
@@ -809,6 +811,13 @@ void Viewer3DController::SetSelectedUuids(
   m_impl->selectionSystem->SetSelectedUuids(uuids);
 }
 
+// Sets selected UUIDs and the subset selected directly in source tables.
+void Viewer3DController::SetSelectedUuids(
+    const std::vector<std::string> &uuids,
+    const std::vector<std::string> &primaryUuids) {
+  ReplaceSelectedUuids(uuids, primaryUuids);
+}
+
 // Applies highlight UUID.
 void Viewer3DController::ApplyHighlightUuid(const std::string &uuid) {
   m_impl->highlightUuid = uuid;
@@ -822,9 +831,19 @@ void Viewer3DController::ApplyHighlightUuid(const std::string &uuid) {
 // Replaces selected UUIDs.
 void Viewer3DController::ReplaceSelectedUuids(
     const std::vector<std::string> &uuids) {
+  ReplaceSelectedUuids(uuids, uuids);
+}
+
+// Replaces selected UUIDs while preserving directly selected UUIDs separately.
+void Viewer3DController::ReplaceSelectedUuids(
+    const std::vector<std::string> &uuids,
+    const std::vector<std::string> &primaryUuids) {
   m_impl->selectedUuids.clear();
   for (const auto &u : uuids)
     m_impl->selectedUuids.insert(u);
+  m_impl->primarySelectedUuids.clear();
+  for (const auto &u : primaryUuids)
+    m_impl->primarySelectedUuids.insert(u);
 }
 
 const Viewer3DController::BoundingBox *
@@ -2088,14 +2107,19 @@ bool Viewer3DController::IsUuidHighlighted(const std::string &uuid) const {
 
 // Checks whether the UUID is highlighted as a hovered group sibling.
 bool Viewer3DController::IsUuidGroupHighlighted(const std::string &uuid) const {
-  return !uuid.empty() && m_impl->groupHighlightUuids.find(uuid) !=
-                              m_impl->groupHighlightUuids.end();
+  return !uuid.empty() &&
+         (m_impl->groupHighlightUuids.find(uuid) !=
+              m_impl->groupHighlightUuids.end() ||
+          (m_impl->selectedUuids.find(uuid) != m_impl->selectedUuids.end() &&
+           m_impl->primarySelectedUuids.find(uuid) ==
+               m_impl->primarySelectedUuids.end()));
 }
 
 // Checks whether uUID Selected.
 bool Viewer3DController::IsUuidSelected(const std::string &uuid) const {
   return !uuid.empty() &&
-         m_impl->selectedUuids.find(uuid) != m_impl->selectedUuids.end();
+         m_impl->primarySelectedUuids.find(uuid) !=
+             m_impl->primarySelectedUuids.end();
 }
 
 // Checks whether capture Only.

--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -106,6 +106,8 @@ public:
 
   void SetHighlightUuid(const std::string &uuid);
   void SetSelectedUuids(const std::vector<std::string> &uuids);
+  void SetSelectedUuids(const std::vector<std::string> &uuids,
+                        const std::vector<std::string> &primaryUuids);
 
   void DrawFixtureLabels(int width, int height);
   void DrawTrussLabels(int width, int height);
@@ -185,6 +187,7 @@ private:
   std::string &m_highlightUuid;
   std::unordered_set<std::string> &m_groupHighlightUuids;
   std::unordered_set<std::string> &m_selectedUuids;
+  std::unordered_set<std::string> &m_primarySelectedUuids;
   ICanvas2D *&m_captureCanvas;
   Viewer2DView &m_captureView;
   bool &m_captureIncludeGrid;
@@ -297,6 +300,8 @@ private:
 
   void ApplyHighlightUuid(const std::string &uuid) override;
   void ReplaceSelectedUuids(const std::vector<std::string> &uuids) override;
+  void ReplaceSelectedUuids(const std::vector<std::string> &uuids,
+                            const std::vector<std::string> &primaryUuids);
   const BoundingBox *FindFixtureBounds(const std::string &uuid) const override;
   const BoundingBox *FindTrussBounds(const std::string &uuid) const override;
   const BoundingBox *FindObjectBounds(const std::string &uuid) const override;

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -3771,12 +3771,14 @@ void Viewer3DPanel::SetSelectedFixtures(const std::vector<std::string>& uuids)
     const std::vector<std::string> expandedUuids =
         scene_grouping::ExpandSelectionForGroupHighlights(
             ConfigManager::Get().GetScene(), typedSelection);
-    if (expandedUuids == m_lastAppliedSelectionUuids)
+    if (expandedUuids == m_lastAppliedSelectionUuids &&
+        uuids == m_lastAppliedPrimarySelectionUuids)
         return;
     m_lastAppliedSelectionUuids = expandedUuids;
+    m_lastAppliedPrimarySelectionUuids = uuids;
     ++m_selectionRevision;
     m_selectionRefreshPending = true;
-    m_controller.SetSelectedUuids(expandedUuids);
+    m_controller.SetSelectedUuids(expandedUuids, uuids);
     Refresh();
 }
 

--- a/viewer3d/viewer3dpanel.h
+++ b/viewer3d/viewer3dpanel.h
@@ -160,6 +160,7 @@ private:
     bool m_cameraMoving = false;
     std::chrono::steady_clock::time_point m_lastResourceSyncCheck{};
     std::vector<std::string> m_lastAppliedSelectionUuids;
+    std::vector<std::string> m_lastAppliedPrimarySelectionUuids;
 
     // Initializes OpenGL settings
     bool InitGL();


### PR DESCRIPTION
### Motivation
- When a group is selected the whole group was rendered with the same cyan, making it impossible to tell which members were directly selected in the table versus which were group-expanded siblings.
- The change introduces a visual distinction so directly selected items keep the bright cyan and other group members use a darker/less vivid blue.
- This improves selection clarity in both 2D and 3D viewers without changing selection semantics.

### Description
- Track the subset of directly selected UUIDs separately by adding `primarySelectedUuids` (Impl state) and preserve the existing `selectedUuids` overlay set so both direct and expanded selections are available to rendering code.
- Add overloads `SetSelectedUuids(const std::vector<std::string>&, const std::vector<std::string>&)` and `ReplaceSelectedUuids(..., primaryUuids)` so callers can pass both the expanded group selection and the direct table selection.
- Make render passes (fixtures/trusses/scene objects, GL primitive and scene renderer) treat `primarySelectedUuids` as the authoritative “selected” color (bright cyan) and treat `selectedUuids` members that are not `primarySelectedUuids` as `groupHighlight` (darker blue), keeping hover/highlight behavior intact.
- Add `BuildDirectSelection` in `viewer2d` and thread the direct-selection argument from table/rectangle selection paths and 3D panel updates to the controller; also cache `m_lastAppliedPrimarySelectionUuids` in 2D/3D panels to avoid redundant updates.
- Adjust `kGroupHighlight*` color constants to a darker blue/cyan tone and update `docs/release-notes-draft.md` with a user-visible entry describing the improvement.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded (`OK`).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded (`OK`).
- Attempted full `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug` configuration but it could not complete due to missing `wxWidgets` development files in the environment (configuration blocked).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6113f4926483249f577861449a302b)