### PR TITLE
Fix macOS dSYM symbol artifact layout

### DIFF
--- a/.github/scripts/assemble_debug_symbols.py
+++ b/.github/scripts/assemble_debug_symbols.py
@@ -101,9 +101,12 @@ def assemble(root: Path, version: str, output_dir: Path) -> Path:
             matches.extend(sorted(p for p in search_root.rglob(spec["pattern"]) if p.is_file() or p.is_dir()))
         unique = sorted({p.resolve() for p in matches})
         if not unique:
-            raise RuntimeError(f"Missing required {platform} symbols")
+            detail = " dSYM bundle" if spec["kind"] == "bundle" else ""
+            raise RuntimeError(f"Missing required {platform} symbols{detail}")
         if not allow_many and len(unique) != 1:
-            raise RuntimeError(f"Expected exactly one {platform} symbol, found {len(unique)}")
+            detail = " dSYM bundle" if spec["kind"] == "bundle" else " symbol"
+            locations = ", ".join(str(path) for path in unique)
+            raise RuntimeError(f"Expected exactly one {platform}{detail}, found {len(unique)}: {locations}")
         for source in unique:
             copy_path(source, platform_dir)
 

--- a/.github/workflows/macos-15-manual-installer.yml
+++ b/.github/workflows/macos-15-manual-installer.yml
@@ -282,7 +282,8 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: Perastage-macos15-symbols
-          path: out/symbols/macos15/Perastage.dSYM
+          path: out/symbols/macos15
+          if-no-files-found: error
 
       # ── 13. Validate staged app bundle ──────────────────────────────────────
       - name: Validate staged app bundle

--- a/.github/workflows/macos-installer.yml
+++ b/.github/workflows/macos-installer.yml
@@ -271,7 +271,8 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: Perastage-macos26-symbols
-          path: out/symbols/macos26/Perastage.dSYM
+          path: out/symbols/macos26
+          if-no-files-found: error
 
       # ── 12. Validate and prepare staged macOS app bundle ─────────────────────
       - name: Validate staged app bundle

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -143,6 +143,7 @@ Official release builds require native secure credential-store support on Window
 - Refactored temporary files, imports, exports, generated resources, and session caches around explicit Perastage-owned lifecycles.
 - Improved shutdown reliability, especially on macOS.
 - Windows crash reports now include a matching `.dmp` minidump for use with release debug symbols.
+- Release debug-symbol packaging now preserves macOS dSYM bundle layout for maintainer crash analysis.
 - Diagnostic reports include improved Windows version information and focused logs for Viewer2D capture and MVR-xchange transfers.
 - Fixed the Updates dialog so **Yes** and **No** close it correctly and reminder suppression can be saved.
 

--- a/tests/check_ci_workflow_architecture.py
+++ b/tests/check_ci_workflow_architecture.py
@@ -57,6 +57,17 @@ for name in ['linux-installer.yml','macos-installer.yml','macos-15-manual-instal
     assert 'CMAKE_BUILD_TYPE=Release' in text, f'{name} must be Release'
     assert '-DBUILD_TESTING=OFF' in text, f'{name} must disable tests'
 
+
+macos_symbol_uploads = {
+    'macos-15-manual-installer.yml': ('Perastage-macos15-symbols', 'out/symbols/macos15'),
+    'macos-installer.yml': ('Perastage-macos26-symbols', 'out/symbols/macos26'),
+}
+for name, (artifact_name, parent_path) in macos_symbol_uploads.items():
+    text = (WORKFLOWS / name).read_text()
+    pattern = rf'name: {re.escape(artifact_name)}\s+path: {re.escape(parent_path)}\s+if-no-files-found: error'
+    assert re.search(pattern, text), f'{name} must upload the parent dSYM symbol directory with if-no-files-found: error'
+    assert f'path: {parent_path}/Perastage.dSYM' not in text, f'{name} must not upload the dSYM bundle as the artifact root'
+
 main_patch = (WORKFLOWS / 'main-patch-test-build.yml').read_text()
 assert 'name: Main Patch Release Artifacts' in main_patch
 assert main_patch.count('uses: ./.github/workflows/windows-installer.yml') == 1

--- a/tests/ci/test_assemble_debug_symbols.py
+++ b/tests/ci/test_assemble_debug_symbols.py
@@ -4,6 +4,13 @@ import zipfile
 from pathlib import Path
 
 SCRIPT = Path(__file__).resolve().parents[2] / ".github" / "scripts" / "assemble_debug_symbols.py"
+MACOS_SYMBOL_ARTIFACTS = ["Perastage-macos15-symbols", "Perastage-macos26-symbols"]
+
+
+def make_downloaded_macos_symbol_artifact(root: Path, artifact_name: str) -> None:
+    dwarf = root / artifact_name / "Perastage.dSYM" / "Contents" / "Resources" / "DWARF"
+    dwarf.mkdir(parents=True)
+    (dwarf / "Perastage").write_text(artifact_name)
 
 
 def make_artifacts(root: Path) -> None:
@@ -17,10 +24,8 @@ def make_artifacts(root: Path) -> None:
     arch.mkdir()
     with zipfile.ZipFile(arch / "Perastage-1.5.0-ArchLinux-symbols.zip", "w") as archive:
         archive.writestr("perastage-debug-1.5.0-1-x86_64.pkg.tar.zst", "archdebug")
-    for name in ["Perastage-macos15-symbols", "Perastage-macos26-symbols"]:
-        dwarf = root / name / "Perastage.dSYM" / "Contents" / "Resources" / "DWARF"
-        dwarf.mkdir(parents=True)
-        (dwarf / "Perastage").write_text(name)
+    for artifact_name in MACOS_SYMBOL_ARTIFACTS:
+        make_downloaded_macos_symbol_artifact(root, artifact_name)
 
 
 def run_assembler(root: Path) -> subprocess.CompletedProcess[str]:
@@ -55,3 +60,31 @@ def test_assembler_rejects_missing_platform_symbols(tmp_path: Path) -> None:
     assert result.returncode != 0
     assert "Linux-AppImage_x86_64" not in result.stderr
     assert "Linux-AppImage-x86_64" in result.stderr
+
+
+def test_assembler_rejects_downloaded_macos_artifact_without_bundle_root(tmp_path: Path) -> None:
+    make_artifacts(tmp_path)
+    broken = tmp_path / "Perastage-macos15-symbols"
+    bundle = broken / "Perastage.dSYM"
+    contents = bundle / "Contents"
+    replacement = tmp_path / "replacement-contents"
+    contents.rename(replacement)
+    bundle.rmdir()
+    replacement.rename(broken / "Contents")
+
+    result = run_assembler(tmp_path)
+
+    assert result.returncode != 0
+    assert "Missing required macOS15-arm64 symbols dSYM bundle" in result.stderr
+
+
+def test_assembler_rejects_duplicate_macos_dsym_bundles(tmp_path: Path) -> None:
+    make_artifacts(tmp_path)
+    duplicate = tmp_path / "Perastage-macos26-symbols" / "nested" / "Perastage.dSYM" / "Contents" / "Resources" / "DWARF"
+    duplicate.mkdir(parents=True)
+    (duplicate / "Perastage").write_text("duplicate")
+
+    result = run_assembler(tmp_path)
+
+    assert result.returncode != 0
+    assert "Expected exactly one macOS26-arm64 dSYM bundle, found 2" in result.stderr


### PR DESCRIPTION
### Motivation
- The macOS symbol upload steps previously uploaded the `.dSYM` bundle directory as the artifact root, which caused downloaded artifacts to contain `Contents/...` instead of a top-level `Perastage.dSYM` bundle, breaking the assembler and `validate-release-assets` checks.
- The change ensures uploaded macOS symbol artifacts preserve the expected `Perastage.dSYM/Contents/...` layout so the assembler can find exactly one macOS dSYM bundle per macOS platform.

### Description
- Updated `.github/workflows/macos-15-manual-installer.yml` and `.github/workflows/macos-installer.yml` to upload the parent symbol directory (`out/symbols/macos15` and `out/symbols/macos26`) and added `if-no-files-found: error`, while keeping artifact names unchanged. 
- Clarified error messages in `.github/scripts/assemble_debug_symbols.py` to report missing or duplicate macOS dSYM bundles and include the discovered locations when duplicates are found. 
- Strengthened CI checks in `tests/check_ci_workflow_architecture.py` to assert the macOS symbol upload uses the parent directory and includes `if-no-files-found: error`, and to forbid uploading the `.dSYM` bundle as the artifact root. 
- Extended `tests/ci/test_assemble_debug_symbols.py` fixtures and tests to model the artifact layout produced by `actions/download-artifact`, and added tests that cover a missing bundle root and duplicate dSYM bundles; updated `docs/release-notes-draft.md` with a short internal note about the packaging fix. 

### Testing
- Verified YAML parsing for workflows with `ruby` and ran `actionlint` after installing it, with no errors. 
- Ran `python3 tests/check_ci_workflow_architecture.py` which printed `OK: GitHub Actions architecture policies are enforced.`. 
- Ran `python3 -m pytest tests/ci/test_assemble_debug_symbols.py -q` which returned `4 passed`. 
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both of which reported `OK`. 
- Validated `.github/release-artifact-contract.json` with `python3 -m json.tool` and ran `git diff --check`, with no issues found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a63331fd6008324aba2944463d72720)