### PR TITLE
Repair Rider truss GDTF resource resolution

### DIFF
--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -1111,6 +1111,32 @@ std::vector<float> SplitTrussSymmetric(float total) {
   return best;
 }
 
+// Removes supported finish adjectives as whole canonical tokens.
+std::string SimplifyTrussFinishWords(const std::string &value) {
+  const std::string normalized = TrussDictionary::NormalizeModelKey(value);
+  if (normalized.empty())
+    return normalized;
+
+  static const std::unordered_set<std::string> kFinishWords = {
+      "NEGRO", "NEGRA", "NEGRAS", "NEGROS", "BLACK",
+      "PLATA", "SILVER", "ALUMINIO", "ALUMINUM"};
+
+  std::istringstream input(normalized);
+  std::ostringstream output;
+  std::string word;
+  bool wroteWord = false;
+  while (input >> word) {
+    if (kFinishWords.find(word) != kFinishWords.end())
+      continue;
+    if (wroteWord)
+      output << ' ';
+    output << word;
+    wroteWord = true;
+  }
+  return wroteWord ? output.str() : normalized;
+}
+
+// Builds prioritized canonical keys for Rider truss dictionary resolution.
 std::vector<std::string>
 BuildTrussDictionaryLookupKeys(const std::string &modelToken,
                                const std::string &trussName) {
@@ -1123,44 +1149,25 @@ BuildTrussDictionaryLookupKeys(const std::string &modelToken,
       keys.push_back(normalized);
   };
 
-  auto simplifyModelToken = [](std::string token) {
-    token = TrussDictionary::NormalizeModelKey(token);
-    if (token.empty())
-      return token;
-
-    static const std::unordered_set<std::string> kFinishWords = {
-        "NEGRO", "NEGRA", "NEGRAS", "NEGROS", "BLACK",
-        "PLATA", "SILVER", "ALUMINIO", "ALUMINUM"};
-
-    std::istringstream iss(token);
-    std::string word;
-    std::vector<std::string> kept;
-    while (iss >> word) {
-      if (kFinishWords.find(word) != kFinishWords.end())
-        continue;
-      kept.push_back(word);
-    }
-    if (kept.empty())
-      return token;
-    std::ostringstream oss;
-    for (size_t i = 0; i < kept.size(); ++i) {
-      if (i > 0)
-        oss << ' ';
-      oss << kept[i];
-    }
-    return oss.str();
-  };
-
   pushNormalized(modelToken);
   if (!modelToken.empty())
     pushNormalized("TRUSS " + modelToken);
-  const std::string simplifiedModelToken = simplifyModelToken(modelToken);
+  const std::string simplifiedModelToken = SimplifyTrussFinishWords(modelToken);
   if (!simplifiedModelToken.empty() &&
       simplifiedModelToken != TrussDictionary::NormalizeModelKey(modelToken)) {
     pushNormalized(simplifiedModelToken);
     pushNormalized("TRUSS " + simplifiedModelToken);
   }
   pushNormalized(trussName);
+  const std::string simplifiedTrussName = SimplifyTrussFinishWords(trussName);
+  if (simplifiedTrussName != TrussDictionary::NormalizeModelKey(trussName)) {
+    pushNormalized(simplifiedTrussName);
+    static const std::string kTrussPrefix = "TRUSS ";
+    if (simplifiedTrussName.rfind(kTrussPrefix, 0) == 0)
+      pushNormalized(simplifiedTrussName.substr(kTrussPrefix.size()));
+    else
+      pushNormalized(kTrussPrefix + simplifiedTrussName);
+  }
 
   return keys;
 }

--- a/core/trussloader.cpp
+++ b/core/trussloader.cpp
@@ -263,7 +263,7 @@ bool IsSupportedTrussDefinitionExtension(const std::string &path) {
   return ext == ".gdtf" || ext == ".gtruss" || ext == ".glb" || ext == ".3ds";
 }
 
-// Loads a GDTF truss archive and resolves its renderable model metadata.
+// Loads GDTF truss metadata and resolves renderable 3D geometry when available.
 bool LoadTrussGdtf(const std::string &gdtfPath, Truss &outTruss) {
   fs::path inputPath = FromUtf8String(gdtfPath);
   if (!fs::exists(inputPath))
@@ -324,9 +324,6 @@ bool LoadTrussGdtf(const std::string &gdtfPath, Truss &outTruss) {
     if (!modelPath.empty())
       outTruss.symbolFile = ToUtf8String(modelPath);
 
-    fs::path symbolPath = FindFirstExisting(baseDir, {fs::path("models/svg") / (fileBase + ".svg")});
-    if (!symbolPath.empty() && outTruss.symbolFile.empty())
-      outTruss.symbolFile = ToUtf8String(symbolPath);
   }
 
   tinyxml2::XMLElement *phys = fixtureType->FirstChildElement("PhysicalDescriptions");
@@ -343,7 +340,7 @@ bool LoadTrussGdtf(const std::string &gdtfPath, Truss &outTruss) {
   if (outTruss.gdtfMode.empty())
     outTruss.gdtfMode = "Default";
 
-  return !outTruss.symbolFile.empty();
+  return true;
 }
 
 // Loads a truss archive through the general truss definition loader.

--- a/docs/developer/ci_test_audit.md
+++ b/docs/developer/ci_test_audit.md
@@ -1255,3 +1255,10 @@ PR #2229 closed Phase 5B/E2 at reviewed head
 Windows, made `RiderPipeImport` green, introduced no new failure name, and left
 `RiderHoistImport` at its deferred Phase 5D backdrop-resource assertion. E2 was
 reached and PR #2229 was approved for merge.
+
+PR #2230 closed Phase 5C/E3 at reviewed head
+`4c1f88e59bb67cde545a208c64f061f2f53ab7ac`. Authoritative run
+`30280209293` made `RiderImportLinearOrder`, `RiderLedScreenObject`, and
+`RiderLxSidesImport` green on Linux and Windows, introduced no new failure
+name, and kept macOS at 6 of 6. E3 was reached and PR #2230 was approved for
+merge.

--- a/docs/developer/ci_test_audit.md
+++ b/docs/developer/ci_test_audit.md
@@ -1262,3 +1262,10 @@ PR #2230 closed Phase 5C/E3 at reviewed head
 `RiderLxSidesImport` green on Linux and Windows, introduced no new failure
 name, and kept macOS at 6 of 6. E3 was reached and PR #2230 was approved for
 merge.
+
+Phase 5D authoritative run `30284186309` made
+`RiderTrussDictionaryNormalization` green on Linux and Windows without a new
+failure name and kept macOS at 6 of 6. `RiderHoistImport` advanced to a stale
+per-piece 12 m BACKDROP assertion; the inherited 12 m span is represented by
+multiple contiguous standard pieces, so final E4 evidence remains pending the
+aggregate-span correction.

--- a/docs/developer/ci_test_audit.md
+++ b/docs/developer/ci_test_audit.md
@@ -1276,3 +1276,11 @@ aggregate BACKDROP span correction. `RiderTrussDictionaryNormalization` failed
 only because its new assertions compared the managed dictionary copy with its
 temporary import source; no unrelated failure name changed and macOS remained
 6 of 6. E4 remains pending the managed-path test correction.
+
+At head `621b2808115e02abf63ae0bdcab3a7f441e60326`, authoritative run
+`30289959436` kept `RiderHoistImport` green while
+`RiderTrussDictionaryNormalization` advanced to its managed-directory
+assertion on Linux and Windows. The test set `PERASTAGE_LIBRARY_PATH` to a
+directory it had not created, so production correctly used the user-data
+fallback; no unrelated failure name changed and macOS remained 6 of 6. E4
+remains pending final isolated-root verification.

--- a/docs/developer/ci_test_audit.md
+++ b/docs/developer/ci_test_audit.md
@@ -1269,3 +1269,10 @@ failure name and kept macOS at 6 of 6. `RiderHoistImport` advanced to a stale
 per-piece 12 m BACKDROP assertion; the inherited 12 m span is represented by
 multiple contiguous standard pieces, so final E4 evidence remains pending the
 aggregate-span correction.
+
+At head `080bf59da85dff8849ead91118e300389a20c66d`, authoritative run
+`30287799107` made `RiderHoistImport` green on Linux and Windows, verifying the
+aggregate BACKDROP span correction. `RiderTrussDictionaryNormalization` failed
+only because its new assertions compared the managed dictionary copy with its
+temporary import source; no unrelated failure name changed and macOS remained
+6 of 6. E4 remains pending the managed-path test correction.

--- a/docs/developer/text_to_scene_rules.md
+++ b/docs/developer/text_to_scene_rules.md
@@ -565,3 +565,17 @@ When changing any text-to-scene parsing or placement behavior:
 ## Suggested user-doc excerpt
 
 Perastage parses rider text by identifying sections, hang positions, fixture lines, and truss declarations, then generates fixtures/trusses with predictable layer, placement, numbering, and auto-patch rules. PDF riders are first converted to text and parsed using the same rule set.
+
+### Truss dictionary and resource resolution
+
+- Dictionary matching is case- and whitespace-insensitive. Known finish words
+  such as `NEGRO`, `BLACK`, and `PLATA` are removed only as complete tokens from
+  both model candidates and length-bearing truss names; explicit lengths remain
+  part of the candidate key.
+- A GDTF path identifies the source archive. An extracted `.glb` or `.3ds` is
+  the renderable 3D symbol resource. An optional GDTF SVG remains a 2D resource
+  and is not assigned to the truss 3D `symbolFile`.
+- Valid metadata-only or SVG-only archives may provide truss metadata, but
+  Rider import retains deterministic dummy geometry when no supported 3D model
+  exists. Imports never fabricate a model path or borrow another hang's
+  resource for an unresolved truss.

--- a/docs/developer/text_to_scene_rules.md
+++ b/docs/developer/text_to_scene_rules.md
@@ -582,3 +582,7 @@ Perastage parses rider text by identifying sections, hang positions, fixture lin
 - Rider truss resource tests distinguish supported 3D resource-path resolution
   from mesh rendering validation. GLB/3DS decoding and native mesh dimensions
   remain owned by the dedicated model-loader tests.
+- Truss dictionary imports are copied into the active dictionary's managed
+  storage. Dictionary-backed Rider trusses use that managed GDTF archive for
+  `modelFile` and `gdtfSpec`; a transient import source is not their stable
+  resource identity.

--- a/docs/developer/text_to_scene_rules.md
+++ b/docs/developer/text_to_scene_rules.md
@@ -579,3 +579,6 @@ Perastage parses rider text by identifying sections, hang positions, fixture lin
   Rider import retains deterministic dummy geometry when no supported 3D model
   exists. Imports never fabricate a model path or borrow another hang's
   resource for an unresolved truss.
+- Rider truss resource tests distinguish supported 3D resource-path resolution
+  from mesh rendering validation. GLB/3DS decoding and native mesh dimensions
+  remain owned by the dedicated model-loader tests.

--- a/docs/developer/text_to_scene_rules.md
+++ b/docs/developer/text_to_scene_rules.md
@@ -586,3 +586,7 @@ Perastage parses rider text by identifying sections, hang positions, fixture lin
   storage. Dictionary-backed Rider trusses use that managed GDTF archive for
   `modelFile` and `gdtfSpec`; a transient import source is not their stable
   resource identity.
+- A `PERASTAGE_LIBRARY_PATH` override root must already exist and be writable.
+  Isolated tests create that root before resolving the active dictionary so
+  transient sources and normal user-data fallback storage never become test
+  fixture ownership locations.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -10,6 +10,10 @@ Changes since **v1.5.0**.
 
 ## Important fixes
 
+- Corrected Rider truss dictionary matching for finish and length variants, and
+  ensured GDTF SVG symbols no longer masquerade as renderable 3D geometry when
+  an imported truss requires an honest dummy fallback.
+
 - Corrected Rider imports so side lighting trusses use their documented default height and LED screens retain accurate dimensions through the shared cube primitive transform.
 
 - Corrected Rider rigging imports so side-fill hoists retain their audio grouping and pipes for lighting bridges, including explicit-length model-free entries, expand consistently across LX positions.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -13,7 +13,7 @@ Changes since **v1.5.0**.
 - Corrected Rider truss dictionary matching for finish and length variants, and
   ensured GDTF SVG symbols no longer masquerade as renderable 3D geometry when
   an imported truss requires an honest dummy fallback, while resolved truss
-  dimensions remain consistent with managed dictionary resources.
+  dimensions remain consistent with portable managed dictionary resources.
 
 - Corrected Rider imports so side lighting trusses use their documented default height and LED screens retain accurate dimensions through the shared cube primitive transform.
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -13,7 +13,7 @@ Changes since **v1.5.0**.
 - Corrected Rider truss dictionary matching for finish and length variants, and
   ensured GDTF SVG symbols no longer masquerade as renderable 3D geometry when
   an imported truss requires an honest dummy fallback, while resolved truss
-  dimensions remain consistent with the selected resource.
+  dimensions remain consistent with managed dictionary resources.
 
 - Corrected Rider imports so side lighting trusses use their documented default height and LED screens retain accurate dimensions through the shared cube primitive transform.
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -12,7 +12,8 @@ Changes since **v1.5.0**.
 
 - Corrected Rider truss dictionary matching for finish and length variants, and
   ensured GDTF SVG symbols no longer masquerade as renderable 3D geometry when
-  an imported truss requires an honest dummy fallback.
+  an imported truss requires an honest dummy fallback, while resolved truss
+  dimensions remain consistent with the selected resource.
 
 - Corrected Rider imports so side lighting trusses use their documented default height and LED screens retain accurate dimensions through the shared cube primitive transform.
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -957,6 +957,7 @@ add_test(NAME TrussPathEncodingRegression COMMAND truss_path_encoding_regression
 
 add_executable(rider_truss_dictionary_normalization_test
                rider_truss_dictionary_normalization_test.cpp
+               support/gdtf_test_fixture_builder.cpp
                build_info_stub.cpp
                pdftext_stub.cpp
                gdtfloader_stub.cpp

--- a/tests/gdtf_test_fixture_builder_test.cpp
+++ b/tests/gdtf_test_fixture_builder_test.cpp
@@ -113,6 +113,25 @@ static bool VerifyOneAddressFixtureXml(const std::string &xml) {
   return true;
 }
 
+// Verifies model dimensions use deterministic decimal serialization.
+static bool VerifyModelDimensions() {
+  const std::string xml = tests::gdtf::BuildMinimalValidFixture()
+                              .WithModelDimensionsMeters(3.0f, 0.4f, 0.4f)
+                              .BuildDescriptionXml();
+  tinyxml2::XMLDocument doc;
+  if (doc.Parse(xml.c_str()) != tinyxml2::XML_SUCCESS)
+    return Fail("Dimension fixture XML did not parse");
+  const auto *model = doc.FirstChildElement("GDTF")
+                          ->FirstChildElement("FixtureType")
+                          ->FirstChildElement("Models")
+                          ->FirstChildElement("Model");
+  if (!model || std::string(model->Attribute("Length")) != "3.0" ||
+      std::string(model->Attribute("Width")) != "0.4" ||
+      std::string(model->Attribute("Height")) != "0.4")
+    return Fail("Model dimensions were not serialized deterministically");
+  return true;
+}
+
 // Verifies the test-support archive path validator accepts and rejects expected paths.
 static bool VerifyArchivePathValidation(const fs::path &root) {
   for (const std::string &path : {"safe..name.png", "models/safe..name.glb"}) {
@@ -155,6 +174,11 @@ int main() {
     return Fail("Generated archive entry permissions are not fixed") ? 0 : 1;
   if (!VerifyOneAddressFixtureXml(entries.front().content))
     return 1;
+  if (!VerifyModelDimensions())
+    return 1;
+  const std::string glb = tests::gdtf::BuildMinimalValidGlb();
+  if (glb.size() != 48 || glb.substr(0, 4) != "glTF")
+    return Fail("Minimal GLB payload has an invalid header or length") ? 0 : 1;
   if (!VerifyArchivePathValidation(root.path))
     return 1;
   return 0;

--- a/tests/rider_hoist_import_test.cpp
+++ b/tests/rider_hoist_import_test.cpp
@@ -148,15 +148,18 @@ int main() {
   assert(RiderImporter::ImportText(filteredBackdropOnlyText));
   const auto &filteredScene = cfg.GetScene();
   bool foundFilteredBackdropTruss = false;
-  bool filteredBackdropTrussHasModelInfo = false;
+  bool filteredBackdropTrussHasFabricatedResource = false;
   int filteredBackdropSupports = 0;
   for (const auto &[uuid, truss] : filteredScene.trusses) {
     (void)uuid;
     if (truss.positionName == "BACKDROP") {
       foundFilteredBackdropTruss = true;
+      assert(!truss.name.empty());
+      assert(!truss.model.empty());
+      assert(std::abs(truss.lengthMm - 12000.0f) < 0.001f);
       if (!truss.modelFile.empty() || !truss.symbolFile.empty() ||
           !truss.gdtfSpec.empty())
-        filteredBackdropTrussHasModelInfo = true;
+        filteredBackdropTrussHasFabricatedResource = true;
     }
   }
   for (const auto &[uuid, support] : filteredScene.supports) {
@@ -165,7 +168,7 @@ int main() {
       ++filteredBackdropSupports;
   }
   assert(foundFilteredBackdropTruss);
-  assert(filteredBackdropTrussHasModelInfo);
+  assert(!filteredBackdropTrussHasFabricatedResource);
   assert(filteredBackdropSupports == 2);
 
   cfg.Reset();

--- a/tests/rider_hoist_import_test.cpp
+++ b/tests/rider_hoist_import_test.cpp
@@ -147,28 +147,56 @@ int main() {
       "2 MOTOR 500Kg PARA BACKDROP\n";
   assert(RiderImporter::ImportText(filteredBackdropOnlyText));
   const auto &filteredScene = cfg.GetScene();
-  bool foundFilteredBackdropTruss = false;
-  bool filteredBackdropTrussHasFabricatedResource = false;
+  constexpr float kBackdropSpanToleranceMm = 0.001f;
+  std::vector<const Truss *> filteredBackdropTrusses;
   int filteredBackdropSupports = 0;
   for (const auto &[uuid, truss] : filteredScene.trusses) {
     (void)uuid;
-    if (truss.positionName == "BACKDROP") {
-      foundFilteredBackdropTruss = true;
-      assert(!truss.name.empty());
-      assert(!truss.model.empty());
-      assert(std::abs(truss.lengthMm - 12000.0f) < 0.001f);
-      if (!truss.modelFile.empty() || !truss.symbolFile.empty() ||
-          !truss.gdtfSpec.empty())
-        filteredBackdropTrussHasFabricatedResource = true;
+    if (truss.positionName == "BACKDROP")
+      filteredBackdropTrusses.push_back(&truss);
+  }
+  std::sort(filteredBackdropTrusses.begin(), filteredBackdropTrusses.end(),
+            [](const Truss *left, const Truss *right) {
+              return left->transform.o[0] < right->transform.o[0];
+            });
+  assert(!filteredBackdropTrusses.empty());
+
+  float filteredBackdropTotalLengthMm = 0.0f;
+  for (size_t i = 0; i < filteredBackdropTrusses.size(); ++i) {
+    const Truss &truss = *filteredBackdropTrusses[i];
+    assert(truss.positionName == "BACKDROP");
+    assert(truss.lengthMm > 0.0f);
+    assert(!truss.name.empty());
+    assert(!truss.model.empty());
+    assert(truss.modelFile.empty());
+    assert(truss.symbolFile.empty());
+    assert(truss.gdtfSpec.empty());
+    filteredBackdropTotalLengthMm += truss.lengthMm;
+    if (i > 0) {
+      const Truss &previous = *filteredBackdropTrusses[i - 1];
+      const float previousEndMm = previous.transform.o[0] + previous.lengthMm;
+      assert(std::abs(truss.transform.o[0] - previousEndMm) <
+             kBackdropSpanToleranceMm);
     }
   }
+  const float filteredBackdropSpanStartMm =
+      filteredBackdropTrusses.front()->transform.o[0];
+  const Truss &filteredBackdropLast = *filteredBackdropTrusses.back();
+  const float filteredBackdropSpanEndMm =
+      filteredBackdropLast.transform.o[0] + filteredBackdropLast.lengthMm;
+  assert(std::abs(filteredBackdropTotalLengthMm - 12000.0f) <
+         kBackdropSpanToleranceMm);
+  assert(std::abs(filteredBackdropSpanEndMm - filteredBackdropSpanStartMm -
+                  12000.0f) < kBackdropSpanToleranceMm);
+  assert(std::abs(filteredBackdropSpanStartMm - (-6000.0f)) <
+         kBackdropSpanToleranceMm);
+  assert(std::abs(filteredBackdropSpanEndMm - 6000.0f) <
+         kBackdropSpanToleranceMm);
   for (const auto &[uuid, support] : filteredScene.supports) {
     (void)uuid;
     if (support.positionName == "BACKDROP")
       ++filteredBackdropSupports;
   }
-  assert(foundFilteredBackdropTruss);
-  assert(!filteredBackdropTrussHasFabricatedResource);
   assert(filteredBackdropSupports == 2);
 
   cfg.Reset();

--- a/tests/rider_truss_dictionary_normalization_test.cpp
+++ b/tests/rider_truss_dictionary_normalization_test.cpp
@@ -62,11 +62,12 @@ bool SameFilesystemIdentity(const std::string &left, const fs::path &right) {
          PathUtils::BuildFilesystemIdentityKey(right);
 }
 
-// Reports whether a path is owned by the configured managed truss directory.
-bool IsInManagedTrussDirectory(const fs::path &path, const fs::path &libraryRoot) {
+// Reports whether a path is a component-safe descendant of a directory.
+bool IsInsideDirectory(const fs::path &path, const fs::path &directory) {
   const std::string pathKey = PathUtils::BuildFilesystemIdentityKey(path);
-  std::string directoryKey =
-      PathUtils::BuildFilesystemIdentityKey(libraryRoot / "trusses");
+  std::string directoryKey = PathUtils::BuildFilesystemIdentityKey(directory);
+  if (pathKey.empty() || directoryKey.empty())
+    return false;
   if (!directoryKey.empty() && directoryKey.back() != '/')
     directoryKey.push_back('/');
   return pathKey.rfind(directoryKey, 0) == 0;
@@ -74,13 +75,13 @@ bool IsInManagedTrussDirectory(const fs::path &path, const fs::path &libraryRoot
 
 // Retrieves and validates the managed archive owned by a dictionary key.
 fs::path GetManagedArchive(const std::string &key, const fs::path &sourceArchive,
-                           const fs::path &libraryRoot) {
+                           const fs::path &managedTrussDirectory) {
   const auto stored = TrussDictionary::Get(key);
   assert(stored.has_value());
   const fs::path managedArchive = PathUtils::PathFromUtf8(*stored);
   assert(fs::exists(managedArchive));
   assert(managedArchive.extension() == ".gdtf");
-  assert(IsInManagedTrussDirectory(managedArchive, libraryRoot));
+  assert(IsInsideDirectory(managedArchive, managedTrussDirectory));
   assert(!SameFilesystemIdentity(*stored, sourceArchive));
   return managedArchive;
 }
@@ -174,10 +175,40 @@ int main() {
       fs::temp_directory_path() / PathUtils::PathFromUtf8("perastage_truss_model_normalization");
   std::error_code ec;
   fs::remove_all(tempRoot, ec);
-  fs::create_directories(tempRoot);
+  assert(!ec);
+  ec.clear();
+  const bool createdTempRoot = fs::create_directories(tempRoot, ec);
+  assert(createdTempRoot && !ec);
+  assert(fs::exists(tempRoot) && fs::is_directory(tempRoot));
 
   const fs::path libraryRoot = tempRoot / PathUtils::PathFromUtf8("library");
+  ec.clear();
+  const bool createdLibraryRoot = fs::create_directories(libraryRoot, ec);
+  assert(createdLibraryRoot && !ec);
+  assert(fs::exists(libraryRoot) && fs::is_directory(libraryRoot));
   SetLibraryPathEnv(ToUtf8String(libraryRoot));
+
+  auto &cfg = ConfigManager::Get();
+  cfg.RemoveKey("trusses_dictionary_active_path");
+  const fs::path activeDictionaryPath = PathUtils::PathFromUtf8(
+      TrussDictionary::GetActiveDictionaryFilePath());
+  assert(!activeDictionaryPath.empty());
+  assert(activeDictionaryPath.filename() == "truss_dictionary.json");
+  const fs::path managedTrussDirectory = activeDictionaryPath.parent_path();
+  assert(fs::exists(managedTrussDirectory));
+  assert(fs::is_directory(managedTrussDirectory));
+  assert(IsInsideDirectory(activeDictionaryPath, tempRoot));
+  assert(IsInsideDirectory(managedTrussDirectory, tempRoot));
+  assert(SameFilesystemIdentity(ToUtf8String(managedTrussDirectory),
+                                libraryRoot / "trusses"));
+  assert(IsInsideDirectory(managedTrussDirectory / "asset.gdtf",
+                           managedTrussDirectory));
+  assert(!IsInsideDirectory(managedTrussDirectory.parent_path() / "trusses-other" /
+                                "asset.gdtf",
+                            managedTrussDirectory));
+  TrussDictionary::Save({});
+  assert(fs::exists(activeDictionaryPath));
+  assert(IsInsideDirectory(activeDictionaryPath, tempRoot));
 
   const fs::path archivePath = tempRoot / PathUtils::PathFromUtf8("FK40Q.gdtf");
   tests::gdtf::BuildMinimalValidFixture()
@@ -188,6 +219,7 @@ int main() {
       .WithArchiveEntry("models/gltf/main.glb", tests::gdtf::BuildMinimalValidGlb())
       .WithArchiveEntry("models/svg/main.svg", "<svg xmlns=\"http://www.w3.org/2000/svg\"/>")
       .WriteArchive(archivePath);
+  assert(!IsInsideDirectory(archivePath, managedTrussDirectory));
 
   Truss geometryAndSvg;
   assert(LoadTrussGdtf(ToUtf8String(archivePath), geometryAndSvg));
@@ -201,6 +233,7 @@ int main() {
       .WithModelDimensionsMeters(3.0f, 0.4f, 0.4f)
       .WithArchiveEntry("models/3ds/main.3ds", "3DS")
       .WriteArchive(geometryOnlyPath);
+  assert(!IsInsideDirectory(geometryOnlyPath, managedTrussDirectory));
   Truss geometryOnly;
   assert(LoadTrussGdtf(ToUtf8String(geometryOnlyPath), geometryOnly));
   assert(PathUtils::PathFromUtf8(geometryOnly.symbolFile).extension() == ".3ds");
@@ -213,18 +246,20 @@ int main() {
       .WithModelDimensionsMeters(3.0f, 0.4f, 0.4f)
       .WithArchiveEntry("models/svg/main.svg", "<svg xmlns=\"http://www.w3.org/2000/svg\"/>")
       .WriteArchive(svgOnlyPath);
+  assert(!IsInsideDirectory(svgOnlyPath, managedTrussDirectory));
   Truss svgOnly;
   assert(LoadTrussGdtf(ToUtf8String(svgOnlyPath), svgOnly));
   assert(svgOnly.gdtfSpec == ToUtf8String(svgOnlyPath));
   assert(svgOnly.symbolFile.empty());
   TrussDictionary::Update("SVGONLY", ToUtf8String(svgOnlyPath));
   const fs::path managedSvgOnly =
-      GetManagedArchive("SVGONLY", svgOnlyPath, libraryRoot);
+      GetManagedArchive("SVGONLY", svgOnlyPath, managedTrussDirectory);
   AssertSvgOnlyResourceUsesDummy(managedSvgOnly, svgOnlyPath);
 
   const fs::path metadataOnlyPath = tempRoot / "metadata-only.gdtf";
   tests::gdtf::BuildMinimalValidFixture().WithModelResource("missing").WriteArchive(
       metadataOnlyPath);
+  assert(!IsInsideDirectory(metadataOnlyPath, managedTrussDirectory));
   Truss metadataOnly;
   assert(LoadTrussGdtf(ToUtf8String(metadataOnlyPath), metadataOnly));
   assert(metadataOnly.symbolFile.empty());
@@ -233,7 +268,7 @@ int main() {
   const auto canonical = TrussDictionary::Get("TRUSS 40X40 3M");
   assert(canonical.has_value());
   const fs::path managedCanonical =
-      GetManagedArchive("TRUSS 40X40 3M", archivePath, libraryRoot);
+      GetManagedArchive("TRUSS 40X40 3M", archivePath, managedTrussDirectory);
 
   const std::vector<std::string> variants = {
       "TRUSS 40X40 3M",
@@ -252,7 +287,7 @@ int main() {
 
   TrussDictionary::Update("FK40Q", ToUtf8String(archivePath));
   const fs::path managedModelToken =
-      GetManagedArchive("FK40Q", archivePath, libraryRoot);
+      GetManagedArchive("FK40Q", archivePath, managedTrussDirectory);
   AssertModelTokenDictionaryLookupWorks("1 truss FK40Q 3 m para lx1\n",
                                         managedModelToken, archivePath);
   AssertModelTokenDictionaryLookupWorks("1 truss fk40q 3 m para lx1\n",
@@ -260,7 +295,7 @@ int main() {
 
   TrussDictionary::Update("TRUSS 40X40 PRO 3M", ToUtf8String(archivePath));
   const fs::path managedFinish =
-      GetManagedArchive("TRUSS 40X40 PRO 3M", archivePath, libraryRoot);
+      GetManagedArchive("TRUSS 40X40 PRO 3M", archivePath, managedTrussDirectory);
   AssertTrussSymbolResolved("1 truss 40X40 PRO NEGRO 3m para lx1\n",
                             managedFinish, archivePath);
   AssertTrussSymbolResolved("1 truss 40X40 PRO BLACK 3m for lx1\n",
@@ -270,11 +305,15 @@ int main() {
 
   TrussDictionary::Update("TRUSS BLACKBIRD 3M", ToUtf8String(archivePath));
   const fs::path managedSubstring =
-      GetManagedArchive("TRUSS BLACKBIRD 3M", archivePath, libraryRoot);
+      GetManagedArchive("TRUSS BLACKBIRD 3M", archivePath, managedTrussDirectory);
   AssertTrussSymbolResolved("1 truss BLACKBIRD 3m para lx1\n", managedSubstring,
                             archivePath);
 
   TrussDictionary::Save({});
+  assert(IsInsideDirectory(activeDictionaryPath, tempRoot));
+  ec.clear();
   fs::remove_all(tempRoot, ec);
+  assert(!ec);
+  assert(!fs::exists(tempRoot));
   return 0;
 }

--- a/tests/rider_truss_dictionary_normalization_test.cpp
+++ b/tests/rider_truss_dictionary_normalization_test.cpp
@@ -18,6 +18,7 @@
 #include "wx_path_utils.h"
 #include <cassert>
 #include "filesystem_path_utils.h"
+#include <cmath>
 #include <cstdlib>
 #include <filesystem>
 #include <string>
@@ -48,8 +49,9 @@ void SetLibraryPathEnv(const std::string &value) {
 #endif
 }
 
-// Verifies that a Rider truss resolves a real renderable geometry resource.
-void AssertTrussSymbolResolved(const std::string &textVariant) {
+// Verifies Rider resolution of a supported 3D geometry resource path and metadata.
+void AssertTrussSymbolResolved(const std::string &textVariant,
+                               const fs::path &sourceArchive) {
   auto &cfg = ConfigManager::Get();
   cfg.Reset();
   assert(RiderImporter::ImportText(textVariant));
@@ -58,10 +60,21 @@ void AssertTrussSymbolResolved(const std::string &textVariant) {
   assert(scene.trusses.size() == 1);
   const auto &truss = scene.trusses.begin()->second;
   assert(!truss.symbolFile.empty());
-  assert(fs::exists(PathUtils::PathFromUtf8(truss.symbolFile)));
+  const fs::path symbolPath = PathUtils::PathFromUtf8(truss.symbolFile);
+  assert(symbolPath.extension() == ".glb" || symbolPath.extension() == ".3ds");
+  assert(fs::exists(symbolPath));
+  assert(truss.modelFile == ToUtf8String(sourceArchive));
+  assert(truss.gdtfSpec == ToUtf8String(sourceArchive));
+  assert(truss.model == "FK40Q");
+  assert(truss.manufacturer == "Perastage");
+  assert(std::abs(truss.lengthMm - 3000.0f) < 0.001f);
+  assert(std::abs(truss.widthMm - 400.0f) < 0.001f);
+  assert(std::abs(truss.heightMm - 400.0f) < 0.001f);
 }
 
-void AssertModelTokenDictionaryLookupWorks(const std::string &textVariant) {
+// Verifies model-token lookup against the principal truss archive.
+void AssertModelTokenDictionaryLookupWorks(const std::string &textVariant,
+                                           const fs::path &sourceArchive) {
   auto &cfg = ConfigManager::Get();
   cfg.Reset();
   assert(RiderImporter::ImportText(textVariant));
@@ -73,6 +86,27 @@ void AssertModelTokenDictionaryLookupWorks(const std::string &textVariant) {
   assert(truss.model == TrussDictionary::NormalizeModelKey("FK40Q"));
   assert(!truss.symbolFile.empty());
   assert(fs::exists(PathUtils::PathFromUtf8(truss.symbolFile)));
+  assert(truss.modelFile == ToUtf8String(sourceArchive));
+  assert(truss.gdtfSpec == ToUtf8String(sourceArchive));
+  assert(std::abs(truss.lengthMm - 3000.0f) < 0.001f);
+}
+
+// Verifies that SVG-only Rider resources retain metadata and use dummy geometry.
+void AssertSvgOnlyResourceUsesDummy(const fs::path &sourceArchive) {
+  auto &cfg = ConfigManager::Get();
+  cfg.Reset();
+  assert(RiderImporter::ImportText("1 truss SVGONLY 3m para lx1\n"));
+
+  const auto &scene = cfg.GetScene();
+  assert(scene.trusses.size() == 1);
+  const Truss &truss = scene.trusses.begin()->second;
+  assert(truss.modelFile == ToUtf8String(sourceArchive));
+  assert(truss.gdtfSpec == ToUtf8String(sourceArchive));
+  assert(truss.symbolFile.empty());
+  assert(std::abs(truss.lengthMm - 3000.0f) < 0.001f);
+  assert(std::abs(truss.widthMm - 400.0f) < 0.001f);
+  assert(std::abs(truss.heightMm - 400.0f) < 0.001f);
+  assert(std::abs(truss.transform.o[0] - (-1500.0f)) < 0.001f);
 }
 
 } // namespace
@@ -95,7 +129,8 @@ int main() {
       .WithFixtureIdentity("FK40Q", "Perastage",
                            tests::gdtf::FixtureBuilder::kMinimalFixtureTypeId)
       .WithModelResource("main")
-      .WithArchiveEntry("models/gltf/main.glb", "glTF")
+      .WithModelDimensionsMeters(3.0f, 0.4f, 0.4f)
+      .WithArchiveEntry("models/gltf/main.glb", tests::gdtf::BuildMinimalValidGlb())
       .WithArchiveEntry("models/svg/main.svg", "<svg xmlns=\"http://www.w3.org/2000/svg\"/>")
       .WriteArchive(archivePath);
 
@@ -108,6 +143,7 @@ int main() {
   const fs::path geometryOnlyPath = tempRoot / "geometry-only.gdtf";
   tests::gdtf::BuildMinimalValidFixture()
       .WithModelResource("main")
+      .WithModelDimensionsMeters(3.0f, 0.4f, 0.4f)
       .WithArchiveEntry("models/3ds/main.3ds", "3DS")
       .WriteArchive(geometryOnlyPath);
   Truss geometryOnly;
@@ -116,13 +152,18 @@ int main() {
 
   const fs::path svgOnlyPath = tempRoot / "svg-only.gdtf";
   tests::gdtf::BuildMinimalValidFixture()
+      .WithFixtureIdentity("SVGONLY", "Perastage",
+                           tests::gdtf::FixtureBuilder::kMinimalFixtureTypeId)
       .WithModelResource("main")
+      .WithModelDimensionsMeters(3.0f, 0.4f, 0.4f)
       .WithArchiveEntry("models/svg/main.svg", "<svg xmlns=\"http://www.w3.org/2000/svg\"/>")
       .WriteArchive(svgOnlyPath);
   Truss svgOnly;
   assert(LoadTrussGdtf(ToUtf8String(svgOnlyPath), svgOnly));
   assert(svgOnly.gdtfSpec == ToUtf8String(svgOnlyPath));
   assert(svgOnly.symbolFile.empty());
+  TrussDictionary::Update("SVGONLY", ToUtf8String(svgOnlyPath));
+  AssertSvgOnlyResourceUsesDummy(svgOnlyPath);
 
   const fs::path metadataOnlyPath = tempRoot / "metadata-only.gdtf";
   tests::gdtf::BuildMinimalValidFixture().WithModelResource("missing").WriteArchive(
@@ -146,21 +187,21 @@ int main() {
     assert(*resolved == *canonical);
   }
 
-  AssertTrussSymbolResolved("1 truss 40X40 3M\n");
-  AssertTrussSymbolResolved("1 truss 40x40 3m\n");
-  AssertTrussSymbolResolved("1 truss   40X40   3M\n");
+  AssertTrussSymbolResolved("1 truss 40X40 3M\n", archivePath);
+  AssertTrussSymbolResolved("1 truss 40x40 3m\n", archivePath);
+  AssertTrussSymbolResolved("1 truss   40X40   3M\n", archivePath);
 
   TrussDictionary::Update("FK40Q", ToUtf8String(archivePath));
-  AssertModelTokenDictionaryLookupWorks("1 truss FK40Q 3 m para lx1\n");
-  AssertModelTokenDictionaryLookupWorks("1 truss fk40q 3 m para lx1\n");
+  AssertModelTokenDictionaryLookupWorks("1 truss FK40Q 3 m para lx1\n", archivePath);
+  AssertModelTokenDictionaryLookupWorks("1 truss fk40q 3 m para lx1\n", archivePath);
 
   TrussDictionary::Update("TRUSS 40X40 PRO 3M", ToUtf8String(archivePath));
-  AssertTrussSymbolResolved("1 truss 40X40 PRO NEGRO 3m para lx1\n");
-  AssertTrussSymbolResolved("1 truss 40X40 PRO BLACK 3m for lx1\n");
-  AssertTrussSymbolResolved("1 truss 40X40 PRO PLATA 3 m para lx1\n");
+  AssertTrussSymbolResolved("1 truss 40X40 PRO NEGRO 3m para lx1\n", archivePath);
+  AssertTrussSymbolResolved("1 truss 40X40 PRO BLACK 3m for lx1\n", archivePath);
+  AssertTrussSymbolResolved("1 truss 40X40 PRO PLATA 3 m para lx1\n", archivePath);
 
   TrussDictionary::Update("TRUSS BLACKBIRD 3M", ToUtf8String(archivePath));
-  AssertTrussSymbolResolved("1 truss BLACKBIRD 3m para lx1\n");
+  AssertTrussSymbolResolved("1 truss BLACKBIRD 3m para lx1\n", archivePath);
 
   TrussDictionary::Save({});
   fs::remove_all(tempRoot, ec);

--- a/tests/rider_truss_dictionary_normalization_test.cpp
+++ b/tests/rider_truss_dictionary_normalization_test.cpp
@@ -19,19 +19,17 @@
 #include <cassert>
 #include "filesystem_path_utils.h"
 #include <cstdlib>
-#include <cstring>
 #include <filesystem>
 #include <string>
 #include <vector>
 
-#include <wx/filename.h>
 #include <wx/init.h>
-#include <wx/wfstream.h>
-#include <wx/zipstrm.h>
 
 #include "configmanager.h"
 #include "riderimporter.h"
 #include "trussdictionary.h"
+#include "trussloader.h"
+#include "support/gdtf_test_fixture_builder.h"
 
 namespace fs = std::filesystem;
 
@@ -50,37 +48,7 @@ void SetLibraryPathEnv(const std::string &value) {
 #endif
 }
 
-bool WriteArchive(const fs::path &archivePath) {
-  wxFileName::Mkdir(archivePath.parent_path().string(), wxS_DIR_DEFAULT,
-                    wxPATH_MKDIR_FULL);
-
-  wxFileOutputStream output(WxPathUtils::WxStringFromFilesystemPath(archivePath));
-  if (!output.IsOk())
-    return false;
-
-  wxZipOutputStream zip(output);
-  if (!zip.IsOk())
-    return false;
-
-  static const char *kDescriptionXml =
-      "<GDTF><FixtureType Manufacturer=\"Perastage\" Name=\"FK40Q\">"
-      "<Models><Model Name=\"main\" File=\"main\" Length=\"3.0\" Width=\"0.3\" Height=\"0.3\"/>"
-      "</Models></FixtureType></GDTF>";
-  static const char *kSvg =
-      "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"10\" height=\"10\"></svg>";
-
-  if (!zip.PutNextEntry("description.xml"))
-    return false;
-  zip.Write(kDescriptionXml, std::strlen(kDescriptionXml));
-
-  if (!zip.PutNextEntry("models/svg/main.svg"))
-    return false;
-  zip.Write(kSvg, std::strlen(kSvg));
-
-  zip.Close();
-  return output.IsOk();
-}
-
+// Verifies that a Rider truss resolves a real renderable geometry resource.
 void AssertTrussSymbolResolved(const std::string &textVariant) {
   auto &cfg = ConfigManager::Get();
   cfg.Reset();
@@ -123,7 +91,45 @@ int main() {
   SetLibraryPathEnv(ToUtf8String(libraryRoot));
 
   const fs::path archivePath = tempRoot / PathUtils::PathFromUtf8("FK40Q.gdtf");
-  assert(WriteArchive(archivePath));
+  tests::gdtf::BuildMinimalValidFixture()
+      .WithFixtureIdentity("FK40Q", "Perastage",
+                           tests::gdtf::FixtureBuilder::kMinimalFixtureTypeId)
+      .WithModelResource("main")
+      .WithArchiveEntry("models/gltf/main.glb", "glTF")
+      .WithArchiveEntry("models/svg/main.svg", "<svg xmlns=\"http://www.w3.org/2000/svg\"/>")
+      .WriteArchive(archivePath);
+
+  Truss geometryAndSvg;
+  assert(LoadTrussGdtf(ToUtf8String(archivePath), geometryAndSvg));
+  assert(geometryAndSvg.gdtfSpec == ToUtf8String(archivePath));
+  assert(PathUtils::PathFromUtf8(geometryAndSvg.symbolFile).extension() == ".glb");
+  assert(fs::exists(PathUtils::PathFromUtf8(geometryAndSvg.symbolFile)));
+
+  const fs::path geometryOnlyPath = tempRoot / "geometry-only.gdtf";
+  tests::gdtf::BuildMinimalValidFixture()
+      .WithModelResource("main")
+      .WithArchiveEntry("models/3ds/main.3ds", "3DS")
+      .WriteArchive(geometryOnlyPath);
+  Truss geometryOnly;
+  assert(LoadTrussGdtf(ToUtf8String(geometryOnlyPath), geometryOnly));
+  assert(PathUtils::PathFromUtf8(geometryOnly.symbolFile).extension() == ".3ds");
+
+  const fs::path svgOnlyPath = tempRoot / "svg-only.gdtf";
+  tests::gdtf::BuildMinimalValidFixture()
+      .WithModelResource("main")
+      .WithArchiveEntry("models/svg/main.svg", "<svg xmlns=\"http://www.w3.org/2000/svg\"/>")
+      .WriteArchive(svgOnlyPath);
+  Truss svgOnly;
+  assert(LoadTrussGdtf(ToUtf8String(svgOnlyPath), svgOnly));
+  assert(svgOnly.gdtfSpec == ToUtf8String(svgOnlyPath));
+  assert(svgOnly.symbolFile.empty());
+
+  const fs::path metadataOnlyPath = tempRoot / "metadata-only.gdtf";
+  tests::gdtf::BuildMinimalValidFixture().WithModelResource("missing").WriteArchive(
+      metadataOnlyPath);
+  Truss metadataOnly;
+  assert(LoadTrussGdtf(ToUtf8String(metadataOnlyPath), metadataOnly));
+  assert(metadataOnly.symbolFile.empty());
 
   TrussDictionary::Update("TRUSS 40X40 3M", ToUtf8String(archivePath));
   const auto canonical = TrussDictionary::Get("TRUSS 40X40 3M");
@@ -151,6 +157,10 @@ int main() {
   TrussDictionary::Update("TRUSS 40X40 PRO 3M", ToUtf8String(archivePath));
   AssertTrussSymbolResolved("1 truss 40X40 PRO NEGRO 3m para lx1\n");
   AssertTrussSymbolResolved("1 truss 40X40 PRO BLACK 3m for lx1\n");
+  AssertTrussSymbolResolved("1 truss 40X40 PRO PLATA 3 m para lx1\n");
+
+  TrussDictionary::Update("TRUSS BLACKBIRD 3M", ToUtf8String(archivePath));
+  AssertTrussSymbolResolved("1 truss BLACKBIRD 3m para lx1\n");
 
   TrussDictionary::Save({});
   fs::remove_all(tempRoot, ec);

--- a/tests/rider_truss_dictionary_normalization_test.cpp
+++ b/tests/rider_truss_dictionary_normalization_test.cpp
@@ -49,8 +49,59 @@ void SetLibraryPathEnv(const std::string &value) {
 #endif
 }
 
+// Reports whether UTF-8 text and a native path identify the same filesystem object.
+bool SameFilesystemIdentity(const std::string &left, const fs::path &right) {
+  if (left.empty() || right.empty())
+    return false;
+  const fs::path leftPath = PathUtils::PathFromUtf8(left);
+  std::error_code ec;
+  if (fs::exists(leftPath, ec) && !ec && fs::exists(right, ec) && !ec &&
+      fs::equivalent(leftPath, right, ec) && !ec)
+    return true;
+  return PathUtils::BuildFilesystemIdentityKey(leftPath) ==
+         PathUtils::BuildFilesystemIdentityKey(right);
+}
+
+// Reports whether a path is owned by the configured managed truss directory.
+bool IsInManagedTrussDirectory(const fs::path &path, const fs::path &libraryRoot) {
+  const std::string pathKey = PathUtils::BuildFilesystemIdentityKey(path);
+  std::string directoryKey =
+      PathUtils::BuildFilesystemIdentityKey(libraryRoot / "trusses");
+  if (!directoryKey.empty() && directoryKey.back() != '/')
+    directoryKey.push_back('/');
+  return pathKey.rfind(directoryKey, 0) == 0;
+}
+
+// Retrieves and validates the managed archive owned by a dictionary key.
+fs::path GetManagedArchive(const std::string &key, const fs::path &sourceArchive,
+                           const fs::path &libraryRoot) {
+  const auto stored = TrussDictionary::Get(key);
+  assert(stored.has_value());
+  const fs::path managedArchive = PathUtils::PathFromUtf8(*stored);
+  assert(fs::exists(managedArchive));
+  assert(managedArchive.extension() == ".gdtf");
+  assert(IsInManagedTrussDirectory(managedArchive, libraryRoot));
+  assert(!SameFilesystemIdentity(*stored, sourceArchive));
+  return managedArchive;
+}
+
+// Verifies dictionary-backed truss fields identify the managed archive only.
+void AssertManagedArchiveIdentity(const Truss &truss,
+                                  const fs::path &expectedManagedArchive,
+                                  const fs::path &sourceArchive) {
+  assert(SameFilesystemIdentity(truss.modelFile, expectedManagedArchive));
+  assert(SameFilesystemIdentity(truss.gdtfSpec, expectedManagedArchive));
+  assert(SameFilesystemIdentity(truss.modelFile,
+                                PathUtils::PathFromUtf8(truss.gdtfSpec)));
+  assert(fs::exists(PathUtils::PathFromUtf8(truss.modelFile)));
+  assert(PathUtils::PathFromUtf8(truss.modelFile).extension() == ".gdtf");
+  assert(!SameFilesystemIdentity(truss.modelFile, sourceArchive));
+  assert(!SameFilesystemIdentity(truss.gdtfSpec, sourceArchive));
+}
+
 // Verifies Rider resolution of a supported 3D geometry resource path and metadata.
 void AssertTrussSymbolResolved(const std::string &textVariant,
+                               const fs::path &expectedManagedArchive,
                                const fs::path &sourceArchive) {
   auto &cfg = ConfigManager::Get();
   cfg.Reset();
@@ -63,8 +114,7 @@ void AssertTrussSymbolResolved(const std::string &textVariant,
   const fs::path symbolPath = PathUtils::PathFromUtf8(truss.symbolFile);
   assert(symbolPath.extension() == ".glb" || symbolPath.extension() == ".3ds");
   assert(fs::exists(symbolPath));
-  assert(truss.modelFile == ToUtf8String(sourceArchive));
-  assert(truss.gdtfSpec == ToUtf8String(sourceArchive));
+  AssertManagedArchiveIdentity(truss, expectedManagedArchive, sourceArchive);
   assert(truss.model == "FK40Q");
   assert(truss.manufacturer == "Perastage");
   assert(std::abs(truss.lengthMm - 3000.0f) < 0.001f);
@@ -74,6 +124,7 @@ void AssertTrussSymbolResolved(const std::string &textVariant,
 
 // Verifies model-token lookup against the principal truss archive.
 void AssertModelTokenDictionaryLookupWorks(const std::string &textVariant,
+                                           const fs::path &expectedManagedArchive,
                                            const fs::path &sourceArchive) {
   auto &cfg = ConfigManager::Get();
   cfg.Reset();
@@ -86,13 +137,16 @@ void AssertModelTokenDictionaryLookupWorks(const std::string &textVariant,
   assert(truss.model == TrussDictionary::NormalizeModelKey("FK40Q"));
   assert(!truss.symbolFile.empty());
   assert(fs::exists(PathUtils::PathFromUtf8(truss.symbolFile)));
-  assert(truss.modelFile == ToUtf8String(sourceArchive));
-  assert(truss.gdtfSpec == ToUtf8String(sourceArchive));
+  AssertManagedArchiveIdentity(truss, expectedManagedArchive, sourceArchive);
   assert(std::abs(truss.lengthMm - 3000.0f) < 0.001f);
+  assert(std::abs(truss.widthMm - 400.0f) < 0.001f);
+  assert(std::abs(truss.heightMm - 400.0f) < 0.001f);
+  assert(truss.manufacturer == "Perastage");
 }
 
 // Verifies that SVG-only Rider resources retain metadata and use dummy geometry.
-void AssertSvgOnlyResourceUsesDummy(const fs::path &sourceArchive) {
+void AssertSvgOnlyResourceUsesDummy(const fs::path &expectedManagedArchive,
+                                    const fs::path &sourceArchive) {
   auto &cfg = ConfigManager::Get();
   cfg.Reset();
   assert(RiderImporter::ImportText("1 truss SVGONLY 3m para lx1\n"));
@@ -100,9 +154,10 @@ void AssertSvgOnlyResourceUsesDummy(const fs::path &sourceArchive) {
   const auto &scene = cfg.GetScene();
   assert(scene.trusses.size() == 1);
   const Truss &truss = scene.trusses.begin()->second;
-  assert(truss.modelFile == ToUtf8String(sourceArchive));
-  assert(truss.gdtfSpec == ToUtf8String(sourceArchive));
+  AssertManagedArchiveIdentity(truss, expectedManagedArchive, sourceArchive);
   assert(truss.symbolFile.empty());
+  assert(truss.model == "SVGONLY");
+  assert(truss.manufacturer == "Perastage");
   assert(std::abs(truss.lengthMm - 3000.0f) < 0.001f);
   assert(std::abs(truss.widthMm - 400.0f) < 0.001f);
   assert(std::abs(truss.heightMm - 400.0f) < 0.001f);
@@ -163,7 +218,9 @@ int main() {
   assert(svgOnly.gdtfSpec == ToUtf8String(svgOnlyPath));
   assert(svgOnly.symbolFile.empty());
   TrussDictionary::Update("SVGONLY", ToUtf8String(svgOnlyPath));
-  AssertSvgOnlyResourceUsesDummy(svgOnlyPath);
+  const fs::path managedSvgOnly =
+      GetManagedArchive("SVGONLY", svgOnlyPath, libraryRoot);
+  AssertSvgOnlyResourceUsesDummy(managedSvgOnly, svgOnlyPath);
 
   const fs::path metadataOnlyPath = tempRoot / "metadata-only.gdtf";
   tests::gdtf::BuildMinimalValidFixture().WithModelResource("missing").WriteArchive(
@@ -175,6 +232,8 @@ int main() {
   TrussDictionary::Update("TRUSS 40X40 3M", ToUtf8String(archivePath));
   const auto canonical = TrussDictionary::Get("TRUSS 40X40 3M");
   assert(canonical.has_value());
+  const fs::path managedCanonical =
+      GetManagedArchive("TRUSS 40X40 3M", archivePath, libraryRoot);
 
   const std::vector<std::string> variants = {
       "TRUSS 40X40 3M",
@@ -187,21 +246,33 @@ int main() {
     assert(*resolved == *canonical);
   }
 
-  AssertTrussSymbolResolved("1 truss 40X40 3M\n", archivePath);
-  AssertTrussSymbolResolved("1 truss 40x40 3m\n", archivePath);
-  AssertTrussSymbolResolved("1 truss   40X40   3M\n", archivePath);
+  AssertTrussSymbolResolved("1 truss 40X40 3M\n", managedCanonical, archivePath);
+  AssertTrussSymbolResolved("1 truss 40x40 3m\n", managedCanonical, archivePath);
+  AssertTrussSymbolResolved("1 truss   40X40   3M\n", managedCanonical, archivePath);
 
   TrussDictionary::Update("FK40Q", ToUtf8String(archivePath));
-  AssertModelTokenDictionaryLookupWorks("1 truss FK40Q 3 m para lx1\n", archivePath);
-  AssertModelTokenDictionaryLookupWorks("1 truss fk40q 3 m para lx1\n", archivePath);
+  const fs::path managedModelToken =
+      GetManagedArchive("FK40Q", archivePath, libraryRoot);
+  AssertModelTokenDictionaryLookupWorks("1 truss FK40Q 3 m para lx1\n",
+                                        managedModelToken, archivePath);
+  AssertModelTokenDictionaryLookupWorks("1 truss fk40q 3 m para lx1\n",
+                                        managedModelToken, archivePath);
 
   TrussDictionary::Update("TRUSS 40X40 PRO 3M", ToUtf8String(archivePath));
-  AssertTrussSymbolResolved("1 truss 40X40 PRO NEGRO 3m para lx1\n", archivePath);
-  AssertTrussSymbolResolved("1 truss 40X40 PRO BLACK 3m for lx1\n", archivePath);
-  AssertTrussSymbolResolved("1 truss 40X40 PRO PLATA 3 m para lx1\n", archivePath);
+  const fs::path managedFinish =
+      GetManagedArchive("TRUSS 40X40 PRO 3M", archivePath, libraryRoot);
+  AssertTrussSymbolResolved("1 truss 40X40 PRO NEGRO 3m para lx1\n",
+                            managedFinish, archivePath);
+  AssertTrussSymbolResolved("1 truss 40X40 PRO BLACK 3m for lx1\n",
+                            managedFinish, archivePath);
+  AssertTrussSymbolResolved("1 truss 40X40 PRO PLATA 3 m para lx1\n",
+                            managedFinish, archivePath);
 
   TrussDictionary::Update("TRUSS BLACKBIRD 3M", ToUtf8String(archivePath));
-  AssertTrussSymbolResolved("1 truss BLACKBIRD 3m para lx1\n", archivePath);
+  const fs::path managedSubstring =
+      GetManagedArchive("TRUSS BLACKBIRD 3M", archivePath, libraryRoot);
+  AssertTrussSymbolResolved("1 truss BLACKBIRD 3m para lx1\n", managedSubstring,
+                            archivePath);
 
   TrussDictionary::Save({});
   fs::remove_all(tempRoot, ec);

--- a/tests/support/gdtf_test_fixture_builder.cpp
+++ b/tests/support/gdtf_test_fixture_builder.cpp
@@ -3,6 +3,9 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cmath>
+#include <iomanip>
+#include <locale>
 #include <sstream>
 #include <stdexcept>
 #include <utility>
@@ -19,6 +22,21 @@ struct ArchiveEntry {
   std::string path;
   std::string bytes;
 };
+
+// Formats a finite positive model dimension deterministically for GDTF XML.
+std::string FormatModelDimension(float value) {
+  if (!std::isfinite(value) || !(value > 0.0f))
+    throw std::invalid_argument("GDTF test model dimensions must be positive");
+  std::ostringstream output;
+  output.imbue(std::locale::classic());
+  output << std::fixed << std::setprecision(6) << value;
+  std::string formatted = output.str();
+  while (formatted.back() == '0')
+    formatted.pop_back();
+  if (formatted.back() == '.')
+    formatted.push_back('0');
+  return formatted;
+}
 
 // Returns true when the path has a Windows drive prefix.
 bool HasDrivePrefix(const std::string &path) {
@@ -89,6 +107,18 @@ FixtureBuilder BuildMinimalValidFixture() {
   return FixtureBuilder{};
 }
 
+// Builds a deterministic minimal GLB 2.0 payload containing valid asset metadata.
+std::string BuildMinimalValidGlb() {
+  static constexpr unsigned char kGlb[] = {
+      0x67, 0x6c, 0x54, 0x46, 0x02, 0x00, 0x00, 0x00,
+      0x30, 0x00, 0x00, 0x00, 0x1c, 0x00, 0x00, 0x00,
+      0x4a, 0x53, 0x4f, 0x4e, 0x7b, 0x22, 0x61, 0x73,
+      0x73, 0x65, 0x74, 0x22, 0x3a, 0x7b, 0x22, 0x76,
+      0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x22, 0x3a,
+      0x22, 0x32, 0x2e, 0x30, 0x22, 0x7d, 0x7d, 0x20};
+  return std::string(reinterpret_cast<const char *>(kGlb), sizeof(kGlb));
+}
+
 // Overrides the fixture identity fields while retaining a canonical structure.
 FixtureBuilder &FixtureBuilder::WithFixtureIdentity(std::string name,
                                                     std::string maker,
@@ -112,6 +142,15 @@ FixtureBuilder &FixtureBuilder::WithModelResource(std::string fileBase) {
   return *this;
 }
 
+// Overrides the default model dimensions in meters.
+FixtureBuilder &FixtureBuilder::WithModelDimensionsMeters(float length, float width,
+                                                          float height) {
+  modelLengthMeters = length;
+  modelWidthMeters = width;
+  modelHeightMeters = height;
+  return *this;
+}
+
 // Adds basic category signal metadata for category-related tests.
 FixtureBuilder &FixtureBuilder::WithFixtureCategorySignals() {
   categorySignals = true;
@@ -127,6 +166,9 @@ FixtureBuilder &FixtureBuilder::WithArchiveEntry(std::string path, std::string b
 // Builds the description.xml payload for the fixture.
 std::string FixtureBuilder::BuildDescriptionXml() const {
   const std::string category = categorySignals ? " FixtureTypeCategory=\"Conventional\"" : "";
+  const std::string modelLength = FormatModelDimension(modelLengthMeters);
+  const std::string modelWidth = FormatModelDimension(modelWidthMeters);
+  const std::string modelHeight = FormatModelDimension(modelHeightMeters);
   return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
          "<GDTF DataVersion=\"1.2\">\n"
          "  <FixtureType Name=\"" + fixtureName + "\" ShortName=\"" + fixtureName +
@@ -137,7 +179,9 @@ std::string FixtureBuilder::BuildDescriptionXml() const {
          "    <AttributeDefinitions><ActivationGroups/><FeatureGroups><FeatureGroup Name=\"Dimmer\" Pretty=\"Dimmer\"><Feature Name=\"Dimmer\"/></FeatureGroup></FeatureGroups><Attributes><Attribute Name=\"Dimmer\" Pretty=\"Dimmer\" Feature=\"Dimmer.Dimmer\" PhysicalUnit=\"LuminousIntensity\"/></Attributes></AttributeDefinitions>\n"
          "    <Wheels/>\n"
          "    <PhysicalDescriptions><Emitters/><Filters/><ColorSpace Mode=\"sRGB\"/><DMXProfiles/><CRIs/><Connectors/></PhysicalDescriptions>\n"
-         "    <Models><Model Name=\"Body\" Length=\"0.1\" Width=\"0.1\" Height=\"0.1\" PrimitiveType=\"Cube\"" +
+         "    <Models><Model Name=\"Body\" Length=\"" + modelLength +
+         "\" Width=\"" + modelWidth + "\" Height=\"" + modelHeight +
+         "\" PrimitiveType=\"Cube\"" +
          (modelFileBase.empty() ? std::string{} : " File=\"" + modelFileBase + "\"") +
          "/></Models>\n"
          "    <Geometries><Geometry Name=\"Root\" Model=\"Body\"/></Geometries>\n"

--- a/tests/support/gdtf_test_fixture_builder.cpp
+++ b/tests/support/gdtf_test_fixture_builder.cpp
@@ -106,6 +106,12 @@ FixtureBuilder &FixtureBuilder::WithDmxMode(std::string name, std::string geomet
   return *this;
 }
 
+// Assigns the standard archive resource basename referenced by the model.
+FixtureBuilder &FixtureBuilder::WithModelResource(std::string fileBase) {
+  modelFileBase = std::move(fileBase);
+  return *this;
+}
+
 // Adds basic category signal metadata for category-related tests.
 FixtureBuilder &FixtureBuilder::WithFixtureCategorySignals() {
   categorySignals = true;
@@ -131,7 +137,9 @@ std::string FixtureBuilder::BuildDescriptionXml() const {
          "    <AttributeDefinitions><ActivationGroups/><FeatureGroups><FeatureGroup Name=\"Dimmer\" Pretty=\"Dimmer\"><Feature Name=\"Dimmer\"/></FeatureGroup></FeatureGroups><Attributes><Attribute Name=\"Dimmer\" Pretty=\"Dimmer\" Feature=\"Dimmer.Dimmer\" PhysicalUnit=\"LuminousIntensity\"/></Attributes></AttributeDefinitions>\n"
          "    <Wheels/>\n"
          "    <PhysicalDescriptions><Emitters/><Filters/><ColorSpace Mode=\"sRGB\"/><DMXProfiles/><CRIs/><Connectors/></PhysicalDescriptions>\n"
-         "    <Models><Model Name=\"Body\" Length=\"0.1\" Width=\"0.1\" Height=\"0.1\" PrimitiveType=\"Cube\"/></Models>\n"
+         "    <Models><Model Name=\"Body\" Length=\"0.1\" Width=\"0.1\" Height=\"0.1\" PrimitiveType=\"Cube\"" +
+         (modelFileBase.empty() ? std::string{} : " File=\"" + modelFileBase + "\"") +
+         "/></Models>\n"
          "    <Geometries><Geometry Name=\"Root\" Model=\"Body\"/></Geometries>\n"
          "    <DMXModes><DMXMode Name=\"" +
          modeName + "\" Geometry=\"" + modeGeometry +

--- a/tests/support/gdtf_test_fixture_builder.h
+++ b/tests/support/gdtf_test_fixture_builder.h
@@ -15,6 +15,7 @@ public:
   FixtureBuilder &WithFixtureIdentity(std::string name, std::string manufacturer,
                                       std::string fixtureTypeId);
   FixtureBuilder &WithDmxMode(std::string name, std::string geometry);
+  FixtureBuilder &WithModelResource(std::string fileBase);
   FixtureBuilder &WithFixtureCategorySignals();
   FixtureBuilder &WithArchiveEntry(std::string path, std::string bytes);
   std::string BuildDescriptionXml() const;
@@ -25,6 +26,7 @@ private:
   std::string fixtureName;
   std::string manufacturer;
   std::string fixtureTypeId;
+  std::string modelFileBase;
   bool categorySignals = false;
   std::vector<std::pair<std::string, std::string>> archiveEntries;
 };

--- a/tests/support/gdtf_test_fixture_builder.h
+++ b/tests/support/gdtf_test_fixture_builder.h
@@ -16,6 +16,7 @@ public:
                                       std::string fixtureTypeId);
   FixtureBuilder &WithDmxMode(std::string name, std::string geometry);
   FixtureBuilder &WithModelResource(std::string fileBase);
+  FixtureBuilder &WithModelDimensionsMeters(float length, float width, float height);
   FixtureBuilder &WithFixtureCategorySignals();
   FixtureBuilder &WithArchiveEntry(std::string path, std::string bytes);
   std::string BuildDescriptionXml() const;
@@ -27,10 +28,14 @@ private:
   std::string manufacturer;
   std::string fixtureTypeId;
   std::string modelFileBase;
+  float modelLengthMeters = 0.1f;
+  float modelWidthMeters = 0.1f;
+  float modelHeightMeters = 0.1f;
   bool categorySignals = false;
   std::vector<std::pair<std::string, std::string>> archiveEntries;
 };
 FixtureBuilder BuildMinimalValidFixture();
+std::string BuildMinimalValidGlb();
 void WriteMissingMandatorySectionsArchive(const std::filesystem::path &archivePath);
 void WriteInvalidGuidArchive(const std::filesystem::path &archivePath);
 void WriteMalformedXmlArchive(const std::filesystem::path &archivePath);


### PR DESCRIPTION
### Motivation

- Fix Rider truss dictionary matching so known finish adjectives are removed deterministically from both the model token and the complete length-bearing truss name so keys like `TRUSS 40X40 PRO 3M` are attempted. 
- Make GDTF resource semantics honest and consistent by distinguishing source archive identity, renderable 3D geometry (`.glb`/`.3ds`), and optional 2D SVG symbols so SVG-only archives do not masquerade as 3D geometry. 
- Convert tests that used an ad-hoc SVG-only archive into canonical deterministic GDTF fixtures covering GLB/3DS, SVG-only, metadata-only, and dictionary variants, and update the retained BACKDROP assertion to require honest fallback behavior.

### Description

- Added `SimplifyTrussFinishWords()` and applied it in `BuildTrussDictionaryLookupKeys()` so finish adjectives are removed only as whole tokens from both `modelToken` and `trussName`, generating deduplicated prioritized lookup keys (core/riderimporter.cpp). 
- Changed `LoadTrussGdtf()` to treat `gdtfSpec`/`modelFile` as the archive identity and to populate `symbolFile` only from existing `.glb` or `.3ds` extraction results (not `.svg`), and to return parsed metadata even when no 3D symbol was resolved (core/trussloader.cpp). 
- Replaced the ad-hoc test archive with the canonical deterministic GDTF fixture builder and extended it with `WithModelResource()` and test cases for GLB+SVG, 3DS-only, SVG-only, and metadata-only, and wired the fixture builder into the test target (tests/support/gdtf_test_fixture_builder.* and tests/CMakeLists.txt). 
- Adjusted tests to assert honest fallback and stable metadata for unresolved BACKDROP entries rather than fabricated model paths, and added dictionary-variant coverage (tests/rider_hoist_import_test.cpp, tests/rider_truss_dictionary_normalization_test.cpp). 
- Documentation updates to record the Phase 5C/E3 closure, the resource-role contract, and a release-note entry (docs/developer/ci_test_audit.md, docs/developer/text_to_scene_rules.md, docs/release-notes-draft.md). 

### Testing

- Performed syntax-only compilation checks for the modified test support and focused test sources with `c++ -fsyntax-only`, which succeeded. 
- Ran repository policy and sanity checks `tests/check_perastage_tree_modules.sh`, `tests/check_no_configmanager_get_in_gui.sh`, `python3 tests/check_test_targets_no_source_root_includes.py`, `python3 tests/check_wx_filesystem_path_boundaries.py`, `python3 tests/check_bash_test_registration.py`, and `bash tests/check_ci_cmake_language_policy.sh`, all of which passed in this environment. 
- Attempted full CMake configure/build and focused test binary build, but CMake configuration and building of the focused CTest binaries was blocked by an unavailable mDNS package configuration in this environment (missing `mdnsConfig.cmake`), so `ctest` runs and repeat-until-fail runs could not be executed here. 
- Recommendation: run the prepared focused tests and full Linux/Windows/macOS CI (including repeat-until-fail:5 for `RiderTrussDictionaryNormalization` and `RiderHoistImport`) in the canonical CI environment before merging; local changes do not introduce new model fields and preserve documented loader/persistence contracts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a678344ad988324b250c9f17ba64523)