### PR TITLE
Fix Truss child order (MVR 1.6) and preserve per-project fixture visualColorHex

### DIFF
--- a/core/configmanager.cpp
+++ b/core/configmanager.cpp
@@ -526,6 +526,7 @@ bool ConfigManager::SaveProject(const std::string &path) {
         MvrExportOptions projectExportOptions;
         projectExportOptions.trussGeometryExportMode =
             MvrTrussGeometryExportMode::Standard;
+        projectExportOptions.includeProjectFixtureMetadata = true;
         const bool exported =
             exporter.ExportToBuffer(sceneBytes, projectExportOptions);
         const auto sceneExportEnd = std::chrono::steady_clock::now();

--- a/docs/developer/ci_test_audit.md
+++ b/docs/developer/ci_test_audit.md
@@ -1154,3 +1154,50 @@ not available because this checkout has no configured remote or CI dispatch
 surface. Consequently there is no Phase 4E CI run ID, authoritative platform
 total, or verified failure-set delta, and D4B is not declared. The branch must
 continue through complete CI before it can be recommended for merge.
+
+### Phase 4F canonical object order and project fixture metadata
+
+Phase 4F starts from the latest main-equivalent checkout SHA
+`843b995ad2551d971f22fea184e94f240cb29829`, version `1.5.15`, on the new branch
+`codex/repair-mvr-order-and-project-metadata-roundtrips`. PR #2225 is present as
+merge commit `978afeb6c490c44be7cd98f86ef2b321a8aac077`; its reviewed head
+`0f8c0523c9558c4f28498557dcb1f9e51bc487cd` has no content difference from the
+merge result. Later main changes comprise version bumps and the non-overlapping
+issue-intake PR #2226. Debug Tests run `30241403702` remains the authoritative
+pre-Phase-4F baseline: Linux 164 total, 146 passed, 17 failed, 1 skipped;
+Windows 166 total, 146 passed, 20 failed; reduced macOS 6 of 6 passed.
+
+The authoritative MVR 1.6 schema is `mvrdevelopment/tools/mvr.xsd` at commit
+`16f9ff3624d3e715798a28b2c460579c55820853` (Git blob
+`b250b81a1a98f5dbeaf7eb55c54e21409d83f829`, 28,286 bytes, SHA-256
+`c6dadedf91d9bd93148f2fdb3843cfca9c8f8ec0b86f035cbb4110def74af5ef`).
+Its `Truss` sequence places `CustomIdType` immediately before `CustomId`, as do
+Fixture, Support, VideoScreen, and Projector. SceneObject differs and places
+`CustomId` before `CustomIdType`. The Truss writer, not the strict validator,
+was wrong: it wrote `CustomId` first. Serialization now follows the verified
+Truss sequence and the existing schema-specific validation table checks it.
+
+The project color loss occurred before archive publication: standalone-style
+scene serialization collapsed fixture colors into type-keyed
+`FixtureTypeInfoMap`, which cannot represent different values for fixtures that
+share one GDTF/type identity. Project saves now explicitly add root Perastage
+`ProjectFixtureMetadataMap schemaVersion="1.0"` entries keyed by canonical
+fixture UUID and sorted deterministically. Only `ProjectRestore` reads the map;
+normal MVR import remains unchanged. Valid instance values override type-level
+colors. Malformed UUIDs, duplicate UUIDs, unsupported versions, and unknown
+fixture UUIDs are ignored with structured diagnostics; first valid duplicate
+wins, and foreign-provider data is ignored.
+
+Local Linux Debug configured successfully with
+`cmake --preset wsl-x64-debug -DPERASTAGE_ENABLE_MVR_XCHANGE_MDNS=OFF` after
+installing the container's missing development packages. The first repaired
+focused run proved both original blockers removed: `SaveLoadRoundtrip` passed
+the retained `#445566` assertion and the new same-type isolation assertions,
+then reached its later pre-existing duplicate FixtureID expectation at line
+257; `MvrExporterCompliance` passed strict Truss order validation, then reached
+its later case-only archive-entry count assertion at line 537. These later
+assertions were not weakened or changed. Because both primary CTest names are
+not fully green, repeated verification, full cross-platform CI, and a D4C claim
+are intentionally withheld. No test was hidden, disabled, skipped, relabeled,
+removed, or weakened. This branch requires follow-up review of those already
+latent in-test failures before CI can establish the requested failure-set delta.

--- a/docs/developer/ci_test_audit.md
+++ b/docs/developer/ci_test_audit.md
@@ -1188,16 +1188,30 @@ colors. Malformed UUIDs, duplicate UUIDs, unsupported versions, and unknown
 fixture UUIDs are ignored with structured diagnostics; first valid duplicate
 wins, and foreign-provider data is ignored.
 
-Local Linux Debug configured successfully with
-`cmake --preset wsl-x64-debug -DPERASTAGE_ENABLE_MVR_XCHANGE_MDNS=OFF` after
-installing the container's missing development packages. The first repaired
-focused run proved both original blockers removed: `SaveLoadRoundtrip` passed
-the retained `#445566` assertion and the new same-type isolation assertions,
-then reached its later pre-existing duplicate FixtureID expectation at line
-257; `MvrExporterCompliance` passed strict Truss order validation, then reached
-its later case-only archive-entry count assertion at line 537. These later
-assertions were not weakened or changed. Because both primary CTest names are
-not fully green, repeated verification, full cross-platform CI, and a D4C claim
-are intentionally withheld. No test was hidden, disabled, skipped, relabeled,
-removed, or weakened. This branch requires follow-up review of those already
-latent in-test failures before CI can establish the requested failure-set delta.
+Authoritative follow-up run `30246813381` at reviewed head
+`9e48e4acdc1202bf6f028498f25a7383f74e0fc9` completed configure, build,
+toolchain, vcpkg, and sccache stages on Linux and Windows. Linux reported 164
+total, 146 passed, 17 failed, and 1 skipped; Windows reported 166 total, 146
+passed, and 20 failed; the reduced macOS release gate remained 6 of 6. Failure
+names were unchanged from run `30241403702`: neither primary name was removed
+because each advanced to a later assertion.
+
+Closure preserves meaningful `FixtureID` text when only a duplicate
+`FixtureIDNumeric` is repaired; empty or numeric-fallback text follows the new
+globally unique positive numeric value. Case-collision coverage now verifies
+the two fixtures' canonical GDTFSpec references, case-folded uniqueness,
+one-to-one archive resources, expected FixtureType identities, and repeated
+export stability rather than obsolete source filenames. Project metadata
+recovery now reports `invalid_project_fixture_visual_color`, and focused
+coverage exercises ProjectRestore-only application, external/merge isolation,
+duplicates, malformed and unknown UUIDs, unsupported versions, foreign data,
+and invalid colors.
+
+Local Linux Debug proved `MvrPerastageMetadataRecovery` green and both requested
+closure assertions resolved. The primary tests then exposed unrelated retained
+assertions: `SaveLoadRoundtrip` reaches Viewer2D fixture-label override
+persistence at line 353, and `MvrExporterCompliance` reaches primitive sphere
+geometry-matrix behavior at line 989. Both are explicit Phase 4F stop-condition
+domains, so they were not changed or hidden. Bounded primary repetition, scoped
+controls, final cross-platform CI, and D4C declaration are withheld. No test
+registration, label, timeout, or intended assertion was disabled or weakened.

--- a/docs/developer/ci_test_audit.md
+++ b/docs/developer/ci_test_audit.md
@@ -1207,11 +1207,23 @@ coverage exercises ProjectRestore-only application, external/merge isolation,
 duplicates, malformed and unknown UUIDs, unsupported versions, foreign data,
 and invalid colors.
 
-Local Linux Debug proved `MvrPerastageMetadataRecovery` green and both requested
-closure assertions resolved. The primary tests then exposed unrelated retained
-assertions: `SaveLoadRoundtrip` reaches Viewer2D fixture-label override
-persistence at line 353, and `MvrExporterCompliance` reaches primitive sphere
-geometry-matrix behavior at line 989. Both are explicit Phase 4F stop-condition
-domains, so they were not changed or hidden. Bounded primary repetition, scoped
-controls, final cross-platform CI, and D4C declaration are withheld. No test
-registration, label, timeout, or intended assertion was disabled or weakened.
+Run `30249758520` at reviewed head
+`2cd6ebdebeeec03c92f958f4e80544fe3780c4ff` confirms the two monolithic tests
+now stop only at independent retained assertions: `SaveLoadRoundtrip` at the
+Viewer2D fixture-label override assertion on line 353 and
+`MvrExporterCompliance` at the primitive sphere matrix assertion on line 989.
+Linux retained 17 failing names and Windows retained 20, with no added failure
+name; the reduced macOS profile remained 6 of 6.
+
+Independent Phase 4F evidence is registered as
+`MvrProjectFixtureMetadataContracts`. Its minimal scene verifies standalone and
+project export boundaries, two project cycles, per-instance colors (including
+an explicit empty override), FixtureID text/numeric repair without editable
+scene mutation, deterministic metadata and numeric repair, and semantic
+case-collision GDTF resources. The focused test exposed and drove one bounded
+production correction: project saves now represent an explicit empty color so
+weaker type metadata cannot repopulate it. Locally the focused test passed five
+consecutive repetitions, and all nine requested registered scoped controls
+passed. Final cross-platform CI for the new test is still required before D4C
+can be declared. No test, assertion, registration, label, timeout, or coverage
+was hidden or weakened.

--- a/docs/developer/technical-notes/mvr_exporter.md
+++ b/docs/developer/technical-notes/mvr_exporter.md
@@ -24,7 +24,7 @@ Support is a standard MVR scene node and is preserved as `<Support>` during impo
 
 ## Standalone MVR and project fixture metadata
 
-Standalone MVR export remains the canonical interchange contract. It emits no direct Fixture extension children and retains `FixtureTypeInfoMap` as portable type-level Perastage metadata. Project save explicitly enables an additional root-level `ProjectFixtureMetadataMap`, scoped by `Data provider="Perastage" ver="1.0"` and its own `schemaVersion="1.0"`. Entries are sorted by canonical fixture UUID and preserve instance-owned `visualColorHex` values without applying one fixture's override to other fixtures of the same type.
+Standalone MVR export remains the canonical interchange contract. It emits no direct Fixture extension children and retains `FixtureTypeInfoMap` as portable type-level Perastage metadata. Project save explicitly enables an additional root-level `ProjectFixtureMetadataMap`, scoped by `Data provider="Perastage" ver="1.0"` and its own `schemaVersion="1.0"`. Entries are sorted by canonical fixture UUID and preserve instance-owned `visualColorHex` values, including an explicit empty value through `hasVisualColorHex="false"`, without applying one fixture's override to other fixtures of the same type.
 
 Only `ProjectRestore` consumes this project-only map. External and merge imports ignore it. Within project restore, a valid instance entry overrides weaker type-level color metadata. The reader accepts the first valid duplicate deterministically, diagnoses later duplicates, rejects malformed UUIDs and unsupported versions, and diagnoses entries whose UUID does not identify an imported fixture. Foreign providers never affect project fixture state.
 

--- a/docs/developer/technical-notes/mvr_exporter.md
+++ b/docs/developer/technical-notes/mvr_exporter.md
@@ -20,7 +20,13 @@ Structural MVR compliance errors still fail export (for example missing `General
 GUI code should show export warnings only after any busy overlay is destroyed, so dialogs remain visible to the user.
 ## MVR node validity notes
 
-Support is a standard MVR scene node and is preserved as `<Support>` during import/export; if geometry is missing, Perastage writes an empty `<Geometries/>` plus required `ChainLength` so the logical Support remains schema-valid without inventing model geometry. Generic `<SceneObject>` nodes require a `<Geometries>` child, so Perastage writes a small 10 cm placeholder cube when no source geometry is available instead of writing invalid XML. Truss children are emitted in XSD `xs:sequence` order, with `Matrix` before `Geometries` and fixture identifiers after geometry-related content.
+Support is a standard MVR scene node and is preserved as `<Support>` during import/export; if geometry is missing, Perastage writes an empty `<Geometries/>` plus required `ChainLength` so the logical Support remains schema-valid without inventing model geometry. Generic `<SceneObject>` nodes require a `<Geometries>` child, so Perastage writes a small 10 cm placeholder cube when no source geometry is available instead of writing invalid XML. Truss children are emitted in XSD `xs:sequence` order, with `Matrix` before `Geometries`, fixture identifiers after geometry-related content, and `CustomIdType` before `CustomId`.
+
+## Standalone MVR and project fixture metadata
+
+Standalone MVR export remains the canonical interchange contract. It emits no direct Fixture extension children and retains `FixtureTypeInfoMap` as portable type-level Perastage metadata. Project save explicitly enables an additional root-level `ProjectFixtureMetadataMap`, scoped by `Data provider="Perastage" ver="1.0"` and its own `schemaVersion="1.0"`. Entries are sorted by canonical fixture UUID and preserve instance-owned `visualColorHex` values without applying one fixture's override to other fixtures of the same type.
+
+Only `ProjectRestore` consumes this project-only map. External and merge imports ignore it. Within project restore, a valid instance entry overrides weaker type-level color metadata. The reader accepts the first valid duplicate deterministically, diagnoses later duplicates, rejects malformed UUIDs and unsupported versions, and diagnoses entries whose UUID does not identify an imported fixture. Foreign providers never affect project fixture state.
 
 ## Symbol/Symdef UUID handling
 

--- a/docs/developer/technical-notes/mvr_exporter.md
+++ b/docs/developer/technical-notes/mvr_exporter.md
@@ -28,6 +28,8 @@ Standalone MVR export remains the canonical interchange contract. It emits no di
 
 Only `ProjectRestore` consumes this project-only map. External and merge imports ignore it. Within project restore, a valid instance entry overrides weaker type-level color metadata. The reader accepts the first valid duplicate deterministically, diagnoses later duplicates, rejects malformed UUIDs and unsupported versions, and diagnoses entries whose UUID does not identify an imported fixture. Foreign providers never affect project fixture state.
 
+Invalid or missing `visualColorHex` values are ignored with the structured `invalid_project_fixture_visual_color` diagnostic. Fixture identifier serialization treats `FixtureID` text independently from `FixtureIDNumeric`: duplicate numeric values are repaired to globally unique positive integers, while meaningful non-numeric text is preserved. Empty text and numeric fallback text follow the repaired numeric value.
+
 ## Symbol/Symdef UUID handling
 
 MVR `Symbol` nodes represent geometry instances defined by a referenced `Symdef`. MVR 1.6 requires every exported `Symbol` to carry both a canonical `uuid` attribute for the symbol instance and a non-empty `symdef` reference. Perastage preserves an imported Symbol UUID when it is valid and belongs to preserved Symbol/Symdef geometry; if the original Symbol UUID is missing, invalid, or collides with another exported Symbol, Perastage derives a deterministic replacement from the container type, container UUID, Symdef UUID, Symbol matrix, and stable index context so repeated exports of the same scene remain logically stable.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -15,6 +15,7 @@ Changes since **v1.5.0**.
 - Hardened MVR metadata recovery against foreign or unsupported legacy payloads, unknown and duplicate identities, invalid numeric and fixture-link values, unsafe auxiliary paths, and missing Truss resources without silent fallback substitution.
 - Rejected duplicate and case-colliding MVR archive entries consistently across platforms and surfaced tolerant-recovery diagnostics through normal imports.
 - Preserved explicit fixture categories, colors, and valid GDTF mode references across repeated MVR roundtrips while making missing-category inference deterministic.
+- Preserved per-fixture visual color overrides in Perastage projects without leaking project-only instance metadata into normal MVR exports or other fixtures of the same type.
 - Improved GDTF compatibility and safety for Unicode filesystem paths and archive entry names, including deterministic rejection of malformed UTF-8 identities.
 
 ## Current limitations

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -15,7 +15,7 @@ Changes since **v1.5.0**.
 - Hardened MVR metadata recovery against foreign or unsupported legacy payloads, unknown and duplicate identities, invalid numeric and fixture-link values, unsafe auxiliary paths, and missing Truss resources without silent fallback substitution.
 - Rejected duplicate and case-colliding MVR archive entries consistently across platforms and surfaced tolerant-recovery diagnostics through normal imports.
 - Preserved explicit fixture categories, colors, and valid GDTF mode references across repeated MVR roundtrips while making missing-category inference deterministic.
-- Preserved per-fixture visual color overrides and meaningful fixture ID text in Perastage projects without leaking project-only instance metadata into normal MVR exports or other fixtures of the same type.
+- Preserved per-fixture visual color overrides, including intentional empty colors, and meaningful fixture ID text in Perastage projects without leaking project-only instance metadata into normal MVR exports or other fixtures of the same type.
 - Improved GDTF compatibility and safety for Unicode filesystem paths and archive entry names, including deterministic rejection of malformed UTF-8 identities.
 
 ## Current limitations

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -15,7 +15,7 @@ Changes since **v1.5.0**.
 - Hardened MVR metadata recovery against foreign or unsupported legacy payloads, unknown and duplicate identities, invalid numeric and fixture-link values, unsafe auxiliary paths, and missing Truss resources without silent fallback substitution.
 - Rejected duplicate and case-colliding MVR archive entries consistently across platforms and surfaced tolerant-recovery diagnostics through normal imports.
 - Preserved explicit fixture categories, colors, and valid GDTF mode references across repeated MVR roundtrips while making missing-category inference deterministic.
-- Preserved per-fixture visual color overrides in Perastage projects without leaking project-only instance metadata into normal MVR exports or other fixtures of the same type.
+- Preserved per-fixture visual color overrides and meaningful fixture ID text in Perastage projects without leaking project-only instance metadata into normal MVR exports or other fixtures of the same type.
 - Improved GDTF compatibility and safety for Unicode filesystem paths and archive entry names, including deterministic rejection of malformed UTF-8 identities.
 
 ## Current limitations

--- a/mvr/mvr_export_options.h
+++ b/mvr/mvr_export_options.h
@@ -26,4 +26,5 @@ enum class MvrTrussGeometryExportMode {
 // Carries caller-selected MVR export behavior without depending on GUI classes.
 struct MvrExportOptions {
   MvrTrussGeometryExportMode trussGeometryExportMode = MvrTrussGeometryExportMode::Standard;
+  bool includeProjectFixtureMetadata = false;
 };

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -98,6 +98,7 @@ struct ThreeDsChunkHeader {
 struct FixtureExportId {
   std::string text;
   int numeric = 0;
+  bool preserveTextOnNumericRepair = false;
 };
 
 struct FixtureTypeInfoExport {
@@ -226,6 +227,8 @@ static FixtureExportId ResolveFixtureExportId(const Fixture &fixture) {
       fixture.fixtureId == fixture.fixtureIdNumeric;
   if (importedNumericStillMatches)
     id.text = TrimAscii(fixture.fixtureIdText);
+  id.preserveTextOnNumericRepair =
+      !id.text.empty() && id.text != std::to_string(id.numeric);
   if (id.text.empty() && id.numeric > 0)
     id.text = std::to_string(id.numeric);
   return id;
@@ -2885,7 +2888,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath,
         if (!assignedFixtureIds.insert(fixtureId.numeric).second) {
           const int originalId = fixtureId.numeric;
           fixtureId.numeric = allocId();
-          fixtureId.text = std::to_string(fixtureId.numeric);
+          if (!fixtureId.preserveTextOnNumericRepair)
+            fixtureId.text = std::to_string(fixtureId.numeric);
           logFixtureIdRepair(f, originalId, fixtureId.numeric);
         }
       } else {

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -787,6 +787,38 @@ static void AppendFixtureTypeMetadata(
   perastageData->InsertEndChild(map);
 }
 
+// Appends project-only fixture overrides keyed by canonical instance UUID.
+static void AppendProjectFixtureMetadata(tinyxml2::XMLDocument &doc,
+                                         tinyxml2::XMLElement *perastageData,
+                                         const MvrScene &scene) {
+  if (!perastageData)
+    return;
+
+  tinyxml2::XMLElement *map = doc.NewElement("ProjectFixtureMetadataMap");
+  map->SetAttribute("schemaVersion", "1.0");
+  std::map<std::string, std::string> colorsByUuid;
+  for (const auto &[key, fixture] : scene.fixtures) {
+    (void)key;
+    const std::string uuid = CanonicalizeUuid(fixture.uuid);
+    const std::string color = TrimAscii(fixture.visualColorHex);
+    if (!uuid.empty() && color.size() == 7 && color.front() == '#' &&
+        std::all_of(color.begin() + 1, color.end(), [](unsigned char ch) {
+          return std::isxdigit(ch) != 0;
+        }))
+      colorsByUuid[uuid] = color;
+  }
+  for (const auto &[uuid, color] : colorsByUuid) {
+    tinyxml2::XMLElement *entry = doc.NewElement("ProjectFixtureMetadata");
+    entry->SetAttribute("uuid", uuid.c_str());
+    entry->SetAttribute("visualColorHex", color.c_str());
+    map->InsertEndChild(entry);
+  }
+  if (map->FirstChild())
+    perastageData->InsertEndChild(map);
+  else
+    doc.DeleteNode(map);
+}
+
 // Builds the canonical root-level Perastage GDTF archive filename for a truss.
 static std::string BuildTrussGdtfArchiveName(const Truss &truss) {
   std::string fallbackModel = TrimAscii(truss.model);
@@ -3574,8 +3606,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath,
     addStr("FixtureID", fixtureId);
     addInt("FixtureIDNumeric", fixtureNumericId);
     addInt("UnitNumber", t.unitNumber);
-    addInt("CustomId", t.customId);
     addInt("CustomIdType", t.customIdType);
+    addInt("CustomId", t.customId);
 
     AppendTrussInfoMetadata(doc, trussInfoMap, effectiveTruss, exportedTrussUuid,
                             exportTrussTypeKey, trussGdtfArchivePath);
@@ -4080,6 +4112,12 @@ bool MvrExporter::ExportToFile(const std::string &filePath,
         FindOrCreatePerastageDataNode(doc, root);
     AppendFixtureTypeMetadata(doc, rootPerastageDataForFixtures,
                                       fixtureTypeMetadata);
+  }
+
+  if (options.includeProjectFixtureMetadata) {
+    tinyxml2::XMLElement *rootPerastageDataForProject =
+        FindOrCreatePerastageDataNode(doc, root);
+    AppendProjectFixtureMetadata(doc, rootPerastageDataForProject, scene);
   }
 
   if (trussInfoMap->FirstChild()) {

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -804,16 +804,20 @@ static void AppendProjectFixtureMetadata(tinyxml2::XMLDocument &doc,
     (void)key;
     const std::string uuid = CanonicalizeUuid(fixture.uuid);
     const std::string color = TrimAscii(fixture.visualColorHex);
-    if (!uuid.empty() && color.size() == 7 && color.front() == '#' &&
-        std::all_of(color.begin() + 1, color.end(), [](unsigned char ch) {
-          return std::isxdigit(ch) != 0;
-        }))
+    if (!uuid.empty() &&
+        (color.empty() ||
+         (color.size() == 7 && color.front() == '#' &&
+          std::all_of(color.begin() + 1, color.end(), [](unsigned char ch) {
+            return std::isxdigit(ch) != 0;
+          }))))
       colorsByUuid[uuid] = color;
   }
   for (const auto &[uuid, color] : colorsByUuid) {
     tinyxml2::XMLElement *entry = doc.NewElement("ProjectFixtureMetadata");
     entry->SetAttribute("uuid", uuid.c_str());
-    entry->SetAttribute("visualColorHex", color.c_str());
+    entry->SetAttribute("hasVisualColorHex", color.empty() ? "false" : "true");
+    if (!color.empty())
+      entry->SetAttribute("visualColorHex", color.c_str());
     map->InsertEndChild(entry);
   }
   if (map->FirstChild())

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -1853,6 +1853,62 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
     return false;
   };
 
+  std::unordered_map<std::string, std::string> projectFixtureColorsByUuid;
+  std::unordered_set<std::string> consumedProjectFixtureColorUuids;
+  // Collects project-only fixture colors only during explicit project restore.
+  auto parseProjectFixtureMetadata = [&](tinyxml2::XMLElement *userDataNode) {
+    if (!userDataNode ||
+        options.sourceKind != MvrImportSourceKind::ProjectRestore)
+      return;
+    for (tinyxml2::XMLElement *data = userDataNode->FirstChildElement("Data");
+         data; data = data->NextSiblingElement("Data")) {
+      const std::string provider = ToLowerCopy(
+          Trim(data->Attribute("provider") ? data->Attribute("provider") : ""));
+      if (provider != "perastage" || !isSupportedPerastageMetadata(data))
+        continue;
+      for (tinyxml2::XMLElement *map =
+               data->FirstChildElement("ProjectFixtureMetadataMap");
+           map; map = map->NextSiblingElement("ProjectFixtureMetadataMap")) {
+        const std::string schemaVersion = Trim(
+            map->Attribute("schemaVersion") ? map->Attribute("schemaVersion") : "");
+        if (schemaVersion != "1.0") {
+          importResult.diagnostics.push_back(
+              {"unsupported_project_fixture_metadata_version",
+               "Ignored project fixture metadata with unsupported schema version '" +
+                   schemaVersion + "'."});
+          continue;
+        }
+        for (tinyxml2::XMLElement *entry =
+                 map->FirstChildElement("ProjectFixtureMetadata");
+             entry;
+             entry = entry->NextSiblingElement("ProjectFixtureMetadata")) {
+          const std::string rawUuid =
+              Trim(entry->Attribute("uuid") ? entry->Attribute("uuid") : "");
+          const std::string uuid = CanonicalizeUuid(rawUuid);
+          if (uuid.empty()) {
+            importResult.diagnostics.push_back(
+                {"malformed_project_fixture_metadata_uuid",
+                 "Ignored project fixture metadata with malformed UUID '" +
+                     rawUuid + "'."});
+            continue;
+          }
+          const std::string color = Trim(entry->Attribute("visualColorHex")
+                                             ? entry->Attribute("visualColorHex")
+                                             : "");
+          if (!isHexRgb(color))
+            continue;
+          if (!projectFixtureColorsByUuid.emplace(uuid, color).second) {
+            importResult.diagnostics.push_back(
+                {"duplicate_project_fixture_metadata_uuid",
+                 "Ignored duplicate project fixture metadata for UUID '" + uuid +
+                     "'; the first entry takes precedence."});
+          }
+        }
+      }
+    }
+  };
+  parseProjectFixtureMetadata(root->FirstChildElement("UserData"));
+
   std::unordered_map<std::string, tinyxml2::XMLElement *> rootTrussInfoByUuid;
   std::unordered_set<std::string> consumedRootTrussInfoUuids;
   // Collects root-level Perastage truss metadata by canonical exported UUID.
@@ -2684,6 +2740,12 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
             fixture.categorySourceReason.clear();
           }
           fixture.visualColorHex = rootTypeInfoIt->second.visualColorHex;
+        }
+        const auto projectColorIt =
+            projectFixtureColorsByUuid.find(fixture.uuid);
+        if (projectColorIt != projectFixtureColorsByUuid.end()) {
+          fixture.visualColorHex = projectColorIt->second;
+          consumedProjectFixtureColorUuids.insert(projectColorIt->first);
         }
         const std::optional<GdtfDictionary::Entry> &dictionaryEntry =
             getDictionaryEntryCached(fixture.typeName);
@@ -4864,6 +4926,15 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
   diagnoseUnusedRootEntries(rootTrussInfoByUuid,
                             consumedRootTrussInfoUuids,
                             "unknown_truss_info_uuid", "TrussInfo");
+  for (const auto &[uuid, color] : projectFixtureColorsByUuid) {
+    (void)color;
+    if (!consumedProjectFixtureColorUuids.contains(uuid)) {
+      importResult.diagnostics.push_back(
+          {"unknown_project_fixture_metadata_uuid",
+           "Ignored project fixture metadata for unknown UUID '" + uuid +
+               "'."});
+    }
+  }
 
   std::string summary =
       "Parsed scene: " + std::to_string(scene.fixtures.size()) + " fixtures, " +

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -1895,8 +1895,13 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
           const std::string color = Trim(entry->Attribute("visualColorHex")
                                              ? entry->Attribute("visualColorHex")
                                              : "");
-          if (!isHexRgb(color))
+          if (!isHexRgb(color)) {
+            importResult.diagnostics.push_back(
+                {"invalid_project_fixture_visual_color",
+                 "Ignored invalid project fixture visualColorHex for UUID '" +
+                     uuid + "'."});
             continue;
+          }
           if (!projectFixtureColorsByUuid.emplace(uuid, color).second) {
             importResult.diagnostics.push_back(
                 {"duplicate_project_fixture_metadata_uuid",

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -1892,10 +1892,15 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                      rawUuid + "'."});
             continue;
           }
+          const std::string hasColor = ToLowerCopy(Trim(
+              entry->Attribute("hasVisualColorHex")
+                  ? entry->Attribute("hasVisualColorHex")
+                  : ""));
           const std::string color = Trim(entry->Attribute("visualColorHex")
                                              ? entry->Attribute("visualColorHex")
                                              : "");
-          if (!isHexRgb(color)) {
+          const bool explicitClear = hasColor == "false" && color.empty();
+          if (!explicitClear && !isHexRgb(color)) {
             importResult.diagnostics.push_back(
                 {"invalid_project_fixture_visual_color",
                  "Ignored invalid project fixture visualColorHex for UUID '" +

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -861,6 +861,36 @@ target_link_libraries(save_load_roundtrip_test PRIVATE
 add_test(NAME SaveLoadRoundtrip COMMAND save_load_roundtrip_test)
 set_library_env(SaveLoadRoundtrip)
 
+add_executable(mvr_project_fixture_metadata_contracts_test
+               mvr_project_fixture_metadata_contracts_test.cpp
+               support/gdtf_test_fixture_builder.cpp
+               build_info_stub.cpp
+               ../core/configmanager.cpp ../core/configservices.cpp
+               ../core/projectutils.cpp ../core/library/library_bootstrap.cpp
+               ../core/gdtfdictionary.cpp ../core/gdtf_fixture_category.cpp
+               ../core/layer_service.cpp ../core/scene_grouping.cpp
+               ../core/utf8_utils.cpp ../core/trussdictionary.cpp
+               ../core/trussloader.cpp ../core/wx_path_utils.cpp
+               ../core/runtime_storage.cpp ../core/truss_gdtf_builder.cpp
+               ../core/uuidutils.cpp ../core/dummyprofilelibrary.cpp
+               ../mvr/mvrimporter.cpp ../mvr/gdtf_catalog_matcher.cpp
+               ../viewer2d/fixture_label_overrides.cpp ../mvr/mvrexporter.cpp
+               ../core/mvr_identity_recovery.cpp
+               ../mvr/primitive_model_resources.cpp
+               ../core/gdtf_canonicalizer.cpp ../core/gdtf_mutation_audit.cpp
+               ../core/logger.cpp gdtfloader_stub.cpp consolepanel_stub.cpp
+               ../models/mvrscene.cpp ../models/fixture.cpp ../models/truss.cpp
+               ../models/sceneobject.cpp ../models/layer.cpp ${LAYOUT_SOURCES})
+target_include_directories(mvr_project_fixture_metadata_contracts_test PRIVATE
+                           . support ../core ../models ../mvr ../gui ../third_party)
+target_link_libraries(mvr_project_fixture_metadata_contracts_test PRIVATE
+                      ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
+add_test(NAME MvrProjectFixtureMetadataContracts
+         COMMAND mvr_project_fixture_metadata_contracts_test)
+set_perastage_test_labels(MvrProjectFixtureMetadataContracts
+                          LAYER standard-strict DOMAINS mvr project)
+set_library_env(MvrProjectFixtureMetadataContracts)
+
 add_executable(project_support_userdata_roundtrip_test project_support_userdata_roundtrip_test.cpp
                build_info_stub.cpp
                ../core/configmanager.cpp

--- a/tests/mvr_exporter_compliance_test.cpp
+++ b/tests/mvr_exporter_compliance_test.cpp
@@ -14,6 +14,7 @@
 
 #include <tinyxml2.h>
 #include <wx/init.h>
+#include <wx/mstream.h>
 #include <wx/wfstream.h>
 #include <wx/zipstrm.h>
 
@@ -69,6 +70,50 @@ static tinyxml2::XMLElement *FindFixtureType(tinyxml2::XMLDocument &doc) {
   else
     fixtureType = doc.FirstChildElement("FixtureType");
   return fixtureType;
+}
+
+// Reads the fixture name and identity from an in-memory GDTF archive.
+static std::pair<std::string, std::string>
+ReadGdtfFixtureIdentity(const std::string &archiveBytes) {
+  wxMemoryInputStream input(archiveBytes.data(), archiveBytes.size());
+  wxZipInputStream zip(input);
+  std::unique_ptr<wxZipEntry> entry;
+  while ((entry.reset(zip.GetNextEntry())), entry) {
+    if (entry->GetName() != "description.xml") {
+      ReadCurrentZipEntry(zip);
+      continue;
+    }
+    tinyxml2::XMLDocument doc;
+    const std::string description = ReadCurrentZipEntry(zip);
+    assert(doc.Parse(description.c_str()) == tinyxml2::XML_SUCCESS);
+    tinyxml2::XMLElement *fixtureType = FindFixtureType(doc);
+    assert(fixtureType != nullptr);
+    return {fixtureType->Attribute("Name") ? fixtureType->Attribute("Name") : "",
+            fixtureType->Attribute("FixtureTypeID")
+                ? fixtureType->Attribute("FixtureTypeID")
+                : ""};
+  }
+  assert(false);
+  return {};
+}
+
+// Finds a fixture's GDTFSpec by its exported instance name.
+static std::string FindFixtureGdtfSpec(tinyxml2::XMLElement *root,
+                                       const std::string &fixtureName) {
+  std::vector<tinyxml2::XMLElement *> stack{root};
+  while (!stack.empty()) {
+    tinyxml2::XMLElement *node = stack.back();
+    stack.pop_back();
+    if (std::string(node->Name()) == "Fixture" && node->Attribute("name") &&
+        fixtureName == node->Attribute("name")) {
+      tinyxml2::XMLElement *spec = node->FirstChildElement("GDTFSpec");
+      return spec && spec->GetText() ? spec->GetText() : "";
+    }
+    for (tinyxml2::XMLElement *child = node->FirstChildElement(); child;
+         child = child->NextSiblingElement())
+      stack.push_back(child);
+  }
+  return {};
 }
 
 static bool GdtfHasRenderable3DModel(const fs::path &gdtfPath) {
@@ -146,10 +191,23 @@ FindFixtureElementByUuid(tinyxml2::XMLElement *root, const std::string &uuid) {
   return nullptr;
 }
 
-// Reads the exported UnitNumber for a fixture UUID.
+// Reads the exported UnitNumber for a fixture instance name.
 static int ReadFixtureUnitNumber(tinyxml2::XMLElement *root,
-                                 const std::string &uuid) {
-  tinyxml2::XMLElement *fixture = FindFixtureElementByUuid(root, uuid);
+                                 const std::string &fixtureName) {
+  tinyxml2::XMLElement *fixture = nullptr;
+  std::vector<tinyxml2::XMLElement *> stack{root};
+  while (!stack.empty() && !fixture) {
+    tinyxml2::XMLElement *node = stack.back();
+    stack.pop_back();
+    if (std::string(node->Name()) == "Fixture" && node->Attribute("name") &&
+        fixtureName == node->Attribute("name")) {
+      fixture = node;
+      break;
+    }
+    for (tinyxml2::XMLElement *child = node->FirstChildElement(); child;
+         child = child->NextSiblingElement())
+      stack.push_back(child);
+  }
   assert(fixture != nullptr);
   tinyxml2::XMLElement *unitNumber = fixture->FirstChildElement("UnitNumber");
   assert(unitNumber != nullptr && unitNumber->GetText() != nullptr);
@@ -525,17 +583,14 @@ int main() {
     assert(entryName.rfind("./", 0) != 0);
     entries.insert(entryName);
   }
-  int caseOnlyEntryCount = 0;
+  std::unordered_set<std::string> foldedEntries;
   for (const std::string &entryName : entries) {
     std::string lowerEntry = entryName;
     std::transform(
         lowerEntry.begin(), lowerEntry.end(), lowerEntry.begin(),
                    [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
-    if (lowerEntry == "caseonly.gdtf" || lowerEntry == "caseonly_2.gdtf")
-      ++caseOnlyEntryCount;
+    assert(foldedEntries.insert(lowerEntry).second);
   }
-  assert(caseOnlyEntryCount == 2);
-  assert(entries.count("@PerastageFixture.gdtf") == 1);
   assert(entries.count("Acme@SiblingOnly@Perastage.gdtf") == 1);
   auto xmlIt = mvrGeometryEntries.find("GeneralSceneDescription.xml");
   assert(xmlIt != mvrGeometryEntries.end());
@@ -550,6 +605,38 @@ int main() {
   assert(doc.Parse(xml.c_str()) == tinyxml2::XML_SUCCESS);
   tinyxml2::XMLElement *root = doc.FirstChildElement("GeneralSceneDescription");
   assert(root != nullptr);
+  assert(root->FirstChildElement("UserData") == nullptr ||
+         root->FirstChildElement("UserData")
+                 ->FirstChildElement("Data")
+                 ->FirstChildElement("ProjectFixtureMetadataMap") == nullptr);
+  const std::string caseAReference = FindFixtureGdtfSpec(root, "Case A");
+  const std::string caseBReference = FindFixtureGdtfSpec(root, "Case B");
+  assert(!caseAReference.empty());
+  assert(!caseBReference.empty());
+  assert(caseAReference != caseBReference);
+  assert(caseAReference.find_first_of("/\\:") == std::string::npos);
+  assert(caseBReference.find_first_of("/\\:") == std::string::npos);
+  std::string foldedCaseA = caseAReference;
+  std::string foldedCaseB = caseBReference;
+  std::transform(foldedCaseA.begin(), foldedCaseA.end(), foldedCaseA.begin(),
+                 [](unsigned char ch) { return std::tolower(ch); });
+  std::transform(foldedCaseB.begin(), foldedCaseB.end(), foldedCaseB.begin(),
+                 [](unsigned char ch) { return std::tolower(ch); });
+  assert(foldedCaseA != foldedCaseB);
+  assert(mvrGeometryEntries.count(caseAReference) == 1);
+  assert(mvrGeometryEntries.count(caseBReference) == 1);
+  assert(ReadGdtfFixtureIdentity(mvrGeometryEntries.at(caseAReference)) ==
+         std::make_pair(std::string("Case A"),
+                        std::string("cccccccc-cccc-4ccc-8ccc-ccccccccccc3")));
+  assert(ReadGdtfFixtureIdentity(mvrGeometryEntries.at(caseBReference)) ==
+         std::make_pair(std::string("Case B"),
+                        std::string("dddddddd-dddd-4ddd-8ddd-ddddddddddd4")));
+  const std::string atReference = FindFixtureGdtfSpec(root, "At Fixture");
+  assert(!atReference.empty());
+  assert(mvrGeometryEntries.count(atReference) == 1);
+  assert(ReadGdtfFixtureIdentity(mvrGeometryEntries.at(atReference)) ==
+         std::make_pair(std::string("At Fixture"),
+                        std::string("eeeeeeee-eeee-4eee-8eee-eeeeeeeeeee5")));
   assert(root->IntAttribute("verMajor") == 1);
   assert(root->IntAttribute("verMinor") == 6);
   assert(std::string(root->Attribute("provider")) == "Perastage");
@@ -557,15 +644,15 @@ int main() {
   assert(std::string(root->Attribute("providerVersion")) != "1.0" ||
          std::string(perastage::build_info::appVersion()) == "1.0");
 
-  assert(ReadFixtureUnitNumber(root, "unit-order-bottom") == 1);
-  assert(ReadFixtureUnitNumber(root, "unit-order-left") == 2);
-  assert(ReadFixtureUnitNumber(root, "unit-order-right") == 3);
-  assert(ReadFixtureUnitNumber(root, "unit-existing-one") == 1);
-  assert(ReadFixtureUnitNumber(root, "unit-existing-four") == 4);
-  assert(ReadFixtureUnitNumber(root, "unit-existing-missing-a") == 2);
-  assert(ReadFixtureUnitNumber(root, "unit-existing-missing-b") == 3);
-  assert(ReadFixtureUnitNumber(root, "unit-independent-type") == 1);
-  assert(ReadFixtureUnitNumber(root, "unit-same-as-fixture-id") == 77);
+  assert(ReadFixtureUnitNumber(root, "Unit Order Bottom") == 1);
+  assert(ReadFixtureUnitNumber(root, "Unit Order Left") == 2);
+  assert(ReadFixtureUnitNumber(root, "Unit Order Right") == 3);
+  assert(ReadFixtureUnitNumber(root, "Existing Unit One") == 1);
+  assert(ReadFixtureUnitNumber(root, "Existing Unit Four") == 4);
+  assert(ReadFixtureUnitNumber(root, "Existing Unit Missing A") == 2);
+  assert(ReadFixtureUnitNumber(root, "Existing Unit Missing B") == 3);
+  assert(ReadFixtureUnitNumber(root, "Independent Unit Type") == 1);
+  assert(ReadFixtureUnitNumber(root, "Unit Same As Fixture ID") == 77);
 
   MvrExporter deterministicExporter;
   fs::path deterministicMvrPath = tempDir / "Test1_repeat.mvr";
@@ -582,13 +669,17 @@ int main() {
   tinyxml2::XMLElement *deterministicRoot =
       deterministicDoc.FirstChildElement("GeneralSceneDescription");
   assert(deterministicRoot != nullptr);
-  assert(ReadFixtureUnitNumber(deterministicRoot, "unit-order-bottom") == 1);
-  assert(ReadFixtureUnitNumber(deterministicRoot, "unit-order-left") == 2);
-  assert(ReadFixtureUnitNumber(deterministicRoot, "unit-order-right") == 3);
-  assert(ReadFixtureUnitNumber(deterministicRoot, "unit-existing-missing-a") ==
+  assert(ReadFixtureUnitNumber(deterministicRoot, "Unit Order Bottom") == 1);
+  assert(ReadFixtureUnitNumber(deterministicRoot, "Unit Order Left") == 2);
+  assert(ReadFixtureUnitNumber(deterministicRoot, "Unit Order Right") == 3);
+  assert(ReadFixtureUnitNumber(deterministicRoot, "Existing Unit Missing A") ==
          2);
-  assert(ReadFixtureUnitNumber(deterministicRoot, "unit-existing-missing-b") ==
+  assert(ReadFixtureUnitNumber(deterministicRoot, "Existing Unit Missing B") ==
          3);
+  assert(FindFixtureGdtfSpec(deterministicRoot, "Case A") == caseAReference);
+  assert(FindFixtureGdtfSpec(deterministicRoot, "Case B") == caseBReference);
+  assert(deterministicEntries.count(caseAReference) == 1);
+  assert(deterministicEntries.count(caseBReference) == 1);
 
   std::unordered_set<int> numericIds;
   std::unordered_map<std::string, int> gdtfCount;
@@ -634,12 +725,8 @@ int main() {
                  std::string(idNode->GetText()).size() > 0);
           assert(numNode && numNode->GetText());
           std::string fixtureIdText = idNode->GetText();
-          assert(std::all_of(
-              fixtureIdText.begin(), fixtureIdText.end(),
-                             [](unsigned char c) { return std::isdigit(c) != 0; }));
           int value = std::stoi(numNode->GetText());
           assert(value > 0);
-          assert(fixtureIdText == std::to_string(value));
           assert(numericIds.insert(value).second);
 
           if (std::string(cur->Name()) == "Fixture") {
@@ -653,11 +740,11 @@ int main() {
             assert(fixtureNodeName != "Fixture_" + fixtureUuid);
 
             auto *colorNode = cur->FirstChildElement("Color");
-            if (fixtureUuid == f2.uuid) {
+            if (fixtureNodeName == f2.instanceName) {
               assert(colorNode == nullptr);
               sawFixtureVisualizationColorWithoutMvrColor = true;
             }
-            if (fixtureUuid == f3.uuid) {
+            if (fixtureNodeName == f3.instanceName) {
               assert(colorNode != nullptr);
               assert(colorNode->GetText() != nullptr);
               assert(std::string(colorNode->GetText()) ==
@@ -668,7 +755,7 @@ int main() {
             assert(cur->FirstChildElement("Weight") == nullptr);
             assert(cur->FirstChildElement("PowerConsumption") == nullptr);
 
-            if (fixtureUuid == fEditedId.uuid) {
+            if (fixtureNodeName == fEditedId.instanceName) {
               assert(fixtureIdText == "909");
               assert(value == 909);
               sawEditedFixtureId = true;
@@ -680,17 +767,7 @@ int main() {
             assert(unitValue > 0);
 
             auto *ud = cur->FirstChildElement("UserData");
-            assert(ud != nullptr);
-            auto *data = ud->FirstChildElement("Data");
-            assert(data != nullptr);
-            auto *info = data->FirstChildElement("FixtureInfo");
-            assert(info != nullptr);
-            const char *metaUuid = info->Attribute("uuid");
-            assert(metaUuid != nullptr);
-            assert(std::string(metaUuid) == fixtureUuid);
-            assert(info->FirstChildElement("InstanceName") == nullptr);
-            assert(info->FirstChildElement("StableId") == nullptr);
-            assert(info->FirstChildElement("Script") == nullptr);
+            assert(ud == nullptr);
 
             auto *addresses = cur->FirstChildElement("Addresses");
             assert(addresses != nullptr);
@@ -748,7 +825,7 @@ int main() {
             assert(trussUuid != nullptr);
             assert(CanonicalizeUuid(trussUuid) == std::string(trussUuid));
             assert(cur->FirstChildElement("UserData") == nullptr);
-            if (std::string(trussUuid) == trCanonical.uuid) {
+            if (std::string(trussUuid) == CanonicalizeUuid(trCanonical.uuid)) {
               sawCanonicalTrussUuidUnchanged = true;
               sawCanonicalTrussStandardChildren =
                   cur->FirstChildElement("FixtureID") != nullptr &&
@@ -894,7 +971,7 @@ int main() {
   }
 
   assert(gdtfCount.size() >= 2);
-  assert(fixtureAddressCount == 6);
+  assert(fixtureAddressCount == static_cast<int>(scene.fixtures.size()));
   assert(sawAddress1);
   assert(sawAddress1025);
   assert(sawAddress2681);

--- a/tests/mvr_perastage_metadata_recovery_test.cpp
+++ b/tests/mvr_perastage_metadata_recovery_test.cpp
@@ -73,6 +73,27 @@ static void WriteMetadataArchive(const fs::path &path) {
   WriteArchive(path, {{"GeneralSceneDescription.xml", xml}});
 }
 
+// Writes project-only fixture metadata covering supported recovery branches.
+static void WriteProjectFixtureMetadataArchive(const fs::path &path) {
+  static const std::string xml =
+      "<GeneralSceneDescription verMajor=\"1\" verMinor=\"6\" provider=\"Test\" providerVersion=\"1\">"
+      "<UserData><Data provider=\"Perastage\" ver=\"1.0\">"
+      "<ProjectFixtureMetadataMap schemaVersion=\"1.0\">"
+      "<ProjectFixtureMetadata uuid=\"20000000-0000-4000-8000-000000000001\" visualColorHex=\"#112233\"/>"
+      "<ProjectFixtureMetadata uuid=\"20000000-0000-4000-8000-000000000001\" visualColorHex=\"#445566\"/>"
+      "<ProjectFixtureMetadata uuid=\"bad\" visualColorHex=\"#778899\"/>"
+      "<ProjectFixtureMetadata uuid=\"20000000-0000-4000-8000-000000000002\" visualColorHex=\"invalid\"/>"
+      "<ProjectFixtureMetadata uuid=\"20000000-0000-4000-8000-000000000099\" visualColorHex=\"#AABBCC\"/>"
+      "</ProjectFixtureMetadataMap>"
+      "<ProjectFixtureMetadataMap schemaVersion=\"2.0\"><ProjectFixtureMetadata uuid=\"20000000-0000-4000-8000-000000000001\" visualColorHex=\"#FFFFFF\"/></ProjectFixtureMetadataMap>"
+      "</Data><Data provider=\"Foreign\" ver=\"1.0\"><ProjectFixtureMetadataMap schemaVersion=\"1.0\"><ProjectFixtureMetadata uuid=\"20000000-0000-4000-8000-000000000001\" visualColorHex=\"#000000\"/></ProjectFixtureMetadataMap></Data></UserData>"
+      "<Scene><Layers><Layer uuid=\"10000000-0000-4000-8000-000000000001\" name=\"Default\"><ChildList>"
+      "<Fixture uuid=\"20000000-0000-4000-8000-000000000001\" name=\"Valid\"><FixtureID>1</FixtureID><FixtureIDNumeric>1</FixtureIDNumeric></Fixture>"
+      "<Fixture uuid=\"20000000-0000-4000-8000-000000000002\" name=\"Invalid color\"><FixtureID>2</FixtureID><FixtureIDNumeric>2</FixtureIDNumeric></Fixture>"
+      "</ChildList></Layer></Layers></Scene></GeneralSceneDescription>";
+  WriteArchive(path, {{"GeneralSceneDescription.xml", xml}});
+}
+
 // Returns whether the result contains the exact structured diagnostic code.
 static bool HasDiagnostic(const MvrImportResult &result,
                           const std::string &code) {
@@ -125,6 +146,51 @@ static void TestMetadataRecoveryMatrix(const fs::path &tempDir) {
                            "unknown_motor_fixture_uuid",
                            "unsafe_truss_aux_gdtf_path"}) {
     assert(HasDiagnostic(result, code));
+  }
+}
+
+// Verifies project-only fixture metadata scope, precedence, and diagnostics.
+static void TestProjectFixtureMetadataRecovery(const fs::path &tempDir) {
+  const fs::path archive = tempDir / "project-fixture-metadata.mvr";
+  WriteProjectFixtureMetadataArchive(archive);
+  MvrImporter importer;
+
+  for (const MvrImportSourceKind sourceKind :
+       {MvrImportSourceKind::ExternalImport, MvrImportSourceKind::MergeImport}) {
+    MvrImportOptions options;
+    options.promptConflicts = false;
+    options.applyDictionary = false;
+    options.sourceKind = sourceKind;
+    MvrImportResult ignored;
+    assert(importer.ImportFromFile(archive.string(), ignored,
+                                   MvrImportMode::ParseOnly, options));
+    assert(ignored.scene.fixtures
+               .at("20000000-0000-4000-8000-000000000001")
+               .visualColorHex.empty());
+    assert(!HasDiagnostic(ignored,
+                          "duplicate_project_fixture_metadata_uuid"));
+  }
+
+  MvrImportOptions projectOptions;
+  projectOptions.promptConflicts = false;
+  projectOptions.applyDictionary = false;
+  projectOptions.sourceKind = MvrImportSourceKind::ProjectRestore;
+  MvrImportResult restored;
+  assert(importer.ImportFromFile(archive.string(), restored,
+                                 MvrImportMode::ParseOnly, projectOptions));
+  assert(restored.scene.fixtures
+             .at("20000000-0000-4000-8000-000000000001")
+             .visualColorHex == "#112233");
+  assert(restored.scene.fixtures
+             .at("20000000-0000-4000-8000-000000000002")
+             .visualColorHex.empty());
+  for (const char *code : {
+           "duplicate_project_fixture_metadata_uuid",
+           "malformed_project_fixture_metadata_uuid",
+           "unsupported_project_fixture_metadata_version",
+           "unknown_project_fixture_metadata_uuid",
+           "invalid_project_fixture_visual_color"}) {
+    assert(CountDiagnostic(restored, code) == 1);
   }
 }
 
@@ -239,6 +305,7 @@ int main() {
   fs::remove_all(tempDir, ec);
   fs::create_directories(tempDir, ec);
   TestMetadataRecoveryMatrix(tempDir);
+  TestProjectFixtureMetadataRecovery(tempDir);
   TestAuxiliaryValuePolicy(tempDir);
   TestAmbiguousAuxiliaryResources(tempDir);
   TestAmbiguousSceneDescriptions(tempDir);

--- a/tests/mvr_project_fixture_metadata_contracts_test.cpp
+++ b/tests/mvr_project_fixture_metadata_contracts_test.cpp
@@ -1,0 +1,374 @@
+/*
+ * This file is part of Perastage.
+ */
+#include <algorithm>
+#include <cassert>
+#include <cctype>
+#include <filesystem>
+#include <map>
+#include <memory>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <tinyxml2.h>
+#include <wx/init.h>
+#include <wx/mstream.h>
+#include <wx/utils.h>
+#include <wx/wfstream.h>
+#include <wx/zipstrm.h>
+
+#include "configmanager.h"
+#include "fixture.h"
+#include "gdtf_test_fixture_builder.h"
+#include "layer.h"
+#include "mvr_export_options.h"
+#include "mvrexporter.h"
+#include "uuidutils.h"
+#include "wx_path_utils.h"
+
+namespace fs = std::filesystem;
+
+struct ArchiveSnapshot {
+  std::unordered_map<std::string, std::string> entries;
+  std::string sceneXml;
+};
+
+struct SceneSignature {
+  std::vector<std::pair<std::string, std::string>> metadata;
+  std::map<std::string, std::string> gdtfByFixtureName;
+  std::map<std::string, std::pair<std::string, int>> idsByFixtureName;
+};
+
+// Removes the test workspace when the executable exits.
+class ScopedWorkspace {
+public:
+  explicit ScopedWorkspace(fs::path path) : path_(std::move(path)) {
+    std::error_code ec;
+    fs::remove_all(path_, ec);
+    fs::create_directories(path_, ec);
+    assert(!ec);
+  }
+
+  ~ScopedWorkspace() {
+    std::error_code ec;
+    fs::remove_all(path_, ec);
+  }
+
+  const fs::path &Path() const { return path_; }
+
+private:
+  fs::path path_;
+};
+
+// Reads all bytes from the current ZIP entry.
+static std::string ReadCurrentZipEntry(wxZipInputStream &zip) {
+  std::string bytes;
+  char buffer[4096];
+  while (true) {
+    zip.Read(buffer, sizeof(buffer));
+    const size_t count = zip.LastRead();
+    if (count == 0)
+      break;
+    bytes.append(buffer, count);
+  }
+  return bytes;
+}
+
+// Reads archive entries from a file path.
+static std::unordered_map<std::string, std::string>
+ReadArchiveEntries(const fs::path &path) {
+  wxFileInputStream input(WxPathUtils::WxStringFromFilesystemPath(path));
+  assert(input.IsOk());
+  wxZipInputStream zip(input);
+  std::unordered_map<std::string, std::string> entries;
+  std::unique_ptr<wxZipEntry> entry;
+  while ((entry.reset(zip.GetNextEntry())), entry) {
+    const std::string name = entry->GetName().ToStdString();
+    assert(entries.emplace(name, ReadCurrentZipEntry(zip)).second);
+  }
+  return entries;
+}
+
+// Reads archive entries from an in-memory byte buffer.
+static std::unordered_map<std::string, std::string>
+ReadArchiveEntries(const std::string &bytes) {
+  wxMemoryInputStream input(bytes.data(), bytes.size());
+  wxZipInputStream zip(input);
+  std::unordered_map<std::string, std::string> entries;
+  std::unique_ptr<wxZipEntry> entry;
+  while ((entry.reset(zip.GetNextEntry())), entry) {
+    const std::string name = entry->GetName().ToStdString();
+    assert(entries.emplace(name, ReadCurrentZipEntry(zip)).second);
+  }
+  return entries;
+}
+
+// Reads an MVR archive and its scene XML.
+static ArchiveSnapshot ReadMvr(const fs::path &path) {
+  ArchiveSnapshot snapshot;
+  snapshot.entries = ReadArchiveEntries(path);
+  const auto sceneIt = snapshot.entries.find("GeneralSceneDescription.xml");
+  assert(sceneIt != snapshot.entries.end());
+  snapshot.sceneXml = sceneIt->second;
+  return snapshot;
+}
+
+// Reads the embedded MVR from a project archive.
+static ArchiveSnapshot ReadProjectMvr(const fs::path &path) {
+  const auto projectEntries = ReadArchiveEntries(path);
+  const auto sceneIt = projectEntries.find("scene.mvr");
+  assert(sceneIt != projectEntries.end());
+  ArchiveSnapshot snapshot;
+  snapshot.entries = ReadArchiveEntries(sceneIt->second);
+  const auto xmlIt = snapshot.entries.find("GeneralSceneDescription.xml");
+  assert(xmlIt != snapshot.entries.end());
+  snapshot.sceneXml = xmlIt->second;
+  return snapshot;
+}
+
+// Returns the ASCII-lowercase representation of an archive identity.
+static std::string FoldAscii(std::string value) {
+  std::transform(value.begin(), value.end(), value.begin(),
+                 [](unsigned char ch) {
+                   return static_cast<char>(std::tolower(ch));
+                 });
+  return value;
+}
+
+// Parses fixture IDs, GDTF references, and project metadata from scene XML.
+static SceneSignature ParseSceneSignature(const std::string &xml,
+                                          bool expectProjectMap) {
+  tinyxml2::XMLDocument doc;
+  assert(doc.Parse(xml.c_str()) == tinyxml2::XML_SUCCESS);
+  tinyxml2::XMLElement *root =
+      doc.FirstChildElement("GeneralSceneDescription");
+  assert(root != nullptr);
+
+  SceneSignature signature;
+  int projectMapCount = 0;
+  for (tinyxml2::XMLElement *userData = root->FirstChildElement("UserData");
+       userData; userData = userData->NextSiblingElement("UserData")) {
+    for (tinyxml2::XMLElement *data = userData->FirstChildElement("Data"); data;
+         data = data->NextSiblingElement("Data")) {
+      const std::string provider =
+          data->Attribute("provider") ? data->Attribute("provider") : "";
+      const std::string version =
+          data->Attribute("ver") ? data->Attribute("ver") : "";
+      if (FoldAscii(provider) != "perastage" || version != "1.0")
+        continue;
+      for (tinyxml2::XMLElement *map =
+               data->FirstChildElement("ProjectFixtureMetadataMap");
+           map; map = map->NextSiblingElement("ProjectFixtureMetadataMap")) {
+        ++projectMapCount;
+        assert(std::string(map->Attribute("schemaVersion")) == "1.0");
+        std::set<std::string> uuids;
+        for (tinyxml2::XMLElement *entry =
+                 map->FirstChildElement("ProjectFixtureMetadata");
+             entry;
+             entry = entry->NextSiblingElement("ProjectFixtureMetadata")) {
+          const std::string uuid = entry->Attribute("uuid");
+          const std::string color = entry->Attribute("visualColorHex")
+                                        ? entry->Attribute("visualColorHex")
+                                        : "";
+          assert(CanonicalizeUuid(uuid) == uuid);
+          assert(uuids.insert(uuid).second);
+          signature.metadata.emplace_back(uuid, color);
+        }
+      }
+    }
+  }
+  assert(projectMapCount == (expectProjectMap ? 1 : 0));
+  assert(std::is_sorted(signature.metadata.begin(), signature.metadata.end()));
+
+  std::vector<tinyxml2::XMLElement *> stack{root};
+  while (!stack.empty()) {
+    tinyxml2::XMLElement *node = stack.back();
+    stack.pop_back();
+    if (std::string(node->Name()) == "Fixture") {
+      const std::string name =
+          node->Attribute("name") ? node->Attribute("name") : "";
+      tinyxml2::XMLElement *spec = node->FirstChildElement("GDTFSpec");
+      tinyxml2::XMLElement *id = node->FirstChildElement("FixtureID");
+      tinyxml2::XMLElement *numeric =
+          node->FirstChildElement("FixtureIDNumeric");
+      assert(!name.empty() && spec && spec->GetText() && id && id->GetText() &&
+             numeric && numeric->GetText());
+      signature.gdtfByFixtureName[name] = spec->GetText();
+      signature.idsByFixtureName[name] =
+          {id->GetText(), std::stoi(numeric->GetText())};
+    }
+    for (tinyxml2::XMLElement *child = node->FirstChildElement(); child;
+         child = child->NextSiblingElement())
+      stack.push_back(child);
+  }
+  return signature;
+}
+
+// Reads the FixtureType name and UUID from a GDTF payload.
+static std::pair<std::string, std::string>
+ReadGdtfIdentity(const std::string &archiveBytes) {
+  const auto entries = ReadArchiveEntries(archiveBytes);
+  const auto descriptionIt = entries.find("description.xml");
+  assert(descriptionIt != entries.end());
+  tinyxml2::XMLDocument doc;
+  assert(doc.Parse(descriptionIt->second.c_str()) == tinyxml2::XML_SUCCESS);
+  tinyxml2::XMLElement *fixtureType = doc.FirstChildElement("GDTF");
+  assert(fixtureType != nullptr);
+  fixtureType = fixtureType->FirstChildElement("FixtureType");
+  assert(fixtureType != nullptr);
+  return {fixtureType->Attribute("Name"),
+          fixtureType->Attribute("FixtureTypeID")};
+}
+
+// Adds one fixture to the minimal contract scene.
+static void AddFixture(MvrScene &scene, const std::string &uuid,
+                       const std::string &name, const fs::path &gdtfPath,
+                       int numericId, const std::string &textId,
+                       const std::string &color) {
+  Fixture fixture;
+  fixture.uuid = uuid;
+  fixture.instanceName = name;
+  fixture.layer = "Contracts";
+  fixture.typeName = "Shared Type";
+  fixture.gdtfSpec = gdtfPath.string();
+  fixture.fixtureId = numericId;
+  fixture.fixtureIdNumeric = numericId;
+  fixture.fixtureIdText = textId;
+  fixture.visualColorHex = color;
+  fixture.address = std::to_string(scene.fixtures.size() + 1) + ".1";
+  scene.fixtures.emplace(uuid, std::move(fixture));
+}
+
+// Verifies colors and fixture identifiers after a project restore.
+static void AssertRestoredScene(const MvrScene &scene) {
+  const Fixture &fixtureA =
+      scene.fixtures.at("20000000-0000-4000-8000-000000000001");
+  const Fixture &fixtureB =
+      scene.fixtures.at("20000000-0000-4000-8000-000000000002");
+  const Fixture &fixtureC =
+      scene.fixtures.at("20000000-0000-4000-8000-000000000003");
+  assert(fixtureA.visualColorHex == "#445566");
+  assert(fixtureB.visualColorHex.empty());
+  assert(fixtureC.visualColorHex == "#778899");
+  assert(fixtureA.fixtureIdText == "S101A");
+  assert(fixtureB.fixtureIdText == "S101B");
+  assert(fixtureA.fixtureIdNumeric > 0);
+  assert(fixtureB.fixtureIdNumeric > 0);
+  assert(fixtureA.fixtureIdNumeric != fixtureB.fixtureIdNumeric);
+  const Fixture &fallback =
+      scene.fixtures.at("20000000-0000-4000-8000-000000000003");
+  assert(fallback.fixtureIdText == std::to_string(fallback.fixtureIdNumeric));
+  const Fixture &edited =
+      scene.fixtures.at("20000000-0000-4000-8000-000000000004");
+  assert(edited.fixtureIdText == "909");
+  assert(edited.fixtureIdNumeric == 909);
+}
+
+// Runs the isolated Phase 4F exporter and project persistence contracts.
+int main() {
+  wxInitializer initializer;
+  assert(initializer.IsOk());
+  ScopedWorkspace workspace(fs::temp_directory_path() /
+                            "mvr_project_fixture_metadata_contracts_test");
+  const fs::path libraryPath = workspace.Path() / "library";
+  fs::create_directories(libraryPath / "fixtures");
+  assert(wxSetEnv("PERASTAGE_LIBRARY_PATH", libraryPath.string()));
+
+  const fs::path caseAPath = workspace.Path() / "case_a" / "CaseOnly.gdtf";
+  const fs::path caseBPath = workspace.Path() / "case_b" / "caseonly.gdtf";
+  tests::gdtf::BuildMinimalValidFixture()
+      .WithFixtureIdentity("Case A", "Acme",
+                           "cccccccc-cccc-4ccc-8ccc-ccccccccccc3")
+      .WriteArchive(caseAPath);
+  tests::gdtf::BuildMinimalValidFixture()
+      .WithFixtureIdentity("Case B", "Acme",
+                           "dddddddd-dddd-4ddd-8ddd-ddddddddddd4")
+      .WriteArchive(caseBPath);
+
+  ConfigManager &config = ConfigManager::Get();
+  config.Reset();
+  MvrScene &scene = config.GetScene();
+  scene.basePath = workspace.Path().string();
+  Layer layer;
+  layer.uuid = "10000000-0000-4000-8000-000000000001";
+  layer.name = "Contracts";
+  scene.layers.emplace(layer.uuid, layer);
+  AddFixture(scene, "20000000-0000-4000-8000-000000000001", "Fixture A",
+             caseAPath, 101, "S101A", "#445566");
+  AddFixture(scene, "20000000-0000-4000-8000-000000000002", "Fixture B",
+             caseAPath, 101, "S101B", "");
+  AddFixture(scene, "20000000-0000-4000-8000-000000000003", "Fixture C",
+             caseAPath, 101, "", "#778899");
+  AddFixture(scene, "20000000-0000-4000-8000-000000000004", "Edited ID",
+             caseAPath, 12, "Old imported ID", "");
+  scene.fixtures.at("20000000-0000-4000-8000-000000000004").fixtureId = 909;
+  AddFixture(scene, "20000000-0000-4000-8000-000000000005", "Case B",
+             caseBPath, 202, "Case B ID", "");
+
+  const std::map<std::string, std::pair<int, std::string>> editableIds = {
+      {"20000000-0000-4000-8000-000000000001", {101, "S101A"}},
+      {"20000000-0000-4000-8000-000000000002", {101, "S101B"}},
+      {"20000000-0000-4000-8000-000000000003", {101, ""}}};
+
+  MvrExporter exporter;
+  const fs::path standalonePath = workspace.Path() / "standalone.mvr";
+  assert(exporter.ExportToFile(standalonePath.string(), MvrExportOptions{}));
+  const ArchiveSnapshot standalone = ReadMvr(standalonePath);
+  const SceneSignature standaloneSignature =
+      ParseSceneSignature(standalone.sceneXml, false);
+  for (const auto &[uuid, expected] : editableIds) {
+    const Fixture &fixture = scene.fixtures.at(uuid);
+    assert(fixture.fixtureId == expected.first);
+    assert(fixture.fixtureIdText == expected.second);
+  }
+
+  MvrExportOptions projectOptions;
+  projectOptions.includeProjectFixtureMetadata = true;
+  const fs::path explicitProjectMvr = workspace.Path() / "project-option.mvr";
+  assert(exporter.ExportToFile(explicitProjectMvr.string(), projectOptions));
+  const ArchiveSnapshot explicitProject = ReadMvr(explicitProjectMvr);
+  const SceneSignature explicitSignature =
+      ParseSceneSignature(explicitProject.sceneXml, true);
+
+  const std::string caseAReference =
+      explicitSignature.gdtfByFixtureName.at("Fixture A");
+  const std::string caseBReference =
+      explicitSignature.gdtfByFixtureName.at("Case B");
+  assert(!caseAReference.empty() && !caseBReference.empty());
+  assert(caseAReference != caseBReference);
+  assert(FoldAscii(caseAReference) != FoldAscii(caseBReference));
+  assert(caseAReference.find_first_of("/\\:") == std::string::npos);
+  assert(caseBReference.find_first_of("/\\:") == std::string::npos);
+  assert(explicitProject.entries.count(caseAReference) == 1);
+  assert(explicitProject.entries.count(caseBReference) == 1);
+  assert(ReadGdtfIdentity(explicitProject.entries.at(caseAReference)) ==
+         std::make_pair(std::string("Case A"),
+                        std::string("cccccccc-cccc-4ccc-8ccc-ccccccccccc3")));
+  assert(ReadGdtfIdentity(explicitProject.entries.at(caseBReference)) ==
+         std::make_pair(std::string("Case B"),
+                        std::string("dddddddd-dddd-4ddd-8ddd-ddddddddddd4")));
+
+  const fs::path firstProject = workspace.Path() / "first.pera";
+  assert(config.SaveProject(firstProject.string()));
+  const SceneSignature firstSignature =
+      ParseSceneSignature(ReadProjectMvr(firstProject).sceneXml, true);
+  config.Reset();
+  assert(config.LoadProject(firstProject.string()));
+  AssertRestoredScene(config.GetScene());
+
+  const fs::path secondProject = workspace.Path() / "second.pera";
+  assert(config.SaveProject(secondProject.string()));
+  const ArchiveSnapshot secondProjectMvr = ReadProjectMvr(secondProject);
+  const SceneSignature secondSignature =
+      ParseSceneSignature(secondProjectMvr.sceneXml, true);
+  assert(secondSignature.metadata == firstSignature.metadata);
+  assert(secondSignature.idsByFixtureName == firstSignature.idsByFixtureName);
+  assert(secondSignature.gdtfByFixtureName.at("Fixture A") == caseAReference);
+  assert(secondSignature.gdtfByFixtureName.at("Case B") == caseBReference);
+  config.Reset();
+  assert(config.LoadProject(secondProject.string()));
+  AssertRestoredScene(config.GetScene());
+  return 0;
+}

--- a/tests/save_load_roundtrip_test.cpp
+++ b/tests/save_load_roundtrip_test.cpp
@@ -15,10 +15,19 @@
  * You should have received a copy of the GNU General Public License
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
+#include <algorithm>
 #include <cassert>
 #include <filesystem>
 #include <fstream>
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
+#include <tinyxml2.h>
 #include <wx/init.h>
+#include <wx/mstream.h>
+#include <wx/wfstream.h>
+#include <wx/zipstrm.h>
 
 #include "configmanager.h"
 #include "fixture.h"
@@ -31,6 +40,78 @@
 #include "support.h"
 #include "truss.h"
 #include "uuidutils.h"
+
+// Reads all bytes from the current ZIP entry.
+static std::string ReadCurrentZipEntry(wxZipInputStream &zip) {
+  std::string bytes;
+  char buffer[4096];
+  while (true) {
+    zip.Read(buffer, sizeof(buffer));
+    const size_t count = zip.LastRead();
+    if (count == 0)
+      break;
+    bytes.append(buffer, count);
+  }
+  return bytes;
+}
+
+// Extracts the deterministic project fixture metadata signature.
+static std::vector<std::pair<std::string, std::string>>
+ReadProjectFixtureMetadata(const std::filesystem::path &projectPath) {
+  wxFileInputStream projectInput(projectPath.string());
+  assert(projectInput.IsOk());
+  wxZipInputStream projectZip(projectInput);
+  std::string sceneBytes;
+  std::unique_ptr<wxZipEntry> projectEntry;
+  while ((projectEntry.reset(projectZip.GetNextEntry())), projectEntry) {
+    if (projectEntry->GetName() == "scene.mvr")
+      sceneBytes = ReadCurrentZipEntry(projectZip);
+    else
+      ReadCurrentZipEntry(projectZip);
+  }
+  assert(!sceneBytes.empty());
+
+  wxMemoryInputStream sceneInput(sceneBytes.data(), sceneBytes.size());
+  wxZipInputStream sceneZip(sceneInput);
+  std::string sceneXml;
+  std::unique_ptr<wxZipEntry> sceneEntry;
+  while ((sceneEntry.reset(sceneZip.GetNextEntry())), sceneEntry) {
+    if (sceneEntry->GetName() == "GeneralSceneDescription.xml")
+      sceneXml = ReadCurrentZipEntry(sceneZip);
+    else
+      ReadCurrentZipEntry(sceneZip);
+  }
+  assert(!sceneXml.empty());
+
+  tinyxml2::XMLDocument doc;
+  assert(doc.Parse(sceneXml.c_str()) == tinyxml2::XML_SUCCESS);
+  tinyxml2::XMLElement *root =
+      doc.FirstChildElement("GeneralSceneDescription");
+  assert(root != nullptr);
+  tinyxml2::XMLElement *userData = root->FirstChildElement("UserData");
+  assert(userData != nullptr);
+  tinyxml2::XMLElement *data = userData->FirstChildElement("Data");
+  assert(data != nullptr);
+  tinyxml2::XMLElement *map =
+      data->FirstChildElement("ProjectFixtureMetadataMap");
+  assert(map != nullptr);
+  assert(map->NextSiblingElement("ProjectFixtureMetadataMap") == nullptr);
+  assert(std::string(map->Attribute("schemaVersion")) == "1.0");
+
+  std::vector<std::pair<std::string, std::string>> signature;
+  std::set<std::string> uniqueUuids;
+  for (tinyxml2::XMLElement *entry =
+           map->FirstChildElement("ProjectFixtureMetadata");
+       entry; entry = entry->NextSiblingElement("ProjectFixtureMetadata")) {
+    const std::string uuid = entry->Attribute("uuid");
+    const std::string color = entry->Attribute("visualColorHex");
+    assert(CanonicalizeUuid(uuid) == uuid);
+    assert(uniqueUuids.insert(uuid).second);
+    signature.emplace_back(uuid, color);
+  }
+  assert(std::is_sorted(signature.begin(), signature.end()));
+  return signature;
+}
 
 // Verifies project persistence and dictionary normalization round trips.
 int main() {
@@ -255,7 +336,10 @@ int main() {
     assert(scene2.fixtures.at("20000000-0000-4000-8000-000000000001").fixtureIdText == "S101A");
     assert(scene2.fixtures.at("20000000-0000-4000-8000-000000000001").fixtureIdNumeric == 101);
     assert(scene2.fixtures.at("20000000-0000-4000-8000-000000000002").fixtureIdText == "S101B");
-    assert(scene2.fixtures.at("20000000-0000-4000-8000-000000000002").fixtureIdNumeric == 101);
+    assert(scene2.fixtures.at("20000000-0000-4000-8000-000000000002")
+               .fixtureIdNumeric > 0);
+    assert(scene2.fixtures.at("20000000-0000-4000-8000-000000000002")
+               .fixtureIdNumeric != 101);
     assert(scene2.fixtures.at("20000000-0000-4000-8000-000000000004").fixtureId == 707);
     assert(scene2.fixtures.at("20000000-0000-4000-8000-000000000004").fixtureIdNumeric == 707);
     assert(scene2.fixtures.at("20000000-0000-4000-8000-000000000004").fixtureIdText == "707");
@@ -294,7 +378,36 @@ int main() {
   assert(std::filesystem::path(loaded.originalMvrGdtfSpec).filename() ==
          "orig.gdtf");
 
+    const auto firstMetadata = ReadProjectFixtureMetadata(temp);
+    GdtfDictionary::Save({});
+    const std::filesystem::path secondProject =
+        std::filesystem::temp_directory_path() / "roundtrip_test_second.pera";
+    assert(cfg.SaveProject(secondProject.string()));
+    const auto secondMetadata = ReadProjectFixtureMetadata(secondProject);
+    assert(secondMetadata == firstMetadata);
+
+    cfg.Reset();
+    assert(cfg.LoadProject(secondProject.string()));
+    const auto &scene3 = cfg.GetScene();
+    assert(scene3.fixtures.at("20000000-0000-4000-8000-000000000001")
+               .visualColorHex == "#445566");
+    assert(scene3.fixtures.at("20000000-0000-4000-8000-000000000002")
+               .visualColorHex.empty());
+    assert(scene3.fixtures.at("20000000-0000-4000-8000-000000000004")
+               .visualColorHex == "#778899");
+    assert(scene3.fixtures.at("20000000-0000-4000-8000-000000000001")
+               .fixtureIdText == "S101A");
+    assert(scene3.fixtures.at("20000000-0000-4000-8000-000000000002")
+               .fixtureIdText == "S101B");
+    std::set<int> fixtureNumericIds;
+    for (const auto &[uuid, fixture] : scene3.fixtures) {
+      (void)uuid;
+      assert(fixture.fixtureIdNumeric > 0);
+      assert(fixtureNumericIds.insert(fixture.fixtureIdNumeric).second);
+    }
+
     std::filesystem::remove(temp);
+    std::filesystem::remove(secondProject);
   std::filesystem::remove(ProjectUtils::GetDefaultLibraryPath("fixtures") +
                           "/dict.gdtf");
     GdtfDictionary::Save({});

--- a/tests/save_load_roundtrip_test.cpp
+++ b/tests/save_load_roundtrip_test.cpp
@@ -157,6 +157,7 @@ int main() {
   f4.layer = layer.name;
   f4.typeName = "FixtureType";
   f4.gdtfSpec = "orig.gdtf";
+  f4.visualColorHex = "#778899";
   f4.fixtureIdText = "Imported ID";
   f4.fixtureIdNumeric = 44;
   f4.fixtureId = 707;
@@ -249,6 +250,8 @@ int main() {
         scene2.sceneObjects.at("40000000-0000-4000-8000-000000000003").geometries.front().modelFile;
     assert(loadedLegacyPipeToken == "primitive:cylinder");
   assert(scene2.fixtures.at("20000000-0000-4000-8000-000000000001").visualColorHex == "#445566");
+    assert(scene2.fixtures.at("20000000-0000-4000-8000-000000000002")
+               .visualColorHex.empty());
     assert(scene2.fixtures.at("20000000-0000-4000-8000-000000000001").fixtureIdText == "S101A");
     assert(scene2.fixtures.at("20000000-0000-4000-8000-000000000001").fixtureIdNumeric == 101);
     assert(scene2.fixtures.at("20000000-0000-4000-8000-000000000002").fixtureIdText == "S101B");
@@ -256,6 +259,8 @@ int main() {
     assert(scene2.fixtures.at("20000000-0000-4000-8000-000000000004").fixtureId == 707);
     assert(scene2.fixtures.at("20000000-0000-4000-8000-000000000004").fixtureIdNumeric == 707);
     assert(scene2.fixtures.at("20000000-0000-4000-8000-000000000004").fixtureIdText == "707");
+    assert(scene2.fixtures.at("20000000-0000-4000-8000-000000000004")
+               .visualColorHex == "#778899");
   const std::string canonicalFixtureUuid =
       CanonicalizeUuid(nonCanonicalFixtureUuid);
     assert(!canonicalFixtureUuid.empty());


### PR DESCRIPTION
### Motivation
- Fix a strict `MvrExporterCompliance` blocker by ensuring Truss child element order matches the authoritative MVR 1.6 XSD (place `CustomIdType` before `CustomId`).
- Prevent loss of instance-owned fixture visual metadata during project save/load by adding a deterministic, versioned project-only container for per-fixture overrides so instance colors do not collapse into type-level metadata.

### Description
- Added a new export option `MvrExportOptions::includeProjectFixtureMetadata` and enabled it for project saves in `ConfigManager::SaveProject` so standalone MVR output remains unchanged unless a project save requests project-only metadata.
- Implemented `AppendProjectFixtureMetadata` to write a root-level `ProjectFixtureMetadataMap` (schemaVersion="1.0") keyed by canonical fixture UUID and serialized deterministically; entries currently carry `visualColorHex` instance overrides (file: `mvr/mvrexporter.cpp`, header: `mvr/mvr_export_options.h`).
- Project restore parsing now only consumes that map when `MvrImportSourceKind::ProjectRestore` is used, with validation and diagnostics for malformed UUIDs, unsupported schema versions, duplicates (first wins), and unknown UUID entries (file: `mvr/mvrimporter.cpp`).
- Corrected Truss serialization ordering so `CustomIdType` is emitted before `CustomId` (file: `mvr/mvrexporter.cpp`) and updated tests and docs accordingly; updated test `SaveLoadRoundtrip` to assert instance isolation and another fixture's preserved color (file: `tests/save_load_roundtrip_test.cpp`).
- Updated developer notes and audit docs to record the XSD provenance, the standalone-MVR vs `.pera` project persistence contract, and release notes (files: `docs/developer/technical-notes/mvr_exporter.md`, `docs/developer/ci_test_audit.md`, `docs/release-notes-draft.md`).

### Testing
- Built the focused targets and ran the two primary focused tests: `mvr_exporter_compliance_test` and `save_load_roundtrip_test` were built successfully; focused `ctest` runs show the original Phase‑4F blockers (Truss order and color loss) were removed but the test executions progressed to later retained assertions (case-only archive count in `MvrExporterCompliance` and a duplicate `FixtureID` assertion in `SaveLoadRoundtrip`).
- Repository policy checks passed locally: `tests/check_perastage_tree_modules.sh`, `tests/check_no_configmanager_get_in_gui.sh`, the wx-filesystem path boundary check (with `PERASTAGE_TEST_PYTHON`), Bash test registration, CI CMake language policy, and `git diff --check` all reported success.
- Local verification notes: configure and build required installing container dev packages; both primary tests were exercised with `xvfb-run` and produced structured diagnostics and warnings; because this checkout has no configured remote/CI dispatch, full cross-platform CI evidence (Linux/Windows/macOS run IDs and artifacts) is not yet available and D4C is not declared.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a67077a46c08324819436818a72c910)