### PR TITLE
fix(mvr): preserve canonical Perastage metadata roundtrips

### DIFF
--- a/docs/developer/ci_test_audit.md
+++ b/docs/developer/ci_test_audit.md
@@ -973,3 +973,23 @@ Windows and complete Debug Tests CI evidence, plus the requested exhaustive
 malformed/duplicate metadata diagnostic matrix, remain the exact acceptance
 blockers. The PR must remain focused and open until that evidence and coverage
 are available; no unrelated repair is included.
+
+### Phase 4C CI follow-up and D3 closure baseline
+
+The reviewed Phase 4C head `5f6128f59205b730ad23d730404dae6dd8f6679f`
+was tested by authoritative Debug Tests run `30203361878`. Linux reported 163
+total, 141 passed, 21 failed, and 1 skipped; Windows reported 165 total, 140
+passed, and 25 failed; the reduced macOS profile remained 6 passed of 6. Linux
+and Windows each removed exactly `ProjectSupportUserDataRoundtrip` and
+`MvrTrussRoundtripStructure`, with no added failing test name.
+
+D3 remained pending at that head because `MvrSupportUserDataRoundtrip` still
+used a plain-text non-GDTF fixture, metadata provider/version, duplicate,
+numeric, and path rejection were not covered, and the Truss test did not prove
+scene-owned auxiliary resource lifetime or safe re-export. The closure work
+replaces the strict fixture with the shared canonical GDTF 1.2 builder, makes
+supported root metadata first-wins over legacy input, exposes import
+diagnostics, rejects non-finite numbers and unsafe or missing auxiliary paths,
+prevents fallback substitution for an explicit missing auxiliary resource, and
+exercises owned-resource re-export. Final D3 status remains contingent on the
+closure test matrix and cross-platform CI evidence.

--- a/docs/developer/ci_test_audit.md
+++ b/docs/developer/ci_test_audit.md
@@ -993,3 +993,27 @@ diagnostics, rejects non-finite numbers and unsafe or missing auxiliary paths,
 prevents fallback substitution for an explicit missing auxiliary resource, and
 exercises owned-resource re-export. Final D3 status remains contingent on the
 closure test matrix and cross-platform CI evidence.
+
+### Phase 4C final diagnostic-closure baseline
+
+Authoritative Debug Tests run `30205630411` tested reviewed head
+`0e64b4ba4d58554e38be6c1852bcbc813ee09c40`. Linux reported 163 total,
+142 passed, 20 failed, and 1 skipped; Windows reported 165 total, 141 passed,
+and 24 failed; the reduced macOS profile remained 6 of 6. The run removed
+`MvrSupportUserDataRoundtrip` on Linux and Windows, added no failing test name,
+and kept all three Support/Truss roundtrip tests passing.
+
+D3 at that head remained pending only executable metadata diagnostic and
+legacy-provider closure. `MvrPerastageMetadataRecovery` now exercises the
+detailed `MvrImportResult` path and asserts structured codes for malformed,
+duplicate, unknown, unsupported-version, legacy-version, numeric,
+MotorFixtureUuid, and unsafe auxiliary metadata while verifying canonical-root
+precedence and foreign-provider isolation. Final D3 declaration still requires
+the new test and unchanged control matrix to pass in cross-platform CI.
+
+Local closure evidence: `MvrPerastageMetadataRecovery` passes and asserts the
+structured diagnostic codes produced by the detailed import overload. The
+repository module checks and `git diff --check` pass. D3 is not declared by
+this local run: authoritative Linux/Windows execution of the newly registered
+test and explicit duplicate-ZIP/case-only archive ambiguity coverage remain the
+exact blockers; PR #2223 stays open pending that evidence and focused coverage.

--- a/docs/developer/ci_test_audit.md
+++ b/docs/developer/ci_test_audit.md
@@ -1011,9 +1011,24 @@ MotorFixtureUuid, and unsafe auxiliary metadata while verifying canonical-root
 precedence and foreign-provider isolation. Final D3 declaration still requires
 the new test and unchanged control matrix to pass in cross-platform CI.
 
-Local closure evidence: `MvrPerastageMetadataRecovery` passes and asserts the
-structured diagnostic codes produced by the detailed import overload. The
-repository module checks and `git diff --check` pass. D3 is not declared by
-this local run: authoritative Linux/Windows execution of the newly registered
-test and explicit duplicate-ZIP/case-only archive ambiguity coverage remain the
-exact blockers; PR #2223 stays open pending that evidence and focused coverage.
+At that diagnostic-closure head, the focused test and repository policy checks
+passed locally. Archive-entry ambiguity and normal-flow diagnostic delivery
+remained intentionally deferred to the next focused closure.
+
+### Phase 4C archive-ambiguity closure baseline
+
+Authoritative Debug Tests run `30207498081` tested reviewed head
+`fa7eaee6381ff722d31ee6e262cc3fca8a69fa23`. Linux reported 164 total,
+143 passed, 20 failed, and 1 skipped; Windows reported 166 total, 142 passed,
+and 24 failed; the reduced macOS profile remained 6 of 6.
+`MvrPerastageMetadataRecovery` passed on Linux and Windows, and the failure-name
+delta from run `30205630411` was empty. All four focused metadata tests passed.
+
+The exact remaining boundaries at that head were deterministic rejection of
+duplicate or ASCII case-colliding ZIP entries and delivery of structured
+diagnostics through common import overloads. Extraction now removes the first
+colliding resource, skips later colliders, clears remaps, fails on ambiguous
+scene XML, and retains collision diagnostics even on failure. Common project
+and scene import entry points deliver final structured diagnostics once; the
+detailed overload remains the non-logging structured source of truth. Final D3
+still requires authoritative cross-platform CI for this closure commit.

--- a/docs/developer/ci_test_audit.md
+++ b/docs/developer/ci_test_audit.md
@@ -952,4 +952,24 @@ The complete Linux and Windows failure-name sets were unchanged from run `301961
 
 `MvrTrussRoundtripStructure` previously stopped because the default exported Layer had no canonical `uuid`. In run `30197537554`, canonical default Layer identity and ChildList checks passed and the first failure moved to `!importedTruss.perastageAuxGdtfArchivePath.empty()` at line 398. This proves the original Layer identity blocker is repaired. Truss auxiliary GDTF archive-path restoration is a separate metadata contract explicitly deferred from Phase 4B.
 
-D2 does not require these mixed-domain tests to become fully green. D2 requires the focused identity/reference matrix to pass repeatedly, the original identity-specific first failures to remain absent, and no new CI failing test name. The closure adds ambiguity-safe alias resolution and complete supported scene-reference rewriting; final D2 acceptance remains pending the follow-up commit's complete CI run.
+D2 does not require these mixed-domain tests to become fully green. D2 requires the focused identity/reference matrix to pass repeatedly, the original identity-specific first failures to remain absent, and no new CI failing test name. The closure adds ambiguity-safe alias resolution and complete supported scene-reference rewriting.
+
+### D2 merge record and Phase 4C baseline
+
+PR #2222 was merged as `9ebdbf6b6cc2cecf00f7dde6c967017c09208e1a`; its final tested head was `fd938a2c3d10cd359ee803dea71daee9b011ca45`. Authoritative Debug Tests run `30199148987` reported Linux 163 total, 139 passed, 23 failed, and 1 skipped; Windows 165 total, 138 passed, and 27 failed; and the reduced macOS profile passed 6 of 6. No failing test name was added or removed relative to run `30197537554`. This is the final cross-platform evidence: D2 was reached.
+
+The post-merge main-equivalent checkout is `2db1dd8ddb1023261a60736f4589c7da92458915`, version `1.5.11`. No remote is configured in this execution checkout, so fetch was unavailable. `git diff fd938a2c3d10cd359ee803dea71daee9b011ca45..2db1dd8` shows only `VERSION` as a post-head content change; the remaining difference is merge topology. Production and tests did not change after the verified head, so D2 controls did not require a baseline rerun.
+
+The exact next failure group is canonical Perastage Support and Truss extension metadata roundtrips. `ProjectSupportUserDataRoundtrip` reaches canonical export and then asserts the obsolete direct `Support/UserData/Data/HoistInfo` shape. `MvrTrussRoundtripStructure` validates the root `TrussInfoMap` values and then reaches the missing auxiliary GDTF field assertion. `MvrSupportUserDataRoundtrip` and `MvrExporterCompliance` remain mixed controls whose first failures must be classified independently.
+
+The pinned public MVR 1.6 XSD is `mvrdevelopment/tools` commit `16f9ff3624d3e715798a28b2c460579c55820853`, `mvr.xsd`, blob `b250b81a1a98f5dbeaf7eb55c54e21409d83f829`. It permits `GeneralSceneDescription/UserData`; Support and Truss do not define direct UserData. Strict Perastage output consequently uses only root `Data provider="Perastage" ver="1.0"` containing `HoistInfoMap` and `TrussInfoMap`. Direct object metadata is tolerant legacy input, and foreign-provider Data is not Perastage metadata.
+
+Focused local classification confirmed `ProjectSupportUserDataRoundtrip` exported successfully before reaching its stale direct-object assertion. `MvrSupportUserDataRoundtrip` fails before canonical MVR export because its ad-hoc `fixture.gdtf` is not a valid ZIP and the canonicalizer rejects it; this is an invalid-fixture blocker rather than a metadata failure. The Truss structure test reaches its canonical root-map assertions before auxiliary-resource restoration. Unrelated GDTF/category repair remains deferred.
+
+After the focused fixture and resource-contract corrections,
+`ProjectSupportUserDataRoundtrip` and `MvrTrussRoundtripStructure` both pass
+locally and pass `ctest --repeat until-fail:20`. D3 is not yet declared:
+Windows and complete Debug Tests CI evidence, plus the requested exhaustive
+malformed/duplicate metadata diagnostic matrix, remain the exact acceptance
+blockers. The PR must remain focused and open until that evidence and coverage
+are available; no unrelated repair is included.

--- a/docs/developer/technical-notes/mvr_hoistinfo_schema.md
+++ b/docs/developer/technical-notes/mvr_hoistinfo_schema.md
@@ -1,46 +1,43 @@
-# Canonical `UserData/Data/HoistInfo` schema
+# Canonical Perastage hoist metadata in MVR
 
-This document defines the canonical Perastage payload for support hoist metadata inside MVR `GeneralSceneDescription.xml`.
+The MVR 1.6 extension point is `GeneralSceneDescription/UserData`. `Support`
+does not permit a direct `UserData` child in the official schema. Perastage
+therefore writes hoist metadata only in a root map:
 
-## Location
+```xml
+<GeneralSceneDescription ...>
+  <UserData>
+    <Data provider="Perastage" ver="1.0">
+      <HoistInfoMap>
+        <HoistInfo uuid="canonical-support-uuid">...</HoistInfo>
+      </HoistInfoMap>
+    </Data>
+  </UserData>
+  <Scene>...</Scene>
+</GeneralSceneDescription>
+```
 
-- `Support/UserData/Data` with attributes:
-  - `provider="Perastage"`
-  - `ver="1.0"` (Perastage user-data schema version, not the app version)
-- Canonical payload node: `HoistInfo`
-- Legacy payload node accepted on import: `MotorInfo`
+The UUID is the canonical exported Support identity. Perastage Data version
+`1.0` is preferred over legacy object metadata; foreign-provider Data blocks
+are not interpreted as Perastage metadata.
 
-## Canonical fields
+## Fields
 
-Inside `HoistInfo`:
+`HoistInfo` can contain `Capacity`, `Weight`, a manually overridden `Load`,
+`RiggingPoint`, `MotorName`, `MotorManufacturer`, `MotorModel`,
+`MotorFixtureUuid`, `UseMotorDefaults`, `DummyProfileId`, the compatibility
+`DummyPreset`, `ValueSource`, and field-level source attributes. Optional
+absent values retain their standard or model defaults.
 
-- `Capacity` (`unit="kg"`, float)
-- `Weight` (`unit="kg"`, float)
-- `RiggingPoint` (string, normalized hoist function)
-- `MotorName` (string)
-- `MotorManufacturer` (string)
-- `MotorModel` (string)
-- `MotorFixtureUuid` (string UUID that links to a fixture)
-- `UseMotorDefaults` (`false` when explicitly disabled; omitted means `true`)
-- `DummyProfileId` (string stable profile id)
-- `DummyPreset` (string display name compatibility field)
-- `ValueSource` (`Inherited` or `Manual`)
+`Function` and `DataSource` remain compatibility aliases for `RiggingPoint`
+and `ValueSource` respectively.
 
-## Compatibility aliases
+## Legacy input
 
-Perastage writes canonical names and also compatibility aliases for older builds:
+The importer tolerates `Support/UserData/Data/HoistInfo` and
+`Support/UserData/Data/MotorInfo`. Canonical supported root metadata takes
+precedence when both shapes exist. A subsequent export migrates accepted
+legacy values into `HoistInfoMap` and never emits direct Support UserData.
 
-- `Function` mirrors `RiggingPoint`.
-- `DataSource` mirrors `ValueSource`.
-
-On import, Perastage reads both canonical and compatibility aliases with this precedence:
-
-1. `RiggingPoint`, fallback `Function`
-2. `ValueSource`, fallback `DataSource`
-
-Legacy `MotorInfo` payload blocks are still parsed and migrated internally to the canonical support fields.
-
-## Versioning policy
-
-- `GeneralSceneDescription@providerVersion` is exported from `perastage::build_info::appVersion()` and identifies the Perastage application build that created the MVR file.
-- `UserData/Data@ver` stays on the Perastage user-data schema version (`1.0`) and only changes when the Perastage custom payload schema changes.
+`GeneralSceneDescription@providerVersion` identifies the application build;
+`Data@ver` independently identifies the Perastage extension schema.

--- a/docs/developer/technical-notes/mvr_hoistinfo_schema.md
+++ b/docs/developer/technical-notes/mvr_hoistinfo_schema.md
@@ -26,7 +26,8 @@ are not interpreted as Perastage metadata.
 `HoistInfo` can contain `Capacity`, `Weight`, a manually overridden `Load`,
 `RiggingPoint`, `MotorName`, `MotorManufacturer`, `MotorModel`,
 `MotorFixtureUuid`, `UseMotorDefaults`, `DummyProfileId`, the compatibility
-`DummyPreset`, `ValueSource`, and field-level source attributes. Optional
+`DummyPreset`, `ValueSource`, and field-level source elements such as
+`MotorNameSource` and `CapacitySource`. Optional
 absent values retain their standard or model defaults.
 
 `Function` and `DataSource` remain compatibility aliases for `RiggingPoint`
@@ -38,6 +39,13 @@ The importer tolerates `Support/UserData/Data/HoistInfo` and
 `Support/UserData/Data/MotorInfo`. Canonical supported root metadata takes
 precedence when both shapes exist. A subsequent export migrates accepted
 legacy values into `HoistInfoMap` and never emits direct Support UserData.
+
+Duplicate canonical entries use the first valid UUID match deterministically;
+later duplicates are diagnosed and ignored. Invalid or non-finite numeric
+tokens do not replace existing standard values. Malformed, unknown, or
+ambiguous `MotorFixtureUuid` values are never resolved by display name.
+Perastage root Data with a schema version other than `1.0` is diagnosed and
+ignored. Foreign-provider Data is outside this policy and is not interpreted.
 
 `GeneralSceneDescription@providerVersion` identifies the application build;
 `Data@ver` independently identifies the Perastage extension schema.

--- a/docs/developer/technical-notes/mvr_hoistinfo_schema.md
+++ b/docs/developer/technical-notes/mvr_hoistinfo_schema.md
@@ -39,11 +39,17 @@ The importer tolerates `Support/UserData/Data/HoistInfo` and
 `Support/UserData/Data/MotorInfo`. Canonical supported root metadata takes
 precedence when both shapes exist. A subsequent export migrates accepted
 legacy values into `HoistInfoMap` and never emits direct Support UserData.
+Direct legacy Data is read only for a case-insensitive `Perastage` provider.
+Version `1.0` is supported; a missing direct-object version is tolerated with a
+diagnostic, while foreign providers and non-empty unsupported versions are
+ignored.
 
 Duplicate canonical entries use the first valid UUID match deterministically;
 later duplicates are diagnosed and ignored. Invalid or non-finite numeric
 tokens do not replace existing standard values. Malformed, unknown, or
 ambiguous `MotorFixtureUuid` values are never resolved by display name.
+Valid links are canonicalized and resolved only against imported Fixture UUIDs;
+malformed and unknown links are diagnosed and left unset.
 Perastage root Data with a schema version other than `1.0` is diagnosed and
 ignored. Foreign-provider Data is outside this policy and is not interpreted.
 

--- a/docs/developer/technical-notes/mvr_truss_metadata_resources.md
+++ b/docs/developer/technical-notes/mvr_truss_metadata_resources.md
@@ -22,6 +22,9 @@ the same root-filename and existence checks before retaining the portable
 identity. Unsupported schema versions, malformed UUIDs, duplicate entries,
 unsafe paths, and missing entries are diagnosed; the first valid canonical
 entry wins over later duplicates and legacy direct metadata.
+Direct legacy Truss Data follows the same provider policy: only Perastage is
+interpreted, version `1.0` is supported, a missing version is tolerated and
+diagnosed, and foreign or unsupported-version payloads are ignored.
 
 Perastage root metadata takes precedence over legacy direct metadata. Foreign
 providers are ignored by the Perastage reader. Unknown Perastage child

--- a/docs/developer/technical-notes/mvr_truss_metadata_resources.md
+++ b/docs/developer/technical-notes/mvr_truss_metadata_resources.md
@@ -32,3 +32,10 @@ extensions currently have no opaque scene-model storage and therefore cannot
 be reproduced after import; this limitation does not affect foreign-provider
 blocks during XML inspection but a newly generated export contains only
 modeled Perastage metadata.
+
+Archive identity comparison normalizes separators and applies an ASCII-only
+case fold independently of the host filesystem. Exact duplicate and case-only
+colliding file entries are ambiguous: neither payload is retained, resource
+references remain unresolved, and a structured collision diagnostic is
+reported. Ambiguous `GeneralSceneDescription.xml` entries fail import rather
+than selecting one document arbitrarily.

--- a/docs/developer/technical-notes/mvr_truss_metadata_resources.md
+++ b/docs/developer/technical-notes/mvr_truss_metadata_resources.md
@@ -1,0 +1,23 @@
+# Perastage truss metadata and resource contract
+
+MVR 1.6 permits extension data at `GeneralSceneDescription/UserData`, not as a
+direct `Truss/UserData` child. Strict Perastage output stores one
+`TrussInfoMap/TrussInfo` entry under `Data provider="Perastage" ver="1.0"`,
+keyed by the canonical exported Truss UUID. Legacy direct `TrussInfo` remains
+tolerated input and is migrated to the root map on export.
+
+`AuxGdtf` is a portable, root-level archive filename. It must not contain a
+directory, platform separator, drive prefix, traversal segment, control
+character, or absolute path. The MVR ZIP must contain the referenced entry.
+On import, `Truss::perastageAuxGdtfArchivePath` retains this portable archive
+identity; `MvrScene::basePath` resolves it to extraction storage owned through
+the scene's runtime resource lease. The lease outlives the temporary importer
+stack and prevents a dangling extraction path without persisting a local path
+in portable metadata.
+
+Perastage root metadata takes precedence over legacy direct metadata. Foreign
+providers are ignored by the Perastage reader. Unknown Perastage child
+extensions currently have no opaque scene-model storage and therefore cannot
+be reproduced after import; this limitation does not affect foreign-provider
+blocks during XML inspection but a newly generated export contains only
+modeled Perastage metadata.

--- a/docs/developer/technical-notes/mvr_truss_metadata_resources.md
+++ b/docs/developer/technical-notes/mvr_truss_metadata_resources.md
@@ -15,6 +15,14 @@ the scene's runtime resource lease. The lease outlives the temporary importer
 stack and prevents a dangling extraction path without persisting a local path
 in portable metadata.
 
+An explicit auxiliary reference is exported only when its owned source file
+exists. A missing explicit resource produces an export warning, emits no
+`AuxGdtf` claim, and never selects the generic fixture fallback. Import applies
+the same root-filename and existence checks before retaining the portable
+identity. Unsupported schema versions, malformed UUIDs, duplicate entries,
+unsafe paths, and missing entries are diagnosed; the first valid canonical
+entry wins over later duplicates and legacy direct metadata.
+
 Perastage root metadata takes precedence over legacy direct metadata. Foreign
 providers are ignored by the Perastage reader. Unknown Perastage child
 extensions currently have no opaque scene-model storage and therefore cannot

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -11,6 +11,7 @@ Changes since **v1.5.0**.
 ## Important fixes
 
 - Stabilized MVR layer and scene-object identities so damaged legacy UUIDs and dependent hierarchy or hoist links recover consistently across project save, reload, and export.
+- Preserved Support hoist and Truss metadata through standards-compliant MVR and project roundtrips, including portable auxiliary Truss GDTF resources.
 
 ## Current limitations
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -12,6 +12,7 @@ Changes since **v1.5.0**.
 
 - Stabilized MVR layer and scene-object identities so damaged legacy UUIDs and dependent hierarchy or hoist links recover consistently across project save, reload, and export.
 - Preserved Support hoist and Truss metadata through standards-compliant MVR and project roundtrips, including portable auxiliary Truss GDTF resources.
+- Hardened MVR metadata recovery against unsupported schemas, duplicate identities, invalid numeric values, unsafe auxiliary paths, and missing Truss resources without silent fallback substitution.
 
 ## Current limitations
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -12,7 +12,7 @@ Changes since **v1.5.0**.
 
 - Stabilized MVR layer and scene-object identities so damaged legacy UUIDs and dependent hierarchy or hoist links recover consistently across project save, reload, and export.
 - Preserved Support hoist and Truss metadata through standards-compliant MVR and project roundtrips, including portable auxiliary Truss GDTF resources.
-- Hardened MVR metadata recovery against unsupported schemas, duplicate identities, invalid numeric values, unsafe auxiliary paths, and missing Truss resources without silent fallback substitution.
+- Hardened MVR metadata recovery against foreign or unsupported legacy payloads, unknown and duplicate identities, invalid numeric and fixture-link values, unsafe auxiliary paths, and missing Truss resources without silent fallback substitution.
 
 ## Current limitations
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -13,6 +13,7 @@ Changes since **v1.5.0**.
 - Stabilized MVR layer and scene-object identities so damaged legacy UUIDs and dependent hierarchy or hoist links recover consistently across project save, reload, and export.
 - Preserved Support hoist and Truss metadata through standards-compliant MVR and project roundtrips, including portable auxiliary Truss GDTF resources.
 - Hardened MVR metadata recovery against foreign or unsupported legacy payloads, unknown and duplicate identities, invalid numeric and fixture-link values, unsafe auxiliary paths, and missing Truss resources without silent fallback substitution.
+- Rejected duplicate and case-colliding MVR archive entries consistently across platforms and surfaced tolerant-recovery diagnostics through normal imports.
 
 ## Current limitations
 

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -2004,10 +2004,7 @@ static void AppendTrussInfoMetadata(tinyxml2::XMLDocument &doc,
   addTxt("TypeKey", trussTypeKey.empty()
                         ? SanitizeArchiveFileName(truss.perastageTypeKey, "")
                         : trussTypeKey);
-  const std::string exportedAuxGdtf = auxGdtfArchivePath.empty()
-                                          ? truss.perastageAuxGdtfArchivePath
-                                          : auxGdtfArchivePath;
-  addTxt("AuxGdtf", SanitizeArchiveFileName(exportedAuxGdtf, ""));
+  addTxt("AuxGdtf", SanitizeArchiveFileName(auxGdtfArchivePath, ""));
   trussInfoMap->InsertEndChild(info);
 }
 
@@ -2613,12 +2610,13 @@ bool MvrExporter::ExportToFile(const std::string &filePath,
   auto registerGdtfResource =
       [&](const std::string &objectUuid, const std::string &rawGdtfPath,
           const std::string &preferredName, bool allowReuseBySource = true,
-          bool usePreferredDerivativeName = false) -> std::string {
+          bool usePreferredDerivativeName = false,
+          bool allowFallback = true) -> std::string {
     if (rawGdtfPath.empty())
       return {};
 
     std::string resolvedGdtfPath = resolveExistingResourceSourcePath(rawGdtfPath);
-    if (resolvedGdtfPath.empty()) {
+    if (resolvedGdtfPath.empty() && allowFallback) {
       resolvedGdtfPath = ResolveFallbackFixtureGdtfPath();
       if (!resolvedGdtfPath.empty()) {
         Logger::Instance().Log(
@@ -2627,6 +2625,14 @@ bool MvrExporter::ExportToFile(const std::string &filePath,
                 "'. Using fallback '" +
                 fs::path(resolvedGdtfPath).filename().generic_string() + "'.");
       }
+    }
+    if (resolvedGdtfPath.empty() && !allowFallback) {
+      const std::string message =
+          "MVR export omitted missing explicit auxiliary Truss GDTF '" +
+          rawGdtfPath + "'; no fallback was substituted.";
+      m_exportWarnings.push_back(message);
+      Logger::Instance().Log(Logger::Level::Warn, message);
+      return {};
     }
     const std::string gdtfSourceForExport =
         resolvedGdtfPath.empty() ? rawGdtfPath : resolvedGdtfPath;
@@ -3378,8 +3384,11 @@ bool MvrExporter::ExportToFile(const std::string &filePath,
       }
 
       std::string trussPreferredName = BuildTrussGdtfArchiveName(effectiveTruss);
+      const bool hasExplicitAuxiliaryGdtf =
+          !t.perastageAuxGdtfArchivePath.empty();
       trussGdtfArchivePath = registerGdtfResource(
-          exportedTrussUuid, trussSourceGdtf, trussPreferredName, true, true);
+          exportedTrussUuid, trussSourceGdtf, trussPreferredName, true, true,
+          !hasExplicitAuxiliaryGdtf);
       if (!trussGdtfArchivePath.empty())
         trussArchiveByTypeKey[trussTypeKey] = trussGdtfArchivePath;
     }

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -2504,8 +2504,6 @@ bool MvrExporter::ExportToFile(const std::string &filePath,
   std::unordered_map<std::string, std::string> gdtfArchiveByObjectUuid;
   std::unordered_map<std::string, GdtfOverrides> gdtfOverrides;
   std::unordered_map<std::string, std::string> trussArchiveByTypeKey;
-  std::unordered_map<std::string, std::string> trussExportTypeKeyByTypeKey;
-  std::unordered_map<std::string, std::string> trussInstanceToTypeKey;
   std::unordered_map<std::string, std::string> primitiveSourceByToken;
   std::unordered_set<std::string> reservedArchivePaths;
   auto primitiveWorkspace = CreateExportWorkspace("mvr-export-primitives");
@@ -3357,6 +3355,9 @@ bool MvrExporter::ExportToFile(const std::string &filePath,
       if (trussSourceGdtf.empty() &&
           fs::path(t.modelFile).extension() == ".gdtf")
         trussSourceGdtf = t.modelFile;
+      if (trussSourceGdtf.empty() &&
+          !t.perastageAuxGdtfArchivePath.empty())
+        trussSourceGdtf = t.perastageAuxGdtfArchivePath;
 
       const bool importedFromMvrGeometry =
           t.sourceRepresentation ==
@@ -3384,11 +3385,6 @@ bool MvrExporter::ExportToFile(const std::string &filePath,
     }
     const std::string exportTrussTypeKey =
         BuildExportTrussTypeKey(effectiveTruss, trussGdtfArchivePath);
-    if (!trussTypeKey.empty()) {
-      trussExportTypeKeyByTypeKey[trussTypeKey] = exportTrussTypeKey;
-      trussInstanceToTypeKey[exportedTrussUuid] = exportTrussTypeKey;
-    }
-
     if (!trussGdtfArchivePath.empty()) {
       auto &ov = gdtfOverrides[trussGdtfArchivePath];
       ov.hasLengthMm = true;
@@ -4111,41 +4107,6 @@ bool MvrExporter::ExportToFile(const std::string &filePath,
   }
 
   sceneNode->InsertEndChild(layersNode);
-
-  if (!trussArchiveByTypeKey.empty()) {
-    tinyxml2::XMLElement *data = FindOrCreatePerastageDataNode(doc, root);
-    tinyxml2::XMLElement *manifest = doc.NewElement("TrussSidecarManifest");
-    for (const auto &[typeKey, archivePath] : trussArchiveByTypeKey) {
-      const auto exportTypeKeyIt = trussExportTypeKeyByTypeKey.find(typeKey);
-      const std::string exportTypeKey =
-          exportTypeKeyIt != trussExportTypeKeyByTypeKey.end()
-                                           ? exportTypeKeyIt->second
-                                           : SanitizeArchiveFileName(typeKey, "truss_type");
-      tinyxml2::XMLElement *typeNode = doc.NewElement("Type");
-      typeNode->SetAttribute("key", exportTypeKey.c_str());
-      typeNode->SetAttribute("gdtf", archivePath.c_str());
-      manifest->InsertEndChild(typeNode);
-      Logger::Instance().Log(
-          Logger::Level::Info,
-          wxString::Format(
-              "MVR export generated truss sidecar GDTF typeKey=%s archive=%s",
-                           exportTypeKey.c_str(), archivePath.c_str())
-              .ToStdString());
-    }
-    for (const auto &[uuid, typeKey] : trussInstanceToTypeKey) {
-      tinyxml2::XMLElement *instNode = doc.NewElement("Instance");
-      instNode->SetAttribute("uuid", uuid.c_str());
-      instNode->SetAttribute("typeKey", typeKey.c_str());
-      manifest->InsertEndChild(instNode);
-      Logger::Instance().Log(
-          Logger::Level::Info,
-          wxString::Format(
-              "MVR export linked truss instance to sidecar uuid=%s typeKey=%s",
-                           uuid.c_str(), typeKey.c_str())
-              .ToStdString());
-    }
-    data->InsertEndChild(manifest);
-  }
 
   // Prunes non-referenced resources so deleted scene elements do not keep stale
   // payload files.

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -971,8 +971,9 @@ ReadLegacyFixtureIdentityFromUserData(tinyxml2::XMLElement *fixtureNode) {
 }
 
 // Reads one Perastage hoist metadata element into a support.
-static void ReadSupportHoistInfoElement(tinyxml2::XMLElement *info,
-                                        Support &support) {
+static void ReadSupportHoistInfoElement(
+    tinyxml2::XMLElement *info, Support &support,
+    std::vector<MvrImportDiagnostic> &diagnostics) {
   if (!info)
     return;
 
@@ -980,8 +981,14 @@ static void ReadSupportHoistInfoElement(tinyxml2::XMLElement *info,
     if (tinyxml2::XMLElement *el = info->FirstChildElement(name)) {
       if (const char *txt = el->GetText()) {
         float parsed = 0.0f;
-        if (TryParseFloat(txt, parsed))
+        if (TryParseFloat(txt, parsed)) {
           out = parsed;
+        } else {
+          diagnostics.push_back(
+              {"invalid_hoist_numeric_field",
+               "Support '" + support.uuid + "' has invalid " + name +
+                   " metadata."});
+        }
       }
     }
   };
@@ -996,8 +1003,15 @@ static void ReadSupportHoistInfoElement(tinyxml2::XMLElement *info,
   readFloat("Capacity", support.capacityKg);
   readFloat("Weight", support.weightKg);
   if (tinyxml2::XMLElement *load = info->FirstChildElement("Load")) {
-    readFloat("Load", support.loadKg);
-    support.loadSource = "Manual";
+    float parsed = 0.0f;
+    if (load->GetText() && TryParseFloat(load->GetText(), parsed)) {
+      support.loadKg = parsed;
+      support.loadSource = "Manual";
+    } else {
+      diagnostics.push_back(
+          {"invalid_hoist_numeric_field",
+           "Support '" + support.uuid + "' has invalid Load metadata."});
+    }
   }
 
   std::string hoistFunction = readText("RiggingPoint");
@@ -1016,13 +1030,30 @@ static void ReadSupportHoistInfoElement(tinyxml2::XMLElement *info,
   if (!model.empty())
     support.motorModel = model;
   const std::string fixtureUuid = readText("MotorFixtureUuid");
-  if (!fixtureUuid.empty())
-    support.motorFixtureUuid = fixtureUuid;
+  if (!fixtureUuid.empty()) {
+    const std::string canonicalFixtureUuid = CanonicalizeUuid(fixtureUuid);
+    if (canonicalFixtureUuid.empty()) {
+      diagnostics.push_back(
+          {"invalid_motor_fixture_uuid",
+           "Support '" + support.uuid +
+               "' has a malformed MotorFixtureUuid."});
+    } else {
+      support.motorFixtureUuid = canonicalFixtureUuid;
+    }
+  }
 
   const std::string useDefaults = ToLowerCopy(readText("UseMotorDefaults"));
   if (!useDefaults.empty()) {
-    support.useMotorDefaults = !(useDefaults == "false" ||
-                                 useDefaults == "0" || useDefaults == "no");
+    if (useDefaults == "true" || useDefaults == "1" || useDefaults == "yes")
+      support.useMotorDefaults = true;
+    else if (useDefaults == "false" || useDefaults == "0" ||
+             useDefaults == "no")
+      support.useMotorDefaults = false;
+    else
+      diagnostics.push_back(
+          {"invalid_use_motor_defaults",
+           "Support '" + support.uuid +
+               "' has invalid UseMotorDefaults metadata."});
   }
 
   const std::string dummyPreset = readText("DummyPreset");
@@ -1072,15 +1103,33 @@ static void ReadSupportHoistInfoElement(tinyxml2::XMLElement *info,
 
 // Reads legacy Support/UserData hoist metadata into a support.
 static void ReadSupportHoistInfoFromUserData(tinyxml2::XMLElement *supportNode,
-                                             Support &support) {
+                                             Support &support,
+                                             std::vector<MvrImportDiagnostic> &diagnostics) {
   for (tinyxml2::XMLElement *ud = supportNode->FirstChildElement("UserData");
        ud; ud = ud->NextSiblingElement("UserData")) {
     for (tinyxml2::XMLElement *data = ud->FirstChildElement("Data"); data;
          data = data->NextSiblingElement("Data")) {
+      const std::string provider = ToLowerCopy(
+          Trim(data->Attribute("provider") ? data->Attribute("provider") : ""));
+      if (provider != "perastage")
+        continue;
+      const std::string version =
+          Trim(data->Attribute("ver") ? data->Attribute("ver") : "");
+      if (version.empty()) {
+        diagnostics.push_back(
+            {"legacy_perastage_metadata_missing_version",
+             "Accepted legacy Support metadata without a schema version."});
+      } else if (version != "1.0") {
+        diagnostics.push_back(
+            {"unsupported_perastage_metadata_version",
+             "Ignored legacy Support metadata with unsupported schema version '" +
+                 version + "'."});
+        continue;
+      }
       tinyxml2::XMLElement *info = data->FirstChildElement("HoistInfo");
       if (!info)
         info = data->FirstChildElement("MotorInfo");
-      ReadSupportHoistInfoElement(info, support);
+      ReadSupportHoistInfoElement(info, support, diagnostics);
     }
   }
 }
@@ -1709,19 +1758,23 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
   };
   parseRootFixtureTypeInfoMap(root->FirstChildElement("UserData"));
 
+  std::unordered_set<tinyxml2::XMLElement *> diagnosedUnsupportedData;
   auto isSupportedPerastageMetadata = [&](tinyxml2::XMLElement *data) {
     const std::string version =
         Trim(data->Attribute("ver") ? data->Attribute("ver") : "");
     if (version == "1.0")
       return true;
-    importResult.diagnostics.push_back(
-        {"unsupported_perastage_metadata_version",
-         "Ignored Perastage root metadata with unsupported schema version '" +
-             version + "'."});
+    if (diagnosedUnsupportedData.insert(data).second) {
+      importResult.diagnostics.push_back(
+          {"unsupported_perastage_metadata_version",
+           "Ignored Perastage root metadata with unsupported schema version '" +
+               version + "'."});
+    }
     return false;
   };
 
   std::unordered_map<std::string, tinyxml2::XMLElement *> rootTrussInfoByUuid;
+  std::unordered_set<std::string> consumedRootTrussInfoUuids;
   // Collects root-level Perastage truss metadata by canonical exported UUID.
   auto parseRootTrussInfoMap = [&](tinyxml2::XMLElement *userDataNode) {
     if (!userDataNode)
@@ -1806,6 +1859,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
   parseRootPrimitiveGeometryMap(root->FirstChildElement("UserData"));
 
   std::unordered_map<std::string, tinyxml2::XMLElement *> rootHoistInfoByUuid;
+  std::unordered_set<std::string> consumedRootHoistInfoUuids;
   // Collects root-level Perastage hoist metadata by exported Support UUID.
   auto parseRootHoistInfoMap = [&](tinyxml2::XMLElement *userDataNode) {
     if (!userDataNode)
@@ -2625,40 +2679,30 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
     if (!info)
       return;
     (void)hasGdtfMetadataAuthority;
+    auto readNumeric = [&](const char *field, float &target) {
+      tinyxml2::XMLElement *element = info->FirstChildElement(field);
+      if (!element)
+        return;
+      float parsed = 0.0f;
+      if (element->GetText() && TryParseFloat(element->GetText(), parsed)) {
+        target = parsed;
+      } else {
+        importResult.diagnostics.push_back(
+            {"invalid_truss_numeric_field",
+             "Truss '" + truss.uuid + "' has invalid " + field +
+                 " metadata."});
+      }
+    };
     if (tinyxml2::XMLElement *m = info->FirstChildElement("Manufacturer"))
       if (m->GetText())
         truss.manufacturer = Trim(m->GetText());
     if (tinyxml2::XMLElement *mo = info->FirstChildElement("Model"))
       if (mo->GetText())
         truss.model = Trim(mo->GetText());
-    if (tinyxml2::XMLElement *len = info->FirstChildElement("Length"))
-      if (len->GetText()) {
-        float parsed = 0.0f;
-        if (TryParseFloat(len->GetText(), parsed))
-          truss.lengthMm = parsed;
-      }
-    if (tinyxml2::XMLElement *wid = info->FirstChildElement("Width"))
-      if (wid->GetText()) {
-        float parsed = 0.0f;
-        if (TryParseFloat(wid->GetText(), parsed))
-          truss.widthMm = parsed;
-        else
-          truss.widthMm = 400.0f;
-      }
-    if (tinyxml2::XMLElement *hei = info->FirstChildElement("Height"))
-      if (hei->GetText()) {
-        float parsed = 0.0f;
-        if (TryParseFloat(hei->GetText(), parsed))
-          truss.heightMm = parsed;
-        else
-          truss.heightMm = 400.0f;
-      }
-    if (tinyxml2::XMLElement *wei = info->FirstChildElement("Weight"))
-      if (wei->GetText()) {
-        float parsed = 0.0f;
-        if (TryParseFloat(wei->GetText(), parsed))
-          truss.weightKg = parsed;
-      }
+    readNumeric("Length", truss.lengthMm);
+    readNumeric("Width", truss.widthMm);
+    readNumeric("Height", truss.heightMm);
+    readNumeric("Weight", truss.weightKg);
     if (tinyxml2::XMLElement *desc = info->FirstChildElement("GdtfDescription"))
       if (desc->GetText())
         truss.gdtfDescription = desc->GetText();
@@ -2676,6 +2720,10 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
         if (TryParseFloat(Trim(load->GetText()), parsed)) {
           truss.manualLoadKg = parsed;
           truss.hasManualLoadOverride = true;
+        } else {
+          importResult.diagnostics.push_back(
+              {"invalid_truss_numeric_field",
+               "Truss '" + truss.uuid + "' has invalid Load metadata."});
         }
       }
     if (tinyxml2::XMLElement *mf = info->FirstChildElement("ModelFile"))
@@ -2838,12 +2886,30 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
 
         auto rootTrussInfoIt = rootTrussInfoByUuid.find(truss.uuid);
         if (rootTrussInfoIt != rootTrussInfoByUuid.end()) {
+          consumedRootTrussInfoUuids.insert(rootTrussInfoIt->first);
           applyTrussInfo(rootTrussInfoIt->second, truss,
                          hasGdtfMetadataAuthority);
         } else if (tinyxml2::XMLElement *ud =
                        node->FirstChildElement("UserData")) {
           for (tinyxml2::XMLElement *data = ud->FirstChildElement("Data"); data;
                data = data->NextSiblingElement("Data")) {
+            const std::string provider = ToLowerCopy(Trim(
+                data->Attribute("provider") ? data->Attribute("provider") : ""));
+            if (provider != "perastage")
+              continue;
+            const std::string version =
+                Trim(data->Attribute("ver") ? data->Attribute("ver") : "");
+            if (version.empty()) {
+              importResult.diagnostics.push_back(
+                  {"legacy_perastage_metadata_missing_version",
+                   "Accepted legacy Truss metadata without a schema version."});
+            } else if (version != "1.0") {
+              importResult.diagnostics.push_back(
+                  {"unsupported_perastage_metadata_version",
+                   "Ignored legacy Truss metadata with unsupported schema version '" +
+                       version + "'."});
+              continue;
+            }
             if (tinyxml2::XMLElement *info =
                     data->FirstChildElement("TrussInfo")) {
               applyTrussInfo(info, truss, hasGdtfMetadataAuthority);
@@ -3021,10 +3087,14 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
           support.modelFile = support.geometries.front().modelFile;
 
         auto rootHoistInfoIt = rootHoistInfoByUuid.find(support.uuid);
-        if (rootHoistInfoIt != rootHoistInfoByUuid.end())
-          ReadSupportHoistInfoElement(rootHoistInfoIt->second, support);
-        else
-          ReadSupportHoistInfoFromUserData(node, support);
+        if (rootHoistInfoIt != rootHoistInfoByUuid.end()) {
+          consumedRootHoistInfoUuids.insert(rootHoistInfoIt->first);
+          ReadSupportHoistInfoElement(rootHoistInfoIt->second, support,
+                                      importResult.diagnostics);
+        } else {
+          ReadSupportHoistInfoFromUserData(node, support,
+                                           importResult.diagnostics);
+        }
         ApplySupportHoistInfoDefaults(support);
         auto posIt = scene.positions.find(support.position);
         if (posIt != scene.positions.end())
@@ -3293,10 +3363,14 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
             }
           }
           auto rootHoistInfoIt = rootHoistInfoByUuid.find(support.uuid);
-          if (rootHoistInfoIt != rootHoistInfoByUuid.end())
-            ReadSupportHoistInfoElement(rootHoistInfoIt->second, support);
-          else
-            ReadSupportHoistInfoFromUserData(node, support);
+          if (rootHoistInfoIt != rootHoistInfoByUuid.end()) {
+            consumedRootHoistInfoUuids.insert(rootHoistInfoIt->first);
+            ReadSupportHoistInfoElement(rootHoistInfoIt->second, support,
+                                        importResult.diagnostics);
+          } else {
+            ReadSupportHoistInfoFromUserData(node, support,
+                                             importResult.diagnostics);
+          }
           ApplySupportHoistInfoDefaults(support);
           scene.supports[support.uuid] = support;
         } else {
@@ -4666,6 +4740,56 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
     }
   }
   LogMessage(Logger::Level::Info, importDiagnostics.str());
+
+  for (auto &[uuid, support] : scene.supports) {
+    if (support.motorFixtureUuid.empty())
+      continue;
+    const std::string canonical = CanonicalizeUuid(support.motorFixtureUuid);
+    if (canonical.empty())
+      continue;
+    auto aliasIt = fixtureUuidRemap.find(support.motorFixtureUuid);
+    const std::string resolved = aliasIt == fixtureUuidRemap.end()
+                                     ? canonical
+                                     : aliasIt->second;
+    if (scene.fixtures.contains(resolved)) {
+      support.motorFixtureUuid = resolved;
+    } else {
+      importResult.diagnostics.push_back(
+          {"unknown_motor_fixture_uuid",
+           "Support '" + uuid +
+               "' references an unknown MotorFixtureUuid."});
+      support.motorFixtureUuid.clear();
+    }
+  }
+
+  auto diagnoseUnusedRootEntries =
+      [&](const auto &entries, const auto &consumed, const char *code,
+          const char *kind) {
+        std::vector<std::string> unknown;
+        for (const auto &[uuid, element] : entries) {
+          (void)element;
+          if (!consumed.contains(uuid))
+            unknown.push_back(uuid);
+        }
+        std::sort(unknown.begin(), unknown.end());
+        for (const std::string &uuid : unknown) {
+          importResult.diagnostics.push_back(
+              {code, std::string("Ignored ") + kind +
+                         " for unknown UUID '" + uuid + "'."});
+        }
+      };
+  diagnoseUnusedRootEntries(rootHoistInfoByUuid,
+                            consumedRootHoistInfoUuids,
+                            "unknown_hoist_info_uuid", "HoistInfo");
+  diagnoseUnusedRootEntries(rootTrussInfoByUuid,
+                            consumedRootTrussInfoUuids,
+                            "unknown_truss_info_uuid", "TrussInfo");
+
+  for (const MvrImportDiagnostic &diagnostic : importResult.diagnostics) {
+    LogMessage(Logger::Level::Warn,
+               "MVR metadata diagnostic [" + diagnostic.code + "]: " +
+                   diagnostic.message);
+  }
 
   std::string summary =
       "Parsed scene: " + std::to_string(scene.fixtures.size()) + " fixtures, " +

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -164,6 +164,23 @@ static std::string NormalizeArchivePathValue(const std::string &archivePath) {
   return normalized;
 }
 
+// Reports whether extension metadata names one portable root-level archive file.
+static bool IsPortableRootArchiveFileName(const std::string &value) {
+  if (value.empty() || value == "." || value == "..")
+    return false;
+  if (std::any_of(value.begin(), value.end(), [](unsigned char ch) {
+        return ch < 32 || ch == 127;
+      }))
+    return false;
+  if (value.find('/') != std::string::npos ||
+      value.find('\\') != std::string::npos ||
+      value.find(':') != std::string::npos)
+    return false;
+  const fs::path path = PathUtils::PathFromUtf8(value);
+  return !path.is_absolute() && !path.has_root_name() &&
+         path.filename().generic_string() == value;
+}
+
 static std::string NormalizeGdtfLookupKey(const std::string &value) {
   std::string normalized = NormalizeArchivePathValue(value);
   if (normalized.empty())
@@ -300,7 +317,9 @@ static bool TryParseFloat(const std::string &text, float &out) {
   std::string trimmedText(trimmed);
   char *endPtr = nullptr;
   const double parsed = std::strtod(trimmedText.c_str(), &endPtr);
-  if (endPtr == trimmedText.c_str() + trimmedText.size() && errno != ERANGE) {
+  if (endPtr == trimmedText.c_str() + trimmedText.size() && errno != ERANGE &&
+      std::isfinite(parsed) &&
+      std::isfinite(static_cast<float>(parsed))) {
     out = static_cast<float>(parsed);
     return true;
   }
@@ -1690,6 +1709,18 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
   };
   parseRootFixtureTypeInfoMap(root->FirstChildElement("UserData"));
 
+  auto isSupportedPerastageMetadata = [&](tinyxml2::XMLElement *data) {
+    const std::string version =
+        Trim(data->Attribute("ver") ? data->Attribute("ver") : "");
+    if (version == "1.0")
+      return true;
+    importResult.diagnostics.push_back(
+        {"unsupported_perastage_metadata_version",
+         "Ignored Perastage root metadata with unsupported schema version '" +
+             version + "'."});
+    return false;
+  };
+
   std::unordered_map<std::string, tinyxml2::XMLElement *> rootTrussInfoByUuid;
   // Collects root-level Perastage truss metadata by canonical exported UUID.
   auto parseRootTrussInfoMap = [&](tinyxml2::XMLElement *userDataNode) {
@@ -1701,14 +1732,23 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
           Trim(data->Attribute("provider") ? data->Attribute("provider") : ""));
       if (provider != "perastage")
         continue;
+      if (!isSupportedPerastageMetadata(data))
+        continue;
       for (tinyxml2::XMLElement *map = data->FirstChildElement("TrussInfoMap");
            map; map = map->NextSiblingElement("TrussInfoMap")) {
         for (tinyxml2::XMLElement *info = map->FirstChildElement("TrussInfo");
              info; info = info->NextSiblingElement("TrussInfo")) {
           const std::string uuid = CanonicalizeUuid(
               Trim(info->Attribute("uuid") ? info->Attribute("uuid") : ""));
-          if (!uuid.empty())
-            rootTrussInfoByUuid[uuid] = info;
+          if (uuid.empty()) {
+            importResult.diagnostics.push_back(
+                {"invalid_truss_info_uuid",
+                 "Ignored TrussInfo with a malformed UUID."});
+          } else if (!rootTrussInfoByUuid.emplace(uuid, info).second) {
+            importResult.diagnostics.push_back(
+                {"duplicate_truss_info",
+                 "Ignored duplicate TrussInfo for UUID '" + uuid + "'."});
+          }
         }
       }
     }
@@ -1776,6 +1816,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
           Trim(data->Attribute("provider") ? data->Attribute("provider") : ""));
       if (provider != "perastage")
         continue;
+      if (!isSupportedPerastageMetadata(data))
+        continue;
       for (tinyxml2::XMLElement *map = data->FirstChildElement("HoistInfoMap");
            map; map = map->NextSiblingElement("HoistInfoMap")) {
         for (tinyxml2::XMLElement *info = map->FirstChildElement("HoistInfo");
@@ -1783,10 +1825,18 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
           const std::string rawUuid =
               Trim(info->Attribute("uuid") ? info->Attribute("uuid") : "");
           const std::string canonicalUuid = CanonicalizeUuid(rawUuid);
-          if (!rawUuid.empty())
-            rootHoistInfoByUuid[rawUuid] = info;
-          if (!canonicalUuid.empty())
-            rootHoistInfoByUuid[canonicalUuid] = info;
+          if (canonicalUuid.empty()) {
+            importResult.diagnostics.push_back(
+                {"invalid_hoist_info_uuid",
+                 "Ignored HoistInfo with a malformed UUID."});
+            continue;
+          }
+          if (!rootHoistInfoByUuid.emplace(canonicalUuid, info).second) {
+            importResult.diagnostics.push_back(
+                {"duplicate_hoist_info",
+                 "Ignored duplicate HoistInfo for UUID '" + canonicalUuid +
+                     "'."});
+          }
         }
       }
     }
@@ -2645,9 +2695,28 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
       if (tk->GetText())
         truss.perastageTypeKey = Trim(tk->GetText());
     if (tinyxml2::XMLElement *ag = info->FirstChildElement("AuxGdtf"))
-      if (ag->GetText())
-        truss.perastageAuxGdtfArchivePath =
-            RemapArchivePathIfNeeded(Trim(ag->GetText()));
+      if (ag->GetText()) {
+        const std::string archiveName = Trim(ag->GetText());
+        if (!IsPortableRootArchiveFileName(archiveName)) {
+          importResult.diagnostics.push_back(
+              {"unsafe_truss_aux_gdtf_path",
+               "Ignored unsafe TrussInfo AuxGdtf path '" + archiveName +
+                   "'."});
+        } else {
+          const std::string remapped = RemapArchivePathIfNeeded(archiveName);
+          const fs::path resolved =
+              ResolveSceneRelativePath(scene.basePath, remapped);
+          std::error_code existsEc;
+          if (fs::is_regular_file(resolved, existsEc) && !existsEc) {
+            truss.perastageAuxGdtfArchivePath = remapped;
+          } else {
+            importResult.diagnostics.push_back(
+                {"missing_truss_aux_gdtf",
+                 "Ignored missing TrussInfo AuxGdtf archive entry '" +
+                     archiveName + "'."});
+          }
+        }
+      }
   };
 
   std::function<void(tinyxml2::XMLElement *, const std::string &,

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -142,6 +142,29 @@ static std::string ToLowerAscii(std::string text) {
   return text;
 }
 
+// Folds only ASCII uppercase characters for platform-neutral archive identity.
+static std::string FoldArchiveIdentityAscii(std::string text) {
+  for (char &ch : text) {
+    if (ch >= 'A' && ch <= 'Z')
+      ch = static_cast<char>(ch - 'A' + 'a');
+  }
+  return text;
+}
+
+// Escapes control characters in archive identities used by diagnostics.
+static std::string EscapeArchiveIdentity(const std::string &identity) {
+  std::ostringstream escaped;
+  for (unsigned char ch : identity) {
+    if (ch < 32 || ch == 127) {
+      escaped << "\\x" << std::hex << std::setw(2) << std::setfill('0')
+              << static_cast<int>(ch) << std::dec;
+    } else {
+      escaped << static_cast<char>(ch);
+    }
+  }
+  return escaped.str();
+}
+
 static std::string ResolveGdtfPath(const std::string &baseDir,
                                    const std::string &spec);
 
@@ -1133,13 +1156,26 @@ static void ReadSupportHoistInfoFromUserData(tinyxml2::XMLElement *supportNode,
     }
   }
 }
+// Logs each structured MVR import diagnostic exactly once for discarded results.
+static void LogMvrImportDiagnostics(
+    const std::vector<MvrImportDiagnostic> &diagnostics) {
+  for (const MvrImportDiagnostic &diagnostic : diagnostics) {
+    LogMessage(Logger::Level::Warn,
+               "MVR metadata diagnostic [" + diagnostic.code + "]: " +
+                   diagnostic.message);
+  }
+}
+
 // Imports an MVR file into the global application scene.
 bool MvrImporter::ImportFromFile(const std::string &filePath,
                                  bool promptConflicts, bool applyDictionary,
                                  ProgressCallback progressCallback) {
   MvrImportResult importResult;
-  return ImportFromFile(filePath, importResult, MvrImportMode::ReplaceProject,
-                        promptConflicts, applyDictionary, progressCallback);
+  const bool imported =
+      ImportFromFile(filePath, importResult, MvrImportMode::ReplaceProject,
+                     promptConflicts, applyDictionary, progressCallback);
+  LogMvrImportDiagnostics(importResult.diagnostics);
+  return imported;
 }
 
 // Imports an MVR file into an import result and optionally replaces the global
@@ -1190,6 +1226,7 @@ bool MvrImporter::ImportSceneFromFile(const std::string &filePath,
   const bool imported =
       ImportFromFile(filePath, importResult, MvrImportMode::ParseOnly, options,
                      progressCallback);
+  LogMvrImportDiagnostics(importResult.diagnostics);
   if (!imported)
     return false;
 
@@ -1264,7 +1301,7 @@ bool MvrImporter::ImportFromFileIntoResult(const std::string &filePath,
   std::string tempDir = ToString(importWorkspace.Path().u8string());
   std::string mvrPath = ToString(path.u8string());
   fs::path tempPath(tempDir);
-  if (!ExtractMvrZip(mvrPath, tempDir)) {
+  if (!ExtractMvrZip(mvrPath, tempDir, importResult.diagnostics)) {
     LogMessage("Failed to extract MVR file.");
     return false;
   }
@@ -1349,8 +1386,9 @@ MvrImporter::RemapArchivePathIfNeeded(const std::string &archivePath) const {
 }
 
 // Extracts an MVR zip archive into the destination directory.
-bool MvrImporter::ExtractMvrZip(const std::string &mvrPath,
-                                const std::string &destDir) {
+bool MvrImporter::ExtractMvrZip(
+    const std::string &mvrPath, const std::string &destDir,
+    std::vector<MvrImportDiagnostic> &diagnostics) {
   wxFileInputStream input(wxString::FromUTF8(mvrPath.c_str()));
   if (!input.IsOk()) {
     LogMessage("Failed to open MVR file.");
@@ -1359,6 +1397,18 @@ bool MvrImporter::ExtractMvrZip(const std::string &mvrPath,
 
   wxZipInputStream zipStream(input);
   std::unique_ptr<wxZipEntry> entry;
+  std::unordered_map<std::string, std::string> identityByFoldedKey;
+  std::unordered_map<std::string, fs::path> extractedPathByIdentity;
+  std::unordered_set<std::string> ambiguousFoldedKeys;
+
+  auto discardCurrentEntry = [&]() {
+    char discardBuffer[4096];
+    while (true) {
+      zipStream.Read(discardBuffer, sizeof(discardBuffer));
+      if (zipStream.LastRead() == 0)
+        break;
+    }
+  };
 
   while ((entry.reset(zipStream.GetNextEntry())), entry) {
     // Extract entry names using UTF-8 to preserve special characters
@@ -1372,12 +1422,7 @@ bool MvrImporter::ExtractMvrZip(const std::string &mvrPath,
                     [](const fs::path &part) { return part == ".."; })) {
       LogMessage(Logger::Level::Warn,
                  "Skipping unsafe MVR archive entry: " + entryName);
-      char discardBuffer[4096];
-      while (true) {
-        zipStream.Read(discardBuffer, sizeof(discardBuffer));
-        if (zipStream.LastRead() == 0)
-          break;
-      }
+      discardCurrentEntry();
       continue;
     }
     fs::path fullPath =
@@ -1389,6 +1434,40 @@ bool MvrImporter::ExtractMvrZip(const std::string &mvrPath,
                         wxPATH_MKDIR_FULL);
       continue;
     }
+
+    const std::string archiveIdentity = normalizedUnsafeCheck;
+    const std::string foldedIdentity =
+        FoldArchiveIdentityAscii(archiveIdentity);
+    if (ambiguousFoldedKeys.contains(foldedIdentity)) {
+      pathRemap.erase(NormalizeArchivePath(archiveIdentity));
+      discardCurrentEntry();
+      continue;
+    }
+    auto priorIdentityIt = identityByFoldedKey.find(foldedIdentity);
+    if (priorIdentityIt != identityByFoldedKey.end()) {
+      const bool exactDuplicate = priorIdentityIt->second == archiveIdentity;
+      const char *code = exactDuplicate ? "duplicate_mvr_archive_entry"
+                                        : "case_colliding_mvr_archive_entry";
+      diagnostics.push_back(
+          {code, std::string("Rejected ambiguous MVR archive entries '") +
+                     EscapeArchiveIdentity(priorIdentityIt->second) + "' and '" +
+                     EscapeArchiveIdentity(archiveIdentity) + "'."});
+      auto extractedIt =
+          extractedPathByIdentity.find(priorIdentityIt->second);
+      if (extractedIt != extractedPathByIdentity.end()) {
+        std::error_code removeEc;
+        fs::remove(extractedIt->second, removeEc);
+        extractedPathByIdentity.erase(extractedIt);
+      }
+      pathRemap.erase(NormalizeArchivePath(priorIdentityIt->second));
+      pathRemap.erase(NormalizeArchivePath(archiveIdentity));
+      ambiguousFoldedKeys.insert(foldedIdentity);
+      discardCurrentEntry();
+      if (foldedIdentity == "generalscenedescription.xml")
+        return false;
+      continue;
+    }
+    identityByFoldedKey.emplace(foldedIdentity, archiveIdentity);
 
     std::string parentUtf8 = ToString(fullPath.parent_path().u8string());
     wxFileName::Mkdir(wxString::FromUTF8(parentUtf8.c_str()), wxS_DIR_DEFAULT,
@@ -1480,6 +1559,7 @@ bool MvrImporter::ExtractMvrZip(const std::string &mvrPath,
     }
 
     output.close();
+    extractedPathByIdentity[archiveIdentity] = fullPath;
   }
 
   return true;
@@ -4785,12 +4865,6 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                             consumedRootTrussInfoUuids,
                             "unknown_truss_info_uuid", "TrussInfo");
 
-  for (const MvrImportDiagnostic &diagnostic : importResult.diagnostics) {
-    LogMessage(Logger::Level::Warn,
-               "MVR metadata diagnostic [" + diagnostic.code + "]: " +
-                   diagnostic.message);
-  }
-
   std::string summary =
       "Parsed scene: " + std::to_string(scene.fixtures.size()) + " fixtures, " +
       std::to_string(scene.trusses.size()) + " trusses, " +
@@ -4821,6 +4895,7 @@ bool MvrImporter::ImportAndRegister(const std::string &filePath,
   const bool imported = importer.ImportFromFile(filePath, importResult,
                                                 MvrImportMode::ReplaceProject,
                                                 options, progressCallback);
+  LogMvrImportDiagnostics(importResult.diagnostics);
   if (!imported)
     return false;
 

--- a/mvr/mvrimporter.h
+++ b/mvr/mvrimporter.h
@@ -20,6 +20,7 @@
 #include <functional>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 #include "mvrscene.h"
 
@@ -42,9 +43,15 @@ struct MvrImportOptions {
     MvrImportSourceKind sourceKind = MvrImportSourceKind::ExternalImport;
 };
 
+struct MvrImportDiagnostic {
+    std::string code;
+    std::string message;
+};
+
 struct MvrImportResult {
     MvrScene scene;
     std::unordered_map<std::string, std::string> fixtureUuidRemap;
+    std::vector<MvrImportDiagnostic> diagnostics;
 };
 
 // Responsible for importing .mvr files into the application's internal data model

--- a/mvr/mvrimporter.h
+++ b/mvr/mvrimporter.h
@@ -124,7 +124,8 @@ private:
     // Creates a temporary directory for extracting the contents of the MVR archive
 
     // Extracts the .mvr (ZIP) contents into the given destination directory
-    bool ExtractMvrZip(const std::string& mvrPath, const std::string& destDir);
+    bool ExtractMvrZip(const std::string& mvrPath, const std::string& destDir,
+                       std::vector<MvrImportDiagnostic>& diagnostics);
 
     // Extracts and parses a .mvr file into an import result payload.
     bool ImportFromFileIntoResult(const std::string& filePath,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1059,6 +1059,35 @@ target_link_libraries(mvr_support_userdata_roundtrip_test PRIVATE
 add_test(NAME MvrSupportUserDataRoundtrip COMMAND mvr_support_userdata_roundtrip_test)
 set_library_env(MvrSupportUserDataRoundtrip)
 
+add_executable(mvr_perastage_metadata_recovery_test
+               mvr_perastage_metadata_recovery_test.cpp
+               build_info_stub.cpp
+               ../core/configmanager.cpp ../core/configservices.cpp
+               ../core/projectutils.cpp ../core/library/library_bootstrap.cpp
+               ../core/gdtfdictionary.cpp ../core/gdtf_fixture_category.cpp
+               ../core/layer_service.cpp ../core/scene_grouping.cpp
+               ../core/utf8_utils.cpp ../core/trussdictionary.cpp
+               ../core/trussloader.cpp ../core/wx_path_utils.cpp
+               ../core/runtime_storage.cpp ../core/truss_gdtf_builder.cpp
+               ../core/uuidutils.cpp ../core/dummyprofilelibrary.cpp
+               ../mvr/mvrimporter.cpp ../mvr/gdtf_catalog_matcher.cpp
+               ../viewer2d/fixture_label_overrides.cpp
+               ../mvr/mvrexporter.cpp ../core/mvr_identity_recovery.cpp
+               ../mvr/primitive_model_resources.cpp
+               ../core/gdtf_canonicalizer.cpp ../core/gdtf_mutation_audit.cpp
+               ../core/logger.cpp gdtfloader_stub.cpp consolepanel_stub.cpp
+               ../models/mvrscene.cpp ../models/fixture.cpp ../models/truss.cpp
+               ../models/sceneobject.cpp ../models/layer.cpp ${LAYOUT_SOURCES})
+target_include_directories(mvr_perastage_metadata_recovery_test PRIVATE
+                           . ../core ../models ../mvr ../gui ../third_party)
+target_link_libraries(mvr_perastage_metadata_recovery_test PRIVATE
+                      ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
+add_test(NAME MvrPerastageMetadataRecovery
+         COMMAND mvr_perastage_metadata_recovery_test)
+set_perastage_test_labels(MvrPerastageMetadataRecovery
+                          LAYER tolerant-recovery DOMAINS mvr zip)
+set_library_env(MvrPerastageMetadataRecovery)
+
 
 add_executable(mvr_layer_appearance_userdata_test mvr_layer_appearance_userdata_test.cpp
                build_info_stub.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1017,6 +1017,7 @@ set_library_env(MvrDmxAddressConversion)
 
 
 add_executable(mvr_support_userdata_roundtrip_test mvr_support_userdata_roundtrip_test.cpp
+               support/gdtf_test_fixture_builder.cpp
                build_info_stub.cpp
                ../core/configmanager.cpp
                ../core/configservices.cpp

--- a/tests/mvr_perastage_metadata_recovery_test.cpp
+++ b/tests/mvr_perastage_metadata_recovery_test.cpp
@@ -1,0 +1,109 @@
+/*
+ * This file is part of Perastage.
+ */
+#include <algorithm>
+#include <cassert>
+#include <filesystem>
+#include <memory>
+#include <string>
+
+#include <wx/init.h>
+#include <wx/wfstream.h>
+#include <wx/zipstrm.h>
+
+#include "mvrimporter.h"
+
+namespace fs = std::filesystem;
+
+// Writes one deterministic minimal MVR archive for metadata recovery testing.
+static void WriteMetadataArchive(const fs::path &path) {
+  static const std::string xml =
+      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+      "<GeneralSceneDescription verMajor=\"1\" verMinor=\"6\" provider=\"Test\" providerVersion=\"1\">"
+      "<UserData>"
+      "<Data provider=\"Perastage\" ver=\"1.0\"><HoistInfoMap>"
+      "<HoistInfo uuid=\"30000000-0000-4000-8000-000000000001\"><Capacity>100</Capacity><Weight>NaN</Weight><MotorFixtureUuid>20000000-0000-4000-8000-000000000001</MotorFixtureUuid><UseMotorDefaults>maybe</UseMotorDefaults><Unknown/></HoistInfo>"
+      "<HoistInfo uuid=\"30000000-0000-4000-8000-000000000003\"><Capacity>55</Capacity><MotorFixtureUuid>20000000-0000-4000-8000-000000000099</MotorFixtureUuid></HoistInfo>"
+      "<HoistInfo uuid=\"{30000000-0000-4000-8000-000000000001}\"><Capacity>999</Capacity></HoistInfo>"
+      "<HoistInfo uuid=\"bad\"><Capacity>888</Capacity></HoistInfo>"
+      "<HoistInfo uuid=\"30000000-0000-4000-8000-000000000099\"><Capacity>777</Capacity></HoistInfo>"
+      "</HoistInfoMap><TrussInfoMap>"
+      "<TrussInfo uuid=\"40000000-0000-4000-8000-000000000001\"><Length>infinity</Length><Width>250</Width><AuxGdtf>../escape.gdtf</AuxGdtf></TrussInfo>"
+      "<TrussInfo uuid=\"40000000-0000-4000-8000-000000000001\"><Width>999</Width></TrussInfo>"
+      "<TrussInfo uuid=\"bad\"/><TrussInfo uuid=\"40000000-0000-4000-8000-000000000099\"/>"
+      "</TrussInfoMap></Data>"
+      "<Data provider=\"Perastage\" ver=\"2.0\"><HoistInfoMap><HoistInfo uuid=\"30000000-0000-4000-8000-000000000001\"><Capacity>555</Capacity></HoistInfo></HoistInfoMap></Data>"
+      "<Data provider=\"Foreign\" ver=\"1.0\"><HoistInfoMap><HoistInfo uuid=\"30000000-0000-4000-8000-000000000001\"><Capacity>444</Capacity></HoistInfo></HoistInfoMap></Data>"
+      "</UserData><Scene><Layers><Layer uuid=\"10000000-0000-4000-8000-000000000001\" name=\"Default\"><ChildList>"
+      "<Fixture uuid=\"20000000-0000-4000-8000-000000000001\" name=\"Motor\"><Matrix>1,0,0,0,1,0,0,0,1,0,0,0</Matrix><FixtureID>1</FixtureID><FixtureIDNumeric>1</FixtureIDNumeric></Fixture>"
+      "<Support uuid=\"30000000-0000-4000-8000-000000000001\" name=\"Target\"><Matrix>1,0,0,0,1,0,0,0,1,0,0,0</Matrix><Geometries/><Function>Other</Function><ChainLength>1</ChainLength><UserData><Data provider=\"Foreign\" ver=\"1.0\"><HoistInfo><Capacity>333</Capacity></HoistInfo></Data><Data provider=\"Perastage\" ver=\"1.0\"><HoistInfo><Capacity>222</Capacity></HoistInfo></Data></UserData></Support>"
+      "<Support uuid=\"30000000-0000-4000-8000-000000000002\" name=\"Legacy\"><Matrix>1,0,0,0,1,0,0,0,1,0,0,0</Matrix><Geometries/><ChainLength>1</ChainLength><UserData><Data provider=\"Perastage\"><MotorInfo><Capacity>42</Capacity><MotorFixtureUuid>bad</MotorFixtureUuid></MotorInfo></Data></UserData></Support>"
+      "<Support uuid=\"30000000-0000-4000-8000-000000000003\" name=\"Unknown Motor\"><Matrix>1,0,0,0,1,0,0,0,1,0,0,0</Matrix><Geometries/><ChainLength>1</ChainLength></Support>"
+      "<Truss uuid=\"40000000-0000-4000-8000-000000000001\" name=\"Truss\"><Matrix>1,0,0,0,1,0,0,0,1,0,0,0</Matrix><Geometries/><FixtureID>2</FixtureID><FixtureIDNumeric>2</FixtureIDNumeric><UserData><Data provider=\"Foreign\" ver=\"1.0\"><TrussInfo><Width>777</Width></TrussInfo></Data></UserData></Truss>"
+      "</ChildList></Layer></Layers></Scene></GeneralSceneDescription>";
+  wxFileOutputStream output(path.generic_string());
+  assert(output.IsOk());
+  wxZipOutputStream zip(output);
+  assert(zip.PutNextEntry("GeneralSceneDescription.xml"));
+  zip.Write(xml.data(), xml.size());
+  zip.Close();
+}
+
+// Returns whether the result contains the exact structured diagnostic code.
+static bool HasDiagnostic(const MvrImportResult &result,
+                          const std::string &code) {
+  return std::any_of(result.diagnostics.begin(), result.diagnostics.end(),
+                     [&](const MvrImportDiagnostic &diagnostic) {
+                       return diagnostic.code == code;
+                     });
+}
+
+// Verifies canonical, legacy, tolerant, and Perastage-extension recovery policy.
+static void TestMetadataRecoveryMatrix(const fs::path &tempDir) {
+  const fs::path archive = tempDir / "metadata-recovery.mvr";
+  WriteMetadataArchive(archive);
+  MvrImporter importer;
+  MvrImportResult result;
+  assert(importer.ImportFromFile(archive.string(), result,
+                                 MvrImportMode::ParseOnly, false, false));
+  const Support &target =
+      result.scene.supports.at("30000000-0000-4000-8000-000000000001");
+  assert(target.capacityKg == 100.0f);
+  assert(target.weightKg == 0.0f);
+  assert(target.motorFixtureUuid ==
+         "20000000-0000-4000-8000-000000000001");
+  assert(result.scene.supports
+             .at("30000000-0000-4000-8000-000000000002")
+             .capacityKg == 42.0f);
+  const Truss &truss =
+      result.scene.trusses.at("40000000-0000-4000-8000-000000000001");
+  assert(truss.lengthMm == 0.0f);
+  assert(truss.widthMm == 250.0f);
+  assert(truss.perastageAuxGdtfArchivePath.empty());
+  for (const char *code : {"duplicate_hoist_info", "invalid_hoist_info_uuid",
+                           "unknown_hoist_info_uuid", "duplicate_truss_info",
+                           "invalid_truss_info_uuid", "unknown_truss_info_uuid",
+                           "unsupported_perastage_metadata_version",
+                           "legacy_perastage_metadata_missing_version",
+                           "invalid_hoist_numeric_field",
+                           "invalid_truss_numeric_field",
+                           "invalid_use_motor_defaults", "invalid_motor_fixture_uuid",
+                           "unknown_motor_fixture_uuid",
+                           "unsafe_truss_aux_gdtf_path"}) {
+    assert(HasDiagnostic(result, code));
+  }
+}
+
+// Runs the GUI-independent metadata recovery test matrix.
+int main() {
+  wxInitializer initializer;
+  assert(initializer.IsOk());
+  const fs::path tempDir =
+      fs::temp_directory_path() / "mvr_perastage_metadata_recovery_test";
+  std::error_code ec;
+  fs::remove_all(tempDir, ec);
+  fs::create_directories(tempDir, ec);
+  TestMetadataRecoveryMatrix(tempDir);
+  fs::remove_all(tempDir, ec);
+  return 0;
+}

--- a/tests/mvr_perastage_metadata_recovery_test.cpp
+++ b/tests/mvr_perastage_metadata_recovery_test.cpp
@@ -6,6 +6,9 @@
 #include <filesystem>
 #include <memory>
 #include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
 
 #include <wx/init.h>
 #include <wx/wfstream.h>
@@ -14,6 +17,32 @@
 #include "mvrimporter.h"
 
 namespace fs = std::filesystem;
+
+// Writes ordered ZIP entries without deduplicating their archive names.
+static void WriteArchive(
+    const fs::path &path,
+    const std::vector<std::pair<std::string, std::string>> &entries) {
+  wxFileOutputStream output(path.generic_string());
+  assert(output.IsOk());
+  wxZipOutputStream zip(output);
+  for (const auto &[name, bytes] : entries) {
+    assert(zip.PutNextEntry(name));
+    zip.Write(bytes.data(), bytes.size());
+  }
+  zip.Close();
+}
+
+// Builds a minimal MVR scene whose TrussInfo references the requested resource.
+static std::string BuildAuxiliarySceneXml(const std::string &auxiliaryName) {
+  return "<GeneralSceneDescription verMajor=\"1\" verMinor=\"6\" provider=\"Test\" providerVersion=\"1\">"
+         "<UserData><Data provider=\"Perastage\" ver=\"1.0\"><TrussInfoMap>"
+         "<TrussInfo uuid=\"40000000-0000-4000-8000-000000000001\"><Manufacturer>Unrelated</Manufacturer><AuxGdtf>" +
+         auxiliaryName +
+         "</AuxGdtf></TrussInfo></TrussInfoMap></Data></UserData>"
+         "<Scene><Layers><Layer uuid=\"10000000-0000-4000-8000-000000000001\" name=\"Default\"><ChildList>"
+         "<Truss uuid=\"40000000-0000-4000-8000-000000000001\" name=\"Truss\"><Matrix>1,0,0,0,1,0,0,0,1,0,0,0</Matrix><Geometries/><FixtureID>1</FixtureID><FixtureIDNumeric>1</FixtureIDNumeric></Truss>"
+         "</ChildList></Layer></Layers></Scene></GeneralSceneDescription>";
+}
 
 // Writes one deterministic minimal MVR archive for metadata recovery testing.
 static void WriteMetadataArchive(const fs::path &path) {
@@ -41,12 +70,7 @@ static void WriteMetadataArchive(const fs::path &path) {
       "<Support uuid=\"30000000-0000-4000-8000-000000000003\" name=\"Unknown Motor\"><Matrix>1,0,0,0,1,0,0,0,1,0,0,0</Matrix><Geometries/><ChainLength>1</ChainLength></Support>"
       "<Truss uuid=\"40000000-0000-4000-8000-000000000001\" name=\"Truss\"><Matrix>1,0,0,0,1,0,0,0,1,0,0,0</Matrix><Geometries/><FixtureID>2</FixtureID><FixtureIDNumeric>2</FixtureIDNumeric><UserData><Data provider=\"Foreign\" ver=\"1.0\"><TrussInfo><Width>777</Width></TrussInfo></Data></UserData></Truss>"
       "</ChildList></Layer></Layers></Scene></GeneralSceneDescription>";
-  wxFileOutputStream output(path.generic_string());
-  assert(output.IsOk());
-  wxZipOutputStream zip(output);
-  assert(zip.PutNextEntry("GeneralSceneDescription.xml"));
-  zip.Write(xml.data(), xml.size());
-  zip.Close();
+  WriteArchive(path, {{"GeneralSceneDescription.xml", xml}});
 }
 
 // Returns whether the result contains the exact structured diagnostic code.
@@ -56,6 +80,16 @@ static bool HasDiagnostic(const MvrImportResult &result,
                      [&](const MvrImportDiagnostic &diagnostic) {
                        return diagnostic.code == code;
                      });
+}
+
+// Counts exact structured diagnostic codes in deterministic result order.
+static size_t CountDiagnostic(const MvrImportResult &result,
+                              const std::string &code) {
+  return static_cast<size_t>(std::count_if(
+      result.diagnostics.begin(), result.diagnostics.end(),
+      [&](const MvrImportDiagnostic &diagnostic) {
+        return diagnostic.code == code;
+      }));
 }
 
 // Verifies canonical, legacy, tolerant, and Perastage-extension recovery policy.
@@ -94,6 +128,107 @@ static void TestMetadataRecoveryMatrix(const fs::path &tempDir) {
   }
 }
 
+// Verifies portable, missing, empty, and unsafe AuxGdtf value policy.
+static void TestAuxiliaryValuePolicy(const fs::path &tempDir) {
+  struct AuxCase {
+    std::string value;
+    const char *diagnosticCode;
+    bool addResource;
+    bool retained;
+  };
+  const std::vector<AuxCase> cases = {
+      {"valid.gdtf", "", true, true},
+      {"missing.gdtf", "missing_truss_aux_gdtf", false, false},
+      {"", "", false, false},
+      {"../escape.gdtf", "unsafe_truss_aux_gdtf_path", false, false},
+      {"subdir/file.gdtf", "unsafe_truss_aux_gdtf_path", false, false},
+      {"/absolute/file.gdtf", "unsafe_truss_aux_gdtf_path", false, false},
+      {"C:\\absolute\\file.gdtf", "unsafe_truss_aux_gdtf_path", false,
+       false},
+      {"\\\\server\\share\\file.gdtf", "unsafe_truss_aux_gdtf_path",
+       false, false},
+      {"folder\\file.gdtf", "unsafe_truss_aux_gdtf_path", false, false},
+      {".", "unsafe_truss_aux_gdtf_path", false, false},
+      {"..", "unsafe_truss_aux_gdtf_path", false, false},
+      {std::string("control") + static_cast<char>(127) + ".gdtf",
+       "unsafe_truss_aux_gdtf_path", false, false}};
+  for (size_t index = 0; index < cases.size(); ++index) {
+    const AuxCase &testCase = cases[index];
+    const fs::path archive =
+        tempDir / ("aux-value-" + std::to_string(index) + ".mvr");
+    std::vector<std::pair<std::string, std::string>> entries = {
+        {"GeneralSceneDescription.xml",
+         BuildAuxiliarySceneXml(testCase.value)}};
+    if (testCase.addResource)
+      entries.emplace_back(testCase.value, "intended-resource");
+    WriteArchive(archive, entries);
+    MvrImporter importer;
+    MvrImportResult result;
+    assert(importer.ImportFromFile(archive.string(), result,
+                                   MvrImportMode::ParseOnly, false, false));
+    const Truss &truss =
+        result.scene.trusses.at("40000000-0000-4000-8000-000000000001");
+    assert((!truss.perastageAuxGdtfArchivePath.empty()) == testCase.retained);
+    assert(truss.manufacturer == "Unrelated");
+    if (*testCase.diagnosticCode)
+      assert(CountDiagnostic(result, testCase.diagnosticCode) == 1);
+  }
+}
+
+// Verifies exact and case-only resource collisions never select either payload.
+static void TestAmbiguousAuxiliaryResources(const fs::path &tempDir) {
+  struct CollisionCase {
+    const char *archiveName;
+    const char *secondName;
+    const char *diagnosticCode;
+  };
+  for (const CollisionCase &testCase : {
+           CollisionCase{"duplicate-resource.mvr", "aux.gdtf",
+                         "duplicate_mvr_archive_entry"},
+           CollisionCase{"case-resource.mvr", "AUX.GDTF",
+                         "case_colliding_mvr_archive_entry"}}) {
+    const fs::path archive = tempDir / testCase.archiveName;
+    WriteArchive(archive,
+                 {{"GeneralSceneDescription.xml",
+                   BuildAuxiliarySceneXml("aux.gdtf")},
+                  {"aux.gdtf", "first"}, {testCase.secondName, "second"}});
+    for (int repetition = 0; repetition < 2; ++repetition) {
+      MvrImporter importer;
+      MvrImportResult result;
+      assert(importer.ImportFromFile(archive.string(), result,
+                                     MvrImportMode::ParseOnly, false, false));
+      assert(CountDiagnostic(result, testCase.diagnosticCode) == 1);
+      const Truss &truss =
+          result.scene.trusses.at("40000000-0000-4000-8000-000000000001");
+      assert(truss.perastageAuxGdtfArchivePath.empty());
+      assert(truss.manufacturer == "Unrelated");
+      assert(!fs::exists(fs::path(result.scene.basePath) / "aux.gdtf"));
+      assert(!fs::exists(fs::path(result.scene.basePath) / "AUX.GDTF"));
+    }
+  }
+}
+
+// Verifies ambiguous scene descriptions fail while retaining collision diagnostics.
+static void TestAmbiguousSceneDescriptions(const fs::path &tempDir) {
+  const std::string xml = BuildAuxiliarySceneXml("");
+  for (const auto &[archiveName, secondName, code] :
+       std::vector<std::tuple<std::string, std::string, std::string>>{
+           {"duplicate-scene.mvr", "GeneralSceneDescription.xml",
+            "duplicate_mvr_archive_entry"},
+           {"case-scene.mvr", "GENERALSCENEDESCRIPTION.XML",
+            "case_colliding_mvr_archive_entry"}}) {
+    const fs::path archive = tempDir / archiveName;
+    WriteArchive(archive, {{"GeneralSceneDescription.xml", xml},
+                           {secondName, xml + " "}});
+    MvrImporter importer;
+    MvrImportResult result;
+    assert(!importer.ImportFromFile(archive.string(), result,
+                                    MvrImportMode::ParseOnly, false, false));
+    assert(CountDiagnostic(result, code) == 1);
+    assert(result.scene.trusses.empty());
+  }
+}
+
 // Runs the GUI-independent metadata recovery test matrix.
 int main() {
   wxInitializer initializer;
@@ -104,6 +239,9 @@ int main() {
   fs::remove_all(tempDir, ec);
   fs::create_directories(tempDir, ec);
   TestMetadataRecoveryMatrix(tempDir);
+  TestAuxiliaryValuePolicy(tempDir);
+  TestAmbiguousAuxiliaryResources(tempDir);
+  TestAmbiguousSceneDescriptions(tempDir);
   fs::remove_all(tempDir, ec);
   return 0;
 }

--- a/tests/mvr_support_userdata_roundtrip_test.cpp
+++ b/tests/mvr_support_userdata_roundtrip_test.cpp
@@ -22,6 +22,7 @@
 #include "projectutils.h"
 #include "sceneobject.h"
 #include "support.h"
+#include "support/gdtf_test_fixture_builder.h"
 
 // Reads the current ZIP entry into a string.
 static std::string ReadCurrentZipEntry(wxZipInputStream &zip) {
@@ -59,14 +60,16 @@ int main() {
   MvrScene &scene = cfg.GetScene();
 
   Layer layer;
-  layer.uuid = "layer1";
+  layer.uuid = "10000000-0000-4000-8000-000000000001";
   layer.name = "Layer1";
   scene.layers[layer.uuid] = layer;
 
   std::filesystem::path tempDir =
       std::filesystem::temp_directory_path() / "mvr_support_userdata_roundtrip";
   std::filesystem::create_directories(tempDir);
-  std::ofstream(tempDir / "fixture.gdtf") << "fixture";
+  tests::gdtf::BuildMinimalValidFixture()
+      .WithDmxMode("ChainMode", "Root")
+      .WriteArchive(tempDir / "fixture.gdtf");
   std::ofstream(tempDir / "support.3ds") << "support-model";
   scene.basePath = tempDir.string();
 
@@ -78,7 +81,7 @@ int main() {
   };
 
   Fixture motorFixture;
-  motorFixture.uuid = "fx-motor";
+  motorFixture.uuid = "20000000-0000-4000-8000-000000000001";
   motorFixture.instanceName = "Motor Fixture";
   motorFixture.layer = layer.name;
   motorFixture.typeName = "MotorType";
@@ -89,7 +92,7 @@ int main() {
   scene.fixtures[motorFixture.uuid] = motorFixture;
 
   Support linked;
-  linked.uuid = "sup-linked";
+  linked.uuid = "30000000-0000-4000-8000-000000000001";
   linked.name = "Linked";
   linked.layer = layer.name;
   linked.chainLength = 1.0f;
@@ -105,7 +108,7 @@ int main() {
   scene.supports[linked.uuid] = linked;
 
   Support dummy;
-  dummy.uuid = "sup-dummy";
+  dummy.uuid = "30000000-0000-4000-8000-000000000002";
   dummy.name = "Dummy";
   dummy.layer = layer.name;
   dummy.chainLength = 1.0f;
@@ -115,7 +118,7 @@ int main() {
   scene.supports[dummy.uuid] = dummy;
 
   Support inheritedDefaults;
-  inheritedDefaults.uuid = "sup-inherited-defaults";
+  inheritedDefaults.uuid = "30000000-0000-4000-8000-000000000003";
   inheritedDefaults.name = "Inherited Defaults";
   inheritedDefaults.layer = layer.name;
   inheritedDefaults.chainLength = 1.0f;
@@ -137,7 +140,7 @@ int main() {
   scene.supports[inheritedDefaults.uuid] = inheritedDefaults;
 
   Support manual;
-  manual.uuid = "sup-manual";
+  manual.uuid = "30000000-0000-4000-8000-000000000004";
   manual.name = "Manual";
   manual.layer = layer.name;
   manual.chainLength = 1.0f;
@@ -147,6 +150,7 @@ int main() {
   manual.weightKg = 61.0f;
   manual.loadKg = 410.0f;
   manual.loadSource = "Manual";
+  manual.function = "Other";
   manual.hoistFunction = "Audio";
   manual.motorName = "ChainMaster D8+";
   manual.motorNameSource = "Manual";
@@ -160,14 +164,14 @@ int main() {
   scene.supports[manual.uuid] = manual;
 
   Support logicalOnly;
-  logicalOnly.uuid = "sup-logical-only";
+  logicalOnly.uuid = "30000000-0000-4000-8000-000000000005";
   logicalOnly.name = "Logical Only";
   logicalOnly.layer = layer.name;
   logicalOnly.chainLength = 0.0f;
   scene.supports[logicalOnly.uuid] = logicalOnly;
 
   SceneObject emptySceneObject;
-  emptySceneObject.uuid = "obj-empty";
+  emptySceneObject.uuid = "40000000-0000-4000-8000-000000000001";
   emptySceneObject.name = "Empty SceneObject";
   scene.sceneObjects[emptySceneObject.uuid] = emptySceneObject;
 
@@ -194,17 +198,38 @@ int main() {
        info; info = info->NextSiblingElement("HoistInfo")) {
     const char *uuid = info->Attribute("uuid");
     assert(uuid != nullptr);
-    if (std::string(uuid) == "sup-linked") {
+    if (std::string(uuid) == "30000000-0000-4000-8000-000000000001") {
       foundLinkedHoistInfo = true;
       assert(info->FirstChildElement("Load") == nullptr);
       assert(info->FirstChildElement("Function") == nullptr);
+      assert(std::string(info->FirstChildElement("MotorFixtureUuid")->GetText()) ==
+             motorFixture.uuid);
+      assert(std::string(info->FirstChildElement("UseMotorDefaults")->GetText()) ==
+             "false");
     }
-    if (std::string(uuid) == "sup-manual") {
+    if (std::string(uuid) == "30000000-0000-4000-8000-000000000004") {
       foundManualHoistInfo = true;
       tinyxml2::XMLElement *load = info->FirstChildElement("Load");
       assert(load != nullptr);
       assert(load->Attribute("source") == nullptr);
       assert(info->FirstChildElement("Function") == nullptr);
+      assert(std::string(info->FirstChildElement("Capacity")->GetText()) ==
+             "1250.000000");
+      assert(std::string(info->FirstChildElement("Weight")->GetText()) ==
+             "61.000000");
+      assert(info->FirstChildElement("RiggingPoint") != nullptr);
+      assert(std::string(info->FirstChildElement("MotorName")->GetText()) ==
+             manual.motorName);
+      assert(std::string(info->FirstChildElement("MotorManufacturer")->GetText()) ==
+             manual.motorManufacturer);
+      assert(std::string(info->FirstChildElement("MotorModel")->GetText()) ==
+             manual.motorModel);
+      assert(std::string(info->FirstChildElement("ValueSource")->GetText()) ==
+             "Manual");
+      assert(std::string(info->FirstChildElement("MotorNameSource")->GetText()) ==
+             "Manual");
+      assert(std::string(info->FirstChildElement("CapacitySource")->GetText()) ==
+             "Manual");
     }
   }
   assert(foundLinkedHoistInfo);
@@ -219,7 +244,7 @@ int main() {
     tinyxml2::XMLElement *current = stack.back();
     stack.pop_back();
     if (std::string(current->Name()) == "Support" &&
-        current->Attribute("uuid") && std::string(current->Attribute("uuid")) == "sup-linked") {
+        current->Attribute("uuid") && std::string(current->Attribute("uuid")) == "30000000-0000-4000-8000-000000000001") {
       foundLinkedSupport = true;
       assert(std::string(current->Attribute("name")) == "Linked");
       assert(current->FirstChildElement("Matrix") != nullptr);
@@ -232,14 +257,14 @@ int main() {
     }
     if (std::string(current->Name()) == "Support" &&
         current->Attribute("uuid") &&
-        std::string(current->Attribute("uuid")) == "sup-manual") {
+        std::string(current->Attribute("uuid")) == "30000000-0000-4000-8000-000000000004") {
       assert(current->FirstChildElement("UserData") == nullptr);
       assert(current->FirstChildElement("SupportInfo") == nullptr);
       assert(current->FirstChildElement("HoistInfo") == nullptr);
     }
     if (std::string(current->Name()) == "Support" &&
         current->Attribute("uuid") &&
-        std::string(current->Attribute("uuid")) == "sup-logical-only") {
+        std::string(current->Attribute("uuid")) == "30000000-0000-4000-8000-000000000005") {
       foundLogicalOnlySupport = true;
       tinyxml2::XMLElement *geometries = current->FirstChildElement("Geometries");
       assert(geometries != nullptr);
@@ -248,7 +273,7 @@ int main() {
     }
     if (std::string(current->Name()) == "SceneObject" &&
         current->Attribute("uuid") &&
-        std::string(current->Attribute("uuid")) == "obj-empty") {
+        std::string(current->Attribute("uuid")) == "40000000-0000-4000-8000-000000000001") {
       foundEmptySceneObjectPlaceholder = true;
       tinyxml2::XMLElement *geometries = current->FirstChildElement("Geometries");
       assert(geometries != nullptr);
@@ -280,20 +305,20 @@ int main() {
 
   const auto &loadedFixtures = cfg.GetScene().fixtures;
   assert(loadedFixtures.size() == 1);
-  assert(loadedFixtures.at("fx-motor").category == "Spot");
+  assert(loadedFixtures.at("20000000-0000-4000-8000-000000000001").category == "Spot");
 
   const auto &loaded = cfg.GetScene().supports;
   assert(loaded.size() == 5);
 
-  const auto &loadedLinked = loaded.at("sup-linked");
-  assert(loadedLinked.motorFixtureUuid == "fx-motor");
+  const auto &loadedLinked = loaded.at("30000000-0000-4000-8000-000000000001");
+  assert(loadedLinked.motorFixtureUuid == "20000000-0000-4000-8000-000000000001");
   assert(!loadedLinked.useMotorDefaults);
 
-  const auto &loadedDummy = loaded.at("sup-dummy");
+  const auto &loadedDummy = loaded.at("30000000-0000-4000-8000-000000000002");
   assert(loadedDummy.dummyProfileId == "d8plus_1000kg");
   assert(loadedDummy.hoistFunction == "Video");
 
-  const auto &loadedManual = loaded.at("sup-manual");
+  const auto &loadedManual = loaded.at("30000000-0000-4000-8000-000000000004");
   assert(loadedManual.hoistDataSource == "Manual");
   assert(loadedManual.capacityKg == 1250.0f);
   assert(loadedManual.weightKg == 61.0f);
@@ -311,7 +336,7 @@ int main() {
   assert(loadedManual.hoistFunctionSource == "Manual");
 
 
-  const auto &loadedInheritedDefaults = loaded.at("sup-inherited-defaults");
+  const auto &loadedInheritedDefaults = loaded.at("30000000-0000-4000-8000-000000000003");
   assert(loadedInheritedDefaults.hoistDataSource == "Inherited");
   assert(loadedInheritedDefaults.useMotorDefaults);
   assert(loadedInheritedDefaults.motorManufacturer == "Perastage");

--- a/tests/mvr_truss_roundtrip_structure_test.cpp
+++ b/tests/mvr_truss_roundtrip_structure_test.cpp
@@ -234,6 +234,11 @@ int main() {
   truss.heightMm = 400.0f;
   truss.weightKg = 40.0f;
   truss.crossSection = "40x40";
+  const fs::path auxiliaryGdtf = tempDir / "tower-40-auxiliary.gdtf";
+  std::string auxiliaryGdtfError;
+  assert(BuildTrussGdtfFromInstance(truss, auxiliaryGdtf,
+                                    &auxiliaryGdtfError));
+  truss.perastageAuxGdtfArchivePath = auxiliaryGdtf.generic_string();
   scene.trusses[truss.uuid] = truss;
   scene.groupObjects[group.uuid].children.push_back({MvrNodeType::Truss, truss.uuid});
 
@@ -349,6 +354,11 @@ int main() {
   tinyxml2::XMLElement *trussInfo = trussInfoMap->FirstChildElement("TrussInfo");
   assert(trussInfo != nullptr);
   assert(std::string(trussInfo->Attribute("uuid")) == truss.uuid);
+  const std::string auxiliaryArchiveName =
+      trussInfo->FirstChildElement("AuxGdtf")->GetText();
+  assert(fs::path(auxiliaryArchiveName).filename().generic_string() ==
+         auxiliaryArchiveName);
+  assert(entries.find(auxiliaryArchiveName) != entries.end());
   assert(std::string(trussInfo->FirstChildElement("Manufacturer")->GetText()) ==
          truss.manufacturer);
   assert(std::string(trussInfo->FirstChildElement("Model")->GetText()) ==

--- a/tests/mvr_truss_roundtrip_structure_test.cpp
+++ b/tests/mvr_truss_roundtrip_structure_test.cpp
@@ -1,6 +1,7 @@
 /*
  * This file is part of Perastage.
  */
+#include <algorithm>
 #include <cassert>
 #include <cmath>
 #include <filesystem>
@@ -50,6 +51,34 @@ ReadArchiveTextEntries(const fs::path &archivePath) {
     entries[entry->GetName().ToStdString()] = ReadCurrentZipEntry(zip);
   }
   return entries;
+}
+
+// Counts ZIP entries whose archive names exactly match the requested name.
+static int CountArchiveEntries(const fs::path &archivePath,
+                               const std::string &entryName) {
+  wxFileInputStream input(archivePath.generic_string());
+  assert(input.IsOk());
+  wxZipInputStream zip(input);
+  int count = 0;
+  std::unique_ptr<wxZipEntry> entry;
+  while ((entry.reset(zip.GetNextEntry())), entry) {
+    if (entry->GetName().ToStdString() == entryName)
+      ++count;
+  }
+  return count;
+}
+
+// Returns whether a canonical child path stays within its canonical root.
+static bool IsPathWithin(const fs::path &root, const fs::path &child) {
+  const fs::path canonicalRoot = fs::weakly_canonical(root);
+  const fs::path canonicalChild = fs::weakly_canonical(child);
+  auto rootIt = canonicalRoot.begin();
+  auto childIt = canonicalChild.begin();
+  for (; rootIt != canonicalRoot.end(); ++rootIt, ++childIt) {
+    if (childIt == canonicalChild.end() || *rootIt != *childIt)
+      return false;
+  }
+  return true;
 }
 
 static std::string ReadFixtureTypeIdFromGdtf(const fs::path &gdtfPath) {
@@ -397,8 +426,10 @@ int main() {
   scene.trusses.at(truss.uuid).hasManualLoadOverride = false;
 
   cfg.Reset();
-  MvrImporter importer;
-  assert(importer.ImportFromFile(mvrPath.string(), false, false));
+  {
+    MvrImporter importer;
+    assert(importer.ImportFromFile(mvrPath.string(), false, false));
+  }
   auto &importedScene = ConfigManager::Get().GetScene();
   assert(importedScene.groupObjects.size() == 1);
   assert(importedScene.trusses.size() == 1);
@@ -406,6 +437,15 @@ int main() {
   assert(importedTruss.sourceRepresentation == Truss::GeometryRepresentation::SymbolSymdef);
   assert(importedTruss.sourceSymbolUuid == sourceSymbolUuid);
   assert(!importedTruss.perastageAuxGdtfArchivePath.empty());
+  assert(!fs::path(importedTruss.perastageAuxGdtfArchivePath).is_absolute());
+  assert(fs::path(importedTruss.perastageAuxGdtfArchivePath)
+             .filename()
+             .generic_string() == importedTruss.perastageAuxGdtfArchivePath);
+  const fs::path importedResourceRoot = importedScene.basePath;
+  const fs::path importedAuxiliaryPath =
+      importedResourceRoot / importedTruss.perastageAuxGdtfArchivePath;
+  assert(fs::exists(importedAuxiliaryPath));
+  assert(IsPathWithin(importedResourceRoot, importedAuxiliaryPath));
   assert(importedTruss.manufacturer == "Perastage");
   assert(importedTruss.model == "Tower 40");
   assert(std::abs(importedTruss.lengthMm - truss.lengthMm) < 0.001f);
@@ -413,9 +453,54 @@ int main() {
   assert(std::abs(importedTruss.heightMm - truss.heightMm) < 0.001f);
   assert(std::abs(importedTruss.weightKg - truss.weightKg) < 0.001f);
   assert(importedTruss.crossSection == truss.crossSection);
+  const std::string importedAuxiliaryArchiveName =
+      importedTruss.perastageAuxGdtfArchivePath;
+
+  const fs::path secondMvrPath = tempDir / "roundtrip-second.mvr";
+  assert(MvrExporter().ExportToFile(secondMvrPath.string()));
+  const auto secondEntries = ReadArchiveTextEntries(secondMvrPath);
+  tinyxml2::XMLDocument secondXml;
+  assert(secondXml.Parse(
+             secondEntries.at("GeneralSceneDescription.xml").c_str()) ==
+         tinyxml2::XML_SUCCESS);
+  tinyxml2::XMLElement *secondInfo =
+      secondXml.FirstChildElement("GeneralSceneDescription")
+          ->FirstChildElement("UserData")
+          ->FirstChildElement("Data")
+          ->FirstChildElement("TrussInfoMap")
+          ->FirstChildElement("TrussInfo");
+  assert(secondInfo != nullptr);
+  const std::string secondAuxiliaryName =
+      secondInfo->FirstChildElement("AuxGdtf")->GetText();
+  assert(secondAuxiliaryName == importedAuxiliaryArchiveName);
+  assert(secondEntries.find(secondAuxiliaryName) != secondEntries.end());
+  assert(CountArchiveEntries(secondMvrPath, secondAuxiliaryName) == 1);
+
+  Truss &missingAuxiliaryTruss = importedScene.trusses.begin()->second;
+  missingAuxiliaryTruss.gdtfSpec.clear();
+  missingAuxiliaryTruss.perastageAuxGdtfArchivePath = "missing-explicit.gdtf";
+  const fs::path missingAuxiliaryMvrPath =
+      tempDir / "missing-explicit-auxiliary.mvr";
+  MvrExporter missingAuxiliaryExporter;
+  assert(missingAuxiliaryExporter.ExportToFile(
+      missingAuxiliaryMvrPath.string()));
+  assert(std::any_of(missingAuxiliaryExporter.GetExportWarnings().begin(),
+                     missingAuxiliaryExporter.GetExportWarnings().end(),
+                     [](const std::string &warning) {
+                       return warning.find("no fallback was substituted") !=
+                              std::string::npos;
+                     }));
+  const auto missingAuxiliaryEntries =
+      ReadArchiveTextEntries(missingAuxiliaryMvrPath);
+  assert(missingAuxiliaryEntries.find("missing-explicit.gdtf") ==
+         missingAuxiliaryEntries.end());
+  assert(missingAuxiliaryEntries.at("GeneralSceneDescription.xml")
+             .find("<AuxGdtf>") == std::string::npos);
 
   cfg.Reset();
-  assert(importer.ImportFromFile(manualLoadMvrPath.string(), false, false));
+  MvrImporter manualLoadImporter;
+  assert(manualLoadImporter.ImportFromFile(manualLoadMvrPath.string(), false,
+                                           false));
   const Truss &manualLoadImportedTruss =
       ConfigManager::Get().GetScene().trusses.begin()->second;
   assert(manualLoadImportedTruss.hasManualLoadOverride);
@@ -445,7 +530,8 @@ int main() {
   }
 
   cfg.Reset();
-  assert(importer.ImportFromFile(legacyMvrPath.string(), false, false));
+  MvrImporter legacyImporter;
+  assert(legacyImporter.ImportFromFile(legacyMvrPath.string(), false, false));
   MvrScene &legacyImportedScene = ConfigManager::Get().GetScene();
   assert(legacyImportedScene.trusses.size() == 1);
   const Truss &legacyImportedTruss = legacyImportedScene.trusses.begin()->second;

--- a/tests/project_support_userdata_roundtrip_test.cpp
+++ b/tests/project_support_userdata_roundtrip_test.cpp
@@ -186,9 +186,28 @@ int main() {
   const auto &loaded = loadedSupports.at(support.uuid);
   assert(loaded.hoistDataSource == "Manual");
   assert(loaded.capacityKg == 1000.0f);
-  assert(loaded.capacityKg > 0.0f);
+  assert(loaded.weightKg == 40.0f);
   assert(loaded.loadKg == 275.0f);
   assert(loaded.hoistFunction == "Audio");
+  assert(loaded.motorName == "ChainMaster D8+");
+  assert(loaded.motorManufacturer == "ChainMaster");
+  assert(loaded.motorModel == "D8+");
+  assert(loaded.capacitySource == "Manual");
+  assert(loaded.weightSource == "Manual");
+  assert(loaded.hoistFunctionSource == "Manual");
+  const Support loadedCopy = loaded;
+
+  const fs::path secondProjectPath =
+      tempDir / "support_userdata_roundtrip_second.pstg";
+  assert(cfg.SaveProject(secondProjectPath.string()));
+  cfg.Reset();
+  assert(cfg.LoadProject(secondProjectPath.string()));
+  const auto &secondLoaded = cfg.GetScene().supports.at(support.uuid);
+  assert(secondLoaded.capacityKg == loadedCopy.capacityKg);
+  assert(secondLoaded.weightKg == loadedCopy.weightKg);
+  assert(secondLoaded.loadKg == loadedCopy.loadKg);
+  assert(secondLoaded.hoistFunction == loadedCopy.hoistFunction);
+  assert(secondLoaded.motorName == loadedCopy.motorName);
 
   fs::remove_all(tempDir, ec);
   return 0;

--- a/tests/project_support_userdata_roundtrip_test.cpp
+++ b/tests/project_support_userdata_roundtrip_test.cpp
@@ -81,9 +81,11 @@ int main() {
   support.capacityKg = 1000.0f;
   support.weightKg = 40.0f;
   support.loadKg = 275.0f;
+  support.function = "Other";
   support.hoistFunction = "Audio";
   support.capacitySource = "Manual";
   support.weightSource = "Manual";
+  support.loadSource = "Manual";
   support.hoistFunctionSource = "Manual";
   support.motorName = "ChainMaster D8+";
   support.motorNameSource = "Manual";
@@ -147,12 +149,21 @@ int main() {
   }
 
   assert(supportNode != nullptr);
-  tinyxml2::XMLElement *userData = supportNode->FirstChildElement("UserData");
+  assert(supportNode->FirstChildElement("UserData") == nullptr);
+  tinyxml2::XMLElement *userData = root->FirstChildElement("UserData");
   assert(userData != nullptr);
   tinyxml2::XMLElement *data = userData->FirstChildElement("Data");
   assert(data != nullptr);
-  tinyxml2::XMLElement *hoistInfo = data->FirstChildElement("HoistInfo");
+  assert(std::string(data->Attribute("provider")) == "Perastage");
+  assert(std::string(data->Attribute("ver")) == "1.0");
+  tinyxml2::XMLElement *hoistInfoMap =
+      data->FirstChildElement("HoistInfoMap");
+  assert(hoistInfoMap != nullptr);
+  tinyxml2::XMLElement *hoistInfo =
+      hoistInfoMap->FirstChildElement("HoistInfo");
   assert(hoistInfo != nullptr);
+  assert(std::string(hoistInfo->Attribute("uuid")) == support.uuid);
+  assert(hoistInfo->NextSiblingElement("HoistInfo") == nullptr);
 
   tinyxml2::XMLElement *capacity = hoistInfo->FirstChildElement("Capacity");
   tinyxml2::XMLElement *load = hoistInfo->FirstChildElement("Load");


### PR DESCRIPTION
### Motivation
- Align Perastage MVR I/O with the MVR 1.6 extension boundary by using root-level `GeneralSceneDescription/UserData/Data provider="Perastage" ver="1.0"` for Support and Truss metadata, avoid emitting direct object `UserData`, and make auxiliary Truss GDTF references portable and owned.
- Repair the two focused roundtrip failures by switching tests and exporter/importer behavior to the canonical root maps rather than obsolete direct-object shapes, while documenting legacy-tolerant input and remaining blockers.

### Description
- Exporter: when selecting a truss GDTF source prefer `Truss::perastageAuxGdtfArchivePath` if present and stop emitting the deprecated `TrussSidecarManifest`; root `TrussInfoMap` entries continue to reference portable archive names. (`mvr/mvrexporter.cpp`)
- Tests: update `ProjectSupportUserDataRoundtrip` to assert the strict root `HoistInfoMap` contract, model manual `Load`/`RiggingPoint` state, and ensure Support has no direct `UserData`; update `MvrTrussRoundtripStructure` to produce a real auxiliary GDTF artifact and assert `AuxGdtf` is a portable archive filename whose entry exists in the MVR. (`tests/*.cpp`)
- Importer/export path handling: use existing `RemapArchivePathIfNeeded` / archive normalization flow so imported auxiliary references resolve to scene-owned resources (no transient extraction paths persisted). (no new public API)
- Documentation: replace and extend the hoist/truss technical notes to record canonical root shapes, legacy input tolerance, and auxiliary GDTF resource contract; update `docs/developer/ci_test_audit.md` with the D2 baseline and focused classification; add a short release-note entry. (`docs/developer/*`, `docs/release-notes-draft.md`)
- Cleanup: remove generation of the obsolete Truss sidecar manifest in the exporter and associated temporary bookkeeping to keep export shape strict and canonical. (`mvr/mvrexporter.cpp`)
- Commit: changes recorded under branch `codex/repair-perastage-mvr-metadata-roundtrips` and committed as `40cc0b3`.

### Testing
- Built locally with Debug/tests enabled via `cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON` and installed required dev packages; build completed.
- Repeated focused roundtrips with `ctest --test-dir build -R '^(ProjectSupportUserDataRoundtrip|MvrTrussRoundtripStructure)$' --repeat until-fail:20 --output-on-failure` and observed both tests pass consistently across repeats.
- Ran `tests/check_perastage_tree_modules.sh`, `tests/check_no_configmanager_get_in_gui.sh`, and `git diff --check`; these checks passed.
- Noted and documented remaining blocker: `MvrSupportUserDataRoundtrip` is still blocked before metadata assertions by an invalid ad-hoc `fixture.gdtf` used by that test (canonicalizer rejects a non-ZIP); this is classified as an invalid-fixture blocker and is documented in the audit notes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a65f138f3c48324aec46fe2af35deca)