### PR TITLE
Initialize isolated NuGet config before adding GitHub Packages source

### DIFF
--- a/.github/scripts/setup_vcpkg_github_packages.py
+++ b/.github/scripts/setup_vcpkg_github_packages.py
@@ -68,6 +68,14 @@ def nuget_command(nuget: str) -> list[str]:
     return [nuget] if platform.system() == "Windows" else ["mono", nuget]
 
 
+def initialize_nuget_config(config: Path) -> None:
+    """Create a clean, credential-free NuGet configuration for the current job."""
+    root = ET.Element("configuration")
+    package_sources = ET.SubElement(root, "packageSources")
+    ET.SubElement(package_sources, "clear")
+    ET.ElementTree(root).write(config, encoding="utf-8", xml_declaration=True)
+
+
 def find_section(root: ET.Element, name: str) -> ET.Element | None:
     """Find a direct NuGet configuration section without depending on XML namespaces."""
     return next((child for child in root if child.tag.rsplit("}", 1)[-1] == name), None)
@@ -140,6 +148,7 @@ def configure(args: argparse.Namespace) -> bool:
         config_dir = Path(os.environ.get("RUNNER_TEMP", tempfile.gettempdir())) / "perastage-vcpkg-nuget"
         config_dir.mkdir(parents=True, exist_ok=True)
         config = config_dir / "NuGet.Config"
+        initialize_nuget_config(config)
         command = nuget_command(fetched)
         run_stage("add-source", command + ["sources", "Add", "-Name", SOURCE_NAME,
                   "-Source", FEED_URL, "-UserName", "PeramatoG", "-Password", token,

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -14,6 +14,8 @@ Changes since **v1.5.0**.
 
 ## Technical and packaging changes
 
+- Fixed GitHub Packages dependency-cache initialization so clean GitHub Actions runners receive an isolated NuGet configuration before the cache source is added.
+
 - Improved GitHub Packages dependency-cache setup with reliable structural validation and safe, redacted failure diagnostics across all supported build platforms.
 
 - Added a secure, platform-compatible persistent dependency cache with main-only publishing for trusted GitHub Actions builds while retaining fast local workflow caches and read-only behavior for CI and installers.

--- a/tests/ci/test_setup_vcpkg_github_packages.py
+++ b/tests/ci/test_setup_vcpkg_github_packages.py
@@ -24,22 +24,57 @@ class SetupTests(unittest.TestCase):
             "GITHUB_ENV": str(self.env_file), "GITHUB_OUTPUT": str(self.out_file),
             "RUNNER_TEMP": self.temp.name, "GITHUB_TOKEN": "secret-value"}, clear=True)
         self.environment.start()
-        self.mock_mode = "read"
 
     def tearDown(self):
         self.environment.stop()
         self.temp.cleanup()
 
     def args(self, mode):
-        self.mock_mode = mode
         return argparse.Namespace(vcpkg="/tools/vcpkg", local_cache=self.temp.name, mode=mode)
 
     def successful_run(self, command, **_kwargs):
         stdout = "/tools/nuget.exe\n" if "fetch" in command else ""
         if "sources" in command and "Add" in command:
             config = Path(command[command.index("-ConfigFile") + 1])
-            self.write_config(config, readwrite=self.mock_mode == "readwrite")
+            self.assert_initial_config(config)
+            self.add_source_and_credentials(config)
+        elif "config" in command and "-Set" in command:
+            config = Path(command[command.index("-ConfigFile") + 1])
+            self.assertTrue(config.is_file())
+            root = ET.parse(config).getroot()
+            section = ET.SubElement(root, "config")
+            ET.SubElement(section, "add", key="defaultPushSource", value=MODULE.FEED_URL)
+            ET.ElementTree(root).write(config, encoding="utf-8", xml_declaration=True)
+        elif "setApiKey" in command:
+            config = Path(command[command.index("-ConfigFile") + 1])
+            self.assertTrue(config.is_file())
+            root = ET.parse(config).getroot()
+            section = ET.SubElement(root, "apikeys")
+            ET.SubElement(section, "add", key=MODULE.FEED_URL, value="secret-value")
+            ET.ElementTree(root).write(config, encoding="utf-8", xml_declaration=True)
         return mock.Mock(stdout=stdout, stderr="", returncode=0)
+
+    def assert_initial_config(self, path):
+        self.assertTrue(path.is_file())
+        root = ET.parse(path).getroot()
+        self.assertEqual(root.tag, "configuration")
+        sources = root.find("packageSources")
+        self.assertIsNotNone(sources)
+        self.assertIsNotNone(sources.find("clear"))
+        self.assertIsNone(root.find("packageSourceCredentials"))
+        text = path.read_text(encoding="utf-8").lower()
+        for credential in ("secret-value", "password", "apikey", "token"):
+            self.assertNotIn(credential, text)
+
+    def add_source_and_credentials(self, path):
+        root = ET.parse(path).getroot()
+        sources = root.find("packageSources")
+        ET.SubElement(sources, "add", key=MODULE.SOURCE_NAME, value=MODULE.FEED_URL)
+        credential_root = ET.SubElement(root, "packageSourceCredentials")
+        section = ET.SubElement(credential_root, MODULE.SOURCE_NAME)
+        ET.SubElement(section, "add", key="Username", value="PeramatoG")
+        ET.SubElement(section, "add", key="ClearTextPassword", value="secret-value")
+        ET.ElementTree(root).write(path, encoding="utf-8", xml_declaration=True)
 
     def write_config(self, path, *, readwrite=False, source=True, feed_url=None,
                      credentials=True, password=True, default_push=True, api_key=True):
@@ -69,6 +104,12 @@ class SetupTests(unittest.TestCase):
         self.assertIn("VCPKG_BINARY_SOURCES=clear;files,", text)
         self.assertNotIn("nugetconfig", text)
         self.assertIn(MODULE.REPOSITORY_URL, text)
+
+    def test_initialize_config_replaces_stale_content(self):
+        path = Path(self.temp.name) / "NuGet.Config"
+        path.write_text("<configuration><stale credential='secret-value'/></configuration>")
+        MODULE.initialize_nuget_config(path)
+        self.assert_initial_config(path)
 
     @mock.patch.object(MODULE.platform, "system", return_value="Windows")
     @mock.patch.object(MODULE.subprocess, "run")


### PR DESCRIPTION
### Motivation
- The NuGet CLI requires an explicitly supplied `NuGet.Config` file to exist before running `nuget sources Add`, and the previous helper only created the parent directory which caused GitHub Actions to fail with a missing config file error. 
- A deterministic, job-local, credential-free initial config prevents stale runner temp data from leaking into the job and preserves isolated, repeatable behavior.

### Description
- Add `initialize_nuget_config(config: Path)` which writes a minimal, valid XML config containing `<configuration><packageSources><clear /></packageSources></configuration>` and no credentials. 
- Invoke `initialize_nuget_config` immediately after creating the temp config directory and before any NuGet command that uses `-ConfigFile`. 
- Update unit test mocks in `tests/ci/test_setup_vcpkg_github_packages.py` so the mock no longer creates the initial config, instead asserting the file exists and is credential-free and then mutating that file for `sources Add`, `config -Set`, and `setApiKey` flows. 
- Update `docs/release-notes-draft.md` with a short packaging reliability fix entry describing the initialization change.

### Testing
- `python3 -m unittest tests.ci.test_setup_vcpkg_github_packages -v` ran 20 tests and passed. 
- `python3 tests/check_ci_workflow_architecture.py` passed. 
- Python compilation checks via `python3 -m py_compile .github/scripts/setup_vcpkg_github_packages.py tests/ci/test_setup_vcpkg_github_packages.py` passed. 
- GitHub workflow YAML files were successfully parsed (`ruby`-based validation used in the CI environment) and repository policy tests including `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh` passed. 
- `python3 tests/check_release_workflows_untouched.py` and `python3 tests/check_docs_links.py` passed and `git diff --check` returned no issues. 

Post-merge validation: manually run the `vcpkg Binary Cache` workflow on `main` with `bypass_local_compiled_cache=true` to confirm runtime binary-cache publishing behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a64970eeca08324b1d578debd15647b)