### PR TITLE
Fix release-gate portability harness and add unresolved-Python policy test

### DIFF
--- a/.github/scripts/summarize_ctest_results.py
+++ b/.github/scripts/summarize_ctest_results.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Write compact machine-readable CTest result counts for CI diagnostics."""
+from __future__ import annotations
+
+import argparse
+import json
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+def parse_int(value: str | None) -> int:
+    try:
+        return int(value or 0)
+    except ValueError:
+        return 0
+
+
+def counts_from_junit(path: Path) -> dict[str, int]:
+    if not path.exists():
+        return {"total": 0, "passed": 0, "failed": 0, "skipped": 0, "disabled_not_run": 0}
+    root = ET.parse(path).getroot()
+    total = parse_int(root.get("tests"))
+    failed = parse_int(root.get("failures")) + parse_int(root.get("errors"))
+    skipped = parse_int(root.get("skipped"))
+    disabled = parse_int(root.get("disabled"))
+    if total == 0:
+        cases = list(root.iter("testcase"))
+        total = len(cases)
+        failed = sum(1 for case in cases if case.find("failure") is not None or case.find("error") is not None)
+        skipped = sum(1 for case in cases if case.find("skipped") is not None)
+    passed = max(total - failed - skipped - disabled, 0)
+    return {"total": total, "passed": passed, "failed": failed, "skipped": skipped, "disabled_not_run": disabled}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--platform", required=True)
+    parser.add_argument("--junit", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--tested-sha", required=True)
+    parser.add_argument("--profile", required=True)
+    parser.add_argument("--labels", default="")
+    args = parser.parse_args()
+
+    counts = counts_from_junit(Path(args.junit))
+    result = {
+        "platform": args.platform,
+        "tested_sha": args.tested_sha,
+        "profile": args.profile,
+        "selected_labels": [label for label in args.labels.split(",") if label],
+        **counts,
+    }
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -151,6 +151,8 @@ jobs:
           if grep -Eq '(^|[[:space:]])-DNDEBUG([[:space:]]|$)' build/linux-debug/compile_commands.json; then echo "Debug tests must not compile with NDEBUG"; exit 1; fi
       - name: Build complete test target set
         run: python3 .github/scripts/run_and_log.py --log "$CI_LOG_DIR/build-linux-debug.log" -- cmake --build build/linux-debug --target all --verbose
+      - name: Generate Linux CTest inventory
+        run: ctest --test-dir build/linux-debug --show-only=json-v1 > "$CI_LOG_DIR/ctest-inventory-linux-debug.json"
       - name: Validate Linux Xvfb display
         run: |
           set -euo pipefail
@@ -167,6 +169,13 @@ jobs:
           bash tests/check_perastage_tree_modules.sh
           bash tests/check_no_configmanager_get_in_gui.sh
           bash tests/check_ci_cmake_language_policy.sh
+      - name: Upload Linux CTest inventory
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ci-linux-debug-ctest-inventory
+          if-no-files-found: ignore
+          path: out/ci-logs/ctest-inventory-linux-debug.json
       - name: Upload failure diagnostics
         if: ${{ always() && (failure() || cancelled()) }}
         uses: actions/upload-artifact@v7
@@ -346,6 +355,9 @@ jobs:
         shell: pwsh
         run: |
           & "$env:PERASTAGE_PYTHON" .github/scripts/run_and_log.py --log "$env:CI_LOG_DIR\build-windows-debug.log" -- cmake --build build-windows-debug --target all --verbose
+      - name: Generate Windows CTest inventory
+        shell: pwsh
+        run: ctest --test-dir build-windows-debug --show-only=json-v1 | Out-File -FilePath "$env:CI_LOG_DIR\ctest-inventory-windows-debug.json" -Encoding utf8
       - name: Run Windows CTest suite
         shell: pwsh
         run: |
@@ -353,6 +365,13 @@ jobs:
           $ctestExit = $LASTEXITCODE
           & "$env:PERASTAGE_PYTHON" .github/scripts/summarize_ctest_failures.py --platform windows --junit "$env:CI_LOG_DIR\ctest-windows-debug.junit.xml" --log "$env:CI_LOG_DIR\ctest-windows-debug.log" --last-tests-failed build-windows-debug\Testing\Temporary\LastTestsFailed.log --output "$env:CI_LOG_DIR\ctest-windows-debug-failures.csv"
           exit $ctestExit
+      - name: Upload Windows CTest inventory
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ci-windows-debug-ctest-inventory
+          if-no-files-found: ignore
+          path: out/ci-logs/ctest-inventory-windows-debug.json
       - name: Upload failure diagnostics
         if: ${{ always() && (failure() || cancelled()) }}
         uses: actions/upload-artifact@v7
@@ -471,11 +490,20 @@ jobs:
           python3 .github/scripts/run_and_log.py --log "$CI_LOG_DIR/cmake-configure-macos-debug.log" -- cmake -S . -B build/macos-debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_OSX_ARCHITECTURES=arm64 -DCMAKE_OSX_SYSROOT="$current_sdk_path" -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=arm64-osx -DVCPKG_INSTALLED_DIR="$VCPKG_INSTALLED" -DVCPKG_MANIFEST_MODE=OFF -DBUILD_TESTING=ON -DPERASTAGE_REQUIRE_SECURE_CREDENTIAL_STORE=ON -DPERASTAGE_ENABLE_COMPILER_CACHE=OFF
       - name: Build release-gate and macOS tests
         run: python3 .github/scripts/run_and_log.py --log "$CI_LOG_DIR/build-macos-debug.log" -- cmake --build build/macos-debug --target gdtf_share_security_test credential_store_native_roundtrip_test --verbose
+      - name: Generate macOS CTest inventory
+        run: ctest --test-dir build/macos-debug --show-only=json-v1 > "$CI_LOG_DIR/ctest-inventory-macos-debug.json"
       - name: Run release-gate and macOS tests
-        run: python3 .github/scripts/run_and_log.py --log "$CI_LOG_DIR/ctest-macos-debug.log" -- ctest --test-dir build/macos-debug -L release-gate --output-on-failure --verbose
+        run: python3 .github/scripts/run_and_log.py --log "$CI_LOG_DIR/ctest-macos-debug.log" -- ctest --test-dir build/macos-debug -L release-gate --output-log "$CI_LOG_DIR/ctest-macos-debug-full.log" --output-junit "$CI_LOG_DIR/ctest-macos-debug.junit.xml" --output-on-failure --verbose
       - name: Summarize macOS CTest failures
         if: ${{ always() }}
-        run: python3 .github/scripts/summarize_ctest_failures.py --platform macos --log "$CI_LOG_DIR/ctest-macos-debug.log" --output "$CI_LOG_DIR/ctest-macos-debug-failures.csv"
+        run: python3 .github/scripts/summarize_ctest_failures.py --platform macos --junit "$CI_LOG_DIR/ctest-macos-debug.junit.xml" --log "$CI_LOG_DIR/ctest-macos-debug.log" --output "$CI_LOG_DIR/ctest-macos-debug-failures.csv"
+      - name: Upload macOS CTest inventory
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ci-macos-debug-ctest-inventory
+          if-no-files-found: ignore
+          path: out/ci-logs/ctest-inventory-macos-debug.json
       - name: Upload failure diagnostics
         if: ${{ always() && (failure() || cancelled()) }}
         uses: actions/upload-artifact@v7

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -149,10 +149,12 @@ jobs:
           python3 .github/scripts/run_and_log.py --log "$CI_LOG_DIR/cmake-configure-linux-debug.log" -- cmake -S . -B build/linux-debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x64-linux -DVCPKG_INSTALLED_DIR="$VCPKG_INSTALLED" -DVCPKG_MANIFEST_MODE=OFF -DBUILD_TESTING=ON -DPERASTAGE_REQUIRE_SECURE_CREDENTIAL_STORE=ON -DPERASTAGE_ENABLE_COMPILER_CACHE=OFF
           test -f build/linux-debug/compile_commands.json || { echo "Debug compile_commands.json was not generated"; exit 1; }
           if grep -Eq '(^|[[:space:]])-DNDEBUG([[:space:]]|$)' build/linux-debug/compile_commands.json; then echo "Debug tests must not compile with NDEBUG"; exit 1; fi
+      - name: Generate Linux CTest inventory
+        run: |
+          ctest --test-dir build/linux-debug -N -V > "$CI_LOG_DIR/ctest-inventory-linux-debug.txt"
+          ctest --test-dir build/linux-debug --show-only=json-v1 > "$CI_LOG_DIR/ctest-inventory-linux-debug.json"
       - name: Build complete test target set
         run: python3 .github/scripts/run_and_log.py --log "$CI_LOG_DIR/build-linux-debug.log" -- cmake --build build/linux-debug --target all --verbose
-      - name: Generate Linux CTest inventory
-        run: ctest --test-dir build/linux-debug --show-only=json-v1 > "$CI_LOG_DIR/ctest-inventory-linux-debug.json"
       - name: Validate Linux Xvfb display
         run: |
           set -euo pipefail
@@ -163,19 +165,27 @@ jobs:
           LC_ALL=C.UTF-8 LANG=C.UTF-8 xvfb-run -a -s "-screen 0 1920x1080x24" ctest --test-dir build/linux-debug --output-log "$CI_LOG_DIR/ctest-linux-debug.log" --output-junit "$CI_LOG_DIR/ctest-linux-debug.junit.xml" --output-on-failure --verbose
           ctest_exit=$?
           python3 .github/scripts/summarize_ctest_failures.py --platform linux --junit "$CI_LOG_DIR/ctest-linux-debug.junit.xml" --log "$CI_LOG_DIR/ctest-linux-debug.log" --last-tests-failed build/linux-debug/Testing/Temporary/LastTestsFailed.log --output "$CI_LOG_DIR/ctest-linux-debug-failures.csv"
+          python3 .github/scripts/summarize_ctest_results.py --platform linux --junit "$CI_LOG_DIR/ctest-linux-debug.junit.xml" --output "$CI_LOG_DIR/ctest-linux-debug-results.json" --tested-sha "${{ needs.resolve-source.outputs.source_sha }}" --profile "$PERASTAGE_CI_PROFILE"
           exit $ctest_exit
       - name: Run repository policy tests
         run: |
           bash tests/check_perastage_tree_modules.sh
           bash tests/check_no_configmanager_get_in_gui.sh
           bash tests/check_ci_cmake_language_policy.sh
-      - name: Upload Linux CTest inventory
+      - name: Upload Linux test results
         if: ${{ always() }}
         uses: actions/upload-artifact@v7
         with:
-          name: ci-linux-debug-ctest-inventory
+          name: ci-linux-debug-test-results
           if-no-files-found: ignore
-          path: out/ci-logs/ctest-inventory-linux-debug.json
+          path: |
+            out/ci-logs/ctest-inventory-linux-debug.*
+            out/ci-logs/ctest-linux-debug.junit.xml
+            out/ci-logs/ctest-linux-debug.log
+            out/ci-logs/ctest-linux-debug-failures.csv
+            out/ci-logs/ctest-linux-debug-results.json
+            build/linux-debug/Testing/Temporary/LastTestsFailed.log
+            build/linux-debug/Testing/Temporary/LastTestsDisabled.log
       - name: Upload failure diagnostics
         if: ${{ always() && (failure() || cancelled()) }}
         uses: actions/upload-artifact@v7
@@ -351,27 +361,37 @@ jobs:
           if (-not $cl) { throw 'cl.exe was not available in the persisted Visual Studio environment.' }
           & "$env:PERASTAGE_PYTHON" .github/scripts/run_and_log.py --log "$env:CI_LOG_DIR\cmake-configure-windows-debug.log" -- cmake -S . -B build-windows-debug -G Ninja -DCMAKE_C_COMPILER=cl.exe -DCMAKE_CXX_COMPILER=cl.exe -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT\scripts\buildsystems\vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x64-windows -DVCPKG_INSTALLED_DIR="$env:VCPKG_INSTALLED" -DVCPKG_MANIFEST_MODE=OFF -DBUILD_TESTING=ON -DPERASTAGE_REQUIRE_SECURE_CREDENTIAL_STORE=ON -DPERASTAGE_ENABLE_COMPILER_CACHE=OFF -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DBASH_EXECUTABLE="$env:PERASTAGE_GIT_BASH"
           & "$env:PERASTAGE_PYTHON" .github/scripts/validate_cmake_toolchain.py --build-dir build-windows-debug --expected-c-id MSVC --expected-cxx-id MSVC --expected-compiler-path-regex "Hostx64[\\/]x64" --forbidden-compiler-path-regex "(mingw|msys|strawberry|Hostx86[\\/]x86|[\\/]x86[\\/]cl\.exe)" --expected-architecture x64 --expected-generator Ninja --expected-build-type Debug
+      - name: Generate Windows CTest inventory
+        shell: pwsh
+        run: |
+          ctest --test-dir build-windows-debug -N -V | Out-File -FilePath "$env:CI_LOG_DIR\ctest-inventory-windows-debug.txt" -Encoding utf8
+          ctest --test-dir build-windows-debug --show-only=json-v1 | Out-File -FilePath "$env:CI_LOG_DIR\ctest-inventory-windows-debug.json" -Encoding utf8
       - name: Build Windows Debug tests
         shell: pwsh
         run: |
           & "$env:PERASTAGE_PYTHON" .github/scripts/run_and_log.py --log "$env:CI_LOG_DIR\build-windows-debug.log" -- cmake --build build-windows-debug --target all --verbose
-      - name: Generate Windows CTest inventory
-        shell: pwsh
-        run: ctest --test-dir build-windows-debug --show-only=json-v1 | Out-File -FilePath "$env:CI_LOG_DIR\ctest-inventory-windows-debug.json" -Encoding utf8
       - name: Run Windows CTest suite
         shell: pwsh
         run: |
           & ctest --test-dir build-windows-debug --output-log "$env:CI_LOG_DIR\ctest-windows-debug.log" --output-junit "$env:CI_LOG_DIR\ctest-windows-debug.junit.xml" --output-on-failure --verbose --interactive-debug-mode 0 --timeout 120
           $ctestExit = $LASTEXITCODE
           & "$env:PERASTAGE_PYTHON" .github/scripts/summarize_ctest_failures.py --platform windows --junit "$env:CI_LOG_DIR\ctest-windows-debug.junit.xml" --log "$env:CI_LOG_DIR\ctest-windows-debug.log" --last-tests-failed build-windows-debug\Testing\Temporary\LastTestsFailed.log --output "$env:CI_LOG_DIR\ctest-windows-debug-failures.csv"
+          & "$env:PERASTAGE_PYTHON" .github/scripts/summarize_ctest_results.py --platform windows --junit "$env:CI_LOG_DIR\ctest-windows-debug.junit.xml" --output "$env:CI_LOG_DIR\ctest-windows-debug-results.json" --tested-sha "${{ needs.resolve-source.outputs.source_sha }}" --profile "$env:PERASTAGE_CI_PROFILE"
           exit $ctestExit
-      - name: Upload Windows CTest inventory
+      - name: Upload Windows test results
         if: ${{ always() }}
         uses: actions/upload-artifact@v7
         with:
-          name: ci-windows-debug-ctest-inventory
+          name: ci-windows-debug-test-results
           if-no-files-found: ignore
-          path: out/ci-logs/ctest-inventory-windows-debug.json
+          path: |
+            out/ci-logs/ctest-inventory-windows-debug.*
+            out/ci-logs/ctest-windows-debug.junit.xml
+            out/ci-logs/ctest-windows-debug.log
+            out/ci-logs/ctest-windows-debug-failures.csv
+            out/ci-logs/ctest-windows-debug-results.json
+            build-windows-debug/Testing/Temporary/LastTestsFailed.log
+            build-windows-debug/Testing/Temporary/LastTestsDisabled.log
       - name: Upload failure diagnostics
         if: ${{ always() && (failure() || cancelled()) }}
         uses: actions/upload-artifact@v7
@@ -488,22 +508,34 @@ jobs:
         run: |
           current_sdk_path="$(xcrun --sdk macosx --show-sdk-path)"
           python3 .github/scripts/run_and_log.py --log "$CI_LOG_DIR/cmake-configure-macos-debug.log" -- cmake -S . -B build/macos-debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_OSX_ARCHITECTURES=arm64 -DCMAKE_OSX_SYSROOT="$current_sdk_path" -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=arm64-osx -DVCPKG_INSTALLED_DIR="$VCPKG_INSTALLED" -DVCPKG_MANIFEST_MODE=OFF -DBUILD_TESTING=ON -DPERASTAGE_REQUIRE_SECURE_CREDENTIAL_STORE=ON -DPERASTAGE_ENABLE_COMPILER_CACHE=OFF
+      - name: Generate macOS CTest inventory
+        run: |
+          ctest --test-dir build/macos-debug -N -V > "$CI_LOG_DIR/ctest-inventory-macos-debug.txt"
+          ctest --test-dir build/macos-debug --show-only=json-v1 > "$CI_LOG_DIR/ctest-inventory-macos-debug.json"
       - name: Build release-gate and macOS tests
         run: python3 .github/scripts/run_and_log.py --log "$CI_LOG_DIR/build-macos-debug.log" -- cmake --build build/macos-debug --target gdtf_share_security_test credential_store_native_roundtrip_test --verbose
-      - name: Generate macOS CTest inventory
-        run: ctest --test-dir build/macos-debug --show-only=json-v1 > "$CI_LOG_DIR/ctest-inventory-macos-debug.json"
       - name: Run release-gate and macOS tests
         run: python3 .github/scripts/run_and_log.py --log "$CI_LOG_DIR/ctest-macos-debug.log" -- ctest --test-dir build/macos-debug -L release-gate --output-log "$CI_LOG_DIR/ctest-macos-debug-full.log" --output-junit "$CI_LOG_DIR/ctest-macos-debug.junit.xml" --output-on-failure --verbose
       - name: Summarize macOS CTest failures
         if: ${{ always() }}
-        run: python3 .github/scripts/summarize_ctest_failures.py --platform macos --junit "$CI_LOG_DIR/ctest-macos-debug.junit.xml" --log "$CI_LOG_DIR/ctest-macos-debug.log" --output "$CI_LOG_DIR/ctest-macos-debug-failures.csv"
-      - name: Upload macOS CTest inventory
+        run: python3 .github/scripts/summarize_ctest_failures.py --platform macos --junit "$CI_LOG_DIR/ctest-macos-debug.junit.xml" --log "$CI_LOG_DIR/ctest-macos-debug.log" --last-tests-failed build/macos-debug/Testing/Temporary/LastTestsFailed.log --output "$CI_LOG_DIR/ctest-macos-debug-failures.csv"
+      - name: Summarize macOS CTest results
+        if: ${{ always() }}
+        run: python3 .github/scripts/summarize_ctest_results.py --platform macos --junit "$CI_LOG_DIR/ctest-macos-debug.junit.xml" --output "$CI_LOG_DIR/ctest-macos-debug-results.json" --tested-sha "${{ needs.resolve-source.outputs.source_sha }}" --profile "$PERASTAGE_CI_PROFILE" --labels release-gate
+      - name: Upload macOS test results
         if: ${{ always() }}
         uses: actions/upload-artifact@v7
         with:
-          name: ci-macos-debug-ctest-inventory
+          name: ci-macos-debug-test-results
           if-no-files-found: ignore
-          path: out/ci-logs/ctest-inventory-macos-debug.json
+          path: |
+            out/ci-logs/ctest-inventory-macos-debug.*
+            out/ci-logs/ctest-macos-debug.junit.xml
+            out/ci-logs/ctest-macos-debug*.log
+            out/ci-logs/ctest-macos-debug-failures.csv
+            out/ci-logs/ctest-macos-debug-results.json
+            build/macos-debug/Testing/Temporary/LastTestsFailed.log
+            build/macos-debug/Testing/Temporary/LastTestsDisabled.log
       - name: Upload failure diagnostics
         if: ${{ always() && (failure() || cancelled()) }}
         uses: actions/upload-artifact@v7

--- a/docs/developer/ci_test_audit.md
+++ b/docs/developer/ci_test_audit.md
@@ -46,3 +46,37 @@ The configure step failed before test generation because this container does not
 3. Classify every current failing test using the project classification taxonomy before changing assertions.
 4. Split `tests/CMakeLists.txt` into domain modules only after current behavior and root causes are understood.
 5. Implement functional PR and full/release CI profiles without hiding known failures.
+
+## Phase 1 CI baseline update for PR #2204
+
+Branch base SHA: `ec6dee42371f51dc02520e3eb9fc4bea4d0daeca`.
+Current reviewed head before this follow-up: `4732460bc10bd2e312bb2714d8a6e82f617c5a01`.
+Current final head after this follow-up: recorded in PR #2204 after the final commit for this task.
+CI Debug Tests run inspected: `29961799720` (`https://github.com/PeramatoG/Perastage/actions/runs/29961799720`).
+
+As of the API inspection performed from this workspace on 2026-07-22, run `29961799720` had not completed. The workflow run status was `in_progress`, with `linux-debug`, `windows-debug`, and `macos-debug` also still `in_progress`; only `resolve-source` had completed successfully. Therefore no completed configure/build/CTest baseline, pass/fail/skip/not-run counts, or current failing-test list can be recorded from that run yet. This must not be represented as a test failure because the jobs had not reached a completed result.
+
+| Platform | Configure result | Build result | CTest result | Passed | Failed | Skipped | Not run | Current failing tests | Log or artifact reference |
+| --- | --- | --- | --- | ---: | ---: | ---: | ---: | --- | --- |
+| Linux | Pending in run `29961799720` | Pending in run `29961799720` | Pending in run `29961799720` | Not available | Not available | Not available | Not available | Not available until completion | `ci-linux-debug-ctest-inventory`; `ci-linux-debug-diagnostics` on failure |
+| Windows | Pending in run `29961799720` | Pending in run `29961799720` | Pending in run `29961799720` | Not available | Not available | Not available | Not available | Not available until completion | `ci-windows-debug-ctest-inventory`; `ci-windows-debug-diagnostics` on failure |
+| macOS | Pending in run `29961799720` | Pending in run `29961799720` | Pending in run `29961799720` | Not available | Not available | Not available | Not available | Not available until completion | `ci-macos-debug-ctest-inventory`; `ci-macos-debug-diagnostics` on failure |
+
+### Focused harness validation status
+
+- Local Linux restricted-path validation passes for `ReleaseGatePolicyPortability`.
+- Cross-runner Linux, Windows Git Bash, and macOS validation remains pending because run `29961799720` had not completed when inspected.
+- `UnresolvedPythonInvocations` passes locally and is registered for CI.
+- Windows Microsoft Store Python launcher avoidance remains pending runner confirmation; the policy test and existing `PythonResolvedInterpreterPolicy` are the focused checks intended to prove it.
+- The portability harness directly runs the release-gate scripts from the repository root and an unrelated temporary working directory with a restricted PATH.
+
+### Diagnostics baseline
+
+- Linux CTest diagnostics are configured to preserve JUnit output, the full CTest log, `LastTestsFailed.log`, and the concise failure CSV in `out/ci-logs` and the build `Testing/Temporary` tree.
+- Windows CTest diagnostics are configured to preserve JUnit output, the full CTest log, `LastTestsFailed.log`, and the concise failure CSV in `out/ci-logs` and the build `Testing/Temporary` tree.
+- macOS now preserves CTest JSON inventory plus both the wrapper log and CTest `--output-log` file, and it writes JUnit output for release-gate tests so the same failure-summary path can include structured test results.
+- Linux, Windows, and macOS now generate `ctest --show-only=json-v1` inventory files under `out/ci-logs` after a successful configure/build and before running tests. These generated inventory files are uploaded as dedicated CI diagnostic artifacts and are not committed to the repository.
+
+### Baseline boundary
+
+This follow-up remains at Safe Merge Point A until a completed CI run confirms the focused harness checks on all three platforms. No production code, product assertions, golden outputs, GDTF/MVR behavior, or rider expectations were changed.

--- a/docs/developer/ci_test_audit.md
+++ b/docs/developer/ci_test_audit.md
@@ -47,36 +47,97 @@ The configure step failed before test generation because this container does not
 4. Split `tests/CMakeLists.txt` into domain modules only after current behavior and root causes are understood.
 5. Implement functional PR and full/release CI profiles without hiding known failures.
 
-## Phase 1 CI baseline update for PR #2204
+## Completed baseline from CI run 29961799720
 
 Branch base SHA: `ec6dee42371f51dc02520e3eb9fc4bea4d0daeca`.
-Current reviewed head before this follow-up: `4732460bc10bd2e312bb2714d8a6e82f617c5a01`.
-Current final head after this follow-up: recorded in PR #2204 after the final commit for this task.
-CI Debug Tests run inspected: `29961799720` (`https://github.com/PeramatoG/Perastage/actions/runs/29961799720`).
+Reviewed head for run `29961799720`: `4732460bc10bd2e312bb2714d8a6e82f617c5a01`.
+Current follow-up head: recorded in PR #2204 after the final commit for this task.
+Workflow: `CI Debug Tests`.
+Run: `29961799720` (`https://github.com/PeramatoG/Perastage/actions/runs/29961799720`).
 
-As of the API inspection performed from this workspace on 2026-07-22, run `29961799720` had not completed. The workflow run status was `in_progress`, with `linux-debug`, `windows-debug`, and `macos-debug` also still `in_progress`; only `resolve-source` had completed successfully. Therefore no completed configure/build/CTest baseline, pass/fail/skip/not-run counts, or current failing-test list can be recorded from that run yet. This must not be represented as a test failure because the jobs had not reached a completed result.
+All three platform jobs completed dependency installation, CMake configuration, and their requested builds. Linux and Windows then failed during CTest execution. macOS passed its reduced release-gate CTest profile. The macOS job is not a full-suite platform-parity run.
 
-| Platform | Configure result | Build result | CTest result | Passed | Failed | Skipped | Not run | Current failing tests | Log or artifact reference |
-| --- | --- | --- | --- | ---: | ---: | ---: | ---: | --- | --- |
-| Linux | Pending in run `29961799720` | Pending in run `29961799720` | Pending in run `29961799720` | Not available | Not available | Not available | Not available | Not available until completion | `ci-linux-debug-ctest-inventory`; `ci-linux-debug-diagnostics` on failure |
-| Windows | Pending in run `29961799720` | Pending in run `29961799720` | Pending in run `29961799720` | Not available | Not available | Not available | Not available | Not available until completion | `ci-windows-debug-ctest-inventory`; `ci-windows-debug-diagnostics` on failure |
-| macOS | Pending in run `29961799720` | Pending in run `29961799720` | Pending in run `29961799720` | Not available | Not available | Not available | Not available | Not available until completion | `ci-macos-debug-ctest-inventory`; `ci-macos-debug-diagnostics` on failure |
+| Platform | Configure result | Build result | CTest result | Total executed | Passed | Failed | Skipped | Not run | Artifact/log reference |
+| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | --- |
+| Linux | Passed | Passed | Failed | 158 | 132 | 25 | 1 | 0 | `ci-linux-debug-diagnostics` from run `29961799720`; `out/ci-logs/ctest-linux-debug.log`; `out/ci-logs/ctest-linux-debug.junit.xml`; `out/ci-logs/ctest-linux-debug-failures.csv`; `build/linux-debug/Testing/Temporary/LastTestsFailed.log` |
+| Windows | Passed | Passed | Failed | 158 | 128 | 30 | 0 | 0 | `ci-windows-debug-diagnostics` from run `29961799720`; `out/ci-logs/ctest-windows-debug.log`; `out/ci-logs/ctest-windows-debug.junit.xml`; `out/ci-logs/ctest-windows-debug-failures.csv`; `build-windows-debug/Testing/Temporary/LastTestsFailed.log` |
+| macOS | Passed | Passed two requested release-gate executables | Passed reduced `release-gate` label profile | 6 | 6 | 0 | 0 | Full suite not run | Successful run `29961799720`; prior workflow uploaded detailed artifacts only on failure, so no JUnit/result artifact was retained for the passing macOS job |
 
-### Focused harness validation status
+### Harness checks verified by run 29961799720
 
-- Local Linux restricted-path validation passes for `ReleaseGatePolicyPortability`.
-- Cross-runner Linux, Windows Git Bash, and macOS validation remains pending because run `29961799720` had not completed when inspected.
-- `UnresolvedPythonInvocations` passes locally and is registered for CI.
-- Windows Microsoft Store Python launcher avoidance remains pending runner confirmation; the policy test and existing `PythonResolvedInterpreterPolicy` are the focused checks intended to prove it.
-- The portability harness directly runs the release-gate scripts from the repository root and an unrelated temporary working directory with a restricted PATH.
+- Linux `ReleaseGatePolicyPortability` passed in approximately 5.6 seconds.
+- Linux `PythonResolvedInterpreterPolicy` passed.
+- Linux `UnresolvedPythonInvocations` passed.
+- Windows `PythonResolvedInterpreterPolicy` passed, confirming the resolved interpreter was used instead of the Microsoft Store launcher.
+- Windows `UnresolvedPythonInvocations` passed.
+- macOS six release-gate tests passed.
 
-### Diagnostics baseline
+### Confirmed harness defect from run 29961799720
 
-- Linux CTest diagnostics are configured to preserve JUnit output, the full CTest log, `LastTestsFailed.log`, and the concise failure CSV in `out/ci-logs` and the build `Testing/Temporary` tree.
-- Windows CTest diagnostics are configured to preserve JUnit output, the full CTest log, `LastTestsFailed.log`, and the concise failure CSV in `out/ci-logs` and the build `Testing/Temporary` tree.
-- macOS now preserves CTest JSON inventory plus both the wrapper log and CTest `--output-log` file, and it writes JUnit output for release-gate tests so the same failure-summary path can include structured test results.
-- Linux, Windows, and macOS now generate `ctest --show-only=json-v1` inventory files under `out/ci-logs` after a successful configure/build and before running tests. These generated inventory files are uploaded as dedicated CI diagnostic artifacts and are not committed to the repository.
+| Test | Platform | First meaningful failure line | Evidence | Remediation |
+| --- | --- | --- | --- | --- |
+| `ReleaseGatePolicyPortability` | Windows Git Bash | `ReleaseGatePolicyPortability ...***Timeout 120.00 sec` after completing `check_windows_ninja_x64_policy.sh` and before `check_ci_cmake_language_policy.sh` completed | `ci-windows-debug-diagnostics`, `out/ci-logs/ctest-windows-debug.log`, `build-windows-debug/Testing/Temporary/LastTestsFailed.log` | The likely slow path was verified locally as the CMake language policy's unpruned `Path('.').rglob('CMakeLists.txt')` traversal. The policy now prunes generated/vendor directory names before descent and the portability harness prints low-noise per-child timings. |
 
-### Baseline boundary
+### Common Linux and Windows unclassified domain failures
 
-This follow-up remains at Safe Merge Point A until a completed CI run confirms the focused harness checks on all three platforms. No production code, product assertions, golden outputs, GDTF/MVR behavior, or rider expectations were changed.
+These failures are current baseline failures only. They are intentionally not classified as production defects, stale expectations, or invalid fixtures until the next domain-specific audit phase traces each contract.
+
+| Test | First meaningful failure line | Reproduction command | Artifact/log reference |
+| --- | --- | --- | --- |
+| `Viewer2DFboCaptureDiagnostics` | `Viewer2DFboCaptureDiagnostics ...***Failed` | `ctest --test-dir <build-dir> -R '^Viewer2DFboCaptureDiagnostics$' --output-on-failure --verbose` | Linux/Windows CTest log and failure CSV from run `29961799720` |
+| `EditableFocusUtils` | `EditableFocusUtils ...***Failed`; Linux output also included an AT-SPI/DBus warning before the failure | `ctest --test-dir <build-dir> -R '^EditableFocusUtils$' --output-on-failure --verbose` | Linux/Windows CTest log and failure CSV from run `29961799720` |
+| `GdtfReadServices` | `GdtfReadServices ...***Failed` | `ctest --test-dir <build-dir> -R '^GdtfReadServices$' --output-on-failure --verbose` | Linux/Windows CTest log and failure CSV from run `29961799720` |
+| `GdtfFixtureCategoryFallback` | `GdtfFixtureCategoryFallback ...***Failed` | `ctest --test-dir <build-dir> -R '^GdtfFixtureCategoryFallback$' --output-on-failure --verbose` | Linux/Windows CTest log and failure CSV from run `29961799720` |
+| `LayoutTemplatePackageService` | `LayoutTemplatePackageService ...***Failed` | `ctest --test-dir <build-dir> -R '^LayoutTemplatePackageService$' --output-on-failure --verbose` | Linux/Windows CTest log and failure CSV from run `29961799720` |
+| `PdfTextComparison` | `PdfTextComparison ...***Failed` | `ctest --test-dir <build-dir> -R '^PdfTextComparison$' --output-on-failure --verbose` | Linux/Windows CTest log and failure CSV from run `29961799720` |
+| `SaveLoadRoundtrip` | `SaveLoadRoundtrip ...***Failed` | `ctest --test-dir <build-dir> -R '^SaveLoadRoundtrip$' --output-on-failure --verbose` | Linux/Windows CTest log and failure CSV from run `29961799720` |
+| `ProjectSupportUserDataRoundtrip` | `ProjectSupportUserDataRoundtrip ...***Failed` | `ctest --test-dir <build-dir> -R '^ProjectSupportUserDataRoundtrip$' --output-on-failure --verbose` | Linux/Windows CTest log and failure CSV from run `29961799720` |
+| `TrussPathEncodingRegression` | `TrussPathEncodingRegression ...***Failed` | `ctest --test-dir <build-dir> -R '^TrussPathEncodingRegression$' --output-on-failure --verbose` | Linux/Windows CTest log and failure CSV from run `29961799720` |
+| `RiderTrussDictionaryNormalization` | `RiderTrussDictionaryNormalization ...***Failed` | `ctest --test-dir <build-dir> -R '^RiderTrussDictionaryNormalization$' --output-on-failure --verbose` | Linux/Windows CTest log and failure CSV from run `29961799720` |
+| `MvrSupportUserDataRoundtrip` | `MvrSupportUserDataRoundtrip ...***Failed` | `ctest --test-dir <build-dir> -R '^MvrSupportUserDataRoundtrip$' --output-on-failure --verbose` | Linux/Windows CTest log and failure CSV from run `29961799720` |
+| `MvrFixtureCategoryRoundtrip` | `MvrFixtureCategoryRoundtrip ...***Failed` | `ctest --test-dir <build-dir> -R '^MvrFixtureCategoryRoundtrip$' --output-on-failure --verbose` | Linux/Windows CTest log and failure CSV from run `29961799720` |
+| `MvrTrussRoundtripStructure` | `MvrTrussRoundtripStructure ...***Failed` | `ctest --test-dir <build-dir> -R '^MvrTrussRoundtripStructure$' --output-on-failure --verbose` | Linux/Windows CTest log and failure CSV from run `29961799720` |
+| `MvrExporterCompliance` | `MvrExporterCompliance ...***Failed` | `ctest --test-dir <build-dir> -R '^MvrExporterCompliance$' --output-on-failure --verbose` | Linux/Windows CTest log and failure CSV from run `29961799720` |
+| `RiderImportLinearOrder` | `RiderImportLinearOrder ...***Failed` | `ctest --test-dir <build-dir> -R '^RiderImportLinearOrder$' --output-on-failure --verbose` | Linux/Windows CTest log and failure CSV from run `29961799720` |
+| `RiderFilterPreview` | `RiderFilterPreview ...***Failed` | `ctest --test-dir <build-dir> -R '^RiderFilterPreview$' --output-on-failure --verbose` | Linux/Windows CTest log and failure CSV from run `29961799720` |
+| `RiderComments` | `RiderComments ...***Failed` | `ctest --test-dir <build-dir> -R '^RiderComments$' --output-on-failure --verbose` | Linux/Windows CTest log and failure CSV from run `29961799720` |
+| `RiderLedScreenObject` | `RiderLedScreenObject ...***Failed` | `ctest --test-dir <build-dir> -R '^RiderLedScreenObject$' --output-on-failure --verbose` | Linux/Windows CTest log and failure CSV from run `29961799720` |
+| `RiderHoistImport` | `RiderHoistImport ...***Failed` | `ctest --test-dir <build-dir> -R '^RiderHoistImport$' --output-on-failure --verbose` | Linux/Windows CTest log and failure CSV from run `29961799720` |
+| `RiderLxSidesImport` | `RiderLxSidesImport ...***Failed` | `ctest --test-dir <build-dir> -R '^RiderLxSidesImport$' --output-on-failure --verbose` | Linux/Windows CTest log and failure CSV from run `29961799720` |
+| `RiderPipeImport` | `RiderPipeImport ...***Failed` | `ctest --test-dir <build-dir> -R '^RiderPipeImport$' --output-on-failure --verbose` | Linux/Windows CTest log and failure CSV from run `29961799720` |
+| `Loader3dsNativeDimensions` | `Loader3dsNativeDimensions ...***Failed` | `ctest --test-dir <build-dir> -R '^Loader3dsNativeDimensions$' --output-on-failure --verbose` | Linux/Windows CTest log and failure CSV from run `29961799720` |
+| `GdtfLoaderSetPropertiesMutation` | `GdtfLoaderSetPropertiesMutation ...***Failed` | `ctest --test-dir <build-dir> -R '^GdtfLoaderSetPropertiesMutation$' --output-on-failure --verbose` | Linux/Windows CTest log and failure CSV from run `29961799720` |
+| `SymbolFixtureApplierGdtfMutation` | `SymbolFixtureApplierGdtfMutation ...***Failed` | `ctest --test-dir <build-dir> -R '^SymbolFixtureApplierGdtfMutation$' --output-on-failure --verbose` | Linux/Windows CTest log and failure CSV from run `29961799720` |
+| `MvrPatchedGdtfExportMutation` | `MvrPatchedGdtfExportMutation ...***Failed` | `ctest --test-dir <build-dir> -R '^MvrPatchedGdtfExportMutation$' --output-on-failure --verbose` | Linux/Windows CTest log and failure CSV from run `29961799720` |
+
+### Additional Windows-only failures
+
+| Test | First meaningful failure line | Reproduction command | Artifact/log reference |
+| --- | --- | --- | --- |
+| `ReleaseGatePolicyPortability` | `ReleaseGatePolicyPortability ...***Timeout 120.00 sec` | `ctest --test-dir build-windows-debug -R '^ReleaseGatePolicyPortability$' --output-on-failure --verbose --interactive-debug-mode 0 --timeout 120` | `ci-windows-debug-diagnostics` from run `29961799720` |
+| `PdfWriterSerialization` | `PdfWriterSerialization ...***Failed` | `ctest --test-dir build-windows-debug -R '^PdfWriterSerialization$' --output-on-failure --verbose --interactive-debug-mode 0 --timeout 120` | `ci-windows-debug-diagnostics` from run `29961799720` |
+| `GdtfFixtureInsertionPreparation` | `GdtfFixtureInsertionPreparation ...***Failed` | `ctest --test-dir build-windows-debug -R '^GdtfFixtureInsertionPreparation$' --output-on-failure --verbose --interactive-debug-mode 0 --timeout 120` | `ci-windows-debug-diagnostics` from run `29961799720` |
+| `LayoutImageResourceRegistry` | `LayoutImageResourceRegistry ...***Failed` | `ctest --test-dir build-windows-debug -R '^LayoutImageResourceRegistry$' --output-on-failure --verbose --interactive-debug-mode 0 --timeout 120` | `ci-windows-debug-diagnostics` from run `29961799720` |
+| `GdtfShareSecurity` | `GdtfShareSecurity ...***Failed` | `ctest --test-dir build-windows-debug -R '^GdtfShareSecurity$' --output-on-failure --verbose --interactive-debug-mode 0 --timeout 120` | `ci-windows-debug-diagnostics` from run `29961799720` |
+
+### EditableFocusUtils Phase 2 note
+
+`EditableFocusUtils` remains an unclassified GUI/headless failure. Linux output includes an AT-SPI/DBus warning, but the available baseline does not prove whether that warning is causal or merely environmental noise before a separate wx lifecycle or focus assertion failure. Windows reports the test as failed without a differentiated first assertion in the baseline summary. The focused reproduction command is `ctest --test-dir <build-dir> -R '^EditableFocusUtils$' --output-on-failure --verbose`. No stderr suppression, skip, assertion change, or product-code change was made in this task.
+
+### Result and inventory artifact contract after this follow-up
+
+Each platform now writes both human-readable and machine-readable inventory/results under `out/ci-logs`:
+
+- `ctest-inventory-<platform>-debug.txt` from `ctest -N -V`.
+- `ctest-inventory-<platform>-debug.json` from `ctest --show-only=json-v1`.
+- `ctest-<platform>-debug.junit.xml`.
+- `ctest-<platform>-debug.log` and, for macOS, the wrapper/full CTest logs.
+- `ctest-<platform>-debug-failures.csv`.
+- `ctest-<platform>-debug-results.json` containing total, passed, failed, skipped, disabled/not-run, selected labels/profile, and tested SHA.
+- `LastTestsFailed.log` and `LastTestsDisabled.log` when CTest produces them.
+
+The small `ci-<platform>-debug-test-results` artifacts are uploaded with `if: always()`. The existing heavy `ci-<platform>-debug-diagnostics` artifacts remain failure-only. Result collection preserves CTest exit codes and does not hide failing suites.
+
+### Safe merge status
+
+Safe Merge Point A is reached for the local harness repair and baseline documentation. Safe Merge Point B requires the next CI run for this follow-up commit to confirm that `ReleaseGatePolicyPortability` passes on Windows Git Bash as well as Linux/macOS and that all per-platform result artifacts are present.

--- a/docs/developer/ci_test_audit.md
+++ b/docs/developer/ci_test_audit.md
@@ -1,0 +1,48 @@
+# CI Debug Tests audit
+
+Baseline SHA: `ec6dee42371f51dc02520e3eb9fc4bea4d0daeca`.
+Audit date: 2026-07-22.
+
+## Standards references pinned for this audit
+
+The audit uses the current upstream public documentation for the project policy target versions:
+
+- GDTF: DIN SPEC 15800:2022-02, GDTF Version 1.2, documented by GDTF Hub at `https://www.gdtf.eu/gdtf/` and `https://www.gdtf.eu/gdtf/prologue/introduction/` on 2026-07-22.
+- MVR: DIN SPEC 15801:2023-12, MVR Version 1.6, documented by GDTF Hub at `https://www.gdtf.eu/mvr/` and `https://www.gdtf.eu/mvr/prologue/introduction/` on 2026-07-22.
+
+Normal PR tests must use local deterministic fixtures and must not download live GDTF Share or schema content during execution.
+
+## Baseline inventory attempt
+
+The local Linux inventory was attempted with:
+
+```sh
+cmake -S . -B out/ci-audit-debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON -DPERASTAGE_ENABLE_COMPILER_CACHE=OFF
+ctest --test-dir out/ci-audit-debug -N -V > out/ci-audit-ctest-inventory.txt
+```
+
+The configure step failed before test generation because this container does not provide wxWidgets development files. No source-tree test artifacts were generated. The failed configure output is an environment limitation, not a test result, and the intended generated inventory location remains `out/ci-audit-ctest-inventory.txt`.
+
+## Current classification matrix
+
+| Test or group | Primary classification | Affected platform | First meaningful failure | Contract | Remediation in this change |
+| --- | --- | --- | --- | --- | --- |
+| `ReleaseGatePolicyPortability` | `test-harness-defect` | macOS, Windows Git Bash, Linux restricted-path simulation | The test hard-coded `/usr/bin/bash`, `/usr/bin/dirname`, `/usr/bin/env`, `/tmp`, and symbolic links. | Release-gate policy scripts must run from the repository root and unrelated working directories using only declared tools, and must not require ripgrep. | Reworked the portability harness to use the CMake-provided or current Bash executable, discover required tools with `command -v`, use a platform-selected temporary root, copy helper tools instead of symlinking them, and execute the scripts under a restricted PATH without `rg`. |
+| Portable shell tests invoking Python | `test-harness-defect` | Windows primarily; all platforms as policy | Historical failures could reach unresolved Python aliases such as the Microsoft Store launcher. | Portable tests must use the CMake-resolved Python interpreter through `PERASTAGE_TEST_PYTHON`, `resolve_test_python`, or `run_test_python`. | Added `UnresolvedPythonInvocations`, a repository-policy test that scans portable test files for direct unresolved `python` or `python3` command invocations. |
+| Full Linux CTest failure groups from prior artifact | `standards-ambiguity-needing-documentation` | Linux baseline artifact | Prior artifact reported MVR/GDTF, rider, layout, PDF, path, geometry, and GUI failures. | Each failure must be reproduced on the latest main SHA before assertions or production behavior are changed. | Not modified in this focused harness repair. The local container cannot configure the suite because wxWidgets development files are unavailable, so these remain pending for an environment with the project dependencies installed. |
+| macOS release-gate-only coverage | `platform-specific-contract` | macOS CI | macOS Debug CI currently builds and runs only release-gate coverage. | CI profiles must make platform coverage explicit and not silently treat a narrow gate as full-suite parity. | Documented as pending audit work; no workflow coverage reduction was made. |
+
+## Decisions
+
+- The release-gate portability failure is a harness defect. It did not expose a production-code defect because the failing assumptions were in the policy test's own runner setup.
+- The Python alias risk is a harness policy defect. The repaired policy prevents new portable tests from bypassing the resolved interpreter.
+- No MVR/GDTF, rider, layout, PDF, 3DS, path, or GUI assertion was changed in this step because the failures were not reproducible in this container after the required configure failure.
+- No obsolete test was removed or quarantined.
+
+## Remaining audit work
+
+1. Re-run configure, build, `ctest -N -V`, and the full Debug CTest suite on Linux, Windows, and macOS runners with project dependencies installed.
+2. Export the complete machine-readable test inventory under `out/` with CTest name, source, target, platform availability, policy layer, domain labels, scope, fixture category, timeout, and required services/tools.
+3. Classify every current failing test using the project classification taxonomy before changing assertions.
+4. Split `tests/CMakeLists.txt` into domain modules only after current behavior and root causes are understood.
+5. Implement functional PR and full/release CI profiles without hiding known failures.

--- a/docs/developer/ci_test_audit.md
+++ b/docs/developer/ci_test_audit.md
@@ -141,3 +141,80 @@ The small `ci-<platform>-debug-test-results` artifacts are uploaded with `if: al
 ### Safe merge status
 
 Safe Merge Point A is reached for the local harness repair and baseline documentation. Safe Merge Point B requires the next CI run for this follow-up commit to confirm that `ReleaseGatePolicyPortability` passes on Windows Git Bash as well as Linux/macOS and that all per-platform result artifacts are present.
+
+## Phase 2 follow-up for CI run 29988207383
+
+Base SHA: `ec6dee42371f51dc02520e3eb9fc4bea4d0daeca`.
+Reviewed head for run `29988207383`: `6575fc25792f45264a0092fcd69994a87b87da59`.
+Current follow-up head: recorded in PR #2204 after the final commit for this task.
+Workflow run: `29988207383` (`https://github.com/PeramatoG/Perastage/actions/runs/29988207383`).
+
+All jobs completed dependency installation and CMake configuration. Linux and Windows built the complete test target set. macOS remained intentionally reduced to the release-gate profile and must not be described as full macOS platform parity.
+
+| Platform | Configure result | Build result | CTest result | Inventory total | Passed | Failed | Skipped | Disabled/not run | Selected labels/profile | Result artifact |
+| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | --- | --- |
+| Linux | Passed | Passed complete test target set | Failed | 159 | 133 | 25 | 1 | 0 | Full Debug suite | `ci-linux-debug-test-results` |
+| Windows | Passed | Passed complete MSVC Hostx64/x64 Ninja test target set | Failed | 159 | 129 | 30 | 0 | 0 | Full Debug suite | `ci-windows-debug-test-results` |
+| macOS | Passed | Passed requested release-gate executables | Passed | Reduced profile only | 6 | 0 | 0 | 0 | `release-gate` | `ci-macos-debug-test-results` |
+
+### Confirmed remaining harness root cause
+
+The remaining Windows harness failure in run `29988207383` was `ReleaseGatePolicyPortability`. The focused timing evidence showed `WindowsNinjaX64Policy` passed as an independent CTest in approximately 94.74 seconds. Inside `ReleaseGatePolicyPortability`, `check_windows_ninja_x64_policy.sh` completed its repository-root execution in approximately 90 seconds, then the wrapper timed out at the existing 120-second CTest timeout before the unrelated-working-directory execution completed. `check_ci_cmake_language_policy.sh` completed in under one second, proving it was no longer the bottleneck.
+
+The root cause is the Windows policy scanner's unpruned `Path.rglob('*')` traversal. It filtered `.git`, `.vcpkg-cache`, `vcpkg`, `build`, `out`, and similar roots only after descending through them. On Windows CI, the checkout contains large generated/cache/dependency trees, so the scanner spent most of its time traversing files that were never part of the first-party policy contract.
+
+### Remediation in this follow-up
+
+`check_windows_ninja_x64_policy.sh` now uses a deterministic top-down `os.walk` traversal and mutates `dirnames` before descent to prune `.git`, `.vcpkg-cache`, `.vcpkg-root`, `.tools`, `build`, `build-*`, `cmake-build-*`, `out`, `third_party`, `vcpkg`, and `vcpkg_installed`. It still scans first-party files for forbidden generated local Windows preset references such as `local Windows preset marker`, reports a concise inspected-file count and elapsed scan time, uses `PERASTAGE_POLICY_ROOT` only for deterministic fixture testing, and continues to use the resolved Python interpreter supplied by the harness.
+
+A new `WindowsNinjaX64PolicyFixtures` policy fixture proves that forbidden `local Windows preset marker` text in excluded generated/vendor/cache roots is ignored, a first-party nested violation is still detected, and the scanner emits an observable first-party inspected-file count. No broad first-party exclusions, timeout increase, skip, `continue-on-error`, or exit-code masking were introduced.
+
+### Current failure sets preserved for Phase 3
+
+The 25 common Linux/Windows domain failures remain untouched and unclassified beyond baseline preservation:
+
+- `Viewer2DFboCaptureDiagnostics`
+- `EditableFocusUtils`
+- `GdtfReadServices`
+- `GdtfFixtureCategoryFallback`
+- `LayoutTemplatePackageService`
+- `PdfTextComparison`
+- `SaveLoadRoundtrip`
+- `ProjectSupportUserDataRoundtrip`
+- `TrussPathEncodingRegression`
+- `RiderTrussDictionaryNormalization`
+- `MvrSupportUserDataRoundtrip`
+- `MvrFixtureCategoryRoundtrip`
+- `MvrTrussRoundtripStructure`
+- `MvrExporterCompliance`
+- `RiderImportLinearOrder`
+- `RiderFilterPreview`
+- `RiderComments`
+- `RiderLedScreenObject`
+- `RiderHoistImport`
+- `RiderLxSidesImport`
+- `RiderPipeImport`
+- `Loader3dsNativeDimensions`
+- `GdtfLoaderSetPropertiesMutation`
+- `SymbolFixtureApplierGdtfMutation`
+- `MvrPatchedGdtfExportMutation`
+
+The Windows-only domain failures remain untouched and unclassified:
+
+- `PdfWriterSerialization`
+- `GdtfFixtureInsertionPreparation`
+- `LayoutImageResourceRegistry`
+- `GdtfShareSecurity`
+
+`ReleaseGatePolicyPortability` is the only Windows-only failure addressed in this task, and it was addressed as a harness traversal defect.
+
+### Future MVR/GDTF I/O policy for Phase 3 branches
+
+- Be permissive on input: Perastage should recover safely and deterministically from damaged, incomplete, legacy, or non-conforming MVR/GDTF files whenever possible, preserve useful data, and emit structured diagnostics instead of rejecting recoverable files unnecessarily.
+- Be canonical on output: every MVR or GDTF archive generated or rewritten by Perastage must conform to the current supported standards target, currently GDTF 1.2 and MVR 1.6, normalize recoverable input, and must not reproduce malformed source structures.
+- Keep standard-strict, legacy-compatibility, tolerant-recovery, and Perastage-extension code paths and tests explicitly separated.
+- Never make the reader less compatible merely to make a strict writer test pass.
+
+### Safe Merge Point B decision
+
+Safe Merge Point B is pending until a completed CI run for the follow-up commit confirms that `ReleaseGatePolicyPortability` passes on Windows Git Bash within the unchanged 120-second timeout and that the domain failure set is unchanged except for removing the harness timeout. Safe Merge Point B must not be declared from local Linux-only evidence.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -14,6 +14,7 @@ Perastage 1.5.0 is a substantial update focused on GDTF and truss editing, multi
 - Added a **Spanish interface**, selectable from Preferences and applied after restarting Perastage.
 - Improved MVR/GDTF compatibility, 3D picking stability, Unicode handling, crash diagnostics, and release packaging.
 - Improved Debug CI stability by rebuilding stale macOS SDK caches instead of failing on equivalent SDK aliases.
+- Improved Debug CI test reliability by making release-gate policy portability checks independent of hard-coded Unix paths, symbolic links, caller working directories, and unresolved Python aliases.
 
 ## New features and improvements
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -14,7 +14,7 @@ Perastage 1.5.0 is a substantial update focused on GDTF and truss editing, multi
 - Added a **Spanish interface**, selectable from Preferences and applied after restarting Perastage.
 - Improved MVR/GDTF compatibility, 3D picking stability, Unicode handling, crash diagnostics, and release packaging.
 - Improved Debug CI stability by rebuilding stale macOS SDK caches instead of failing on equivalent SDK aliases.
-- Improved Debug CI test reliability by making release-gate policy portability checks independent of hard-coded Unix paths, symbolic links, caller working directories, and unresolved Python aliases.
+- Improved Debug CI test reliability by making release-gate policy portability checks independent of hard-coded Unix paths, symbolic links, caller working directories, and unresolved Python aliases, and by preserving CTest inventory diagnostics for baseline audits.
 
 ## New features and improvements
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -14,7 +14,7 @@ Perastage 1.5.0 is a substantial update focused on GDTF and truss editing, multi
 - Added a **Spanish interface**, selectable from Preferences and applied after restarting Perastage.
 - Improved MVR/GDTF compatibility, 3D picking stability, Unicode handling, crash diagnostics, and release packaging.
 - Improved Debug CI stability by rebuilding stale macOS SDK caches instead of failing on equivalent SDK aliases.
-- Improved Debug CI test reliability by making release-gate policy portability checks independent of hard-coded Unix paths, symbolic links, caller working directories, and unresolved Python aliases, and by preserving CTest inventory diagnostics for baseline audits.
+- Improved Debug CI test reliability by making release-gate policy checks independent of hard-coded Unix paths, symbolic links, caller working directories, unresolved Python aliases, and generated-cache traversal costs, while preserving CTest result and inventory diagnostics for baseline audits.
 
 ## New features and improvements
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -66,7 +66,7 @@ function(add_bash_policy_test test_name script_path)
              COMMAND "${BASH_EXECUTABLE}" "${script_path}" ${POLICY_ARGS})
     set_tests_properties(${test_name} PROPERTIES
                          WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
-                         ENVIRONMENT "PERASTAGE_TEST_PYTHON=${Python3_EXECUTABLE}")
+                         ENVIRONMENT "PERASTAGE_TEST_PYTHON=${Python3_EXECUTABLE};PERASTAGE_TEST_BASH=${BASH_EXECUTABLE}")
     if(POLICY_LABELS)
         list(JOIN POLICY_LABELS ";" labels)
         set_tests_properties(${test_name} PROPERTIES LABELS "${labels}")
@@ -82,7 +82,7 @@ function(add_repository_policy_test test_name command_path)
              COMMAND "${command_path}" ${POLICY_ARGS})
     set_tests_properties(${test_name} PROPERTIES
                          WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
-                         ENVIRONMENT "PERASTAGE_TEST_PYTHON=${Python3_EXECUTABLE}")
+                         ENVIRONMENT "PERASTAGE_TEST_PYTHON=${Python3_EXECUTABLE};PERASTAGE_TEST_BASH=${BASH_EXECUTABLE}")
     if(POLICY_LABELS)
         list(JOIN POLICY_LABELS ";" labels)
         set_tests_properties(${test_name} PROPERTIES LABELS "${labels}")
@@ -180,6 +180,9 @@ if(Python3_Interpreter_FOUND)
                                ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_missing_ripgrep_behavior.py --bash ${BASH_EXECUTABLE})
     add_repository_policy_test(CtestFailureSummary ${Python3_EXECUTABLE}
                                ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_summarize_ctest_failures.py)
+    add_repository_policy_test(UnresolvedPythonInvocations ${Python3_EXECUTABLE}
+                               ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_unresolved_python_invocations.py
+                               LABELS standard-strict policy)
 endif()
 
 link_libraries(perastage_test_active_dictionary_storage)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -180,6 +180,9 @@ if(Python3_Interpreter_FOUND)
                                ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_missing_ripgrep_behavior.py --bash ${BASH_EXECUTABLE})
     add_repository_policy_test(CtestFailureSummary ${Python3_EXECUTABLE}
                                ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_summarize_ctest_failures.py)
+    add_repository_policy_test(CtestResultSummary ${Python3_EXECUTABLE}
+                               ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_summarize_ctest_results.py
+                               LABELS standard-strict policy ci)
     add_repository_policy_test(UnresolvedPythonInvocations ${Python3_EXECUTABLE}
                                ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_unresolved_python_invocations.py
                                LABELS standard-strict policy)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -174,6 +174,9 @@ if(Python3_Interpreter_FOUND)
                                ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_validate_cmake_toolchain.py)
     add_repository_policy_test(CiCMakeLanguagePolicyFixtures ${Python3_EXECUTABLE}
                                ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_ci_cmake_language_policy_fixtures.py --bash ${BASH_EXECUTABLE})
+    add_repository_policy_test(WindowsNinjaX64PolicyFixtures ${Python3_EXECUTABLE}
+                               ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_windows_ninja_x64_policy_fixtures.py --bash ${BASH_EXECUTABLE}
+                               LABELS standard-strict policy windows)
     add_repository_policy_test(PolicyWorkingDirectories ${Python3_EXECUTABLE}
                                ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_policy_working_directories.py --bash ${BASH_EXECUTABLE})
     add_repository_policy_test(MissingRipgrepBehavior ${Python3_EXECUTABLE}

--- a/tests/check_ci_cmake_language_policy.sh
+++ b/tests/check_ci_cmake_language_policy.sh
@@ -6,7 +6,9 @@ cd "$repo_root"
 
 run_test_python - <<'PY'
 from pathlib import Path
+import os
 import re
+import time
 
 root_path = Path('CMakeLists.txt')
 root = root_path.read_text()
@@ -22,13 +24,17 @@ if 'CMP0177' not in root or 'cmake_policy(SET CMP0177 NEW)' not in root:
 excluded_roots = {'.git', '.vcpkg-cache', 'vcpkg', 'build', 'out', 'third_party'}
 excluded_prefixes = ('build-', 'cmake-build-')
 
-def is_first_party_cmake(path: Path) -> bool:
-    parts = path.parts
-    if any(part in excluded_roots for part in parts):
-        return False
-    if any(part.startswith(excluded_prefixes) for part in parts):
-        return False
-    return True
+def is_excluded_dirname(name: str) -> bool:
+    return name in excluded_roots or any(name.startswith(prefix) for prefix in excluded_prefixes)
+
+def iter_first_party_cmake_lists(root: Path):
+    for current_root, dirnames, filenames in os.walk(root):
+        dirnames[:] = [name for name in dirnames if not is_excluded_dirname(name)]
+        current = Path(current_root)
+        if current == root:
+            continue
+        if 'CMakeLists.txt' in filenames:
+            yield current / 'CMakeLists.txt'
 
 tests_cmake = Path('tests/CMakeLists.txt')
 if tests_cmake.exists():
@@ -36,7 +42,10 @@ if tests_cmake.exists():
     if re.search(r'(?m)^\s*(project|enable_language)\s*\(', text):
         raise SystemExit('tests/CMakeLists.txt must not unconditionally call project() or enable_language().')
 
-all_cmake = [p for p in Path('.').rglob('CMakeLists.txt') if p != Path('CMakeLists.txt') and is_first_party_cmake(p)]
+scan_start = time.monotonic()
+all_cmake = list(iter_first_party_cmake_lists(Path('.')))
+scan_elapsed = time.monotonic() - scan_start
+print(f'Checked {len(all_cmake)} first-party CMakeLists.txt files in {scan_elapsed:.3f}s.')
 for path in all_cmake:
     text = path.read_text(errors='ignore')
     if re.search(r'(?m)^\s*enable_language\s*\(', text):

--- a/tests/check_ci_cmake_language_policy_fixtures.py
+++ b/tests/check_ci_cmake_language_policy_fixtures.py
@@ -4,6 +4,7 @@ import argparse
 import os
 import shutil
 import subprocess
+import sys
 import tempfile
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -25,11 +26,18 @@ with tempfile.TemporaryDirectory() as tmp:
     (repo / 'tests/CMakeLists.txt').write_text('add_test(NAME Example COMMAND example)\n')
     (repo / 'vcpkg/buildtrees/liblzma').mkdir(parents=True)
     (repo / 'vcpkg/buildtrees/liblzma/CMakeLists.txt').write_text('enable_language(C)\n')
-    env = {**os.environ, 'PERASTAGE_POLICY_ROOT': str(repo)}
+    (repo / '.vcpkg-cache/packages/generated').mkdir(parents=True)
+    (repo / '.vcpkg-cache/packages/generated/CMakeLists.txt').write_text('enable_language(C)\n')
+    (repo / 'build-debug/generated').mkdir(parents=True)
+    (repo / 'build-debug/generated/CMakeLists.txt').write_text('enable_language(C)\n')
+    (repo / 'third_party/vendor').mkdir(parents=True)
+    (repo / 'third_party/vendor/CMakeLists.txt').write_text('enable_language(C)\n')
+    env = {**os.environ, 'PERASTAGE_POLICY_ROOT': str(repo), 'PERASTAGE_TEST_PYTHON': sys.executable}
     ok = subprocess.run([BASH, str(SCRIPT)], env=env, text=True, capture_output=True)
     assert ok.returncode == 0, ok.stderr + ok.stdout
+    assert 'Checked ' in ok.stdout, ok.stderr + ok.stdout
     (repo / 'cmake').mkdir()
     (repo / 'cmake/CMakeLists.txt').write_text('enable_language(C)\n')
     bad = subprocess.run([BASH, str(SCRIPT)], env=env, text=True, capture_output=True)
     assert bad.returncode != 0 and 'Nested enable_language()' in (bad.stderr + bad.stdout), bad.stderr + bad.stdout
-print('OK: CMake language policy fixtures cover first-party failures and vcpkg exclusions.')
+print('OK: CMake language policy fixtures cover first-party failures and pruned generated/vendor exclusions.')

--- a/tests/check_ci_workflow_architecture.py
+++ b/tests/check_ci_workflow_architecture.py
@@ -24,21 +24,23 @@ for platform, text in sections.items():
         assert needle in text, f'{platform} Debug is missing {needle}'
     assert text.index('Prepare vcpkg and diagnostics directories') < text.index('Bootstrap vcpkg'), f'{platform} must create vcpkg directories before bootstrap'
     assert 'VCPKG_DOWNLOADS' in text and 'VCPKG_INSTALLED' in text and 'VCPKG_PACKAGES' in text and 'VCPKG_BINARY_CACHE' in text, f'{platform} must prepare all vcpkg directories'
-    assert 'debug-v1' in text or 'macos-26-xcode-26-debug-v1' in text, f'{platform} installed cache key must be Debug/toolchain scoped'
+    assert 'debug-v1' in text or 'debug-v2' in text or 'macos-26-xcode-26-debug-v1' in text, f'{platform} installed cache key must be Debug/toolchain scoped'
     assert ('run_and_log.py --log' in text or '--output-log' in text) and 'ctest-' in text, f'{platform} build and test logs must be captured'
 
 linux = sections['linux']
-for needle in ['-DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"', '-DVCPKG_TARGET_TRIPLET=x64-linux', '-DVCPKG_INSTALLED_DIR="$VCPKG_INSTALLED"', '-DCMAKE_EXPORT_COMPILE_COMMANDS=ON', 'compile_commands.json was not generated', 'ripgrep', 'xvfb', 'locales', 'es_ES.UTF-8', 'zh_CN.UTF-8', 'xauth', 'x11-utils', 'xdpyinfo', 'xvfb-run -a', '--output-junit', '--verbose']:
+for needle in ['-DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"', '-DVCPKG_TARGET_TRIPLET=x64-linux', '-DVCPKG_INSTALLED_DIR="$VCPKG_INSTALLED"', '-DCMAKE_EXPORT_COMPILE_COMMANDS=ON', 'compile_commands.json was not generated', 'ripgrep', 'xvfb', 'locales', 'es_ES.UTF-8', 'zh_CN.UTF-8', 'xauth', 'x11-utils', 'xdpyinfo', 'xvfb-run -a', '--output-junit', '--verbose', 'ctest-inventory-linux-debug.txt', 'ctest-linux-debug-results.json', 'ci-linux-debug-test-results']:
     assert needle in linux, f'Linux Debug is missing {needle}'
+assert 'summarize_ctest_results.py' in ci, 'CI Debug must produce compact result summaries'
+assert 'LastTestsDisabled.log' in ci, 'CI Debug test-result artifacts must retain disabled-test diagnostics when present'
 assert 'wxwidgets' not in linux.lower(), 'Linux Debug must not install system wxWidgets packages'
 
 windows = sections['windows']
-for needle in ['$env:GITHUB_ENV', '$env:GITHUB_PATH', 'PERASTAGE_PYTHON', 'Get-Command python', 'INCLUDE', 'LIBPATH', 'VSCMD_ARG_HOST_ARCH', 'VSCMD_ARG_TGT_ARCH', 'validate_cmake_toolchain.py', '--expected-c-id MSVC', '--expected-cxx-id MSVC', '--interactive-debug-mode 0', '--timeout 120', '--output-junit', 'timeout-minutes: 180']:
+for needle in ['$env:GITHUB_ENV', '$env:GITHUB_PATH', 'PERASTAGE_PYTHON', 'Get-Command python', 'INCLUDE', 'LIBPATH', 'VSCMD_ARG_HOST_ARCH', 'VSCMD_ARG_TGT_ARCH', 'validate_cmake_toolchain.py', '--expected-c-id MSVC', '--expected-cxx-id MSVC', '--interactive-debug-mode 0', '--timeout 120', '--output-junit', 'timeout-minutes: 180', 'ctest-inventory-windows-debug.txt', 'ctest-windows-debug-results.json', 'ci-windows-debug-test-results']:
     assert needle in windows, f'Windows Debug environment persistence is missing {needle}'
 assert windows.index('Persist Visual Studio Hostx64 x64 environment') < windows.index('Configure Windows Debug tests') < windows.index('Build Windows Debug tests')
 
 macos = sections['macos']
-for needle in ['macos-26-xcode-26-debug-v1', 'xcrun --sdk macosx --show-sdk-path', '-DCMAKE_OSX_SYSROOT="$current_sdk_path"', 'Stale macOS SDK path metadata']:
+for needle in ['debug-v2', 'xcrun --sdk macosx --show-sdk-path', '-DCMAKE_OSX_SYSROOT="$current_sdk_path"', '--output-junit', 'ctest-inventory-macos-debug.txt', 'ctest-macos-debug-results.json', 'ci-macos-debug-test-results']:
     assert needle in macos, f'macOS Debug is missing {needle}'
 
 builders = ['windows-installer.yml','linux-installer.yml','macos-installer.yml','macos-15-manual-installer.yml','arch-package.yml']

--- a/tests/check_policy_working_directories.py
+++ b/tests/check_policy_working_directories.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 from pathlib import Path
 import argparse
+import os
 import subprocess
+import sys
 import tempfile
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -19,6 +21,7 @@ with tempfile.TemporaryDirectory() as tmp:
     build.mkdir(parents=True, exist_ok=True)
     for cwd in [ROOT, build, Path(tmp)]:
         for script in SCRIPTS:
-            result = subprocess.run([BASH, str(script)], cwd=cwd, text=True, capture_output=True)
+            env = {**os.environ, 'PERASTAGE_TEST_PYTHON': os.environ.get('PERASTAGE_TEST_PYTHON', sys.executable)}
+            result = subprocess.run([BASH, str(script)], cwd=cwd, env=env, text=True, capture_output=True)
             assert result.returncode == 0, f'{script.name} failed from {cwd}:\n{result.stdout}\n{result.stderr}'
 print('OK: representative policy scripts resolve repository paths from root, build, and temporary working directories.')

--- a/tests/check_release_gate_policy_portability.sh
+++ b/tests/check_release_gate_policy_portability.sh
@@ -2,14 +2,55 @@
 set -euo pipefail
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/test_tool_requirements.sh"
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-tmp_root="$(mktemp -d)"
+
+make_portable_temp_dir() {
+  local base="${TMPDIR:-${TEMP:-${TMP:-}}}"
+  if [[ -z "$base" ]]; then
+    base="$(pwd)"
+  fi
+  mkdir -p "$base"
+  mktemp -d "$base/perastage-release-gate-policy.XXXXXX"
+}
+
+copy_tool_to_bin() {
+  local tool_name="$1"
+  local source_path
+  source_path="$(command -v "$tool_name")" || {
+    echo "Required portability tool is not available: $tool_name" >&2
+    exit 127
+  }
+  local target_name="$tool_name"
+  case "$source_path" in
+    *.exe) target_name="$tool_name.exe" ;;
+  esac
+  cp "$source_path" "$tmp_bin/$target_name"
+  chmod +x "$tmp_bin/$target_name"
+}
+
+bash_path="${PERASTAGE_TEST_BASH:-${BASH:-}}"
+if [[ -z "$bash_path" || ! -x "$bash_path" ]]; then
+  bash_path="$(command -v bash)" || {
+    echo 'Required portability tool is not available: bash' >&2
+    exit 127
+  }
+fi
+python_path="$(resolve_test_python)"
+python_path="$("$python_path" - <<'PY_RESOLVE'
+import sys
+print(sys.executable)
+PY_RESOLVE
+)"
+tmp_root="$(make_portable_temp_dir)"
 trap 'rm -rf "$tmp_root"' EXIT
 
 tmp_bin="$tmp_root/bin"
 mkdir -p "$tmp_bin"
-ln -s /usr/bin/bash "$tmp_bin/bash"
-ln -s /usr/bin/dirname "$tmp_bin/dirname"
-ln -s /usr/bin/env "$tmp_bin/env"
+copy_tool_to_bin bash
+copy_tool_to_bin dirname
+copy_tool_to_bin env
+copy_tool_to_bin cp
+copy_tool_to_bin chmod
+copy_tool_to_bin mkdir
 
 scripts=(
   "$repo_root/tests/check_securestore_build_policy.sh"
@@ -17,11 +58,9 @@ scripts=(
   "$repo_root/tests/check_ci_cmake_language_policy.sh"
 )
 
-python_path="$(resolve_test_python)"
-
 for script in "${scripts[@]}"; do
-  (cd "$repo_root" && PATH="$tmp_bin" PERASTAGE_TEST_PYTHON="$python_path" /usr/bin/bash "$script")
-  (cd "$tmp_root" && PATH="$tmp_bin" PERASTAGE_TEST_PYTHON="$python_path" /usr/bin/bash "$script")
+  (cd "$repo_root" && PATH="$tmp_bin" PERASTAGE_TEST_PYTHON="$python_path" "$bash_path" "$script")
+  (cd "$tmp_root" && PATH="$tmp_bin" PERASTAGE_TEST_PYTHON="$python_path" "$bash_path" "$script")
 done
 
 if PATH="$tmp_bin" command -v rg >/dev/null 2>&1; then

--- a/tests/check_release_gate_policy_portability.sh
+++ b/tests/check_release_gate_policy_portability.sh
@@ -59,8 +59,15 @@ scripts=(
 )
 
 for script in "${scripts[@]}"; do
+  script_name="$(basename "$script")"
+  start_seconds="$SECONDS"
   (cd "$repo_root" && PATH="$tmp_bin" PERASTAGE_TEST_PYTHON="$python_path" "$bash_path" "$script")
+  root_elapsed=$((SECONDS - start_seconds))
+  echo "${script_name} from repository root completed in ${root_elapsed}s."
+  start_seconds="$SECONDS"
   (cd "$tmp_root" && PATH="$tmp_bin" PERASTAGE_TEST_PYTHON="$python_path" "$bash_path" "$script")
+  unrelated_elapsed=$((SECONDS - start_seconds))
+  echo "${script_name} from unrelated working directory completed in ${unrelated_elapsed}s."
 done
 
 if PATH="$tmp_bin" command -v rg >/dev/null 2>&1; then

--- a/tests/check_summarize_ctest_results.py
+++ b/tests/check_summarize_ctest_results.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import json
+import subprocess
+import sys
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[1]
+TOOL = ROOT / '.github/scripts/summarize_ctest_results.py'
+
+with tempfile.TemporaryDirectory() as tmp:
+    base = Path(tmp)
+    junit = base / 'ctest.junit.xml'
+    out = base / 'results.json'
+    junit.write_text('''<testsuite tests="5" failures="1" errors="1" skipped="1" disabled="1">
+<testcase name="Passed" />
+<testcase name="Failed"><failure message="failed" /></testcase>
+<testcase name="Errored"><error message="error" /></testcase>
+<testcase name="Skipped"><skipped message="skipped" /></testcase>
+<testcase name="Disabled" />
+</testsuite>''')
+    subprocess.run([
+        sys.executable, str(TOOL), '--platform', 'linux', '--junit', str(junit),
+        '--output', str(out), '--tested-sha', 'abc123', '--profile', 'pr', '--labels', 'release-gate,policy'
+    ], check=True)
+    data = json.loads(out.read_text())
+    assert data['total'] == 5, data
+    assert data['passed'] == 1, data
+    assert data['failed'] == 2, data
+    assert data['skipped'] == 1, data
+    assert data['disabled_not_run'] == 1, data
+    assert data['tested_sha'] == 'abc123', data
+    assert data['selected_labels'] == ['release-gate', 'policy'], data
+print('OK: CTest result summary writes compact counts and selection metadata.')

--- a/tests/check_unresolved_python_invocations.py
+++ b/tests/check_unresolved_python_invocations.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CHECKED_ROOTS = [ROOT / "tests"]
+IGNORED_DIRS = {".git", "build", "out", "third_party", "vcpkg", ".vcpkg-cache"}
+ALLOWED_FILES = {
+    Path("tests/check_unresolved_python_invocations.py"),
+    Path("tests/ci/test_vcpkg_install_retry.py"),
+}
+DIRECT_PYTHON = re.compile(
+    r"(?m)(?:^|[;&|`$()]\s*)(?P<cmd>python3?|/[^\s'\"]*/python3?)(?:\s|$)"
+)
+ALLOWED_CONTEXTS = (
+    "#!/usr/bin/env python3",
+    "PERASTAGE_TEST_PYTHON",
+    "run_test_python",
+    "resolve_test_python",
+    "Get-Command python",
+)
+
+
+def is_ignored(path: Path) -> bool:
+    rel = path.relative_to(ROOT)
+    return rel in ALLOWED_FILES or any(part in IGNORED_DIRS for part in rel.parts)
+
+
+def main() -> int:
+    violations: list[str] = []
+    for root in CHECKED_ROOTS:
+        for path in root.rglob("*"):
+            if not path.is_file() or is_ignored(path):
+                continue
+            try:
+                text = path.read_text(encoding="utf-8")
+            except UnicodeDecodeError:
+                text = path.read_text(errors="ignore")
+            for line_number, line in enumerate(text.splitlines(), start=1):
+                if not DIRECT_PYTHON.search(line):
+                    continue
+                if any(marker in line for marker in ALLOWED_CONTEXTS):
+                    continue
+                violations.append(f"{path.relative_to(ROOT)}:{line_number}: {line.strip()}")
+    if violations:
+        print("Portable tests must use PERASTAGE_TEST_PYTHON/run_test_python instead of unresolved python aliases:")
+        print("\n".join(violations))
+        return 1
+    print("OK: portable tests do not invoke unresolved python aliases.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/check_windows_ninja_x64_policy.sh
+++ b/tests/check_windows_ninja_x64_policy.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/test_tool_requirements.sh"
-repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+repo_root="${PERASTAGE_POLICY_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 cd "$repo_root"
 
 run_test_python - <<'PY'
 import json
+import os
 import re
+import time
 from pathlib import Path
 
 ROOT = Path('.')
@@ -62,16 +64,36 @@ for forbidden in [
     assert forbidden not in script, forbidden
 assert "Write-Host 'MSVC compiler architecture: x64'" not in script, 'setup must not print unconditional x64 status'
 
-ignored_roots = {'.git', 'build', 'out', 'vcpkg', '.vcpkg-cache'}
-for path in ROOT.rglob('*'):
-    if not path.is_file() or ignored_roots.intersection(path.parts) or path == ROOT / 'tests/check_windows_ninja_x64_policy.sh':
+excluded_roots = {'.git', '.vcpkg-cache', '.vcpkg-root', '.tools', 'build', 'out', 'third_party', 'vcpkg', 'vcpkg_installed'}
+excluded_prefixes = ('build-', 'cmake-build-')
+
+def is_excluded_dirname(name):
+    return name in excluded_roots or any(name.startswith(prefix) for prefix in excluded_prefixes)
+
+def iter_first_party_files(root):
+    for current_root, dirnames, filenames in os.walk(root):
+        dirnames[:] = [name for name in dirnames if not is_excluded_dirname(name)]
+        current = Path(current_root)
+        for filename in filenames:
+            path = current / filename
+            if path == ROOT / 'tests/check_windows_ninja_x64_policy.sh':
+                continue
+            yield path
+
+scan_start = time.monotonic()
+scanned_files = 0
+for path in iter_first_party_files(ROOT):
+    if not path.is_file():
         continue
+    scanned_files += 1
     try:
         text = path.read_text(errors='ignore')
     except OSError:
         continue
     if 'local-win-' in text:
         raise SystemExit(f'Tracked files must not reference generated local Windows presets: {path}')
+scan_elapsed = time.monotonic() - scan_start
+print(f'Checked {scanned_files} first-party files for generated Windows preset references in {scan_elapsed:.3f}s.')
 
 for pattern in [r'&\s+\$[^\n]*vcpkg[^\n]*\s+install\b', r"vcpkg(?:\.exe)?[\"\']?\s+install\b"]:
     match = re.search(pattern, script, re.IGNORECASE)

--- a/tests/check_windows_ninja_x64_policy_fixtures.py
+++ b/tests/check_windows_ninja_x64_policy_fixtures.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[1]
+parser = argparse.ArgumentParser()
+parser.add_argument('--bash', required=True)
+args = parser.parse_args()
+BASH = args.bash
+SCRIPT = ROOT / 'tests/check_windows_ninja_x64_policy.sh'
+NEEDED = ['CMakePresets.json', 'setup_windows.ps1']
+
+
+def write_policy_root(repo: Path) -> None:
+    for rel in NEEDED:
+        target = repo / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(ROOT / rel, target)
+    (repo / 'tests').mkdir(exist_ok=True)
+
+
+def run_policy(repo: Path) -> subprocess.CompletedProcess[str]:
+    env = {**os.environ, 'PERASTAGE_POLICY_ROOT': str(repo), 'PERASTAGE_TEST_PYTHON': sys.executable}
+    return subprocess.run([BASH, str(SCRIPT)], env=env, text=True, capture_output=True)
+
+
+with tempfile.TemporaryDirectory() as tmp:
+    repo = Path(tmp) / 'repo'
+    repo.mkdir()
+    write_policy_root(repo)
+    for excluded in ['.git', '.vcpkg-cache', '.vcpkg-root', '.tools', 'build', 'build-windows-debug', 'cmake-build-debug', 'out', 'third_party', 'vcpkg', 'vcpkg_installed']:
+        generated = repo / excluded / 'generated'
+        generated.mkdir(parents=True, exist_ok=True)
+        (generated / 'ignored.txt').write_text('local-' + 'win-debug-ninja\n')
+    ok = run_policy(repo)
+    assert ok.returncode == 0, ok.stderr + ok.stdout
+    assert 'Checked ' in ok.stdout and 'first-party files' in ok.stdout, ok.stderr + ok.stdout
+
+    first_party = repo / 'cmake' / 'policy.txt'
+    first_party.parent.mkdir(parents=True, exist_ok=True)
+    first_party.write_text('local-' + 'win-debug-ninja\n')
+    bad = run_policy(repo)
+    assert bad.returncode != 0 and 'generated local Windows presets' in (bad.stderr + bad.stdout), bad.stderr + bad.stdout
+
+print('OK: Windows Ninja x64 policy prunes generated roots and still detects first-party local preset references.')


### PR DESCRIPTION
### Motivation
- The `ReleaseGatePolicyPortability` policy test relied on hard-coded `/usr/bin` paths, `/tmp` assumptions, and symlink setup which made it non-portable across macOS, Windows Git Bash, and constrained CI runners.  
- Unresolved `python`/`python3` aliases in shell tests risked invoking platform launcher aliases (e.g. Microsoft Store) instead of the harness-resolved interpreter.  
- The work here is a focused harness/audit step to enable trustworthy cross-platform policy checks before any production assertion or GDTF/MVR behavioral changes are considered; baseline SHA: `ec6dee42371f51dc02520e3eb9fc4bea4d0daeca`, final SHA: `fe7199956376df38910053e0e31026c968d0ccb6`.

### Description
- Reworked `tests/check_release_gate_policy_portability.sh` to stop using hard-coded `/usr/bin` tools and symlinks and instead discover required tools with `command -v`, copy helpers into a restricted `PATH`, create a platform-derived temporary workspace, and run scripts using a resolved Bash (`PERASTAGE_TEST_BASH` or discovered `bash`).  
- Updated `tests/CMakeLists.txt` test registration to export `PERASTAGE_TEST_BASH` alongside `PERASTAGE_TEST_PYTHON` so policy tests receive the CMake-resolved shell executable.  
- Added `tests/check_unresolved_python_invocations.py`, a repository-policy test that scans portable test files for unresolved `python`/`python3` invocations and enforces use of `PERASTAGE_TEST_PYTHON`/`run_test_python`/`resolve_test_python`.  
- Added `docs/developer/ci_test_audit.md` with the initial evidence-based classification, standards references (GDTF 1.2 and MVR 1.6), the attempted inventory, decisions, and remaining audit work, and updated `docs/release-notes-draft.md` with the CI reliability note.

### Testing
- Executed `PERASTAGE_TEST_PYTHON=$(python3 -c 'import sys; print(sys.executable)') bash tests/check_release_gate_policy_portability.sh` and it completed successfully under the repaired harness.  
- Ran `python3 tests/check_unresolved_python_invocations.py` and it reported no unresolved `python` invocations after the pattern adjustments, so the new policy test passes locally.  
- Ran focused policy checks `PERASTAGE_TEST_PYTHON=$(python3 -c 'import sys; print(sys.executable)') bash tests/check_perastage_tree_modules.sh` and `PERASTAGE_TEST_PYTHON=$(python3 -c 'import sys; print(sys.executable)') bash tests/check_no_configmanager_get_in_gui.sh`, both of which passed in this environment.  
- Attempted a full configure/inventory with `cmake -S . -B out/ci-audit-debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON -DPERASTAGE_ENABLE_COMPILER_CACHE=OFF` but the configure failed in this container due to missing `wxWidgets` development files, so a complete `ctest -N -V` inventory and full Debug suite run remain to be executed on dependency-complete CI runners.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a613dbea64c832494cf82b233075451)