### PR TITLE
Harden GDTF Unicode archive paths and malformed ZIP identities

### DIFF
--- a/core/gdtf_archive_reader.cpp
+++ b/core/gdtf_archive_reader.cpp
@@ -1,5 +1,7 @@
 #include "gdtf_archive_reader.h"
 
+#include "wx_path_utils.h"
+
 #include <algorithm>
 #include <cctype>
 #include <cstdint>
@@ -41,12 +43,6 @@ struct DecodedZipEntryName {
   bool usedUtf8Fallback = false;
   bool failed = false;
 };
-
-// Converts a filesystem path to UTF-8 text for wxWidgets file streams.
-std::string PathToUtf8(const std::filesystem::path &path) {
-  const std::u8string utf8 = path.u8string();
-  return std::string(utf8.begin(), utf8.end());
-}
 
 // Reports whether raw bytes contain only portable ASCII characters.
 bool IsAscii(const std::string &value) {
@@ -354,6 +350,21 @@ void AddDiagnostic(ArchiveReadResult &result, ArchiveDiagnosticCode code,
       {code, std::move(message), std::move(entryPath)});
 }
 
+// Rejects malformed raw identities before wxWidgets can skip or reorder them.
+bool ValidateRawZipEntryNames(const std::vector<RawZipEntryName> &rawNames,
+                              ArchiveReadResult &result) {
+  bool valid = true;
+  for (const RawZipEntryName &rawName : rawNames) {
+    if (!DecodeZipEntryName(rawName).failed)
+      continue;
+    AddDiagnostic(
+        result, ArchiveDiagnosticCode::FilenameDecodeFailed,
+        "A GDTF archive entry filename could not be decoded safely.");
+    valid = false;
+  }
+  return valid;
+}
+
 // Reports whether an archive diagnostic prevents a usable read result.
 bool IsFatalDiagnostic(ArchiveDiagnosticCode code) {
   switch (code) {
@@ -536,7 +547,8 @@ ArchiveReadResult ReadGdtfArchive(const std::filesystem::path &sourcePath) {
       return result;
     }
 
-    wxFileInputStream input(wxString::FromUTF8(PathToUtf8(sourcePath)));
+    wxFileInputStream input(
+        WxPathUtils::WxStringFromFilesystemPath(sourcePath));
     if (!input.IsOk()) {
       AddDiagnostic(result, ArchiveDiagnosticCode::OpenFailed,
                     "Could not open GDTF archive.");
@@ -545,6 +557,8 @@ ArchiveReadResult ReadGdtfArchive(const std::filesystem::path &sourcePath) {
 
     const std::vector<RawZipEntryName> rawNames =
         ReadRawCentralDirectoryNames(sourcePath);
+    if (!ValidateRawZipEntryNames(rawNames, result))
+      return result;
     wxZipInputStream zipInput(input);
     std::unique_ptr<wxZipEntry> entry;
     size_t entryIndex = 0;
@@ -679,7 +693,17 @@ GdtfResourceReadResult ReadGdtfArchiveResource(
     return result;
   }
   const std::vector<std::string> preferredPaths = BuildResourcePreferredPaths(normalizedRequest);
-  wxFileInputStream input(wxString::FromUTF8(PathToUtf8(sourcePath)));
+  const std::vector<RawZipEntryName> rawNames =
+      ReadRawCentralDirectoryNames(sourcePath);
+  for (const RawZipEntryName &rawName : rawNames) {
+    if (!DecodeZipEntryName(rawName).failed)
+      continue;
+    result.diagnostics.push_back(
+        {ArchiveDiagnosticCode::FilenameDecodeFailed,
+         "A GDTF archive entry filename could not be decoded safely.", {}});
+    return result;
+  }
+  wxFileInputStream input(WxPathUtils::WxStringFromFilesystemPath(sourcePath));
   if (!input.IsOk()) {
     if (TryReadExplodedGdtfResource(sourcePath, normalizedRequest, preferredPaths, extraResourceRoots, maxBytes, result))
       return result;
@@ -698,9 +722,17 @@ GdtfResourceReadResult ReadGdtfArchiveResource(
   std::vector<Candidate> candidates;
   wxZipInputStream inventory(input);
   std::unique_ptr<wxZipEntry> entry;
+  size_t entryIndex = 0;
   while ((entry.reset(inventory.GetNextEntry())), entry) {
-    const wxScopedCharBuffer utf8 = entry->GetName().ToUTF8();
-    const std::string path = NormalizeArchivePath(utf8 ? std::string(utf8.data()) : std::string());
+    DecodedZipEntryName decodedName;
+    if (entryIndex < rawNames.size())
+      decodedName = DecodeZipEntryName(rawNames[entryIndex]);
+    else {
+      const wxScopedCharBuffer utf8 = entry->GetName().ToUTF8();
+      decodedName.path = utf8 ? std::string(utf8.data()) : std::string();
+    }
+    ++entryIndex;
+    const std::string path = NormalizeArchivePath(decodedName.path);
     if (entry->IsDir() || IsUnsafeArchivePath(path))
       continue;
     const std::string lowerPath = LowerAscii(path);
@@ -746,11 +778,20 @@ GdtfResourceReadResult ReadGdtfArchiveResource(
     }
   }
 
-  wxFileInputStream dataInput(wxString::FromUTF8(PathToUtf8(sourcePath)));
+  wxFileInputStream dataInput(
+      WxPathUtils::WxStringFromFilesystemPath(sourcePath));
   wxZipInputStream zipInput(dataInput);
+  entryIndex = 0;
   while ((entry.reset(zipInput.GetNextEntry())), entry) {
-    const wxScopedCharBuffer utf8 = entry->GetName().ToUTF8();
-    const std::string path = NormalizeArchivePath(utf8 ? std::string(utf8.data()) : std::string());
+    DecodedZipEntryName decodedName;
+    if (entryIndex < rawNames.size())
+      decodedName = DecodeZipEntryName(rawNames[entryIndex]);
+    else {
+      const wxScopedCharBuffer utf8 = entry->GetName().ToUTF8();
+      decodedName.path = utf8 ? std::string(utf8.data()) : std::string();
+    }
+    ++entryIndex;
+    const std::string path = NormalizeArchivePath(decodedName.path);
     if (path != result.entryPath)
       continue;
     const wxFileOffset knownSize = entry->GetSize();
@@ -796,7 +837,8 @@ ExtractGdtfArchive(const std::filesystem::path &sourcePath,
       return result;
     }
 
-    wxFileInputStream input(wxString::FromUTF8(PathToUtf8(sourcePath)));
+    wxFileInputStream input(
+        WxPathUtils::WxStringFromFilesystemPath(sourcePath));
     if (!input.IsOk()) {
       AddDiagnostic(result, ArchiveDiagnosticCode::OpenFailed,
                     "Could not open GDTF archive.");
@@ -805,6 +847,8 @@ ExtractGdtfArchive(const std::filesystem::path &sourcePath,
 
     const std::vector<RawZipEntryName> rawNames =
         ReadRawCentralDirectoryNames(sourcePath);
+    if (!ValidateRawZipEntryNames(rawNames, result))
+      return result;
     wxZipInputStream zipInput(input);
     std::unique_ptr<wxZipEntry> entry;
     size_t entryIndex = 0;

--- a/core/gdtf_metadata_summary.cpp
+++ b/core/gdtf_metadata_summary.cpp
@@ -19,6 +19,7 @@
 
 #include "gdtf_archive_reader.h"
 #include "gdtf_description_reader.h"
+#include "filesystem_path_utils.h"
 
 #include <wx/datetime.h>
 
@@ -64,6 +65,12 @@ void ApplyLatestRevision(const gdtf::GdtfDescriptionSnapshot &snapshot,
 
 // Loads a compact metadata summary from a GDTF archive.
 bool LoadGdtfMetadataSummary(const std::string &gdtfPath,
+                             GdtfMetadataSummary &outSummary) {
+  return LoadGdtfMetadataSummary(PathUtils::PathFromUtf8(gdtfPath), outSummary);
+}
+
+// Loads a compact metadata summary from a native filesystem path.
+bool LoadGdtfMetadataSummary(const std::filesystem::path &gdtfPath,
                              GdtfMetadataSummary &outSummary) {
   outSummary = {};
   outSummary.userId = "0";

--- a/core/gdtf_metadata_summary.h
+++ b/core/gdtf_metadata_summary.h
@@ -17,6 +17,7 @@
  */
 #pragma once
 
+#include <filesystem>
 #include <string>
 
 struct GdtfMetadataSummary {
@@ -31,4 +32,6 @@ struct GdtfMetadataSummary {
 };
 
 bool LoadGdtfMetadataSummary(const std::string &gdtfPath,
+                             GdtfMetadataSummary &outSummary);
+bool LoadGdtfMetadataSummary(const std::filesystem::path &gdtfPath,
                              GdtfMetadataSummary &outSummary);

--- a/docs/developer/ci_test_audit.md
+++ b/docs/developer/ci_test_audit.md
@@ -1080,3 +1080,77 @@ Linux Debug configure and focused builds passed with `cmake --preset wsl-x64-deb
 - `git diff --check`: passed.
 
 No Linux full registered-suite run, Windows run, or macOS reduced release-gate run was available in this Linux container. Consequently there is no new CI run ID or authoritative full-suite failure-set delta, and D4A is not declared. The final branch commit SHA and CI run ID must be added to the PR evidence after push and CI; the prior authoritative baseline remains run `30209219695` at tested head `d0b28a3924281164755279187bac565e638ab002`.
+
+### D4A merge evidence and Phase 4E baseline
+
+PR #2224 merged reviewed branch `codex/fix-gdtf-reference-roundtrips` as merge
+commit `240edbef812837398d843869b05604e565d9feba`. Its base was
+`0fb8e12be42fe4c4bbf9162fd72016aa419f3747`, reviewed head was
+`1ecafba0ceb0a97db254b30b0f303c7678a440ac`, and authoritative Debug Tests run
+`30239020200` reported Linux 164 total, 145 passed, 18 failed, and 1 skipped;
+Windows 166 total, 144 passed, and 22 failed; and the reduced macOS release gate
+6 passed of 6. Configure, build, toolchain, vcpkg, and sccache stages passed on
+Linux and Windows. The reduced macOS profile is not full macOS parity.
+
+Relative to D3 run `30209219695`, Linux and Windows each removed exactly
+`GdtfFixtureCategoryFallback` and `MvrFixtureCategoryRoundtrip`, with no added
+failing test name. Both Phase 4D primary tests and all retained D1-D3 focused
+controls passed on Linux and Windows. D4A was reached and PR #2224 was safe to
+merge.
+
+The Phase 4E branch `codex/repair-gdtf-read-services-unicode-paths` starts from
+post-merge main-equivalent SHA
+`d3861f141f92d7a16868d251c706c54f25ea0b6f`, version `1.5.13`. No remote is
+configured in this execution checkout, so `git fetch --all --prune` had no
+remote updates to retrieve. Local ancestry confirms that this base contains the
+reviewed Phase 4D head and merge commit above.
+
+Before production changes, Linux Debug reproduced `GdtfReadServices` at the
+malformed-byte subcase: invalid filename bytes with ZIP UTF-8 bit 11 set still
+left `read.Success()` true at line 492. `GdtfFixtureInsertionPreparation` passed
+on Linux. Authoritative Windows run `30239020200` independently records the
+platform-specific outer-path failures: `GdtfReadServices` could not access
+`metadata_ñ_测试.gdtf`, and `GdtfFixtureInsertionPreparation` failed to prepare
+`Perastage_ñ_fixture.gdtf`. The required contract is documented in
+`technical-notes/gdtf_unicode_zip_filename_compatibility.md` before application
+behavior changes.
+
+### Phase 4E local repair evidence
+
+The Linux malformed-byte failure was primarily a test-fixture construction
+defect: the arbitrary byte search compared signed `char` UTF-8 bytes with
+`unsigned char` archive bytes and therefore never changed the intended Unicode
+name. The fixture now parses ZIP local and central headers, matches the exact
+raw identity byte-for-byte, changes only its first name byte and bit 11 fields,
+and proves exactly one local and one central record were patched. Cases place
+the invalid entry before and after `description.xml`, among multiple entries,
+on `description.xml` itself, and beside a valid Unicode resource.
+
+Production now validates every raw central-directory identity before asking
+wxWidgets to stream payloads. An explicitly UTF-8 but undecodable identity
+therefore fails with `FilenameDecodeFailed` before a skipped entry can shift raw
+metadata onto another payload. Archive, resource, and extraction streams use
+the shared native `WxPathUtils` conversion. Metadata summary loading also has a
+native filesystem-path overload, and the two test ZIP writers no longer route
+native paths through narrow `generic_string()` text. These path conversions
+classify the two Windows primaries as platform-specific wx/filesystem boundary
+defects.
+
+Local Linux Debug results:
+
+- The two primary tests passed 20 consecutive repetitions each.
+- Eight registered scoped controls ran; seven passed. The requested
+  `GdtfModeChannelPresenter` name is not registered in this checkout.
+  `TrussPathEncodingRegression` advanced to its unrelated broad persisted
+  last-project-path assertion at line 120 and remains visible and deferred.
+- Both mandatory module checks, the wx filesystem scanner, Bash registration
+  check, CI CMake language policy, and `git diff --check` passed. The CMake
+  language check required `PERASTAGE_TEST_PYTHON` to be supplied by the harness,
+  as documented by that policy test.
+
+No test was skipped, disabled, hidden, renamed, relabeled, removed, or weakened.
+Full Linux/Windows Debug Tests and reduced macOS release-gate CI artifacts are
+not available because this checkout has no configured remote or CI dispatch
+surface. Consequently there is no Phase 4E CI run ID, authoritative platform
+total, or verified failure-set delta, and D4B is not declared. The branch must
+continue through complete CI before it can be recommended for merge.

--- a/docs/developer/technical-notes/gdtf_unicode_zip_filename_compatibility.md
+++ b/docs/developer/technical-notes/gdtf_unicode_zip_filename_compatibility.md
@@ -16,13 +16,40 @@ The archive reader now reads raw central-directory filename bytes and applies on
 - Unflagged names that are not valid UTF-8 are not passed through a lossy platform ANSI conversion. They fail with a structured diagnostic until a safe reversible legacy decoder is added.
 - Ambiguous filename interpretations must fail without guessing.
 
+Raw central-directory identities are validated before wxWidgets streams any
+payload. A malformed identity therefore cannot be skipped by the ZIP stream and
+shift the sequential association between later raw names and payloads. The
+reader never substitutes a platform-decoded name for an identity that is
+explicitly marked as UTF-8 but contains invalid bytes.
+
 The compatibility warning uses `GDTF_ARCHIVE_UTF8_FALLBACK_USED` semantics and reports a message such as: `GDTF archive uses valid UTF-8 filenames without the ZIP UTF-8 flag; compatibility fallback applied to N entries.`
 
 ## Path safety and Windows behavior
 
 Filename decoding happens before path normalization, extraction, and safety checks. The decoded archive path must still be relative, must not contain drive or root syntax, must not contain `..` traversal, and must not contain unsafe empty paths. Unicode fallback does not weaken traversal protection.
 
-On Windows, callers should keep filesystem paths as `std::filesystem::path` for native operations and use explicit UTF-8 conversion only at serialization, storage, or logging boundaries. GDTF archive entry names are stored as UTF-8 text after safe decoding, independent of the operating-system locale, and extraction writes through native `std::filesystem::path` objects.
+On Windows, callers keep filesystem paths as `std::filesystem::path` for native
+operations and pass them to wxWidgets with
+`WxPathUtils::WxStringFromFilesystemPath`. UTF-8 conversion is reserved for
+serialization, storage, or logging boundaries; converting a native path through
+`path.string()` or `path.generic_string()` at a wxWidgets filesystem boundary is
+not permitted. GDTF archive entry names are stored as UTF-8 text after safe
+decoding, independent of the operating-system locale, and extraction writes
+through native `std::filesystem::path` objects.
+
+## Fixture classifications
+
+- `standard-strict`: canonical `description.xml`, ASCII names without bit 11,
+  and valid Unicode names with bit 11.
+- `legacy-compatibility`: independently documented legacy formats with a safe,
+  reversible interpretation.
+- `tolerant-recovery`: valid UTF-8 Unicode names missing bit 11 and recoverable
+  case or nesting variants of `description.xml`; each recovery is diagnosed.
+- `malformed-byte`: invalid UTF-8 bytes with bit 11 set, patched structurally in
+  the intended local and central filename records; the archive identity is
+  rejected with `FilenameDecodeFailed`.
+- `platform-specific`: Unicode outer filesystem paths, created as native
+  `std::filesystem::path` values and opened through the shared wx path helper.
 
 ## Read/write separation
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -15,6 +15,7 @@ Changes since **v1.5.0**.
 - Hardened MVR metadata recovery against foreign or unsupported legacy payloads, unknown and duplicate identities, invalid numeric and fixture-link values, unsafe auxiliary paths, and missing Truss resources without silent fallback substitution.
 - Rejected duplicate and case-colliding MVR archive entries consistently across platforms and surfaced tolerant-recovery diagnostics through normal imports.
 - Preserved explicit fixture categories, colors, and valid GDTF mode references across repeated MVR roundtrips while making missing-category inference deterministic.
+- Improved GDTF compatibility and safety for Unicode filesystem paths and archive entry names, including deterministic rejection of malformed UTF-8 identities.
 
 ## Current limitations
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -459,7 +459,8 @@ add_executable(gdtf_read_services_test
                gdtf_read_services_test.cpp
                ../core/gdtf_archive_reader.cpp
                ../core/gdtf_description_reader.cpp
-               ../core/gdtf_metadata_summary.cpp)
+               ../core/gdtf_metadata_summary.cpp
+               ../core/filesystem_path_utils.cpp)
 target_include_directories(gdtf_read_services_test PRIVATE ../core)
 target_link_libraries(gdtf_read_services_test PRIVATE ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
 add_test(NAME GdtfReadServices COMMAND gdtf_read_services_test)
@@ -529,7 +530,8 @@ add_executable(gdtf_fixture_insertion_preparation_test
                gdtf_fixture_insertion_preparation_test.cpp
                ../core/gdtf_archive_reader.cpp
                ../core/gdtf_description_reader.cpp
-               ../core/gdtf_fixture_insertion_preparation.cpp)
+               ../core/gdtf_fixture_insertion_preparation.cpp
+               ../core/filesystem_path_utils.cpp)
 target_include_directories(gdtf_fixture_insertion_preparation_test PRIVATE ../core)
 target_link_libraries(gdtf_fixture_insertion_preparation_test PRIVATE
                       ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)

--- a/tests/gdtf_fixture_insertion_preparation_test.cpp
+++ b/tests/gdtf_fixture_insertion_preparation_test.cpp
@@ -1,4 +1,6 @@
 #include "gdtf_fixture_insertion_preparation.h"
+#include "filesystem_path_utils.h"
+#include "wx_path_utils.h"
 
 #include <cassert>
 #include <cmath>
@@ -19,7 +21,7 @@ namespace {
 // Writes a ZIP/GDTF archive with the requested text entries.
 bool WriteArchive(const fs::path &path,
                   const std::vector<std::pair<std::string, std::string>> &entries) {
-  wxFileOutputStream output(wxString::FromUTF8(path.generic_string().c_str()));
+  wxFileOutputStream output(WxPathUtils::WxStringFromFilesystemPath(path));
   if (!output.IsOk())
     return false;
   wxZipOutputStream zip(output);
@@ -204,7 +206,8 @@ void AssertWiringObjectPowerFallback(const fs::path &dir) {
 
 // Verifies Unicode paths and unsafe archive paths are handled deterministically.
 void AssertUnicodeAndUnsafePaths(const fs::path &dir) {
-  const fs::path unicode = dir / "Perastage_ñ_fixture.gdtf";
+  const fs::path unicode =
+      dir / PathUtils::PathFromUtf8("Perastage_ñ_fixture.gdtf");
   assert(WriteArchive(unicode, {{"assets/ñ.txt", "ok"},
                                 {"description.xml", GdtfXml(Modes({"Mode"}))}}));
   auto preparation = gdtf::PrepareGdtfFixtureInsertion(unicode);

--- a/tests/gdtf_read_services_test.cpp
+++ b/tests/gdtf_read_services_test.cpp
@@ -14,6 +14,8 @@
 #include "gdtf_archive_reader.h"
 #include "gdtf_description_reader.h"
 #include "gdtf_metadata_summary.h"
+#include "filesystem_path_utils.h"
+#include "wx_path_utils.h"
 
 namespace fs = std::filesystem;
 
@@ -55,6 +57,47 @@ static void WriteLe16(std::vector<unsigned char> &data, size_t offset,
   data[offset + 1] = static_cast<unsigned char>((value >> 8) & 0xff);
 }
 
+struct ZipNamePatchCounts {
+  size_t localRecords = 0;
+  size_t centralRecords = 0;
+};
+
+// Patches one exact ZIP entry identity in its local and central records.
+static ZipNamePatchCounts PatchEntryNameAsInvalidFlaggedUtf8(
+    std::vector<unsigned char> &data, const std::string &entryName) {
+  ZipNamePatchCounts counts;
+  for (size_t i = 0; i + 30 <= data.size(); ++i) {
+    const uint32_t signature = ReadLe32(data, i);
+    const bool local = signature == 0x04034b50;
+    const bool central = signature == 0x02014b50;
+    if (!local && !central)
+      continue;
+    const size_t headerSize = local ? 30 : 46;
+    if (i + headerSize > data.size())
+      continue;
+    const size_t nameLengthOffset = i + (local ? 26 : 28);
+    const size_t nameOffset = i + headerSize;
+    const uint16_t nameLength = ReadLe16(data, nameLengthOffset);
+    if (nameLength != entryName.size() ||
+        nameOffset + nameLength > data.size() ||
+        !std::equal(entryName.begin(), entryName.end(),
+                    data.begin() + nameOffset,
+                    [](char expected, unsigned char actual) {
+                      return static_cast<unsigned char>(expected) == actual;
+                    }))
+      continue;
+    data[nameOffset] = 0xff;
+    const size_t flagOffset = i + (local ? 6 : 8);
+    WriteLe16(data, flagOffset,
+              static_cast<uint16_t>(ReadLe16(data, flagOffset) | (1u << 11)));
+    if (local)
+      ++counts.localRecords;
+    else
+      ++counts.centralRecords;
+  }
+  return counts;
+}
+
 // Forces or clears the ZIP UTF-8 filename flag in local and central headers.
 static void PatchUtf8Flags(const fs::path &path, bool enabled) {
   std::vector<unsigned char> data = ReadBinary(path);
@@ -73,28 +116,36 @@ static void PatchUtf8Flags(const fs::path &path, bool enabled) {
   WriteBinary(path, data);
 }
 
-// Reports whether all ZIP central-directory entries consistently use UTF-8
-// flags.
-static bool CentralDirectoryUtf8FlagsMatch(const fs::path &path,
-                                           bool expected) {
+// Reports whether one raw central-directory identity has the expected UTF-8 flag.
+static bool CentralDirectoryEntryUtf8FlagMatches(const fs::path &path,
+                                                 const std::string &entryName,
+                                                 bool expected) {
   const std::vector<unsigned char> data = ReadBinary(path);
-  bool sawCentralEntry = false;
   for (size_t i = 0; i + 46 <= data.size(); ++i) {
     if (ReadLe32(data, i) != 0x02014b50)
       continue;
-    sawCentralEntry = true;
+    const uint16_t nameLength = ReadLe16(data, i + 28);
+    const size_t nameOffset = i + 46;
+    if (nameLength != entryName.size() ||
+        nameOffset + nameLength > data.size() ||
+        !std::equal(entryName.begin(), entryName.end(),
+                    data.begin() + nameOffset,
+                    [](char expectedByte, unsigned char actualByte) {
+                      return static_cast<unsigned char>(expectedByte) ==
+                             actualByte;
+                    }))
+      continue;
     const bool hasFlag = (ReadLe16(data, i + 8) & (1u << 11)) != 0;
-    if (hasFlag != expected)
-      return false;
+    return hasFlag == expected;
   }
-  return sawCentralEntry;
+  return false;
 }
 
 // Writes a ZIP/GDTF archive with the requested text entries.
 static bool
 WriteArchive(const fs::path &path,
              const std::vector<std::pair<std::string, std::string>> &entries) {
-  wxFileOutputStream output(wxString::FromUTF8(path.generic_string().c_str()));
+  wxFileOutputStream output(WxPathUtils::WxStringFromFilesystemPath(path));
   if (!output.IsOk())
     return false;
   wxZipOutputStream zip(output);
@@ -395,7 +446,8 @@ static void TestUnknownUnicodeAndSummary(const fs::path &dir) {
         diagnostic.code == gdtf::DescriptionDiagnosticCode::UnknownElement;
   assert(foundUnknown);
 
-  const fs::path unicodePath = dir / std::string("metadata_ñ_测试.gdtf");
+  const fs::path unicodePath =
+      dir / PathUtils::PathFromUtf8("metadata_ñ_测试.gdtf");
   assert(WriteArchive(unicodePath, {{std::string("assets/ñ.txt"), "ok"},
                                     {"description.xml", xml}}));
   gdtf::ArchiveReadResult read = gdtf::ReadGdtfArchive(unicodePath);
@@ -406,7 +458,7 @@ static void TestUnknownUnicodeAndSummary(const fs::path &dir) {
   assert(foundUnicodeEntry);
 
   GdtfMetadataSummary summary;
-  assert(LoadGdtfMetadataSummary(unicodePath.generic_string(), summary));
+  assert(LoadGdtfMetadataSummary(unicodePath, summary));
   assert(summary.manufacturer == "Perastage");
   assert(summary.description == "Test fixture");
   assert(summary.creationDate == "2026-01-02 03:04:05");
@@ -478,20 +530,51 @@ static void TestUnicodeZipFilenameCompatibility(const fs::path &dir) {
   assert(!HasArchiveDiagnostic(read,
                                gdtf::ArchiveDiagnosticCode::Utf8FallbackUsed));
 
-  const fs::path invalidFlagged = dir / "invalid_flagged.gdtf";
-  assert(WriteArchive(invalidFlagged,
-                      {{unicodeName, "png"}, {"description.xml", xml}}));
-  std::vector<unsigned char> data = ReadBinary(invalidFlagged);
-  for (size_t i = 0; i + unicodeName.size() <= data.size(); ++i) {
-    if (std::equal(unicodeName.begin(), unicodeName.end(), data.begin() + i))
-      data[i] = 0xff;
-  }
-  WriteBinary(invalidFlagged, data);
-  PatchUtf8Flags(invalidFlagged, true);
-  read = gdtf::ReadGdtfArchive(invalidFlagged);
-  assert(!read.Success());
-  assert(HasArchiveDiagnostic(
-      read, gdtf::ArchiveDiagnosticCode::FilenameDecodeFailed));
+  auto assertMalformedByteArchive =
+      [&](const std::string &fileName,
+          const std::vector<std::pair<std::string, std::string>> &entries,
+          const std::string &corruptedName) {
+        const fs::path archivePath = dir / fileName;
+        assert(WriteArchive(archivePath, entries));
+        std::vector<unsigned char> data = ReadBinary(archivePath);
+        const ZipNamePatchCounts counts =
+            PatchEntryNameAsInvalidFlaggedUtf8(data, corruptedName);
+        assert(counts.localRecords == 1);
+        assert(counts.centralRecords == 1);
+        WriteBinary(archivePath, data);
+        const std::vector<unsigned char> patched = ReadBinary(archivePath);
+        assert(patched == data);
+
+        const gdtf::ArchiveReadResult malformedRead =
+            gdtf::ReadGdtfArchive(archivePath);
+        assert(!malformedRead.Success());
+        assert(HasArchiveDiagnostic(
+            malformedRead,
+            gdtf::ArchiveDiagnosticCode::FilenameDecodeFailed));
+        assert(malformedRead.entries.empty());
+        assert(malformedRead.descriptionXml.empty());
+      };
+
+  assertMalformedByteArchive(
+      "invalid_before_description.gdtf",
+      {{unicodeName, "png"}, {"description.xml", xml}}, unicodeName);
+  assertMalformedByteArchive(
+      "invalid_after_description.gdtf",
+      {{"description.xml", xml}, {unicodeName, "png"}}, unicodeName);
+  assertMalformedByteArchive(
+      "invalid_among_multiple.gdtf",
+      {{"models/body.glb", "model"}, {unicodeName, "png"},
+       {"description.xml", xml}},
+      unicodeName);
+  assertMalformedByteArchive(
+      "invalid_description.gdtf",
+      {{"description.xml", xml}, {"models/body.glb", "model"}},
+      "description.xml");
+  assertMalformedByteArchive(
+      "valid_unicode_and_invalid_resource.gdtf",
+      {{"wheels/ñ.png", "valid"}, {unicodeName, "invalid"},
+       {"description.xml", xml}},
+      unicodeName);
 }
 
 // Verifies Perastage-created ZIP entries carry UTF-8 filename metadata for
@@ -500,7 +583,8 @@ static void TestUnicodeZipWriteMetadata(const fs::path &dir) {
   const fs::path path = dir / "unicode_written.gdtf";
   assert(WriteArchive(path, {{"wheels/Φ113金属图案盘二.png", "png"},
                              {"description.xml", GdtfXml("")}}));
-  assert(CentralDirectoryUtf8FlagsMatch(path, true));
+  assert(CentralDirectoryEntryUtf8FlagMatches(
+      path, "wheels/Φ113金属图案盘二.png", true));
   gdtf::ArchiveReadResult read = gdtf::ReadGdtfArchive(path);
   assert(read.Success());
   assert(read.utf8FlagMissingEntryCount == 0);


### PR DESCRIPTION
### Motivation

- Fix intermittent failures in `GdtfReadServices` and `GdtfFixtureInsertionPreparation` caused by malformed ZIP entry names and inconsistent std::filesystem ↔ wxWidgets conversions, while preserving existing tolerant/diagnostic behavior. 
- Ensure raw central-directory entry bytes are validated and cannot shift decoded identities onto different payloads, and enforce repository path-conversion helpers at wxWidgets boundaries.

### Description

- Use the shared `WxPathUtils::WxStringFromFilesystemPath` at all wxWidgets file-stream boundaries in archive readers and test writers to avoid lossy `path.string()`/`generic_string()` conversions. (files: `core/gdtf_archive_reader.cpp`, `tests/*.cpp`) 
- Validate raw central-directory entry names before streaming with wxZip to deterministically reject invalid UTF-8 when the ZIP UTF-8 flag is set, emitting `FilenameDecodeFailed` diagnostics. (file: `core/gdtf_archive_reader.cpp`) 
- Replace fragile test fixture byte-patching with structural local/central ZIP record matching and patching that asserts exactly one local and one central record were modified, and add regression cases for ordering/association permutations. (file: `tests/gdtf_read_services_test.cpp`) 
- Add a native-path overload for `LoadGdtfMetadataSummary` that accepts `std::filesystem::path` and keep the string overload as a wrapper. (files: `core/gdtf_metadata_summary.{cpp,h}`) 
- Update documentation: record D4A evidence, document the decoding policy, classify fixture types (standard-strict, legacy-compatibility, tolerant-recovery, malformed-byte, platform-specific), and add a release-note entry for Unicode/path safety. (files: `docs/developer/ci_test_audit.md`, `docs/developer/technical-notes/gdtf_unicode_zip_filename_compatibility.md`, `docs/release-notes-draft.md`) 

### Testing

- Built and ran focused tests locally with `cmake --preset wsl-x64-debug` and `cmake --build --preset wsl-debug-build`.
- Repeated primary test matrix: `ctest --test-dir build/wsl-x64-debug -R '^(GdtfReadServices|GdtfFixtureInsertionPreparation)$' --repeat until-fail:20 --output-on-failure`, both primaries passed 20 consecutive repetitions.
- Ran scoped controls: `ctest -R '^(GdtfMetadataSummary|GdtfSourceFingerprint|GdtfTestFixtureBuilder|DummyGdtfFallbackArchiveStructure|DummyGdtfFallbackIntegration|GdtfModeChannelBrowser|GdtfModeChannelPresenter|WxFilesystemPathBoundaries|TrussPathEncodingRegression)$'`; seven of eight registered controls passed and `TrussPathEncodingRegression` surfaced an unrelated persistence assertion and remains deferred.
- Ran repository checks: `tests/check_perastage_tree_modules.sh`, `tests/check_no_configmanager_get_in_gui.sh`, `PERASTAGE_TEST_PYTHON="$(command -v python3)" python3 tests/check_wx_filesystem_path_boundaries.py`, `python3 tests/check_bash_test_registration.py`, `PERASTAGE_TEST_PYTHON="$(command -v python3)" bash tests/check_ci_cmake_language_policy.sh`, and `git diff --check` — all passed locally.
- Note: full CI runs (Linux/Windows/macOS) are not yet available from this checkout (no configured remote/CI dispatch), so authoritative CI run ID, artifacts, and cross-platform failure-set delta remain pending; D4B is not declared yet.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a66f0bb295883248880c96c7096eb6e)