### PR TITLE
Fix Minor Draft Release temporary ref qualification

### DIFF
--- a/.github/workflows/minor-draft-release.yml
+++ b/.github/workflows/minor-draft-release.yml
@@ -63,7 +63,7 @@ jobs:
           git ls-remote --exit-code --tags origin "refs/tags/${NEW_TAG}" >/dev/null 2>&1 && { echo "Tag already exists: $NEW_TAG"; exit 1; } || true
           RELEASE_TITLE="$RELEASE_TITLE_INPUT"; [ -n "$RELEASE_TITLE" ] || RELEASE_TITLE="Perastage ${NEW_TAG}"
           BASE_SHA="$(git rev-parse HEAD)"
-          TEMP_REF="automation/release-${NEW_TAG}-${GITHUB_RUN_ID}"
+          TEMP_REF="refs/heads/automation/release-${NEW_TAG}-${GITHUB_RUN_ID}"
           {
             echo "base_sha=$BASE_SHA"
             echo "previous_version=$VERSION_RAW"
@@ -115,7 +115,8 @@ jobs:
           printf '%s\n' "$NEW_VERSION" > VERSION
           git add VERSION
           git commit -m "chore: prepare minor release ${NEW_TAG} [skip version-bump]"
-          git push origin HEAD:"$TEMP_REF"
+          echo "Creating temporary release ref: ${TEMP_REF}"
+          git push origin "HEAD:${TEMP_REF}"
           echo "release_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
   windows-installer:
@@ -207,7 +208,7 @@ jobs:
           [ -s docs/release-notes-draft.md ] && cmd+=(--notes-file docs/release-notes-draft.md) || cmd+=(--generate-notes)
           [ "$PRERELEASE" = true ] && cmd+=(--prerelease)
           "${cmd[@]}"
-          git push origin --delete "$TEMP_REF"
+          git push origin ":${TEMP_REF}"
 
   cleanup-temp-ref:
     if: ${{ always() && needs.resolve-release.outputs.dry_run != 'true' }}
@@ -223,10 +224,11 @@ jobs:
           TEMP_REF: ${{ needs.resolve-release.outputs.temp_ref }}
         run: |
           set -euo pipefail
-          if git ls-remote --exit-code --heads origin "$TEMP_REF" >/dev/null 2>&1; then
-            echo "Temporary release ref exists: $TEMP_REF"
-            git push origin --delete "$TEMP_REF"
-            echo "Deleted temporary release ref: $TEMP_REF"
+          echo "Checking temporary release ref: ${TEMP_REF}"
+          if git ls-remote --exit-code origin "${TEMP_REF}" >/dev/null 2>&1; then
+            echo "Temporary release ref exists: ${TEMP_REF}"
+            git push origin ":${TEMP_REF}"
+            echo "Deleted temporary release ref: ${TEMP_REF}"
           else
-            echo "Temporary release ref does not exist: $TEMP_REF"
+            echo "Temporary release ref does not exist: ${TEMP_REF}"
           fi

--- a/docs/developer/packaging.md
+++ b/docs/developer/packaging.md
@@ -207,6 +207,8 @@ Minor releases build both Apple Silicon DMG variants automatically:
 - `Perastage-<version>-macOS15-arm64.dmg` from the `macos-15` runner with deployment target `15.0`.
 - `Perastage-<version>-macOS26-arm64.dmg` from the regular `macos-26` runner.
 
+Minor Draft Release prepares the version bump on a run-specific temporary branch named `refs/heads/automation/release-v<version>-<run-id>`. The workflow builds every required package and validates the release assets from that temporary commit before promoting it to `main`, creating the tag, and opening the draft release. Failed attempts delete only their exact temporary branch, leaving `main`, tags, and draft releases unchanged when package builds or asset validation fail.
+
 The validated release asset step fails if any required platform package or symbol artifact is missing or duplicated. The unified developer-only debug-symbol archive is assembled from the actual PDB, separated Linux debug file, Arch debug package, and macOS dSYM bundle contents, and has this top-level layout:
 
 ```text

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -186,6 +186,7 @@ The provided macOS packages support **Apple Silicon (`arm64`)**. Separate packag
 - Generated fallback GDTF assets are now produced deterministically in the build tree and kept out of the source checkout.
 - Windows PDB files are no longer included in the installer.
 - Debug symbols for all release platforms are grouped into one clearly marked developer-only archive.
+- Minor draft releases now use exact run-specific temporary release branches, keeping failed package or asset-validation attempts from touching `main`, tags, or draft releases.
 - Localization catalogs are included and validated in packaged builds.
 - Documentation has been reorganized into clearer user, developer, technical-note, and reference sections.
 

--- a/tests/check_ci_workflow_architecture.py
+++ b/tests/check_ci_workflow_architecture.py
@@ -96,9 +96,20 @@ assert 'symbol-files.txt' not in minor, 'final symbol archive must not be a path
 assert re.search(r'publish-release:[\s\S]+needs: \[resolve-release, stage-release-commit, validate-release-assets\]', minor)
 assert minor.find('git tag -a') > minor.find('validate-release-assets'), 'final tag must be created after asset validation'
 assert 'git push origin "$RELEASE_SHA":main' in minor and 'main moved' in minor
-assert 'git push origin --delete "$TEMP_REF"' in minor
+assert 'TEMP_REF="refs/heads/automation/release-${NEW_TAG}-${GITHUB_RUN_ID}"' in minor, 'minor release temp ref must be fully qualified under refs/heads/automation/release-'
+assert 'TEMP_REF="automation/release-' not in minor, 'minor release must not use a short temporary branch name'
+assert re.search(r'echo\s+"Creating temporary release ref:\s+\$\{TEMP_REF\}"', minor), 'staging must log the exact temporary ref before push'
+assert re.search(r'git\s+push\s+origin\s+"HEAD:\$\{TEMP_REF\}"', minor), 'staging must push detached HEAD with an explicit fully qualified refspec'
+assert 'git push origin HEAD:"$TEMP_REF"' not in minor, 'staging must not use the old ambiguous short destination syntax'
+assert 'git push origin "$RELEASE_SHA":main' in minor and 'main moved' in minor
+assert re.search(r'git\s+push\s+origin\s+":\$\{TEMP_REF\}"', minor), 'successful publication must delete the exact temporary refspec'
+assert 'git push origin --delete "$TEMP_REF"' not in minor, 'minor release must not delete temporary refs through short-name guessing'
 cleanup = minor[minor.index('  cleanup-temp-ref:'):]
-assert 'actions/checkout@v6' in cleanup and 'git ls-remote --exit-code --heads origin "$TEMP_REF"' in cleanup
+assert 'if: ${{ always() && needs.resolve-release.outputs.dry_run != \'true\' }}' in cleanup
+assert 'actions/checkout@v6' in cleanup
+assert re.search(r'git\s+ls-remote\s+--exit-code\s+origin\s+"\$\{TEMP_REF\}"', cleanup), 'fallback cleanup must check the exact fully qualified temporary ref'
+assert re.search(r'git\s+push\s+origin\s+":\$\{TEMP_REF\}"', cleanup), 'fallback cleanup must delete the exact temporary refspec'
+assert not re.search(r'automation/\*|refs/heads/automation/\*|for\s+.+automation|git\s+branch\s+-r[\s\S]+automation', cleanup), 'fallback cleanup must not enumerate or wildcard-delete automation branches'
 assert 'git push origin --delete "$TEMP_REF" || true' not in cleanup
 
 contract = json.loads(Path('.github/release-artifact-contract.json').read_text())

--- a/tests/ci/check_detached_head_temp_ref.py
+++ b/tests/ci/check_detached_head_temp_ref.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Verify release temp refs are pushed and deleted with explicit full refspecs."""
+
+from pathlib import Path
+import subprocess
+import tempfile
+
+
+def run(args, cwd, check=True):
+    return subprocess.run(args, cwd=cwd, check=check, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
+with tempfile.TemporaryDirectory(prefix='perastage-temp-ref-') as root:
+    root_path = Path(root)
+    remote = root_path / 'remote.git'
+    source = root_path / 'source'
+    full_ref = 'refs/heads/automation/release-v1.5.0-test'
+
+    run(['git', 'init', '--bare', str(remote)], cwd=root_path)
+    run(['git', 'init', str(source)], cwd=root_path)
+    run(['git', 'config', 'user.name', 'Perastage CI Test'], cwd=source)
+    run(['git', 'config', 'user.email', 'ci-test@example.invalid'], cwd=source)
+    run(['git', 'remote', 'add', 'origin', str(remote)], cwd=source)
+
+    (source / 'VERSION').write_text('1.5.0\n')
+    run(['git', 'add', 'VERSION'], cwd=source)
+    run(['git', 'commit', '-m', 'test release ref'], cwd=source)
+    commit = run(['git', 'rev-parse', 'HEAD'], cwd=source).stdout.strip()
+    run(['git', 'checkout', '--detach', commit], cwd=source)
+
+    previous = run(['git', 'push', 'origin', 'HEAD:automation/release-v1.5.0-test'], cwd=source, check=False)
+    assert previous.returncode != 0, previous.stdout + previous.stderr
+
+    run(['git', 'push', 'origin', f'HEAD:{full_ref}'], cwd=source)
+    run(['git', 'ls-remote', '--exit-code', 'origin', full_ref], cwd=source)
+
+    run(['git', 'push', 'origin', f':{full_ref}'], cwd=source)
+    missing = run(['git', 'ls-remote', '--exit-code', 'origin', full_ref], cwd=source, check=False)
+    assert missing.returncode != 0, missing.stdout + missing.stderr
+
+print('OK: detached HEAD temporary release ref requires and supports a fully qualified destination.')


### PR DESCRIPTION
### Motivation
- The Minor Draft Release workflow used a short temporary ref and an ambiguous push refspec which caused detached-HEAD pushes to fail with "not a full refname" and risked accidental branch guessing on deletion.
- The change makes the temporary release branch an explicit fully qualified ref for creation, checks, and deletion so staging and cleanup are unambiguous and safe.

### Description
- Change the temporary ref to a fully qualified ref by setting `TEMP_REF="refs/heads/automation/release-${NEW_TAG}-${GITHUB_RUN_ID}"` in `.github/workflows/minor-draft-release.yml` and keep it exposed via the existing `temp_ref` output.
- Log the temporary ref and create it from a detached HEAD with an explicit refspec using `git push origin "HEAD:${TEMP_REF}"` instead of the ambiguous short form.
- Delete the temporary ref with an exact refspec `git push origin ":${TEMP_REF}"` both after successful publication and in the fallback cleanup job, and make the cleanup check the exact remote ref before deleting.
- Preserve transactional release guarantees (no force-push, no tag/main mutation until validation, unique run-specific branch naming) and avoid any wildcard or broad `automation/*` deletion.
- Strengthen `tests/check_ci_workflow_architecture.py` to assert the fully qualified `TEMP_REF`, presence of the explicit staging push, exact deletion refspecs, and absence of ambiguous or wildcard deletions.
- Add a local-only regression test `tests/ci/check_detached_head_temp_ref.py` that verifies the old short destination fails for detached HEAD, the fully qualified push succeeds, and the exact deletion works.
- Update developer docs `docs/developer/packaging.md` and `docs/release-notes-draft.md` to document the run-specific fully qualified temporary branch behavior.

### Testing
- Parsed all `.github/workflows/*.yml` with Ruby YAML loader and ran `actionlint .github/workflows/*.yml` (installed via `go install`) with no issues.
- Ran `python3 tests/check_ci_workflow_architecture.py` and the updated assertions passed successfully.
- Ran the new regression `python3 tests/ci/check_detached_head_temp_ref.py` which passed and demonstrates the detached-HEAD push requires a fully qualified destination.
- Ran policy checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, validated `.github/release-artifact-contract.json` with `python3 -m json.tool`, executed `git diff --check`, and verified removed ambiguous patterns are absent; all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6351e7687c8324ba59f2be23868226)