### PR TITLE
Improve issue intake and awaiting-feedback triage

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -18,15 +18,15 @@ body:
       options:
         - label: I searched existing issues to avoid duplicates
           required: true
-        - label: I am using the latest beta release (or I can specify the exact build/commit)
+        - label: I tested the latest official release, or I will identify the exact development build below
           required: false
 
   - type: input
     id: version
     attributes:
       label: Perastage version
-      description: "Example: 0.1.0 (or commit hash if built from source)"
-      placeholder: "0.1.0"
+      description: "Copy the version shown by Perastage, or provide the commit hash for a source build."
+      placeholder: "Version shown in About, or source commit hash"
     validations:
       required: true
 
@@ -55,11 +55,41 @@ body:
   - type: input
     id: install_method
     attributes:
-      label: Installation method
-      description: "How are you running Perastage?"
-      placeholder: "GitHub Release installer / portable / built from source"
+      label: Installation or build origin
+      description: "Identify the exact package or build source."
+      placeholder: "Official release package / compatibility build / portable package / source build"
+    validations:
+      required: true
+
+  - type: input
+    id: architecture
+    attributes:
+      label: System architecture
+      description: "Examples: x64, arm64, or Apple Silicon."
+      placeholder: "x64"
     validations:
       required: false
+
+  - type: input
+    id: graphics
+    attributes:
+      label: GPU and graphics driver
+      description: "If relevant, provide the GPU model and graphics-driver version."
+      placeholder: "GPU model and driver version"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: frequency
+    attributes:
+      label: How often does this happen?
+      options:
+        - Always
+        - Intermittently
+        - Only under specific conditions (describe below)
+        - Unsure
+    validations:
+      required: true
 
   - type: textarea
     id: repro_steps
@@ -93,8 +123,8 @@ body:
   - type: textarea
     id: logs
     attributes:
-      label: Logs / console output
-      description: "Paste relevant logs here. You can also attach a file if it's long."
+      label: Diagnostic report, crash report, or logs (optional)
+      description: "Use Help -> Export Diagnostic Report. If Perastage terminated unexpectedly, also check Help -> Open Logs Folder and attach the relevant file from its crash_reports folder. You may paste short console output here."
       render: text
     validations:
       required: false
@@ -103,8 +133,8 @@ body:
     id: attachments
     attributes:
       label: Attachments (optional)
-      description: "Screenshots, sample files (MVR/GDTF), or minimal reproduction projects."
-      placeholder: "Drag and drop files here, or describe what you can share."
+      description: "When relevant, attach screenshots and a minimal MVR, GDTF, project, or other reproduction file. Remove confidential production data and do not upload anything you are not allowed to share publicly."
+      placeholder: "Drag and drop files here, or describe the minimal example you can share."
     validations:
       required: false
 
@@ -112,6 +142,6 @@ body:
     id: extra
     attributes:
       label: Additional context
-      placeholder: "Anything else that might help diagnose the issue (hardware, GPU, etc.)."
+      placeholder: "Describe specific conditions, recent changes, or anything else that may help."
     validations:
       required: false

--- a/.github/ISSUE_TRIAGE.md
+++ b/.github/ISSUE_TRIAGE.md
@@ -1,0 +1,47 @@
+# Issue triage policy
+
+This policy keeps issue decisions consistent without treating inactivity as evidence that a problem is resolved.
+
+## Labels
+
+Label categories are complementary:
+
+- `bug` identifies a reported defect.
+- `platform:*` identifies operating-system-specific scope.
+- `area:*` identifies the affected subsystem. Add narrowly named areas as the project grows rather than maintaining a fixed exhaustive list.
+- `type:*` identifies a special technical category, such as a crash.
+- `status:*` records the current workflow state.
+
+Apply the useful categories together, but keep status labels mutually exclusive: an issue must have no more than one `status:*` label at a time.
+
+## Confirmed bugs
+
+A confirmed or reproducible bug remains open even if the original reporter stops responding. Silence is not evidence that the bug has disappeared. Inactivity automation must not process a confirmed bug unless a maintainer explicitly changes its status to `status: awaiting-feedback` because progress is genuinely blocked.
+
+## Awaiting feedback
+
+Use `status: awaiting-feedback` only when investigation is blocked by missing information, a requested test, or reporter confirmation. Never apply it merely because an issue is old. When the requested information arrives and the issue is reviewed, remove the label or replace it with the single appropriate status.
+
+The awaiting-feedback workflow warns after 30 days without human activity. If another 14 days pass after that warning without human activity, it removes `status: awaiting-feedback` and closes the issue as not planned. The issue can be revisited when the missing information becomes available.
+
+## Closing issues
+
+### Duplicates
+
+Link a duplicate to its canonical issue with GitHub's duplicate relationship where possible, leave a short and friendly explanation, and close it with the **duplicate** state reason rather than completed.
+
+### Completed
+
+Close as **completed** when the reported problem has been corrected. When release availability is part of the user-facing resolution, wait until the fix is available in an official release. Reference the fixing pull request or release when useful. Thank reporters warmly, especially when they supplied logs, dumps, test files, or development-build testing.
+
+### Not planned
+
+Use **not planned** for deliberate scope decisions or an awaiting-feedback issue that completed the warning and timeout process above. Do not use it instead of investigating a confirmed bug, platform limitation, or upstream issue that still needs tracking.
+
+## Milestones and assignment
+
+Apply a milestone only when work is genuinely planned for that release. Do not assign an issue mechanically when no owner has accepted the work.
+
+## Tone
+
+Keep comments human, appreciative, and concise. Avoid cold boilerplate when someone has spent time testing or providing diagnostics.

--- a/.github/scripts/awaiting_feedback_triage.py
+++ b/.github/scripts/awaiting_feedback_triage.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Conservatively maintain issues explicitly awaiting reporter feedback."""
+
+import argparse
+import dataclasses
+import datetime as dt
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+TARGET_LABEL = "status: awaiting-feedback"
+WARNING_MARKER = "<!-- perastage-awaiting-feedback-warning:v1 -->"
+CLOSE_MARKER = "<!-- perastage-awaiting-feedback-close:v1 -->"
+WARNING_DAYS = 30
+CLOSE_DAYS = 14
+
+WARNING_COMMENT = f"""{WARNING_MARKER}
+Hi! This issue is currently waiting for the additional information requested above. If you are still able to reproduce the problem, any new details or test results would be very helpful. If there is no further information within the next 14 days, the issue may be closed for now, but it can still be reviewed again when the missing information becomes available. Thank you!"""
+
+CLOSE_COMMENT = f"""{CLOSE_MARKER}
+Hi! Since we have not received the additional information needed to continue the investigation, I am closing this issue for now. This does not mean the report was unimportant. Please comment again or open a new issue with the requested details if the problem persists in a current Perastage release. Thank you for taking the time to report it."""
+
+
+@dataclasses.dataclass(frozen=True)
+class Decision:
+    action: str
+    reason: str
+
+
+def parse_time(value):
+    return dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def is_automation_comment(comment):
+    body = comment.get("body") or ""
+    author_type = (comment.get("user") or {}).get("type")
+    return WARNING_MARKER in body or CLOSE_MARKER in body or author_type == "Bot"
+
+
+def decide(issue, comments, now):
+    """Return the safe action for one issue from issue and comment snapshots."""
+    labels = {label.get("name") for label in issue.get("labels", [])}
+    if issue.get("state") != "open":
+        return Decision("ignore", "issue is not open")
+    if "pull_request" in issue:
+        return Decision("ignore", "item is a pull request")
+    if TARGET_LABEL not in labels:
+        return Decision("ignore", "target label is absent")
+    if any(CLOSE_MARKER in (comment.get("body") or "") for comment in comments):
+        return Decision("ignore", "closing comment already exists")
+
+    human_times = [parse_time(issue["created_at"])]
+    human_times.extend(
+        parse_time(comment["created_at"])
+        for comment in comments
+        if not is_automation_comment(comment)
+    )
+    warning_times = [
+        parse_time(comment["created_at"])
+        for comment in comments
+        if WARNING_MARKER in (comment.get("body") or "")
+    ]
+    latest_human = max(human_times)
+    latest_warning = max(warning_times, default=None)
+
+    # An issue edit or label event is relevant activity even when it has no comment.
+    # The warning itself also updates the issue, so exclude only an exact timestamp match.
+    updated_at = parse_time(issue.get("updated_at", issue["created_at"]))
+    if not latest_warning or updated_at != latest_warning:
+        latest_human = max(latest_human, updated_at)
+
+    if latest_warning and latest_warning > latest_human:
+        if now - latest_warning >= dt.timedelta(days=CLOSE_DAYS):
+            return Decision("close", "14 days passed after the latest warning")
+        return Decision("ignore", "warning grace period is active")
+    if now - latest_human >= dt.timedelta(days=WARNING_DAYS):
+        return Decision("warn", "30 days passed without human activity")
+    return Decision("ignore", "inactivity period has not elapsed")
+
+
+class GitHubApi:
+    def __init__(self, repository, token):
+        self.base = f"https://api.github.com/repos/{repository}"
+        self.token = token
+
+    def request(self, method, path, payload=None):
+        data = json.dumps(payload).encode() if payload is not None else None
+        request = urllib.request.Request(
+            self.base + path,
+            data=data,
+            method=method,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {self.token}",
+                "X-GitHub-Api-Version": "2022-11-28",
+                "User-Agent": "perastage-awaiting-feedback",
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                body = response.read()
+                return (json.loads(body) if body else None), response.headers.get("Link")
+        except urllib.error.HTTPError as error:
+            detail = error.read().decode(errors="replace")[:500]
+            raise RuntimeError(f"GitHub API {method} {path} failed with HTTP {error.code}: {detail}") from error
+        except urllib.error.URLError as error:
+            raise RuntimeError(f"GitHub API {method} {path} failed: {error.reason}") from error
+
+    def paginated(self, path):
+        items = []
+        next_path = path
+        while next_path:
+            page, link = self.request("GET", next_path)
+            if not isinstance(page, list):
+                raise RuntimeError(f"GitHub API returned a non-list page for {path}")
+            items.extend(page)
+            next_url = next_link(link)
+            next_path = next_url.removeprefix(self.base) if next_url else None
+        return items
+
+    def issues(self):
+        label = urllib.parse.quote(TARGET_LABEL)
+        return self.paginated(f"/issues?state=open&labels={label}&per_page=100")
+
+    def comments(self, number):
+        return self.paginated(f"/issues/{number}/comments?per_page=100")
+
+    def current_issue(self, number):
+        return self.request("GET", f"/issues/{number}")[0]
+
+    def comment(self, number, body):
+        self.request("POST", f"/issues/{number}/comments", {"body": body})
+
+    def remove_label(self, number):
+        label = urllib.parse.quote(TARGET_LABEL, safe="")
+        self.request("DELETE", f"/issues/{number}/labels/{label}")
+
+    def close_not_planned(self, number):
+        self.request("PATCH", f"/issues/{number}", {"state": "closed", "state_reason": "not_planned"})
+
+
+def next_link(header):
+    if not header:
+        return None
+    for part in header.split(","):
+        segments = [segment.strip() for segment in part.split(";")]
+        if len(segments) > 1 and 'rel="next"' in segments[1:]:
+            return segments[0].strip("<>")
+    return None
+
+
+def still_eligible(issue):
+    labels = {label.get("name") for label in issue.get("labels", [])}
+    return issue.get("state") == "open" and "pull_request" not in issue and TARGET_LABEL in labels
+
+
+def run(api, dry_run, now):
+    for issue in api.issues():
+        number = issue["number"]
+        decision = decide(issue, api.comments(number), now)
+        print(f"Issue #{number}: {decision.action} ({decision.reason})")
+        if decision.action == "ignore" or dry_run:
+            continue
+        current = api.current_issue(number)
+        if not still_eligible(current):
+            print(f"Issue #{number}: skipped after eligibility recheck")
+            continue
+        if decision.action == "warn":
+            api.comment(number, WARNING_COMMENT)
+        elif decision.action == "close":
+            api.comment(number, CLOSE_COMMENT)
+            api.remove_label(number)
+            api.close_not_planned(number)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+    repository = os.environ.get("GITHUB_REPOSITORY")
+    token = os.environ.get("GITHUB_TOKEN")
+    if not repository or not token:
+        parser.error("GITHUB_REPOSITORY and GITHUB_TOKEN are required")
+    try:
+        run(GitHubApi(repository, token), args.dry_run, dt.datetime.now(dt.timezone.utc))
+    except RuntimeError as error:
+        print(f"Error: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/awaiting_feedback_triage.py
+++ b/.github/scripts/awaiting_feedback_triage.py
@@ -15,11 +15,12 @@ import urllib.request
 TARGET_LABEL = "status: awaiting-feedback"
 WARNING_MARKER = "<!-- perastage-awaiting-feedback-warning:v1 -->"
 CLOSE_MARKER = "<!-- perastage-awaiting-feedback-close:v1 -->"
+WARNING_REVISION_PREFIX = "<!-- perastage-awaiting-feedback-warning-revision:v1:"
 CLOSE_REVISION_PREFIX = "<!-- perastage-awaiting-feedback-revision:v1:"
 WARNING_DAYS = 30
 CLOSE_DAYS = 14
 
-WARNING_COMMENT = f"""{WARNING_MARKER}
+WARNING_COMMENT_TEXT = f"""{WARNING_MARKER}
 Hi! This issue is currently waiting for the additional information requested above. If you are still able to reproduce the problem, any new details or test results would be very helpful. If there is no further information within the next 14 days, the issue may be closed for now, but it can still be reviewed again when the missing information becomes available. Thank you!"""
 
 CLOSE_COMMENT_TEXT = f"""{CLOSE_MARKER}
@@ -59,12 +60,17 @@ def close_comment(issue):
     return f"{CLOSE_COMMENT_TEXT}\n{marker}"
 
 
-def close_revision(comment):
+def warning_comment(issue):
+    marker = f"{WARNING_REVISION_PREFIX}{issue_revision(issue)} -->"
+    return f"{WARNING_COMMENT_TEXT}\n{marker}"
+
+
+def marked_revision(comment, prefix):
     body = comment.get("body") or ""
-    start = body.find(CLOSE_REVISION_PREFIX)
+    start = body.find(prefix)
     if start == -1:
         return None
-    start += len(CLOSE_REVISION_PREFIX)
+    start += len(prefix)
     end = body.find(" -->", start)
     return body[start:end] if end != -1 else None
 
@@ -84,13 +90,20 @@ def decide(issue, comments, now):
         for comment in comments
         if not is_automation_comment(comment)
     )
-    warning_times = [
-        parse_time(comment["created_at"])
+    warning_comments = [
+        comment
         for comment in comments
         if WARNING_MARKER in (comment.get("body") or "")
     ]
     latest_human = max(human_times)
-    latest_warning = max(warning_times, default=None)
+    latest_warning_comment = max(
+        warning_comments, key=lambda comment: parse_time(comment["created_at"]), default=None
+    )
+    latest_warning = (
+        parse_time(latest_warning_comment["created_at"])
+        if latest_warning_comment
+        else None
+    )
     close_comments = [
         comment
         for comment in comments
@@ -106,11 +119,17 @@ def decide(issue, comments, now):
     )
 
     if latest_close and latest_close > latest_human:
-        if close_revision(latest_close_comment) != issue_revision(issue):
+        if marked_revision(latest_close_comment, CLOSE_REVISION_PREFIX) != issue_revision(issue):
             return Decision("ignore", "issue changed after the closing comment")
         return Decision("finalize_close", "closing comment awaits final state update")
 
     if latest_warning and latest_warning > latest_human:
+        warning_revision = marked_revision(latest_warning_comment, WARNING_REVISION_PREFIX)
+        if warning_revision != issue_revision(issue):
+            renewed_at = max(latest_human, parse_time(issue["updated_at"]))
+            if now - renewed_at >= dt.timedelta(days=WARNING_DAYS):
+                return Decision("warn", "30 days passed after the issue changed")
+            return Decision("ignore", "issue changed after the warning")
         if now - latest_warning >= dt.timedelta(days=CLOSE_DAYS):
             return Decision("close", "14 days passed after the latest warning")
         return Decision("ignore", "warning grace period is active")
@@ -227,7 +246,7 @@ def run(api, dry_run, now):
             print(f"Issue #{number}: skipped after complete decision recheck")
             continue
         if decision.action == "warn":
-            api.comment(number, WARNING_COMMENT)
+            api.comment(number, warning_comment(current))
         elif decision.action == "close":
             api.comment(number, close_comment(current))
             finalize_close(api, number, now)

--- a/.github/scripts/awaiting_feedback_triage.py
+++ b/.github/scripts/awaiting_feedback_triage.py
@@ -4,6 +4,7 @@
 import argparse
 import dataclasses
 import datetime as dt
+import hashlib
 import json
 import os
 import sys
@@ -14,13 +15,14 @@ import urllib.request
 TARGET_LABEL = "status: awaiting-feedback"
 WARNING_MARKER = "<!-- perastage-awaiting-feedback-warning:v1 -->"
 CLOSE_MARKER = "<!-- perastage-awaiting-feedback-close:v1 -->"
+CLOSE_REVISION_PREFIX = "<!-- perastage-awaiting-feedback-revision:v1:"
 WARNING_DAYS = 30
 CLOSE_DAYS = 14
 
 WARNING_COMMENT = f"""{WARNING_MARKER}
 Hi! This issue is currently waiting for the additional information requested above. If you are still able to reproduce the problem, any new details or test results would be very helpful. If there is no further information within the next 14 days, the issue may be closed for now, but it can still be reviewed again when the missing information becomes available. Thank you!"""
 
-CLOSE_COMMENT = f"""{CLOSE_MARKER}
+CLOSE_COMMENT_TEXT = f"""{CLOSE_MARKER}
 Hi! Since we have not received the additional information needed to continue the investigation, I am closing this issue for now. This does not mean the report was unimportant. Please comment again or open a new issue with the requested details if the problem persists in a current Perastage release. Thank you for taking the time to report it."""
 
 
@@ -40,6 +42,33 @@ def is_automation_comment(comment):
     return WARNING_MARKER in body or CLOSE_MARKER in body or author_type == "Bot"
 
 
+def issue_revision(issue):
+    snapshot = {
+        "title": issue.get("title"),
+        "body": issue.get("body"),
+        "labels": sorted(label.get("name") for label in issue.get("labels", [])),
+        "assignees": sorted(user.get("login") for user in issue.get("assignees", [])),
+        "milestone": (issue.get("milestone") or {}).get("number"),
+    }
+    encoded = json.dumps(snapshot, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def close_comment(issue):
+    marker = f"{CLOSE_REVISION_PREFIX}{issue_revision(issue)} -->"
+    return f"{CLOSE_COMMENT_TEXT}\n{marker}"
+
+
+def close_revision(comment):
+    body = comment.get("body") or ""
+    start = body.find(CLOSE_REVISION_PREFIX)
+    if start == -1:
+        return None
+    start += len(CLOSE_REVISION_PREFIX)
+    end = body.find(" -->", start)
+    return body[start:end] if end != -1 else None
+
+
 def decide(issue, comments, now):
     """Return the safe action for one issue from issue and comment snapshots."""
     labels = {label.get("name") for label in issue.get("labels", [])}
@@ -49,9 +78,6 @@ def decide(issue, comments, now):
         return Decision("ignore", "item is a pull request")
     if TARGET_LABEL not in labels:
         return Decision("ignore", "target label is absent")
-    if any(CLOSE_MARKER in (comment.get("body") or "") for comment in comments):
-        return Decision("ignore", "closing comment already exists")
-
     human_times = [parse_time(issue["created_at"])]
     human_times.extend(
         parse_time(comment["created_at"])
@@ -65,12 +91,24 @@ def decide(issue, comments, now):
     ]
     latest_human = max(human_times)
     latest_warning = max(warning_times, default=None)
+    close_comments = [
+        comment
+        for comment in comments
+        if CLOSE_MARKER in (comment.get("body") or "")
+    ]
+    latest_close_comment = max(
+        close_comments, key=lambda comment: parse_time(comment["created_at"]), default=None
+    )
+    latest_close = (
+        parse_time(latest_close_comment["created_at"])
+        if latest_close_comment
+        else None
+    )
 
-    # An issue edit or label event is relevant activity even when it has no comment.
-    # The warning itself also updates the issue, so exclude only an exact timestamp match.
-    updated_at = parse_time(issue.get("updated_at", issue["created_at"]))
-    if not latest_warning or updated_at != latest_warning:
-        latest_human = max(latest_human, updated_at)
+    if latest_close and latest_close > latest_human:
+        if close_revision(latest_close_comment) != issue_revision(issue):
+            return Decision("ignore", "issue changed after the closing comment")
+        return Decision("finalize_close", "closing comment awaits final state update")
 
     if latest_warning and latest_warning > latest_human:
         if now - latest_warning >= dt.timedelta(days=CLOSE_DAYS):
@@ -134,12 +172,17 @@ class GitHubApi:
     def comment(self, number, body):
         self.request("POST", f"/issues/{number}/comments", {"body": body})
 
-    def remove_label(self, number):
-        label = urllib.parse.quote(TARGET_LABEL, safe="")
-        self.request("DELETE", f"/issues/{number}/labels/{label}")
-
-    def close_not_planned(self, number):
-        self.request("PATCH", f"/issues/{number}", {"state": "closed", "state_reason": "not_planned"})
+    def close_not_planned(self, issue):
+        labels = [
+            label["name"]
+            for label in issue.get("labels", [])
+            if label.get("name") != TARGET_LABEL
+        ]
+        self.request(
+            "PATCH",
+            f"/issues/{issue['number']}",
+            {"state": "closed", "state_reason": "not_planned", "labels": labels},
+        )
 
 
 def next_link(header):
@@ -157,6 +200,20 @@ def still_eligible(issue):
     return issue.get("state") == "open" and "pull_request" not in issue and TARGET_LABEL in labels
 
 
+def fresh_decision(api, number, now):
+    issue = api.current_issue(number)
+    comments = api.comments(number)
+    return issue, comments, decide(issue, comments, now)
+
+
+def finalize_close(api, number, now):
+    issue, _comments, decision = fresh_decision(api, number, now)
+    if decision.action != "finalize_close" or not still_eligible(issue):
+        print(f"Issue #{number}: final close skipped after activity recheck")
+        return
+    api.close_not_planned(issue)
+
+
 def run(api, dry_run, now):
     for issue in api.issues():
         number = issue["number"]
@@ -164,16 +221,18 @@ def run(api, dry_run, now):
         print(f"Issue #{number}: {decision.action} ({decision.reason})")
         if decision.action == "ignore" or dry_run:
             continue
-        current = api.current_issue(number)
-        if not still_eligible(current):
-            print(f"Issue #{number}: skipped after eligibility recheck")
+        current, _comments, fresh = fresh_decision(api, number, now)
+        revision_changed = current.get("updated_at") != issue.get("updated_at")
+        if revision_changed or fresh.action != decision.action or not still_eligible(current):
+            print(f"Issue #{number}: skipped after complete decision recheck")
             continue
         if decision.action == "warn":
             api.comment(number, WARNING_COMMENT)
         elif decision.action == "close":
-            api.comment(number, CLOSE_COMMENT)
-            api.remove_label(number)
-            api.close_not_planned(number)
+            api.comment(number, close_comment(current))
+            finalize_close(api, number, now)
+        elif decision.action == "finalize_close":
+            api.close_not_planned(current)
 
 
 def main():

--- a/.github/workflows/awaiting-feedback.yml
+++ b/.github/workflows/awaiting-feedback.yml
@@ -1,0 +1,33 @@
+name: Awaiting Feedback Triage
+
+on:
+  schedule:
+    - cron: "17 4 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Report decisions without changing issues.
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: awaiting-feedback-triage
+  cancel-in-progress: false
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Review issues awaiting feedback
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >-
+          python3 .github/scripts/awaiting_feedback_triage.py
+          ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run && '--dry-run' || '' }}

--- a/docs/developer/github_actions_workflows.md
+++ b/docs/developer/github_actions_workflows.md
@@ -4,7 +4,7 @@ Perastage uses separate workflows for validation, automatic test artifacts, comp
 
 ## Issue maintenance
 
-`Awaiting Feedback Triage` runs daily and can be dispatched manually in a safe dry-run mode. It processes only open issues explicitly labeled `status: awaiting-feedback`; see the [issue triage policy](../../.github/ISSUE_TRIAGE.md) for its conservative warning and closure rules. The workflow has read-only repository access plus issue write access and does not process pull requests or apply the label itself. Every write follows a fresh decision check, and a versioned issue-revision marker lets an interrupted close resume without duplicating comments or overriding later human changes.
+`Awaiting Feedback Triage` runs daily and can be dispatched manually in a safe dry-run mode. It processes only open issues explicitly labeled `status: awaiting-feedback`; see the [issue triage policy](../../.github/ISSUE_TRIAGE.md) for its conservative warning and closure rules. The workflow has read-only repository access plus issue write access and does not process pull requests or apply the label itself. Every write follows a fresh decision check. Versioned issue-revision markers on warnings restart inactivity after later edits, while the closing marker lets an interrupted close resume without duplicating comments or overriding later human changes.
 
 ## Pull requests
 

--- a/docs/developer/github_actions_workflows.md
+++ b/docs/developer/github_actions_workflows.md
@@ -2,6 +2,10 @@
 
 Perastage uses separate workflows for validation, automatic test artifacts, compatibility packages, and formal releases. The separation keeps Debug test coverage out of Release package builders and prevents release publication before every package and asset check has succeeded.
 
+## Issue maintenance
+
+`Awaiting Feedback Triage` runs daily and can be dispatched manually in a safe dry-run mode. It processes only open issues explicitly labeled `status: awaiting-feedback`; see the [issue triage policy](../../.github/ISSUE_TRIAGE.md) for its conservative warning and closure rules. The workflow has read-only repository access plus issue write access and does not process pull requests or apply the label itself.
+
 ## Pull requests
 
 Pull requests targeting `main` run `CI Debug Tests` from `.github/workflows/ci-tests.yml`.

--- a/docs/developer/github_actions_workflows.md
+++ b/docs/developer/github_actions_workflows.md
@@ -4,7 +4,7 @@ Perastage uses separate workflows for validation, automatic test artifacts, comp
 
 ## Issue maintenance
 
-`Awaiting Feedback Triage` runs daily and can be dispatched manually in a safe dry-run mode. It processes only open issues explicitly labeled `status: awaiting-feedback`; see the [issue triage policy](../../.github/ISSUE_TRIAGE.md) for its conservative warning and closure rules. The workflow has read-only repository access plus issue write access and does not process pull requests or apply the label itself.
+`Awaiting Feedback Triage` runs daily and can be dispatched manually in a safe dry-run mode. It processes only open issues explicitly labeled `status: awaiting-feedback`; see the [issue triage policy](../../.github/ISSUE_TRIAGE.md) for its conservative warning and closure rules. The workflow has read-only repository access plus issue write access and does not process pull requests or apply the label itself. Every write follows a fresh decision check, and a versioned issue-revision marker lets an interrupted close resume without duplicating comments or overriding later human changes.
 
 ## Pull requests
 

--- a/docs/developer/index.md
+++ b/docs/developer/index.md
@@ -14,3 +14,4 @@ This section collects maintainer-facing build, architecture, packaging, policy, 
 - [GUI Shortcut Architecture](gui_shortcut_architecture.md)
 - [Technical Notes](technical-notes/index.md)
 - [GitHub Actions workflow architecture](github_actions_workflows.md)
+- [Issue triage policy](../../.github/ISSUE_TRIAGE.md)

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -21,7 +21,7 @@ Changes since **v1.5.0**.
 
 ## Technical and packaging changes
 
-- Improved maintainer issue intake and triage with clearer diagnostic guidance and failure-resilient, conservative automation limited to reports explicitly awaiting feedback.
+- Improved maintainer issue intake and triage with clearer diagnostic guidance and revision-aware, failure-resilient automation limited to reports explicitly awaiting feedback.
 
 - Aligned CI policy checks with the validated Windows Git Bash initial-cache data flow and strengthened cross-platform filesystem path boundary coverage.
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -21,7 +21,7 @@ Changes since **v1.5.0**.
 
 ## Technical and packaging changes
 
-- Improved maintainer issue intake and triage with clearer diagnostic guidance and conservative automation limited to reports explicitly awaiting feedback.
+- Improved maintainer issue intake and triage with clearer diagnostic guidance and failure-resilient, conservative automation limited to reports explicitly awaiting feedback.
 
 - Aligned CI policy checks with the validated Windows Git Bash initial-cache data flow and strengthened cross-platform filesystem path boundary coverage.
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -21,6 +21,8 @@ Changes since **v1.5.0**.
 
 ## Technical and packaging changes
 
+- Improved maintainer issue intake and triage with clearer diagnostic guidance and conservative automation limited to reports explicitly awaiting feedback.
+
 - Aligned CI policy checks with the validated Windows Git Bash initial-cache data flow and strengthened cross-platform filesystem path boundary coverage.
 
 - Added native object-cache acceleration with GitHub-scoped CI isolation, resource-aware Windows embedded-debug validation, and measurable compiler-cache diagnostics without changing installer, dependency-cache, or test behavior.

--- a/tests/ci/test_awaiting_feedback_triage.py
+++ b/tests/ci/test_awaiting_feedback_triage.py
@@ -56,23 +56,23 @@ class DecisionTests(unittest.TestCase):
         self.assertEqual(triage.decide(issue(days_ago=30), [], NOW).action, "warn")
 
     def test_duplicate_warning_is_not_posted(self):
-        comments = [comment(5, triage.WARNING_COMMENT, "Bot")]
+        comments = [comment(5, triage.warning_comment(issue(days_ago=60)), "Bot")]
         self.assertEqual(triage.decide(issue(), comments, NOW).action, "ignore")
 
     def test_closing_occurs_14_days_after_latest_warning(self):
-        comments = [comment(14, triage.WARNING_COMMENT, "Bot")]
+        comments = [comment(14, triage.warning_comment(issue(days_ago=60)), "Bot")]
         self.assertEqual(triage.decide(issue(days_ago=60), comments, NOW).action, "close")
 
     def test_human_comment_after_warning_prevents_closure(self):
-        comments = [comment(20, triage.WARNING_COMMENT, "Bot"), comment(10)]
+        comments = [comment(20, triage.warning_comment(issue(days_ago=60)), "Bot"), comment(10)]
         self.assertEqual(triage.decide(issue(days_ago=60), comments, NOW).action, "ignore")
 
     def test_renewed_inactivity_can_produce_new_warning(self):
-        comments = [comment(50, triage.WARNING_COMMENT, "Bot"), comment(30)]
+        comments = [comment(50, triage.warning_comment(issue(days_ago=60)), "Bot"), comment(30)]
         self.assertEqual(triage.decide(issue(days_ago=90), comments, NOW).action, "warn")
 
     def test_removing_target_label_prevents_closure(self):
-        comments = [comment(14, triage.WARNING_COMMENT, "Bot")]
+        comments = [comment(14, triage.warning_comment(issue(days_ago=60)), "Bot")]
         self.assertEqual(triage.decide(issue(labels=["bug"]), comments, NOW).action, "ignore")
 
     def test_closed_issue_is_ignored(self):
@@ -85,8 +85,42 @@ class DecisionTests(unittest.TestCase):
     def test_warning_and_issue_timestamps_may_differ(self):
         value = issue(days_ago=60)
         value["updated_at"] = (NOW - dt.timedelta(days=14, seconds=-7)).isoformat()
-        comments = [comment(14, triage.WARNING_COMMENT, "Bot")]
+        comments = [comment(14, triage.warning_comment(issue(days_ago=60)), "Bot")]
         self.assertEqual(triage.decide(value, comments, NOW).action, "close")
+
+    def test_edit_after_twenty_day_old_warning_prevents_closure(self):
+        original = issue(days_ago=60)
+        edited = dict(original, title="Edited title", updated_at=timestamp(10))
+        comments = [comment(20, triage.warning_comment(original), "Bot")]
+        self.assertEqual(triage.decide(edited, comments, NOW).action, "ignore")
+
+    def test_edit_before_run_prevents_closure_at_fourteen_days(self):
+        original = issue(days_ago=60)
+        edited = dict(original, body="New reproduction detail", updated_at=timestamp(1))
+        comments = [comment(14, triage.warning_comment(original), "Bot")]
+        self.assertEqual(triage.decide(edited, comments, NOW).action, "ignore")
+
+    def test_thirty_days_after_edit_allows_new_warning(self):
+        original = issue(days_ago=90)
+        edited = dict(original, body="New reproduction detail", updated_at=timestamp(30))
+        comments = [comment(60, triage.warning_comment(original), "Bot")]
+        self.assertEqual(triage.decide(edited, comments, NOW).action, "warn")
+
+    def test_each_semantic_issue_change_after_warning_prevents_closure(self):
+        original = issue(days_ago=60)
+        warning = [comment(14, triage.warning_comment(original), "Bot")]
+        changes = {
+            "title": "Changed title",
+            "body": "Changed body",
+            "labels": [{"name": triage.TARGET_LABEL}, {"name": "area:viewer"}],
+            "assignees": [{"login": "maintainer"}],
+            "milestone": {"number": 12},
+        }
+        for field, changed_value in changes.items():
+            with self.subTest(field=field):
+                edited = dict(original, updated_at=timestamp(1))
+                edited[field] = changed_value
+                self.assertEqual(triage.decide(edited, warning, NOW).action, "ignore")
 
     def test_open_issue_with_close_marker_resumes_finalization(self):
         value = issue(days_ago=60)
@@ -140,12 +174,23 @@ class ApiTests(unittest.TestCase):
         triage.run(api, False, NOW)
         api.comment.assert_not_called()
 
+    def test_renewed_inactivity_posts_one_warning_with_current_revision(self):
+        original = issue(days_ago=90)
+        edited = dict(original, body="Updated details", updated_at=timestamp(30))
+        old_warning = [comment(60, triage.warning_comment(original), "Bot")]
+        api = mock.Mock()
+        api.issues.return_value = [edited]
+        api.current_issue.return_value = edited
+        api.comments.side_effect = [old_warning, old_warning]
+        triage.run(api, False, NOW)
+        api.comment.assert_called_once_with(7, triage.warning_comment(edited))
+
     def test_label_removal_during_run_prevents_writes(self):
         api = mock.Mock()
         api.issues.return_value = [issue(days_ago=60)]
         api.comments.side_effect = [
-            [comment(14, triage.WARNING_COMMENT, "Bot")],
-            [comment(14, triage.WARNING_COMMENT, "Bot")],
+            [comment(14, triage.warning_comment(issue(days_ago=60)), "Bot")],
+            [comment(14, triage.warning_comment(issue(days_ago=60)), "Bot")],
         ]
         api.current_issue.return_value = issue(labels=["bug"])
         triage.run(api, False, NOW)
@@ -170,7 +215,7 @@ class ApiTests(unittest.TestCase):
     def test_successful_close_rechecks_after_marker_and_posts_once(self):
         api = mock.Mock()
         value = issue(days_ago=60)
-        warning = [comment(14, triage.WARNING_COMMENT, "Bot")]
+        warning = [comment(14, triage.warning_comment(issue(days_ago=60)), "Bot")]
         closing = warning + [closing_comment(0, value)]
         api.issues.return_value = [value]
         api.current_issue.return_value = value
@@ -213,7 +258,7 @@ class ApiTests(unittest.TestCase):
 
     def test_failure_after_posting_close_comment_recovers_without_duplicate(self):
         value = issue(days_ago=60)
-        warning = [comment(14, triage.WARNING_COMMENT, "Bot")]
+        warning = [comment(14, triage.warning_comment(issue(days_ago=60)), "Bot")]
         closing = warning + [closing_comment(0, value)]
         first_api = mock.Mock()
         first_api.issues.return_value = [value]

--- a/tests/ci/test_awaiting_feedback_triage.py
+++ b/tests/ci/test_awaiting_feedback_triage.py
@@ -38,6 +38,10 @@ def comment(days_ago, body="human response", author_type="User"):
     }
 
 
+def closing_comment(days_ago, value=None):
+    return comment(days_ago, triage.close_comment(value or issue(days_ago=60)), "Bot")
+
+
 class DecisionTests(unittest.TestCase):
     def test_issue_without_target_label_is_ignored(self):
         self.assertEqual(triage.decide(issue(labels=["bug"]), [], NOW).action, "ignore")
@@ -63,12 +67,6 @@ class DecisionTests(unittest.TestCase):
         comments = [comment(20, triage.WARNING_COMMENT, "Bot"), comment(10)]
         self.assertEqual(triage.decide(issue(days_ago=60), comments, NOW).action, "ignore")
 
-    def test_issue_edit_after_warning_prevents_closure(self):
-        value = issue(days_ago=60)
-        value["updated_at"] = timestamp(10)
-        comments = [comment(20, triage.WARNING_COMMENT, "Bot")]
-        self.assertEqual(triage.decide(value, comments, NOW).action, "ignore")
-
     def test_renewed_inactivity_can_produce_new_warning(self):
         comments = [comment(50, triage.WARNING_COMMENT, "Bot"), comment(30)]
         self.assertEqual(triage.decide(issue(days_ago=90), comments, NOW).action, "warn")
@@ -83,6 +81,22 @@ class DecisionTests(unittest.TestCase):
     def test_automation_comments_are_not_human_activity(self):
         comments = [comment(35, "unrelated automation", "Bot")]
         self.assertEqual(triage.decide(issue(days_ago=40), comments, NOW).action, "warn")
+
+    def test_warning_and_issue_timestamps_may_differ(self):
+        value = issue(days_ago=60)
+        value["updated_at"] = (NOW - dt.timedelta(days=14, seconds=-7)).isoformat()
+        comments = [comment(14, triage.WARNING_COMMENT, "Bot")]
+        self.assertEqual(triage.decide(value, comments, NOW).action, "close")
+
+    def test_open_issue_with_close_marker_resumes_finalization(self):
+        value = issue(days_ago=60)
+        comments = [closing_comment(1, value)]
+        self.assertEqual(triage.decide(value, comments, NOW).action, "finalize_close")
+
+    def test_human_activity_after_close_marker_prevents_finalization(self):
+        value = issue(days_ago=60)
+        comments = [closing_comment(2, value), comment(1)]
+        self.assertEqual(triage.decide(value, comments, NOW).action, "ignore")
 
 
 class ApiTests(unittest.TestCase):
@@ -102,36 +116,142 @@ class ApiTests(unittest.TestCase):
         triage.run(api, True, NOW)
         api.current_issue.assert_not_called()
         api.comment.assert_not_called()
-        api.remove_label.assert_not_called()
         api.close_not_planned.assert_not_called()
 
-    def test_closure_rechecks_label_and_uses_not_planned(self):
+    def test_human_comment_after_initial_decision_prevents_warning(self):
         api = mock.Mock()
-        api.issues.return_value = [issue(days_ago=60)]
-        api.comments.return_value = [comment(14, triage.WARNING_COMMENT, "Bot")]
-        api.current_issue.return_value = issue(days_ago=60)
+        initial = issue()
+        current = issue()
+        current["updated_at"] = timestamp(0)
+        api.issues.return_value = [initial]
+        api.comments.side_effect = [[], [comment(0)]]
+        api.current_issue.return_value = current
         triage.run(api, False, NOW)
-        api.comment.assert_called_once_with(7, triage.CLOSE_COMMENT)
-        api.remove_label.assert_called_once_with(7)
-        api.close_not_planned.assert_called_once_with(7)
+        api.comment.assert_not_called()
+
+    def test_issue_edit_after_initial_decision_prevents_warning(self):
+        api = mock.Mock()
+        initial = issue()
+        current = issue()
+        current["updated_at"] = timestamp(0)
+        api.issues.return_value = [initial]
+        api.comments.side_effect = [[], []]
+        api.current_issue.return_value = current
+        triage.run(api, False, NOW)
+        api.comment.assert_not_called()
 
     def test_label_removal_during_run_prevents_writes(self):
         api = mock.Mock()
         api.issues.return_value = [issue(days_ago=60)]
-        api.comments.return_value = [comment(14, triage.WARNING_COMMENT, "Bot")]
+        api.comments.side_effect = [
+            [comment(14, triage.WARNING_COMMENT, "Bot")],
+            [comment(14, triage.WARNING_COMMENT, "Bot")],
+        ]
         api.current_issue.return_value = issue(labels=["bug"])
         triage.run(api, False, NOW)
         api.comment.assert_not_called()
-        api.remove_label.assert_not_called()
         api.close_not_planned.assert_not_called()
 
-    def test_close_payload_uses_not_planned(self):
+    def test_close_payload_atomically_removes_target_and_uses_not_planned(self):
         api = triage.GitHubApi("owner/repository", "token")
         api.request = mock.Mock()
-        api.close_not_planned(7)
+        value = issue(labels=[triage.TARGET_LABEL, "bug", "platform:linux"])
+        api.close_not_planned(value)
         api.request.assert_called_once_with(
-            "PATCH", "/issues/7", {"state": "closed", "state_reason": "not_planned"}
+            "PATCH",
+            "/issues/7",
+            {
+                "state": "closed",
+                "state_reason": "not_planned",
+                "labels": ["bug", "platform:linux"],
+            },
         )
+
+    def test_successful_close_rechecks_after_marker_and_posts_once(self):
+        api = mock.Mock()
+        value = issue(days_ago=60)
+        warning = [comment(14, triage.WARNING_COMMENT, "Bot")]
+        closing = warning + [closing_comment(0, value)]
+        api.issues.return_value = [value]
+        api.current_issue.return_value = value
+        api.comments.side_effect = [warning, warning, closing]
+        triage.run(api, False, NOW)
+        api.comment.assert_called_once_with(7, triage.close_comment(value))
+        api.close_not_planned.assert_called_once_with(value)
+
+    def test_partial_close_recovers_without_duplicate_comment(self):
+        value = issue(days_ago=60)
+        closing = [closing_comment(1, value)]
+        api = mock.Mock()
+        api.issues.return_value = [value]
+        api.current_issue.return_value = value
+        api.comments.side_effect = [closing, closing]
+        triage.run(api, False, NOW)
+        api.comment.assert_not_called()
+        api.close_not_planned.assert_called_once_with(value)
+
+    def test_human_activity_after_partial_close_prevents_recovery(self):
+        value = issue(days_ago=60)
+        comments = [closing_comment(2, value), comment(1)]
+        api = mock.Mock()
+        api.issues.return_value = [value]
+        api.comments.return_value = comments
+        triage.run(api, False, NOW)
+        api.comment.assert_not_called()
+        api.close_not_planned.assert_not_called()
+
+    def test_issue_edit_after_partial_close_prevents_recovery(self):
+        original = issue(days_ago=60)
+        edited = dict(original, title="Edited after pending close")
+        comments = [closing_comment(2, original)]
+        api = mock.Mock()
+        api.issues.return_value = [edited]
+        api.comments.return_value = comments
+        triage.run(api, False, NOW)
+        api.comment.assert_not_called()
+        api.close_not_planned.assert_not_called()
+
+    def test_failure_after_posting_close_comment_recovers_without_duplicate(self):
+        value = issue(days_ago=60)
+        warning = [comment(14, triage.WARNING_COMMENT, "Bot")]
+        closing = warning + [closing_comment(0, value)]
+        first_api = mock.Mock()
+        first_api.issues.return_value = [value]
+        first_api.current_issue.return_value = value
+        first_api.comments.side_effect = [warning, warning, closing]
+        first_api.close_not_planned.side_effect = RuntimeError("final update failed")
+        with self.assertRaises(RuntimeError):
+            triage.run(first_api, False, NOW)
+        first_api.comment.assert_called_once_with(7, triage.close_comment(value))
+
+        recovery_api = mock.Mock()
+        recovery_api.issues.return_value = [value]
+        recovery_api.current_issue.return_value = value
+        recovery_api.comments.side_effect = [closing, closing]
+        triage.run(recovery_api, False, NOW)
+        recovery_api.comment.assert_not_called()
+        recovery_api.close_not_planned.assert_called_once_with(value)
+
+    def test_failed_atomic_final_update_recovers_on_next_run(self):
+        value = issue(days_ago=60)
+        closing = [closing_comment(1, value)]
+        for failure_stage in ("label update", "issue closure"):
+            with self.subTest(failure_stage=failure_stage):
+                failing_api = mock.Mock()
+                failing_api.issues.return_value = [value]
+                failing_api.current_issue.return_value = value
+                failing_api.comments.side_effect = [closing, closing]
+                failing_api.close_not_planned.side_effect = RuntimeError(failure_stage)
+                with self.assertRaises(RuntimeError):
+                    triage.run(failing_api, False, NOW)
+
+                recovery_api = mock.Mock()
+                recovery_api.issues.return_value = [value]
+                recovery_api.current_issue.return_value = value
+                recovery_api.comments.side_effect = [closing, closing]
+                triage.run(recovery_api, False, NOW)
+                recovery_api.comment.assert_not_called()
+                recovery_api.close_not_planned.assert_called_once_with(value)
 
 
 if __name__ == "__main__":

--- a/tests/ci/test_awaiting_feedback_triage.py
+++ b/tests/ci/test_awaiting_feedback_triage.py
@@ -1,0 +1,138 @@
+import datetime as dt
+import importlib.util
+from pathlib import Path
+import unittest
+from unittest import mock
+
+
+SCRIPT = Path(__file__).parents[2] / ".github/scripts/awaiting_feedback_triage.py"
+SPEC = importlib.util.spec_from_file_location("awaiting_feedback_triage", SCRIPT)
+triage = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(triage)
+
+NOW = dt.datetime(2026, 7, 27, tzinfo=dt.timezone.utc)
+
+
+def timestamp(days_ago):
+    return (NOW - dt.timedelta(days=days_ago)).isoformat().replace("+00:00", "Z")
+
+
+def issue(*, days_ago=31, labels=None, state="open", pull_request=False):
+    value = {
+        "number": 7,
+        "state": state,
+        "created_at": timestamp(days_ago),
+        "updated_at": timestamp(days_ago),
+        "labels": [{"name": name} for name in (labels or [triage.TARGET_LABEL])],
+    }
+    if pull_request:
+        value["pull_request"] = {"url": "example"}
+    return value
+
+
+def comment(days_ago, body="human response", author_type="User"):
+    return {
+        "created_at": timestamp(days_ago),
+        "body": body,
+        "user": {"type": author_type},
+    }
+
+
+class DecisionTests(unittest.TestCase):
+    def test_issue_without_target_label_is_ignored(self):
+        self.assertEqual(triage.decide(issue(labels=["bug"]), [], NOW).action, "ignore")
+
+    def test_pull_request_is_ignored(self):
+        self.assertEqual(triage.decide(issue(pull_request=True), [], NOW).action, "ignore")
+
+    def test_issue_below_30_days_is_ignored(self):
+        self.assertEqual(triage.decide(issue(days_ago=29), [], NOW).action, "ignore")
+
+    def test_first_warning_is_posted_after_30_days(self):
+        self.assertEqual(triage.decide(issue(days_ago=30), [], NOW).action, "warn")
+
+    def test_duplicate_warning_is_not_posted(self):
+        comments = [comment(5, triage.WARNING_COMMENT, "Bot")]
+        self.assertEqual(triage.decide(issue(), comments, NOW).action, "ignore")
+
+    def test_closing_occurs_14_days_after_latest_warning(self):
+        comments = [comment(14, triage.WARNING_COMMENT, "Bot")]
+        self.assertEqual(triage.decide(issue(days_ago=60), comments, NOW).action, "close")
+
+    def test_human_comment_after_warning_prevents_closure(self):
+        comments = [comment(20, triage.WARNING_COMMENT, "Bot"), comment(10)]
+        self.assertEqual(triage.decide(issue(days_ago=60), comments, NOW).action, "ignore")
+
+    def test_issue_edit_after_warning_prevents_closure(self):
+        value = issue(days_ago=60)
+        value["updated_at"] = timestamp(10)
+        comments = [comment(20, triage.WARNING_COMMENT, "Bot")]
+        self.assertEqual(triage.decide(value, comments, NOW).action, "ignore")
+
+    def test_renewed_inactivity_can_produce_new_warning(self):
+        comments = [comment(50, triage.WARNING_COMMENT, "Bot"), comment(30)]
+        self.assertEqual(triage.decide(issue(days_ago=90), comments, NOW).action, "warn")
+
+    def test_removing_target_label_prevents_closure(self):
+        comments = [comment(14, triage.WARNING_COMMENT, "Bot")]
+        self.assertEqual(triage.decide(issue(labels=["bug"]), comments, NOW).action, "ignore")
+
+    def test_closed_issue_is_ignored(self):
+        self.assertEqual(triage.decide(issue(state="closed"), [], NOW).action, "ignore")
+
+    def test_automation_comments_are_not_human_activity(self):
+        comments = [comment(35, "unrelated automation", "Bot")]
+        self.assertEqual(triage.decide(issue(days_ago=40), comments, NOW).action, "warn")
+
+
+class ApiTests(unittest.TestCase):
+    def test_pagination_collects_multiple_pages(self):
+        api = triage.GitHubApi("owner/repository", "token")
+        api.request = mock.Mock(side_effect=[
+            ([{"number": 1}], '<https://api.github.com/repos/owner/repository/issues?page=2>; rel="next"'),
+            ([{"number": 2}], None),
+        ])
+        self.assertEqual([item["number"] for item in api.paginated("/issues?page=1")], [1, 2])
+        self.assertEqual(api.request.call_count, 2)
+
+    def test_dry_run_performs_no_writes(self):
+        api = mock.Mock()
+        api.issues.return_value = [issue()]
+        api.comments.return_value = []
+        triage.run(api, True, NOW)
+        api.current_issue.assert_not_called()
+        api.comment.assert_not_called()
+        api.remove_label.assert_not_called()
+        api.close_not_planned.assert_not_called()
+
+    def test_closure_rechecks_label_and_uses_not_planned(self):
+        api = mock.Mock()
+        api.issues.return_value = [issue(days_ago=60)]
+        api.comments.return_value = [comment(14, triage.WARNING_COMMENT, "Bot")]
+        api.current_issue.return_value = issue(days_ago=60)
+        triage.run(api, False, NOW)
+        api.comment.assert_called_once_with(7, triage.CLOSE_COMMENT)
+        api.remove_label.assert_called_once_with(7)
+        api.close_not_planned.assert_called_once_with(7)
+
+    def test_label_removal_during_run_prevents_writes(self):
+        api = mock.Mock()
+        api.issues.return_value = [issue(days_ago=60)]
+        api.comments.return_value = [comment(14, triage.WARNING_COMMENT, "Bot")]
+        api.current_issue.return_value = issue(labels=["bug"])
+        triage.run(api, False, NOW)
+        api.comment.assert_not_called()
+        api.remove_label.assert_not_called()
+        api.close_not_planned.assert_not_called()
+
+    def test_close_payload_uses_not_planned(self):
+        api = triage.GitHubApi("owner/repository", "token")
+        api.request = mock.Mock()
+        api.close_not_planned(7)
+        api.request.assert_called_once_with(
+            "PATCH", "/issues/7", {"state": "closed", "state_reason": "not_planned"}
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- The open issue backlog has been manually reviewed and the project needs a clearer, future-proof bug report form and a safe, narrowly scoped automation for issues that are truly waiting on reporter feedback.
- The goal is to avoid aggressive stale automation: confirmed or reproducible bugs, platform limitations, and active investigations must never be closed for inactivity unless a maintainer explicitly opts them into a monitored `status: awaiting-feedback` state. 
- The change centralizes maintainer triage policy and automates only the single status `status: awaiting-feedback` so maintainers can track genuinely blocked issues without risking incorrect closures.

### Description
- Modernized the issue form at `.github/ISSUE_TEMPLATE/bug_report.yml` to keep the `bug` label, preserve required fields, remove obsolete wording, and add optional fields for `installation/build origin`, `system architecture`, `GPU/driver`, occurrence frequency, and canonical diagnostic/log guidance and safe reproduction-file instructions. 
- Added `.github/ISSUE_TRIAGE.md` documenting complementary label categories (`bug`, `platform:*`, `area:*`, `type:*`, and `status:*`), the rule that `status:*` labels are mutually exclusive, confirmed-bug handling, `status: awaiting-feedback` usage, duplicates, completed/not-planned policies, milestones, and maintainer tone. 
- Implemented conservative triage automation as a small repository-owned script `.github/scripts/awaiting_feedback_triage.py` that uses stable HTML markers (`<!-- perastage-awaiting-feedback-warning:v1 -->` and `<!-- perastage-awaiting-feedback-close:v1 -->`), supports GitHub API pagination, treats only open issues with the exact `status: awaiting-feedback` label, distinguishes human vs automation activity, rechecks eligibility immediately before writes, and closes with `state_reason: not_planned`. 
- Added a scheduled workflow `.github/workflows/awaiting-feedback.yml` that runs daily at 04:17 UTC and supports `workflow_dispatch` with a safe `--dry-run` mode; the workflow uses minimal permissions `contents: read` and `issues: write` and does not use `pull_request_target` or mutate release/packaging CI. 
- Added focused unit tests `tests/ci/test_awaiting_feedback_triage.py` covering label/PR filtering, inactivity thresholds (30/14 days), duplicate-warning prevention, closure behavior, human activity resets, label-removal safety, pagination handling, dry-run behavior, eligibility rechecks, and that closure uses `not_planned`; linked the triage policy from developer docs and included a short internal release-note entry. 
- Exact automation timing and closure behavior: after 30 days without human activity the script posts one warning, and if 14 additional days pass without human activity it posts a closing comment, removes `status: awaiting-feedback`, and closes the issue with `not_planned`; human comments or issue edits restart the inactivity timer. 

### Testing
- `python3 -m unittest tests/ci/test_awaiting_feedback_triage.py -v` passed (17 tests), and `python3 -m py_compile .github/scripts/awaiting_feedback_triage.py tests/ci/test_awaiting_feedback_triage.py` succeeded. 
- YAML parsing for `.github/ISSUE_TEMPLATE/bug_report.yml`, `.github/ISSUE_TEMPLATE/config.yml`, and `.github/workflows/awaiting-feedback.yml` succeeded via the repository YAML loader used in CI checks. 
- Repository policy checks passed: `python3 tests/check_ci_workflow_architecture.py`, `python3 tests/check_docs_links.py`, `tests/check_perastage_tree_modules.sh`, and `tests/check_no_configmanager_get_in_gui.sh` all succeeded locally. 
- `git diff --check` passed and the working tree was committed on branch `chore/issue-intake-triage`; `actionlint` was not available in the environment but YAML syntax and workflow-architecture checks passed. 
- Confirmation: the automation only processes open issues that currently carry `status: awaiting-feedback` and never processes pull requests; confirmed or reproducible bugs and any issue without `status: awaiting-feedback` are not processed unless a maintainer explicitly applies that label. 
- Limitations / follow-up: GitHub issue metadata does not encode the semantic intent of every edit, so the script treats ambiguous edits conservatively as activity to avoid mistaken closures, and future improvements can add more nuanced heuristics or metrics if maintainers request them.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a66fd65cebc8324942cc7967c6ac19a)