### PR TITLE
CI: validate NuGet binary-cache configuration without remote search

### DIFF
--- a/.github/scripts/setup_vcpkg_github_packages.py
+++ b/.github/scripts/setup_vcpkg_github_packages.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import os
 import platform
+import re
 import subprocess
 import sys
 import tempfile
@@ -13,6 +14,46 @@ from pathlib import Path
 FEED_URL = "https://nuget.pkg.github.com/PeramatoG/index.json"
 SOURCE_NAME = "PerastageGitHubPackages"
 REPOSITORY_URL = "https://github.com/PeramatoG/Perastage"
+
+
+def redact_diagnostics(value: str, secrets: tuple[str, ...] = ()) -> str:
+    """Remove known secrets and NuGet credential values from diagnostic text."""
+    redacted = value or ""
+    for secret in secrets:
+        if secret:
+            redacted = redacted.replace(secret, "[REDACTED]")
+    redacted = re.sub(
+        r"(<(?:add\s+key=[\"'](?:ClearTextPassword|Password|[^\"']*ApiKey)[\"']\s+value=[\"']))[^\"']*",
+        r"\1[REDACTED]",
+        redacted,
+        flags=re.IGNORECASE,
+    )
+    redacted = re.sub(
+        r"((?:-Password|setApiKey)\s+)(\S+)", r"\1[REDACTED]", redacted,
+        flags=re.IGNORECASE,
+    )
+    return redacted
+
+
+class SetupFailure(RuntimeError):
+    """Describe a failed setup stage without exposing its credentials."""
+
+    def __init__(self, stage: str, error: BaseException, secrets: tuple[str, ...] = ()) -> None:
+        exit_code = getattr(error, "returncode", "unavailable")
+        stdout = redact_diagnostics(getattr(error, "stdout", "") or "", secrets).strip()
+        stderr = redact_diagnostics(getattr(error, "stderr", "") or str(error), secrets).strip()
+        super().__init__(
+            f"GitHub Packages setup stage '{stage}' failed (exit code: {exit_code}); "
+            f"stdout: {stdout or '<empty>'}; stderr: {stderr or '<empty>'}"
+        )
+
+
+def run_stage(stage: str, command: list[str], secrets: tuple[str, ...]) -> subprocess.CompletedProcess:
+    """Run one NuGet setup stage and convert process errors to safe diagnostics."""
+    try:
+        return subprocess.run(command, check=True, capture_output=True, text=True)
+    except (OSError, subprocess.CalledProcessError) as error:
+        raise SetupFailure(stage, error, secrets) from error
 
 
 def append_command_file(variable: str, name: str, value: str) -> None:
@@ -41,32 +82,44 @@ def configure(args: argparse.Namespace) -> bool:
         append_command_file("GITHUB_ENV", "VCPKG_BINARY_SOURCES", local_sources)
         return False
 
+    secrets = (token,)
     try:
-        fetched = subprocess.run(
-            [args.vcpkg, "fetch", "nuget"], check=True, capture_output=True, text=True
-        ).stdout.strip().splitlines()[-1]
+        fetch_result = run_stage("fetch-nuget", [args.vcpkg, "fetch", "nuget"], secrets)
+        fetched_lines = fetch_result.stdout.strip().splitlines()
+        if not fetched_lines:
+            raise SetupFailure("fetch-nuget", RuntimeError("vcpkg returned no NuGet path"), secrets)
+        fetched = fetched_lines[-1]
         config_dir = Path(os.environ.get("RUNNER_TEMP", tempfile.gettempdir())) / "perastage-vcpkg-nuget"
         config_dir.mkdir(parents=True, exist_ok=True)
         config = config_dir / "NuGet.Config"
         command = nuget_command(fetched)
-        subprocess.run(command + ["sources", "Add", "-Name", SOURCE_NAME, "-Source", FEED_URL,
-                       "-UserName", "PeramatoG", "-Password", token, "-StorePasswordInClearText",
-                       "-ConfigFile", str(config), "-NonInteractive"], check=True,
-                       stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, text=True)
+        run_stage("add-source", command + ["sources", "Add", "-Name", SOURCE_NAME,
+                  "-Source", FEED_URL, "-UserName", "PeramatoG", "-Password", token,
+                  "-StorePasswordInClearText", "-ConfigFile", str(config),
+                  "-NonInteractive"], secrets)
         if args.mode == "readwrite":
-            subprocess.run(command + ["config", "-Set", f"defaultPushSource={FEED_URL}",
-                           "-ConfigFile", str(config), "-NonInteractive"], check=True,
-                           stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, text=True)
-            subprocess.run(command + ["setApiKey", token, "-Source", FEED_URL,
-                           "-ConfigFile", str(config), "-NonInteractive"], check=True,
-                           stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, text=True)
-        subprocess.run(command + ["list", "-Source", SOURCE_NAME, "-ConfigFile", str(config),
-                       "-NonInteractive"], check=True, stdout=subprocess.DEVNULL,
-                       stderr=subprocess.PIPE, text=True)
-    except (OSError, subprocess.CalledProcessError) as error:
+            run_stage("set-default-push-source", command + ["config", "-Set",
+                      f"defaultPushSource={FEED_URL}", "-ConfigFile", str(config),
+                      "-NonInteractive"], secrets)
+            run_stage("set-api-key", command + ["setApiKey", token, "-Source", FEED_URL,
+                      "-ConfigFile", str(config), "-NonInteractive"], secrets)
+        validation = run_stage("validate-config", command + ["sources", "List", "-ConfigFile",
+                               str(config), "-Format", "Short", "-NonInteractive"], secrets)
+        if SOURCE_NAME not in validation.stdout or FEED_URL not in validation.stdout:
+            raise SetupFailure(
+                "validate-config",
+                subprocess.CalledProcessError(
+                    0,
+                    command + ["sources", "List"],
+                    output=validation.stdout,
+                    stderr="configured source name or feed URL is missing",
+                ),
+                secrets,
+            )
+    except SetupFailure as error:
         if args.mode == "readwrite":
-            raise RuntimeError("GitHub Packages setup failed for trusted publication") from error
-        print("::warning::GitHub Packages setup failed; using the local vcpkg cache only.")
+            raise RuntimeError(str(error)) from error
+        print(f"::warning::{error}; using the local vcpkg cache only.")
         append_command_file("GITHUB_ENV", "VCPKG_BINARY_SOURCES", local_sources)
         return False
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -14,6 +14,8 @@ Changes since **v1.5.0**.
 
 ## Technical and packaging changes
 
+- Improved GitHub Packages dependency-cache setup validation and added safe, redacted failure diagnostics across all supported build platforms.
+
 - Added a secure, platform-compatible persistent dependency cache with main-only publishing for trusted GitHub Actions builds while retaining fast local workflow caches and read-only behavior for CI and installers.
 
 - Improved GitHub Actions vcpkg caching so dependency builds are saved immediately after successful installation and can be reused across compatible CI and installer workflows.

--- a/tests/check_ci_workflow_architecture.py
+++ b/tests/check_ci_workflow_architecture.py
@@ -48,6 +48,9 @@ assert 'https://nuget.pkg.github.com/PeramatoG/index.json' in helper
 assert 'https://github.com/PeramatoG/Perastage' in helper
 assert 'defaultPushSource={FEED_URL}' in helper
 assert '["setApiKey", token, "-Source", FEED_URL' in helper
+assert '["sources", "List", "-ConfigFile"' in helper
+assert 'SOURCE_NAME not in validation.stdout or FEED_URL not in validation.stdout' in helper
+assert '["list", "-Source"' not in helper, 'setup must not query packages to validate NuGet configuration'
 assert helper.index('files,{Path(args.local_cache).resolve()},readwrite') < helper.index('nugetconfig')
 assert sum(text.count('nuget.exe') for text in all_workflows.values()) == 0, 'NuGet setup must remain centralized'
 assert 'arch-package.yml' not in consumers and '--mode read' not in all_workflows['arch-package.yml'], 'Arch must remain local-only'

--- a/tests/ci/test_setup_vcpkg_github_packages.py
+++ b/tests/ci/test_setup_vcpkg_github_packages.py
@@ -31,6 +31,12 @@ class SetupTests(unittest.TestCase):
     def args(self, mode):
         return argparse.Namespace(vcpkg="/tools/vcpkg", local_cache=self.temp.name, mode=mode)
 
+    def successful_run(self, command, **_kwargs):
+        stdout = "/tools/nuget.exe\n" if "fetch" in command else ""
+        if "List" in command:
+            stdout = f"E {MODULE.SOURCE_NAME} {MODULE.FEED_URL}\n"
+        return mock.Mock(stdout=stdout, stderr="", returncode=0)
+
     def test_disabled_writes_local_source_and_repository(self):
         self.assertFalse(MODULE.configure(self.args("disabled")))
         text = self.env_file.read_text()
@@ -41,17 +47,27 @@ class SetupTests(unittest.TestCase):
     @mock.patch.object(MODULE.platform, "system", return_value="Windows")
     @mock.patch.object(MODULE.subprocess, "run")
     def test_windows_read_invokes_nuget_directly(self, run, _system):
-        run.return_value.stdout = "C:\\tools\\nuget.exe\n"
+        def windows_run(command, **kwargs):
+            result = self.successful_run(command, **kwargs)
+            if "fetch" in command:
+                result.stdout = "C:\\tools\\nuget.exe\n"
+            return result
+
+        run.side_effect = windows_run
         self.assertTrue(MODULE.configure(self.args("read")))
         commands = [call.args[0] for call in run.call_args_list]
         self.assertTrue(any(command[0] == "C:\\tools\\nuget.exe" for command in commands))
+        self.assertFalse(any("list" in command for command in commands))
+        validation = next(command for command in commands if "List" in command)
+        self.assertIn("sources", validation)
+        self.assertIn("-Format", validation)
         self.assertIn("nugetconfig", self.env_file.read_text())
         self.assertIn(",read\n", self.env_file.read_text())
 
     @mock.patch.object(MODULE.platform, "system", return_value="Linux")
     @mock.patch.object(MODULE.subprocess, "run")
     def test_non_windows_readwrite_uses_mono_and_api_key(self, run, _system):
-        run.return_value.stdout = "/tools/nuget.exe\n"
+        run.side_effect = self.successful_run
         self.assertTrue(MODULE.configure(self.args("readwrite")))
         commands = [call.args[0] for call in run.call_args_list]
         self.assertTrue(any(command[:2] == ["mono", "/tools/nuget.exe"] for command in commands))
@@ -66,6 +82,37 @@ class SetupTests(unittest.TestCase):
         ))
         self.assertNotIn("secret-value", self.env_file.read_text())
 
+    @mock.patch.object(MODULE.subprocess, "run")
+    def test_validation_requires_source_name_and_feed_url(self, run):
+        run.side_effect = lambda command, **_kwargs: mock.Mock(
+            stdout="/tools/nuget.exe\n" if "fetch" in command else "unrelated source\n",
+            stderr="", returncode=0,
+        )
+        self.assertFalse(MODULE.configure(self.args("read")))
+        self.assertNotIn("nugetconfig", self.env_file.read_text())
+
+    def test_redaction_removes_tokens_and_credential_xml_values(self):
+        diagnostic = (
+            'secret-value -Password another-secret setApiKey third-secret '
+            '<add key="ClearTextPassword" value="xml-secret" />'
+        )
+        redacted = MODULE.redact_diagnostics(diagnostic, ("secret-value",))
+        for secret in ("secret-value", "another-secret", "third-secret", "xml-secret"):
+            self.assertNotIn(secret, redacted)
+        self.assertIn("[REDACTED]", redacted)
+
+    @mock.patch.object(MODULE.subprocess, "run")
+    def test_failure_diagnostic_identifies_stage_and_redacts_token(self, run):
+        run.side_effect = [
+            mock.Mock(stdout="/tools/nuget.exe\n", stderr="", returncode=0),
+            MODULE.subprocess.CalledProcessError(
+                17, ["nuget"], output="token secret-value", stderr="password secret-value"
+            ),
+        ]
+        with self.assertRaisesRegex(RuntimeError, "add-source.*exit code: 17") as raised:
+            MODULE.configure(self.args("readwrite"))
+        self.assertNotIn("secret-value", str(raised.exception))
+
     @mock.patch.object(MODULE.subprocess, "run", side_effect=OSError("offline"))
     def test_read_failure_falls_back(self, _run):
         self.assertFalse(MODULE.configure(self.args("read")))
@@ -73,7 +120,7 @@ class SetupTests(unittest.TestCase):
 
     @mock.patch.object(MODULE.subprocess, "run")
     def test_main_writes_github_outputs_without_token(self, run):
-        run.return_value.stdout = "/tools/nuget.exe\n"
+        run.side_effect = self.successful_run
         with mock.patch.object(MODULE.sys, "argv", ["setup", "--vcpkg", "/tools/vcpkg", "--local-cache", self.temp.name, "--mode", "read"]):
             self.assertEqual(MODULE.main(), 0)
         output = self.out_file.read_text()


### PR DESCRIPTION
### Motivation
- The vcpkg GitHub Packages helper must not probe remote feeds with `nuget list` during setup because that requires a populated remote registry and can cause CI failures.
- Improve diagnostics so setup failures identify the logical stage and return code while never leaking `GITHUB_TOKEN`, API keys, passwords, or credential-bearing `NuGet.Config` content.
- Preserve the existing authentication model and fallback behavior where `read` mode falls back to the local cache and `readwrite` mode remains fatal if setup cannot be completed.
- Add local structural validation and expand tests to prevent regressions and ensure CI workflow architecture rules remain enforced.

### Description
- Replaced the remote package probe with a local structural validation using `nuget sources List -ConfigFile <temp> -Format Short` and verify the configured source name and feed URL are present. 
- Added a reusable `redact_diagnostics` helper plus `SetupFailure` and `run_stage` wrappers to run NuGet stages (`fetch-nuget`, `add-source`, `set-default-push-source`, `set-api-key`, `validate-config`) and produce stage-aware, sanitized failure messages. 
- Replaced direct `subprocess.run(..., check=True)` calls with `run_stage(...)` so process errors are converted to safe diagnostics and secrets are redacted; preserved `defaultPushSource` and API-key configuration for readwrite mode. 
- Extended unit tests in `tests/ci/test_setup_vcpkg_github_packages.py` to assert no `nuget list` probe, to validate `sources List` usage and feed/source checks, to verify redaction behavior, to assert read fallback and fatal writer behavior, and updated the architecture policy test to forbid the remote search. 
- Updated `docs/release-notes-draft.md` with an internal note about safer GitHub Packages cache setup and diagnostics improvements.

### Testing
- Ran `python3 -m unittest tests.ci.test_setup_vcpkg_github_packages -v` and the unit tests all passed. 
- Ran `python3 tests/check_ci_workflow_architecture.py` and the workflow architecture checks passed. 
- Ran repository policy checks including `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh` and both checks passed. 
- Performed additional validations: parsed all `.github/workflows/*.yml` with Ruby YAML, ran `python3 -m py_compile` on the modified Python sources, and ran `git diff --check`; all automated checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a648b3c260c83249701b61adb29bc53)