### PR TITLE
ci: make minor release publication atomic/idempotent and add recovery workflow

### DIFF
--- a/.github/scripts/validate_final_release_assets.py
+++ b/.github/scripts/validate_final_release_assets.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Validate final Perastage release assets and write checksums/provenance."""
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import hashlib
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+LEGACY_SHA = "c857665b99aacf9f466edd4416584dfb56ac1a1f"
+LEGACY_VERSION = "1.5.0"
+INSTALLER_EXTENSIONS = (".exe", ".AppImage", ".dmg", ".pkg.tar.zst", ".zip")
+
+
+def load_contract(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def ensure_safe_tree(root: Path) -> None:
+    resolved_root = root.resolve()
+    for entry in root.rglob("*"):
+        if entry.is_symlink():
+            target = entry.resolve(strict=False)
+            try:
+                target.relative_to(resolved_root)
+            except ValueError as exc:
+                raise SystemExit(f"Escaping symlink is not allowed: {entry} -> {target}") from exc
+
+
+def expected_patterns(contract: dict, version: str) -> dict[str, str]:
+    patterns = dict(contract["packages"])
+    patterns["debugSymbols"] = f"Perastage-{version}-Debug-Symbols-Developers-Only.zip"
+    return patterns
+
+
+def collect_assets(root: Path, contract: dict, version: str) -> list[Path]:
+    ensure_safe_tree(root)
+    files = sorted(path for path in root.iterdir() if path.is_file())
+    patterns = expected_patterns(contract, version)
+    matched: dict[str, list[Path]] = {name: [] for name in patterns}
+    for path in files:
+        for name, pattern in patterns.items():
+            if fnmatch.fnmatch(path.name, pattern):
+                matched[name].append(path)
+    errors: list[str] = []
+    for name, paths in matched.items():
+        if len(paths) != 1:
+            errors.append(f"{name} count {len(paths)} for pattern {patterns[name]}")
+    allowed = {paths[0] for paths in matched.values() if len(paths) == 1}
+    for path in files:
+        if path not in allowed and path.name.endswith(INSTALLER_EXTENSIONS):
+            errors.append(f"Unexpected release asset: {path.name}")
+    version_token = version.replace(".", r"[._-]")
+    version_re = re.compile(rf"(^|[^0-9]){version_token}([^0-9]|$)")
+    for path in allowed:
+        if not version_re.search(path.name):
+            errors.append(f"Stale asset version in filename: {path.name}")
+        if path.stat().st_size <= 0:
+            errors.append(f"Empty release asset: {path.name}")
+    if errors:
+        raise SystemExit("\n".join(errors))
+    return sorted(allowed)
+
+
+def write_checksums(assets: list[Path], output: Path | None) -> dict[str, str]:
+    checksums = {asset.name: sha256_file(asset) for asset in assets}
+    if output:
+        output.write_text("".join(f"{digest}  {name}\n" for name, digest in checksums.items()), encoding="utf-8")
+    return checksums
+
+
+def write_provenance(args: argparse.Namespace, assets: list[Path], checksums: dict[str, str]) -> None:
+    if not args.provenance_output:
+        return
+    payload = {
+        "repository": args.repository,
+        "workflow_run_id": args.workflow_run_id,
+        "workflow_run_attempt": args.workflow_run_attempt,
+        "base_sha": args.base_sha,
+        "release_sha": args.release_sha,
+        "release_version": args.version,
+        "tag": f"v{args.version}",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "final_asset_filenames": [asset.name for asset in assets],
+        "sha256": checksums,
+    }
+    args.provenance_output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def validate_provenance(root: Path, release_sha: str, version: str) -> None:
+    path = root / "release-provenance.json"
+    if not path.exists():
+        if release_sha == LEGACY_SHA and version == LEGACY_VERSION:
+            return
+        raise SystemExit("Missing release-provenance.json in validated artifact")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    expected = {"release_sha": release_sha, "release_version": version, "tag": f"v{version}"}
+    for key, value in expected.items():
+        if data.get(key) != value:
+            raise SystemExit(f"Provenance {key} mismatch: expected {value}, got {data.get(key)}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--assets-dir", required=True, type=Path)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--contract", default=Path(".github/release-artifact-contract.json"), type=Path)
+    parser.add_argument("--checksums-output", type=Path)
+    parser.add_argument("--provenance-output", type=Path)
+    parser.add_argument("--validate-provenance", action="store_true")
+    parser.add_argument("--release-sha", default="")
+    parser.add_argument("--repository", default=os.environ.get("GITHUB_REPOSITORY", ""))
+    parser.add_argument("--workflow-run-id", default=os.environ.get("GITHUB_RUN_ID", ""))
+    parser.add_argument("--workflow-run-attempt", default=os.environ.get("GITHUB_RUN_ATTEMPT", ""))
+    parser.add_argument("--base-sha", default="")
+    args = parser.parse_args()
+    if not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", args.version):
+        raise SystemExit(f"Invalid semantic version: {args.version}")
+    assets = collect_assets(args.assets_dir, load_contract(args.contract), args.version)
+    if args.validate_provenance:
+        validate_provenance(args.assets_dir, args.release_sha, args.version)
+    checksums = write_checksums(assets, args.checksums_output)
+    write_provenance(args, assets, checksums)
+    for name, digest in checksums.items():
+        print(f"{digest}  {name}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/minor-draft-release.yml
+++ b/.github/workflows/minor-draft-release.yml
@@ -168,8 +168,19 @@ jobs:
           single macOS15 'Perastage-*-macOS15-arm64.dmg'
           single macOS26 'Perastage-*-macOS26-arm64.dmg'
           single Arch 'Perastage-*-arch-x86_64.pkg.tar.zst'
-          for f in release-assets/final/*; do [[ "$(basename "$f")" == *"$RELEASE_VERSION"* ]] || { echo "Stale asset: $f"; exit 1; }; done
           python3 .github/scripts/assemble_debug_symbols.py --artifacts release-assets --version "$RELEASE_VERSION" --output-dir release-assets/final
+          python3 .github/scripts/validate_final_release_assets.py \
+            --assets-dir release-assets/final \
+            --version "$RELEASE_VERSION" \
+            --contract .github/release-artifact-contract.json \
+            --checksums-output release-assets/final/SHA256SUMS.txt \
+            --provenance-output release-assets/final/release-provenance.json \
+            --repository "${GITHUB_REPOSITORY}" \
+            --workflow-run-id "${GITHUB_RUN_ID}" \
+            --workflow-run-attempt "${GITHUB_RUN_ATTEMPT}" \
+            --base-sha "${{ needs.resolve-release.outputs.base_sha }}" \
+            --release-sha "${{ needs.stage-release-commit.outputs.release_sha }}"
+          cat release-assets/final/SHA256SUMS.txt >> "$GITHUB_STEP_SUMMARY"
       - uses: actions/upload-artifact@v7
         with:
           name: Perastage-validated-release-assets
@@ -200,14 +211,40 @@ jobs:
           set -euo pipefail
           git fetch origin main --tags
           CURRENT_MAIN="$(git rev-parse origin/main)"
-          [ "$CURRENT_MAIN" = "$BASE_SHA" ] || { echo "main moved from $BASE_SHA to $CURRENT_MAIN; rerun the release."; exit 1; }
-          git push origin "$RELEASE_SHA":main
-          git tag -a "$NEW_TAG" "$RELEASE_SHA" -m "Perastage $NEW_TAG"
-          git push origin "$NEW_TAG"
-          cmd=(gh release create "$NEW_TAG" release-assets/final/* --draft --title "$RELEASE_TITLE")
-          [ -s docs/release-notes-draft.md ] && cmd+=(--notes-file docs/release-notes-draft.md) || cmd+=(--generate-notes)
-          [ "$PRERELEASE" = true ] && cmd+=(--prerelease)
-          "${cmd[@]}"
+          TAG_TARGET=""
+          if git rev-parse -q --verify "refs/tags/${NEW_TAG}" >/dev/null; then
+            TAG_TARGET="$(git rev-parse "refs/tags/${NEW_TAG}^{commit}")"
+            [ "$TAG_TARGET" = "$RELEASE_SHA" ] || { echo "Tag ${NEW_TAG} points to ${TAG_TARGET}, not ${RELEASE_SHA}."; exit 1; }
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if [ "$CURRENT_MAIN" = "$BASE_SHA" ] && [ -z "$TAG_TARGET" ]; then
+            git tag -a "$NEW_TAG" "$RELEASE_SHA" -m "Perastage $NEW_TAG"
+            git push --atomic origin \
+              "${RELEASE_SHA}:refs/heads/main" \
+              "refs/tags/${NEW_TAG}:refs/tags/${NEW_TAG}"
+          elif [ "$CURRENT_MAIN" = "$RELEASE_SHA" ] && [ "$TAG_TARGET" = "$RELEASE_SHA" ]; then
+            echo "Git publication is already complete for ${NEW_TAG}."
+          elif [ "$CURRENT_MAIN" = "$RELEASE_SHA" ] && [ -z "$TAG_TARGET" ]; then
+            git tag -a "$NEW_TAG" "$RELEASE_SHA" -m "Perastage $NEW_TAG"
+            git push origin "refs/tags/${NEW_TAG}:refs/tags/${NEW_TAG}"
+          else
+            echo "Unsupported publication state: origin/main=${CURRENT_MAIN}, base=${BASE_SHA}, release=${RELEASE_SHA}, tag=${TAG_TARGET:-absent}."
+            exit 1
+          fi
+          mapfile -t public_assets < <(find release-assets/final -maxdepth 1 -type f ! -name release-provenance.json ! -name SHA256SUMS.txt | sort)
+          release_json="$(mktemp)"
+          if gh release view "$NEW_TAG" --json isDraft,isPrerelease,name --jq . > "$release_json" 2>/dev/null; then
+            is_draft="$(python3 -c 'import json,sys; print(str(json.load(open(sys.argv[1]))["isDraft"]).lower())' "$release_json")"
+            [ "$is_draft" = true ] || { echo "Release ${NEW_TAG} already exists and is not a draft."; exit 1; }
+            gh release edit "$NEW_TAG" --draft --title "$RELEASE_TITLE" $([ "$PRERELEASE" = true ] && printf '%s' --prerelease || printf '%s' --latest=false)
+            gh release upload "$NEW_TAG" "${public_assets[@]}" --clobber
+          else
+            cmd=(gh release create "$NEW_TAG" "${public_assets[@]}" --draft --title "$RELEASE_TITLE")
+            [ -s docs/release-notes-draft.md ] && cmd+=(--notes-file docs/release-notes-draft.md) || cmd+=(--generate-notes)
+            [ "$PRERELEASE" = true ] && cmd+=(--prerelease)
+            "${cmd[@]}"
+          fi
           git push origin ":${TEMP_REF}"
 
   cleanup-temp-ref:

--- a/.github/workflows/recover-minor-release.yml
+++ b/.github/workflows/recover-minor-release.yml
@@ -1,0 +1,155 @@
+name: Recover Validated Minor Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_run_id:
+        description: Failed Minor Draft Release run containing Perastage-validated-release-assets.
+        required: true
+        type: string
+      release_sha:
+        description: Exact release commit SHA to publish.
+        required: true
+        type: string
+        default: c857665b99aacf9f466edd4416584dfb56ac1a1f
+      release_version:
+        description: Exact semantic version already present at the release commit.
+        required: true
+        type: string
+        default: 1.5.0
+      release_title:
+        description: Draft release title.
+        required: false
+        type: string
+        default: Perastage v1.5.0
+      prerelease:
+        description: Mark the draft release as a prerelease.
+        required: false
+        type: boolean
+        default: false
+      dry_run:
+        description: Validate without creating tags or releases.
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: write
+  actions: read
+
+concurrency:
+  group: perastage-minor-release-recovery
+  cancel-in-progress: false
+
+jobs:
+  recover:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+      - name: Validate release identity
+        env:
+          RELEASE_SHA: ${{ inputs.release_sha }}
+          RELEASE_VERSION: ${{ inputs.release_version }}
+        run: |
+          set -euo pipefail
+          [[ "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo "release_sha must be a full 40-character lowercase hexadecimal SHA."; exit 1; }
+          [[ "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "release_version must use MAJOR.MINOR.PATCH format."; exit 1; }
+          git fetch origin main --tags
+          git fetch origin "$RELEASE_SHA"
+          ACTUAL_VERSION="$(git show "${RELEASE_SHA}:VERSION" | tr -d '[:space:]')"
+          [ "$ACTUAL_VERSION" = "$RELEASE_VERSION" ] || { echo "VERSION at ${RELEASE_SHA} is ${ACTUAL_VERSION}, not ${RELEASE_VERSION}."; exit 1; }
+          git merge-base --is-ancestor "$RELEASE_SHA" origin/main || { echo "${RELEASE_SHA} is not reachable from origin/main."; exit 1; }
+          echo "TAG=v${RELEASE_VERSION}" >> "$GITHUB_ENV"
+      - name: Validate source workflow run
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+        run: |
+          set -euo pipefail
+          run_json="$(mktemp)"
+          gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${SOURCE_RUN_ID}" > "$run_json"
+          repo="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["repository"]["full_name"])' "$run_json")"
+          name="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("name") or json.load(open(sys.argv[1])).get("display_title"))' "$run_json")"
+          status="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["status"])' "$run_json")"
+          [ "$repo" = "$GITHUB_REPOSITORY" ] || { echo "Source run repository mismatch: ${repo}."; exit 1; }
+          [ "$name" = "Minor Draft Release" ] || { echo "Source run is ${name}, not Minor Draft Release."; exit 1; }
+          [ "$status" = "completed" ] || { echo "Source run status is ${status}, not completed."; exit 1; }
+          artifacts_json="$(mktemp)"
+          gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${SOURCE_RUN_ID}/artifacts?per_page=100" > "$artifacts_json"
+          python3 - "$artifacts_json" <<'PY'
+          import json, sys
+          artifacts = json.load(open(sys.argv[1]))["artifacts"]
+          matches = [a for a in artifacts if a["name"] == "Perastage-validated-release-assets"]
+          if len(matches) != 1:
+              raise SystemExit(f"Expected one Perastage-validated-release-assets artifact, found {len(matches)}")
+          if matches[0].get("expired"):
+              raise SystemExit("Perastage-validated-release-assets is expired")
+          PY
+      - name: Download validated release artifact
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+        run: |
+          set -euo pipefail
+          mkdir -p release-assets/final
+          gh run download "$SOURCE_RUN_ID" --name Perastage-validated-release-assets --dir release-assets/final
+      - name: Revalidate downloaded final assets
+        env:
+          RELEASE_SHA: ${{ inputs.release_sha }}
+          RELEASE_VERSION: ${{ inputs.release_version }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/validate_final_release_assets.py \
+            --assets-dir release-assets/final \
+            --version "$RELEASE_VERSION" \
+            --contract .github/release-artifact-contract.json \
+            --checksums-output release-assets/final/SHA256SUMS.txt \
+            --validate-provenance \
+            --release-sha "$RELEASE_SHA"
+          {
+            echo "# Recovery asset checksums"
+            echo '```'
+            cat release-assets/final/SHA256SUMS.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Validate tag and release state
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_SHA: ${{ inputs.release_sha }}
+          RELEASE_TITLE: ${{ inputs.release_title }}
+          PRERELEASE: ${{ inputs.prerelease }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          git fetch origin --tags
+          TAG_TARGET=""
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            TAG_TARGET="$(git rev-parse "refs/tags/${TAG}^{commit}")"
+            [ "$TAG_TARGET" = "$RELEASE_SHA" ] || { echo "Tag ${TAG} points to ${TAG_TARGET}, not ${RELEASE_SHA}."; exit 1; }
+          fi
+          if gh release view "$TAG" --json isDraft --jq .isDraft >/tmp/release-is-draft 2>/dev/null; then
+            [ "$(cat /tmp/release-is-draft)" = true ] || { echo "Release ${TAG} already exists and is not a draft."; exit 1; }
+          fi
+          if [ "$DRY_RUN" = true ]; then
+            echo "Dry run completed without creating a tag, editing a release, or moving main." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if [ -z "$TAG_TARGET" ]; then
+            git tag -a "$TAG" "$RELEASE_SHA" -m "Perastage $TAG"
+            git push origin "refs/tags/${TAG}:refs/tags/${TAG}"
+          fi
+          git show "${RELEASE_SHA}:docs/release-notes-draft.md" > release-notes-draft.md
+          mapfile -t public_assets < <(find release-assets/final -maxdepth 1 -type f ! -name release-provenance.json ! -name SHA256SUMS.txt | sort)
+          if gh release view "$TAG" --json isDraft --jq . >/dev/null 2>&1; then
+            gh release edit "$TAG" --draft --title "$RELEASE_TITLE" $([ "$PRERELEASE" = true ] && printf '%s' --prerelease || printf '%s' --latest=false) --notes-file release-notes-draft.md
+            gh release upload "$TAG" "${public_assets[@]}" --clobber
+          else
+            cmd=(gh release create "$TAG" "${public_assets[@]}" --draft --title "$RELEASE_TITLE" --notes-file release-notes-draft.md)
+            [ "$PRERELEASE" = true ] && cmd+=(--prerelease)
+            "${cmd[@]}"
+          fi

--- a/docs/developer/github_actions_workflows.md
+++ b/docs/developer/github_actions_workflows.md
@@ -80,3 +80,38 @@ Stable artifact names:
 - `Perastage-archlinux-symbols`
 
 Builder workflows must preserve the package filenames and symbol artifact structures unless the producer and collector contract is updated and tested in the same change.
+
+## Minor draft release publication and recovery
+
+The `Minor Draft Release` workflow publishes Git state only after all installer builders and final asset validation have succeeded. The publisher configures the repository-local Git identity as `github-actions[bot]` before creating annotated tags so fresh GitHub-hosted checkouts can run `git tag -a` without depending on machine-global configuration.
+
+Normal publication is intentionally transactional on the first publish attempt. It fetches `main` and tags, verifies that `origin/main` still equals the resolved base SHA, creates the annotated release tag locally at the validated release SHA, and pushes `main` plus the tag with one `git push --atomic` command. There is no non-atomic fallback; if the server rejects the atomic update, the workflow fails without intentionally publishing only half of the Git state.
+
+The normal publisher is retry-safe for the known safe states:
+
+- `origin/main` is still the base SHA and the tag is absent: create the annotated tag and atomically push `main` and the tag.
+- `origin/main` is already the release SHA and the tag peels to that same release SHA: treat Git publication as complete and continue to draft release creation.
+- `origin/main` is already the release SHA and the tag is absent: treat this as the legacy partial state from the v1.5.0 publication failure, create the exact annotated tag, and push only the tag.
+
+Any other `main` SHA, any tag that peels to a different commit, or any situation requiring a force push is rejected. Tag checks use the peeled commit target (`tag^{commit}`), not the tag object's SHA, because release tags are annotated.
+
+Draft release creation is also idempotent. The publisher checks `gh release view` before creating a release. If no release exists, it creates a draft and attaches only the public final assets. If a matching draft exists, it updates the title, notes, and prerelease state and reuploads assets with `--clobber`. If a non-draft release exists, publication stops rather than editing an already-published release or creating a duplicate.
+
+### Recovering a validated but unpublished minor release
+
+Use `Recover Validated Minor Release` only when a `Minor Draft Release` run completed all builders and `validate-release-assets` but failed during publication. The recovery workflow is manual-only, never calculates a new version from current `main`, never updates `main`, and never rebuilds installers in the normal recovery path. It downloads only the `Perastage-validated-release-assets` artifact from the supplied source run and places it under `release-assets/final`.
+
+For the v1.5.0 incident, rerunning the normal minor workflow after merge would read `VERSION` as `1.5.0` on `main` and calculate `1.6.0`, so recovery must be used instead. Run the recovery workflow with:
+
+- `source_run_id=<SOURCE_RUN_ID>` from the failed workflow URL.
+- `release_sha=c857665b99aacf9f466edd4416584dfb56ac1a1f`.
+- `release_version=1.5.0`.
+- `dry_run=true` first.
+
+After the dry run validates the source run, commit identity, asset names, checksums, tag state, release state, and release notes source, run the same workflow inputs again with `dry_run=false`. Confirm afterwards that `v1.5.0` points to `c857665b99aacf9f466edd4416584dfb56ac1a1f`, the GitHub Release exists as a draft, all six final public assets are attached, and `main` was not moved by recovery.
+
+### Validated artifact provenance
+
+Future `Perastage-validated-release-assets` workflow artifacts include an internal `release-provenance.json` file. This file records the repository, workflow run ID and attempt, base SHA, release SHA, release version, tag, timestamp, final asset filenames, and SHA-256 checksum for each final asset. The provenance file is retained inside the workflow artifact to support safe future recovery, but it is excluded from public GitHub Release uploads unless the artifact contract is explicitly changed to publish it.
+
+The v1.5.0 artifact predates provenance. The validator permits exactly one legacy missing-provenance exception for release SHA `c857665b99aacf9f466edd4416584dfb56ac1a1f` and release version `1.5.0`; other SHA/version pairs must include matching provenance.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -144,6 +144,7 @@ Official release builds require native secure credential-store support on Window
 - Improved shutdown reliability, especially on macOS.
 - Windows crash reports now include a matching `.dmp` minidump for use with release debug symbols.
 - Release debug-symbol packaging now preserves macOS dSYM bundle layout for maintainer crash analysis.
+- Minor release publication is safer and retryable, with atomic Git updates, explicit tag identity, validated artifact provenance, and a manual recovery path for validated-but-unpublished releases.
 - Diagnostic reports include improved Windows version information and focused logs for Viewer2D capture and MVR-xchange transfers.
 - Fixed the Updates dialog so **Yes** and **No** close it correctly and reminder suppression can be saved.
 

--- a/tests/check_ci_workflow_architecture.py
+++ b/tests/check_ci_workflow_architecture.py
@@ -92,16 +92,21 @@ assert 'uses: ./.github/workflows/ci-tests.yml' not in minor, 'minor package cre
 assert re.search(r'stage-release-commit:[\s\S]+needs: resolve-release', minor), 'stage-release-commit must depend only on release metadata resolution'
 assert 'validate-release-assets' in minor and 'publish-release' in minor
 assert 'python3 .github/scripts/assemble_debug_symbols.py' in minor
+assert 'validate_final_release_assets.py' in minor and 'release-provenance.json' in minor
 assert 'symbol-files.txt' not in minor, 'final symbol archive must not be a path list only'
 assert re.search(r'publish-release:[\s\S]+needs: \[resolve-release, stage-release-commit, validate-release-assets\]', minor)
 assert minor.find('git tag -a') > minor.find('validate-release-assets'), 'final tag must be created after asset validation'
-assert 'git push origin "$RELEASE_SHA":main' in minor and 'main moved' in minor
+assert 'git push --atomic origin' in minor, 'normal publication must use atomic branch and tag push'
+assert '"${RELEASE_SHA}:refs/heads/main"' in minor and '"refs/tags/${NEW_TAG}:refs/tags/${NEW_TAG}"' in minor
+assert 'git push origin "$RELEASE_SHA":main' not in minor, 'normal publication must not push main before tagging'
+assert 'git config user.name "github-actions[bot]"' in minor and minor.find('git config user.name "github-actions[bot]"', minor.find('publish-release:')) < minor.find('git tag -a', minor.find('publish-release:'))
+assert 'refs/tags/${NEW_TAG}^{commit}' in minor, 'annotated tags must be compared by peeled commit target'
+assert 'Unsupported publication state' in minor and 'Git publication is already complete' in minor
 assert 'TEMP_REF="refs/heads/automation/release-${NEW_TAG}-${GITHUB_RUN_ID}"' in minor, 'minor release temp ref must be fully qualified under refs/heads/automation/release-'
 assert 'TEMP_REF="automation/release-' not in minor, 'minor release must not use a short temporary branch name'
 assert re.search(r'echo\s+"Creating temporary release ref:\s+\$\{TEMP_REF\}"', minor), 'staging must log the exact temporary ref before push'
 assert re.search(r'git\s+push\s+origin\s+"HEAD:\$\{TEMP_REF\}"', minor), 'staging must push detached HEAD with an explicit fully qualified refspec'
 assert 'git push origin HEAD:"$TEMP_REF"' not in minor, 'staging must not use the old ambiguous short destination syntax'
-assert 'git push origin "$RELEASE_SHA":main' in minor and 'main moved' in minor
 assert re.search(r'git\s+push\s+origin\s+":\$\{TEMP_REF\}"', minor), 'successful publication must delete the exact temporary refspec'
 assert 'git push origin --delete "$TEMP_REF"' not in minor, 'minor release must not delete temporary refs through short-name guessing'
 cleanup = minor[minor.index('  cleanup-temp-ref:'):]
@@ -111,6 +116,24 @@ assert re.search(r'git\s+ls-remote\s+--exit-code\s+origin\s+"\$\{TEMP_REF\}"', c
 assert re.search(r'git\s+push\s+origin\s+":\$\{TEMP_REF\}"', cleanup), 'fallback cleanup must delete the exact temporary refspec'
 assert not re.search(r'automation/\*|refs/heads/automation/\*|for\s+.+automation|git\s+branch\s+-r[\s\S]+automation', cleanup), 'fallback cleanup must not enumerate or wildcard-delete automation branches'
 assert 'git push origin --delete "$TEMP_REF" || true' not in cleanup
+
+
+recover = (WORKFLOWS / 'recover-minor-release.yml').read_text()
+assert 'name: Recover Validated Minor Release' in recover
+assert 'workflow_dispatch:' in recover and 'source_run_id:' in recover and 'dry_run:' in recover
+assert 'contents: write' in recover and 'actions: read' in recover
+assert 'perastage-minor-release-recovery' in recover
+assert 'c857665b99aacf9f466edd4416584dfb56ac1a1f' in recover and 'default: 1.5.0' in recover
+assert 'git fetch origin "$RELEASE_SHA"' in recover, 'recovery must fetch the exact supplied SHA'
+assert 'git show "${RELEASE_SHA}:VERSION"' in recover, 'recovery must read VERSION from the exact supplied commit'
+assert 'git merge-base --is-ancestor "$RELEASE_SHA" origin/main' in recover
+assert 'git push --atomic' not in recover and 'refs/heads/main' not in recover and ':main' not in recover, 'recovery must never update main'
+assert 'Perastage-validated-release-assets' in recover and 'gh run download "$SOURCE_RUN_ID" --name Perastage-validated-release-assets' in recover
+assert 'validate_final_release_assets.py' in recover and '--validate-provenance' in recover
+assert 'if [ "$DRY_RUN" = true ]; then' in recover
+assert recover.find('if [ "$DRY_RUN" = true ]; then') < recover.find('git tag -a "$TAG"'), 'dry run must exit before writes'
+assert 'git config user.name "github-actions[bot]"' in recover and recover.find('git config user.name "github-actions[bot]"') < recover.find('git tag -a "$TAG"')
+assert 'gh release view "$TAG"' in recover and 'gh release upload "$TAG" "${public_assets[@]}" --clobber' in recover
 
 contract = json.loads(Path('.github/release-artifact-contract.json').read_text())
 patterns = contract['packages']

--- a/tests/ci/test_release_workflow_publication.py
+++ b/tests/ci/test_release_workflow_publication.py
@@ -1,0 +1,64 @@
+import subprocess
+from pathlib import Path
+
+WORKFLOWS = Path(__file__).resolve().parents[2] / ".github" / "workflows"
+
+
+def run(cmd, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=cwd, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
+
+
+def test_fresh_checkout_can_create_annotated_tag_after_workflow_identity(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    run(["git", "init"], repo)
+    run(["git", "config", "user.name", "Initial Author"], repo)
+    run(["git", "config", "user.email", "author@example.invalid"], repo)
+    (repo / "VERSION").write_text("1.5.0\n")
+    run(["git", "add", "VERSION"], repo)
+    run(["git", "commit", "-m", "initial"], repo)
+    run(["git", "config", "--unset", "user.name"], repo)
+    run(["git", "config", "--unset", "user.email"], repo)
+    run(["git", "config", "user.name", "github-actions[bot]"], repo)
+    run(["git", "config", "user.email", "41898282+github-actions[bot]@users.noreply.github.com"], repo)
+    run(["git", "tag", "-a", "v1.5.0", "HEAD", "-m", "Perastage v1.5.0"], repo)
+    target = run(["git", "rev-parse", "refs/tags/v1.5.0^{commit}"], repo).stdout.strip()
+    head = run(["git", "rev-parse", "HEAD"], repo).stdout.strip()
+    assert target == head
+
+
+def test_workflows_encode_safe_publication_and_recovery_guards() -> None:
+    minor = (WORKFLOWS / "minor-draft-release.yml").read_text()
+    recover = (WORKFLOWS / "recover-minor-release.yml").read_text()
+    assert "git push --atomic origin" in minor
+    assert "git push origin \"$RELEASE_SHA\":main" not in minor
+    assert "Unsupported publication state" in minor
+    assert "refs/tags/${NEW_TAG}^{commit}" in minor
+    assert recover.count("refs/heads/main") == 0
+    assert "git fetch origin \"$RELEASE_SHA\"" in recover
+    assert "gh run download \"$SOURCE_RUN_ID\" --name Perastage-validated-release-assets" in recover
+    assert recover.find("if [ \"$DRY_RUN\" = true ]; then") < recover.find("git tag -a \"$TAG\"")
+
+
+def test_atomic_branch_and_tag_push_succeeds_against_local_bare_remote(tmp_path: Path) -> None:
+    remote = tmp_path / "remote.git"
+    run(["git", "init", "--bare", str(remote)], tmp_path)
+    repo = tmp_path / "repo"
+    run(["git", "clone", str(remote), str(repo)], tmp_path)
+    run(["git", "config", "user.name", "Initial Author"], repo)
+    run(["git", "config", "user.email", "author@example.invalid"], repo)
+    (repo / "VERSION").write_text("1.4.157\n")
+    run(["git", "add", "VERSION"], repo)
+    run(["git", "commit", "-m", "base"], repo)
+    run(["git", "push", "origin", "HEAD:refs/heads/main"], repo)
+    base_sha = run(["git", "rev-parse", "HEAD"], repo).stdout.strip()
+    (repo / "VERSION").write_text("1.5.0\n")
+    run(["git", "commit", "-am", "release"], repo)
+    release_sha = run(["git", "rev-parse", "HEAD"], repo).stdout.strip()
+    run(["git", "config", "user.name", "github-actions[bot]"], repo)
+    run(["git", "config", "user.email", "41898282+github-actions[bot]@users.noreply.github.com"], repo)
+    assert run(["git", "rev-parse", "origin/main"], repo).stdout.strip() == base_sha
+    run(["git", "tag", "-a", "v1.5.0", release_sha, "-m", "Perastage v1.5.0"], repo)
+    run(["git", "push", "--atomic", "origin", f"{release_sha}:refs/heads/main", "refs/tags/v1.5.0:refs/tags/v1.5.0"], repo)
+    assert run(["git", "ls-remote", str(remote), "refs/heads/main"], tmp_path).stdout.startswith(release_sha)
+    assert run(["git", "ls-remote", str(remote), "refs/tags/v1.5.0^{}"], tmp_path).stdout.startswith(release_sha)

--- a/tests/ci/test_validate_final_release_assets.py
+++ b/tests/ci/test_validate_final_release_assets.py
@@ -1,0 +1,70 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[2] / ".github" / "scripts" / "validate_final_release_assets.py"
+CONTRACT = Path(__file__).resolve().parents[2] / ".github" / "release-artifact-contract.json"
+LEGACY_SHA = "c857665b99aacf9f466edd4416584dfb56ac1a1f"
+
+
+def make_assets(root: Path, version: str = "1.5.0", provenance: bool = True, sha: str = LEGACY_SHA) -> None:
+    names = [
+        f"Perastage_{version}_Setup.exe",
+        f"Perastage-{version}-x86_64.AppImage",
+        f"Perastage-{version}-macOS15-arm64.dmg",
+        f"Perastage-{version}-macOS26-arm64.dmg",
+        f"Perastage-{version}-arch-x86_64.pkg.tar.zst",
+        f"Perastage-{version}-Debug-Symbols-Developers-Only.zip",
+    ]
+    for name in names:
+        (root / name).write_text(name)
+    if provenance:
+        (root / "release-provenance.json").write_text(json.dumps({"release_sha": sha, "release_version": version, "tag": f"v{version}"}))
+
+
+def run_validator(root: Path, version: str = "1.5.0", *extra: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--assets-dir", str(root), "--version", version, "--contract", str(CONTRACT), *extra],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def test_validator_accepts_complete_assets_and_generates_provenance(tmp_path: Path) -> None:
+    make_assets(tmp_path, provenance=False)
+    checksums = tmp_path / "SHA256SUMS.txt"
+    provenance = tmp_path / "release-provenance.json"
+    result = run_validator(tmp_path, "1.5.0", "--checksums-output", str(checksums), "--provenance-output", str(provenance), "--release-sha", LEGACY_SHA)
+    assert result.returncode == 0, result.stderr
+    data = json.loads(provenance.read_text())
+    assert data["release_sha"] == LEGACY_SHA
+    assert data["release_version"] == "1.5.0"
+    assert len(data["final_asset_filenames"]) == 6
+    assert checksums.read_text().count("Perastage-") >= 5
+
+
+def test_validator_rejects_missing_duplicate_empty_stale_and_unexpected_assets(tmp_path: Path) -> None:
+    make_assets(tmp_path)
+    (tmp_path / "Perastage-1.5.0-x86_64.AppImage").unlink()
+    (tmp_path / "Perastage-1.5.0-copy-macOS15-arm64.dmg").write_text("dup")
+    (tmp_path / "Perastage-1.5.0-macOS26-arm64.dmg").write_text("")
+    (tmp_path / "Perastage_1.4.0_Setup.exe").write_text("stale")
+    (tmp_path / "Other-1.5.0.dmg").write_text("unexpected")
+    result = run_validator(tmp_path)
+    assert result.returncode != 0
+    assert "linux count 0" in result.stderr
+    assert "macos15 count 2" in result.stderr
+    assert "windows count 2" in result.stderr
+    assert "Empty release asset" in result.stderr
+    assert "Unexpected release asset" in result.stderr
+
+
+def test_validator_legacy_provenance_exception_is_exact_pair_only(tmp_path: Path) -> None:
+    make_assets(tmp_path, provenance=False)
+    ok = run_validator(tmp_path, "1.5.0", "--validate-provenance", "--release-sha", LEGACY_SHA)
+    assert ok.returncode == 0, ok.stderr
+    bad = run_validator(tmp_path, "1.5.0", "--validate-provenance", "--release-sha", "0" * 40)
+    assert bad.returncode != 0
+    assert "Missing release-provenance.json" in bad.stderr


### PR DESCRIPTION
### Motivation
- Repair the failure mode that left `main` updated without an annotated tag due to missing Git identity during `git tag -a` and make publication retry-safe.
- Avoid updating `main` before the tag is prepared and make the publisher idempotent for known safe states.
- Provide a manual, safe recovery path to publish a validated-but-unpublished minor release reusing the already-validated artifact.
- Add provenance and shared validation so future recoveries can be verified without rebuilding installers.

### Description
- Configure repository-local Git identity (`github-actions[bot]`) before creating annotated tags and ensure annotated tags are compared by peeled commit (`refs/tags/...^{commit}`).
- Create the annotated tag locally and perform the first publish attempt with an atomic push of both branch and tag using `git push --atomic` to avoid partial publication states, and reject unsupported states that would require force-push.
- Make draft release creation idempotent by inspecting with `gh release view` and either creating a draft or updating an existing draft and reuploading assets with `--clobber` (never auto-publishing a draft).
- Add `.github/scripts/validate_final_release_assets.py` to validate final asset filenames, reject missing/duplicate/empty/stale/unexpected assets, prevent escaping symlinks, produce SHA-256 checksums, and optionally write `release-provenance.json` (with a scoped legacy exception for v1.5.0).
- Add a manual workflow `Recover Validated Minor Release` that validates the exact `release_sha` / `release_version`, verifies the source run and presence of `Perastage-validated-release-assets`, revalidates the downloaded final assets (including provenance), supports `dry_run=true`, never updates `main`, and will create/push only the exact annotated tag and create/update a draft release when `dry_run=false`.
- Exclude internal provenance/checksum files from public release uploads while retaining them inside the validated artifact for recovery.
- Update documentation: `docs/developer/github_actions_workflows.md` (atomic publication, identity, recovery) and `docs/release-notes-draft.md` (release-ready note mentioning the improved publication/recovery behavior).
- Add focused tests under `tests/ci/` and expand `tests/check_ci_workflow_architecture.py` to assert the new behaviors and recovery guards.

### Testing
- YAML parsing of all workflows with a Ruby YAML load succeeded (`ruby -e "require 'yaml' ..."`).
- `actionlint .github/workflows/*.yml` succeeded (checked after installing `actionlint`).
- Architecture checks: `python3 tests/check_ci_workflow_architecture.py` succeeded.
- Unit and integration tests: `python3 -m pytest tests/ci/test_validate_final_release_assets.py tests/ci/test_release_workflow_publication.py tests/ci/test_assemble_debug_symbols.py tests/ci/test_vcpkg_install_retry.py -q` all passed.
- Repository policy checks: `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh` passed.
- JSON contract parsing (`python3 -m json.tool .github/release-artifact-contract.json`) and `git diff --check` passed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a636749892483249f0fedf7397a33bb)