### PR TITLE
Repair layout image resource portability

### DIFF
--- a/core/configservices.cpp
+++ b/core/configservices.cpp
@@ -166,6 +166,9 @@ bool IsLayoutImageResourceEntry(const std::string &entryName) {
 
 // Rejects archive paths that could escape the project resource extraction directory.
 bool IsSafeArchiveRelativePath(const std::string &entryName) {
+  if (entryName.empty() || entryName.find('\\') != std::string::npos ||
+      (entryName.size() >= 2 && entryName[1] == ':'))
+    return false;
   const fs::path path(entryName);
   if (path.empty() || path.is_absolute())
     return false;
@@ -202,7 +205,8 @@ bool WriteZipBytes(wxZipOutputStream &zip, const std::string &entryName,
                    const std::vector<std::uint8_t> &bytes) {
   if (entryName.empty() || !IsSafeArchiveRelativePath(entryName))
     return false;
-  auto *entry = new wxZipEntry(entryName);
+  auto *entry = new wxZipEntry();
+  entry->SetName(wxString::FromUTF8(entryName.c_str()), wxPATH_UNIX);
   entry->SetMethod(SelectZipCompressionMethod(entryName, bytes.size()));
   if (!zip.PutNextEntry(entry))
     return false;

--- a/core/layouts/LayoutTemplatePackageService.cpp
+++ b/core/layouts/LayoutTemplatePackageService.cpp
@@ -17,6 +17,7 @@
 #include "runtime_storage.h"
 
 #include <algorithm>
+#include <array>
 #include <cctype>
 #include <filesystem>
 #include <fstream>
@@ -25,6 +26,7 @@
 #include <map>
 #include <memory>
 #include <set>
+#include <limits>
 #include <sstream>
 
 #include <wx/filename.h>
@@ -126,6 +128,11 @@ bool ValidateArchivePathComponents(const std::string &canonicalName,
       *reason = "UNC-style path";
     return false;
   }
+  if (canonicalName.find("//") != std::string::npos) {
+    if (reason)
+      *reason = "empty path component";
+    return false;
+  }
   if (!allowTrailingSlash && canonicalName.back() == '/') {
     if (reason)
       *reason = "file path has trailing slash";
@@ -186,6 +193,183 @@ bool ValidateArchiveDirectoryPath(const std::string &canonicalName,
 bool IsSafePackageFilePath(const std::string &name) {
   std::string reason;
   return ValidateArchiveFilePath(name, &reason);
+}
+
+// Decodes one little-endian 16-bit ZIP metadata value.
+std::uint16_t ReadLe16(const unsigned char *bytes) {
+  return static_cast<std::uint16_t>(bytes[0]) |
+         (static_cast<std::uint16_t>(bytes[1]) << 8);
+}
+
+// Decodes one little-endian 32-bit ZIP metadata value.
+std::uint32_t ReadLe32(const unsigned char *bytes) {
+  return static_cast<std::uint32_t>(bytes[0]) |
+         (static_cast<std::uint32_t>(bytes[1]) << 8) |
+         (static_cast<std::uint32_t>(bytes[2]) << 16) |
+         (static_cast<std::uint32_t>(bytes[3]) << 24);
+}
+
+// Reads an exact byte range from a package without allocating from ZIP metadata.
+bool ReadRawBytes(std::ifstream &input, std::uint64_t offset, void *buffer,
+                  std::size_t size) {
+  if (offset > static_cast<std::uint64_t>(
+                   std::numeric_limits<std::streamoff>::max()))
+    return false;
+  input.clear();
+  input.seekg(static_cast<std::streamoff>(offset), std::ios::beg);
+  if (!input.good())
+    return false;
+  input.read(static_cast<char *>(buffer), static_cast<std::streamsize>(size));
+  return input.gcount() == static_cast<std::streamsize>(size);
+}
+
+// Returns true when raw ZIP name bytes form well-formed UTF-8.
+bool IsValidUtf8(const std::string &text) {
+  for (std::size_t index = 0; index < text.size();) {
+    const unsigned char lead = static_cast<unsigned char>(text[index]);
+    std::size_t continuationCount = 0;
+    std::uint32_t codePoint = 0;
+    if (lead <= 0x7f) {
+      ++index;
+      continue;
+    } else if (lead >= 0xc2 && lead <= 0xdf) {
+      continuationCount = 1;
+      codePoint = lead & 0x1f;
+    } else if (lead >= 0xe0 && lead <= 0xef) {
+      continuationCount = 2;
+      codePoint = lead & 0x0f;
+    } else if (lead >= 0xf0 && lead <= 0xf4) {
+      continuationCount = 3;
+      codePoint = lead & 0x07;
+    } else {
+      return false;
+    }
+    if (continuationCount > text.size() - index - 1)
+      return false;
+    for (std::size_t part = 1; part <= continuationCount; ++part) {
+      const unsigned char byte = static_cast<unsigned char>(text[index + part]);
+      if ((byte & 0xc0) != 0x80)
+        return false;
+      codePoint = (codePoint << 6) | (byte & 0x3f);
+    }
+    if ((continuationCount == 2 && codePoint < 0x800) ||
+        (continuationCount == 3 && codePoint < 0x10000) ||
+        (codePoint >= 0xd800 && codePoint <= 0xdfff) || codePoint > 0x10ffff)
+      return false;
+    index += continuationCount + 1;
+  }
+  return true;
+}
+
+// Sets a deterministic raw ZIP preflight failure message.
+bool FailRawPreflight(std::string *error, const std::string &category,
+                      const std::string &detail = {}) {
+  if (error) {
+    *error = "Layout package " + category;
+    if (!detail.empty())
+      *error += ": " + detail;
+    *error += ".";
+  }
+  return false;
+}
+
+// Validates raw local and central ZIP names before wxWidgets normalizes them.
+bool ValidateRawArchiveEntryNames(const std::string &sourcePath,
+                                  std::string *error) {
+  std::ifstream input(PathUtils::PathFromUtf8(sourcePath), std::ios::binary);
+  if (!input.is_open())
+    return FailRawPreflight(error, "has malformed ZIP directory/header metadata");
+  input.seekg(0, std::ios::end);
+  const std::streamoff endPosition = input.tellg();
+  if (endPosition < 22)
+    return FailRawPreflight(error, "has malformed ZIP directory/header metadata");
+  const std::uint64_t fileSize = static_cast<std::uint64_t>(endPosition);
+  const std::size_t tailSize = static_cast<std::size_t>(
+      std::min<std::uint64_t>(fileSize, 22 + 0xffff));
+  std::vector<unsigned char> tail(tailSize);
+  if (!ReadRawBytes(input, fileSize - tailSize, tail.data(), tail.size()))
+    return FailRawPreflight(error, "has malformed ZIP directory/header metadata");
+
+  std::size_t eocdInTail = std::string::npos;
+  for (std::size_t offset = tail.size() - 22;; --offset) {
+    if (ReadLe32(tail.data() + offset) == 0x06054b50 &&
+        offset + 22 + ReadLe16(tail.data() + offset + 20) == tail.size()) {
+      eocdInTail = offset;
+      break;
+    }
+    if (offset == 0)
+      break;
+  }
+  if (eocdInTail == std::string::npos)
+    return FailRawPreflight(error, "has malformed ZIP directory/header metadata");
+  const unsigned char *eocd = tail.data() + eocdInTail;
+  const std::uint16_t disk = ReadLe16(eocd + 4);
+  const std::uint16_t centralDisk = ReadLe16(eocd + 6);
+  const std::uint16_t entriesOnDisk = ReadLe16(eocd + 8);
+  const std::uint16_t entryCount = ReadLe16(eocd + 10);
+  const std::uint32_t centralSize = ReadLe32(eocd + 12);
+  const std::uint32_t centralOffset = ReadLe32(eocd + 16);
+  if (disk != 0 || centralDisk != 0 || entriesOnDisk != entryCount)
+    return FailRawPreflight(error, "uses an unsupported multi-disk ZIP structure");
+  if (entryCount == 0xffff || centralSize == 0xffffffffU ||
+      centralOffset == 0xffffffffU)
+    return FailRawPreflight(error, "uses an unsupported ZIP64 structure");
+  if (entryCount > kMaxEntries || centralOffset > fileSize ||
+      centralSize > fileSize - centralOffset ||
+      centralOffset + centralSize != fileSize - tailSize + eocdInTail)
+    return FailRawPreflight(error, "has malformed ZIP directory/header metadata");
+
+  std::uint64_t cursor = centralOffset;
+  const std::uint64_t centralEnd = centralOffset + centralSize;
+  for (std::uint16_t index = 0; index < entryCount; ++index) {
+    std::array<unsigned char, 46> central{};
+    if (cursor > centralEnd || centralEnd - cursor < central.size() ||
+        !ReadRawBytes(input, cursor, central.data(), central.size()) ||
+        ReadLe32(central.data()) != 0x02014b50)
+      return FailRawPreflight(error, "has malformed ZIP directory/header metadata");
+    const std::uint16_t nameLength = ReadLe16(central.data() + 28);
+    const std::uint16_t extraLength = ReadLe16(central.data() + 30);
+    const std::uint16_t commentLength = ReadLe16(central.data() + 32);
+    const std::uint16_t startDisk = ReadLe16(central.data() + 34);
+    const std::uint32_t localOffset = ReadLe32(central.data() + 42);
+    const std::uint64_t recordSize = 46ULL + nameLength + extraLength + commentLength;
+    if (startDisk != 0)
+      return FailRawPreflight(error, "uses an unsupported multi-disk ZIP structure");
+    if (recordSize > centralEnd - cursor || nameLength == 0)
+      return FailRawPreflight(error, "has malformed ZIP directory/header metadata");
+    std::string centralName(nameLength, '\0');
+    if (!ReadRawBytes(input, cursor + 46, centralName.data(), nameLength))
+      return FailRawPreflight(error, "has malformed ZIP directory/header metadata");
+
+    std::array<unsigned char, 30> local{};
+    if (localOffset >= centralOffset || centralOffset - localOffset < local.size() ||
+        !ReadRawBytes(input, localOffset, local.data(), local.size()) ||
+        ReadLe32(local.data()) != 0x04034b50)
+      return FailRawPreflight(error, "has malformed ZIP directory/header metadata");
+    const std::uint16_t localNameLength = ReadLe16(local.data() + 26);
+    const std::uint16_t localExtraLength = ReadLe16(local.data() + 28);
+    if (30ULL + localNameLength + localExtraLength > centralOffset - localOffset)
+      return FailRawPreflight(error, "has malformed ZIP directory/header metadata");
+    std::string localName(localNameLength, '\0');
+    if (!ReadRawBytes(input, static_cast<std::uint64_t>(localOffset) + 30,
+                      localName.data(), localNameLength))
+      return FailRawPreflight(error, "has malformed ZIP directory/header metadata");
+    if (localName != centralName)
+      return FailRawPreflight(error, "contains a local/central entry-name mismatch");
+
+    std::string reason;
+    const bool directory = centralName.back() == '/';
+    if (!IsValidUtf8(centralName))
+      return FailRawPreflight(error, "contains an unsafe raw archive entry");
+    if (!ValidateArchivePathComponents(centralName, directory, &reason)) {
+      return FailRawPreflight(error, "contains an unsafe raw archive entry",
+                              QuoteEntryForError(centralName));
+    }
+    cursor += recordSize;
+  }
+  if (cursor != centralEnd)
+    return FailRawPreflight(error, "has malformed ZIP directory/header metadata");
+  return true;
 }
 
 // Extracts a ZIP entry name using explicit Unix path semantics.
@@ -368,6 +552,8 @@ bool MaterializeImages(LayoutDefinition &layout,
 bool ReadAndValidatePortablePackage(const std::string &sourcePath,
                                     ParsedLayoutPackage &result,
                                     std::string *error) {
+  if (!ValidateRawArchiveEntryNames(sourcePath, error))
+    return false;
   wxFFileInputStream input(wxString::FromUTF8(sourcePath.c_str()));
   if (!input.IsOk()) {
     if (error)

--- a/docs/developer/ci_test_audit.md
+++ b/docs/developer/ci_test_audit.md
@@ -1306,3 +1306,16 @@ rejecting backslash and drive-prefixed alternate path conventions. The two
 content-addressed resource-key implementations were compared and remain
 byte-for-byte equivalent, so they were intentionally left separate rather than
 introducing an unrelated serialization refactor.
+
+At head `98985d8cb2998e3bf1e958c731e4eb6c5b73156b`, authoritative run
+`30302888988` made `LayoutImageResourceRegistry` green on Windows, while
+`LayoutTemplatePackageService` advanced past its image deduplication assertions
+on Linux and Windows and stopped at the absolute-entry security fixture. Linux
+reported 166 total, 156 passed, 9 failed, and 1 skipped; Windows reported 168
+total, 157 passed, and 11 failed; macOS remained 6 of 6. No unrelated failure
+name appeared. The fixture used `wxZipEntry::SetName`, which stripped the
+leading slash before publication, and the same wx path conversion can normalize
+names while reading externally produced archives. Phase 6A therefore requires
+a raw local-header and central-directory preflight before the retained wx
+logical-name validation. E5 remains pending authoritative evidence for that
+final raw-name correction.

--- a/docs/developer/ci_test_audit.md
+++ b/docs/developer/ci_test_audit.md
@@ -1284,3 +1284,25 @@ assertion on Linux and Windows. The test set `PERASTAGE_LIBRARY_PATH` to a
 directory it had not created, so production correctly used the user-data
 fallback; no unrelated failure name changed and macOS remained 6 of 6. E4
 remains pending final isolated-root verification.
+
+PR #2231 closed Phase 5 E4 at final reviewed head
+`d03c2b5c5288c1d001bb32d6c662ee82becef937`. Authoritative run
+`30298301335` made `RiderHoistImport` and
+`RiderTrussDictionaryNormalization` green on Linux and Windows. Linux reported
+166 total, 156 passed, 9 failed, and 1 skipped; Windows reported 168 total, 156
+passed, and 12 failed; macOS remained 6 of 6. No new failure name appeared, E4
+was reached, and PR #2231 was approved for merge.
+
+Phase 6A classifies the shared `LayoutTemplatePackageService` failure as a test
+reader counting the `resources/layout_images/` directory entry as an image
+payload. The Windows-only `LayoutImageResourceRegistry` failure is a separate
+test presentation defect: `wxZipEntry::GetName()` exposed native separators,
+while the assertion correctly used canonical portable metadata. Shared test
+support now reads names explicitly with `wxPATH_UNIX`, converts them explicitly
+to UTF-8, and distinguishes directories from payload files. The ProjectSession
+resource writer audit also identified an implicit-name construction boundary;
+resource entries now set UTF-8 names explicitly with `wxPATH_UNIX`, while
+rejecting backslash and drive-prefixed alternate path conventions. The two
+content-addressed resource-key implementations were compared and remain
+byte-for-byte equivalent, so they were intentionally left separate rather than
+introducing an unrelated serialization refactor.

--- a/docs/developer/default_layout_templates.md
+++ b/docs/developer/default_layout_templates.md
@@ -43,6 +43,11 @@ the package. Layout package and project archive resource names are canonical
 UTF-8 ZIP paths: they are relative, use `/` separators on every platform, and
 reject backslashes, drive-qualified paths, absolute paths, and traversal. ZIP
 directory entries are metadata and never count as packaged image payloads.
+Validation first inspects raw local-header and central-directory names and
+requires them to match byte-for-byte before wxWidgets can normalize them. It
+then applies the existing canonical logical-path, duplicate, ambiguity, entry
+count, and payload-size checks to the names exposed by the ZIP reader. Both
+layers must succeed.
 
 When a package is imported, Perastage materializes image files into owned runtime
 storage, updates the runtime `imagePath`, preserves `projectResourcePath`, and

--- a/docs/developer/default_layout_templates.md
+++ b/docs/developer/default_layout_templates.md
@@ -39,7 +39,10 @@ Portable `.pslayout` files must be self-contained. Export rewrites image element
 metadata so both `path` and `projectResource` reference the packaged
 `resources/layout_images/` entry, and `originalPath` is omitted to avoid leaking
 local source paths. Image payloads are content-addressed and deduplicated inside
-the package.
+the package. Layout package and project archive resource names are canonical
+UTF-8 ZIP paths: they are relative, use `/` separators on every platform, and
+reject backslashes, drive-qualified paths, absolute paths, and traversal. ZIP
+directory entries are metadata and never count as packaged image payloads.
 
 When a package is imported, Perastage materializes image files into owned runtime
 storage, updates the runtime `imagePath`, preserves `projectResourcePath`, and

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -33,7 +33,9 @@ Changes since **v1.5.0**.
 ## Technical and packaging changes
 
 - Standardized embedded layout-image resource names in project archives as
-  portable UTF-8 paths with forward slashes on every platform.
+  portable UTF-8 paths with forward slashes on every platform, and strengthened
+  layout-package validation against unsafe names hidden by ZIP path
+  normalization.
 
 - Improved maintainer issue intake and triage with clearer diagnostic guidance and revision-aware, failure-resilient automation limited to reports explicitly awaiting feedback.
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -32,6 +32,9 @@ Changes since **v1.5.0**.
 
 ## Technical and packaging changes
 
+- Standardized embedded layout-image resource names in project archives as
+  portable UTF-8 paths with forward slashes on every platform.
+
 - Improved maintainer issue intake and triage with clearer diagnostic guidance and revision-aware, failure-resilient automation limited to reports explicitly awaiting feedback.
 
 - Aligned CI policy checks with the validated Windows Git Bash initial-cache data flow and strengthened cross-platform filesystem path boundary coverage.

--- a/tests/layout_image_resource_registry_test.cpp
+++ b/tests/layout_image_resource_registry_test.cpp
@@ -4,15 +4,17 @@
 #include "configmanager.h"
 #include "configservices.h"
 #include "json.hpp"
+#include "support/zip_test_utils.h"
+#include "support/archive_entry_test_utils.h"
 
 #include <wx/wfstream.h>
 class wxZipStreamLink;
 #include <wx/zipstrm.h>
 
 #include <cassert>
+#include <algorithm>
 #include <filesystem>
 #include <fstream>
-#include <map>
 #include <iterator>
 #include <memory>
 #include <string>
@@ -20,34 +22,6 @@ class wxZipStreamLink;
 
 namespace {
 namespace fs = std::filesystem;
-
-// Reads the current ZIP entry payload into a string for archive assertions.
-std::string ReadCurrentZipEntry(wxZipInputStream &zip) {
-  std::string data;
-  char buffer[256];
-  while (true) {
-    zip.Read(buffer, sizeof(buffer));
-    const size_t bytes = zip.LastRead();
-    if (bytes == 0)
-      break;
-    data.append(buffer, bytes);
-  }
-  return data;
-}
-
-// Reads all file entries from a ZIP archive into a name-to-payload map.
-std::map<std::string, std::string> ReadArchiveEntries(const fs::path &archivePath) {
-  std::map<std::string, std::string> entries;
-  wxFileInputStream input(WxPathUtils::WxStringFromFilesystemPath(archivePath));
-  assert(input.IsOk());
-  wxZipInputStream zip(input);
-  std::unique_ptr<wxZipEntry> entry;
-  while ((entry.reset(zip.GetNextEntry())), entry) {
-    if (!entry->IsDir())
-      entries[entry->GetName().ToStdString()] = ReadCurrentZipEntry(zip);
-  }
-  return entries;
-}
 
 // Creates a small binary image fixture at the requested path.
 void WriteImageFixture(const fs::path &path, const std::string &bytes) {
@@ -63,7 +37,8 @@ int main() {
   const fs::path tempDir = fs::temp_directory_path() / "perastage_layout_image_resource_test";
   std::error_code ec;
   fs::remove_all(tempDir, ec);
-  fs::create_directories(tempDir, ec);
+  ec.clear();
+  assert(fs::create_directories(tempDir, ec) && !ec);
 
   const fs::path usedImage = tempDir / "used.png";
   const fs::path unusedImage = tempDir / "unused.png";
@@ -128,12 +103,30 @@ int main() {
       });
   assert(saved);
 
-  const auto entries = ReadArchiveEntries(projectPath);
-  assert(entries.find(storedFirstResourcePath) != entries.end());
-  assert(entries.at(storedFirstResourcePath) == "used-image-bytes");
-  assert(entries.find(unusedResourcePath) == entries.end());
+  const auto entries = tests::zip::ReadEntries(projectPath);
+  int storedResourceCount = 0;
+  for (const auto &entry : entries) {
+    if (entry.isDirectory)
+      continue;
+    assert(entry.name.find('\\') == std::string::npos);
+    if (entry.name == storedFirstResourcePath) {
+      ++storedResourceCount;
+      assert(entry.payload == "used-image-bytes");
+    }
+    assert(entry.name != unusedResourcePath);
+  }
+  assert(storedResourceCount == 1);
+  std::string centralDirectoryError;
+  const auto storedNames = tests::archive::ReadRawCentralDirectoryEntryNames(
+      projectPath.string(), centralDirectoryError);
+  assert(centralDirectoryError.empty());
+  assert(std::count(storedNames.begin(), storedNames.end(),
+                    storedFirstResourcePath) == 1);
+  for (const auto &storedName : storedNames)
+    assert(storedName.find('\\') == std::string::npos);
 
   layouts::LayoutImageResourceRegistry::Get().Clear();
   fs::remove_all(tempDir, ec);
+  assert(!ec);
   return 0;
 }

--- a/tests/layout_template_package_service_test.cpp
+++ b/tests/layout_template_package_service_test.cpp
@@ -4,6 +4,7 @@
 #include "LayoutImageResourceRegistry.h"
 #include "runtime_storage.h"
 #include "support/zip_test_utils.h"
+#include "support/archive_entry_test_utils.h"
 #include "json.hpp"
 
 #include <cassert>
@@ -76,6 +77,38 @@ std::vector<std::pair<std::string, std::string>> MinimalPackageEntries() {
 })";
   return {{"manifest.json", manifest},
           {"layout.json", layouts::ToTemplateDocument({layout}).dump(2)}};
+}
+
+// Writes a package fixture while preserving every requested raw ZIP name byte.
+void WriteRawPackageZip(
+    const fs::path &path,
+    const std::vector<std::pair<std::string, std::string>> &entries) {
+  std::string error;
+  assert(tests::archive::WriteStoredZipWithRawNames(ToUtf8(path), entries,
+                                                    error));
+  assert(error.empty());
+}
+
+// Verifies one unsafe raw name is stored identically and rejected before wx parsing.
+void AssertUnsafeRawArchiveName(const fs::path &dir, const std::string &caseName,
+                                const std::string &rawName) {
+  const fs::path package = dir / (caseName + ".pslayout");
+  auto entries = MinimalPackageEntries();
+  entries.push_back({rawName, "bad"});
+  WriteRawPackageZip(package, entries);
+  std::string inspectionError;
+  const auto centralNames = tests::archive::ReadRawCentralDirectoryEntryNames(
+      ToUtf8(package), inspectionError);
+  assert(inspectionError.empty());
+  const auto localNames = tests::archive::ReadRawLocalHeaderEntryNames(
+      ToUtf8(package), inspectionError);
+  assert(inspectionError.empty());
+  assert(centralNames == localNames);
+  assert(centralNames.back() == rawName);
+  std::string validationError;
+  assert(!layouts::LayoutTemplatePackageService::ValidatePortablePackage(
+      ToUtf8(package), &validationError));
+  assert(validationError.find("unsafe raw archive entry") != std::string::npos);
 }
 
 // Verifies packages without images can be round-tripped.
@@ -218,29 +251,13 @@ void TestArchiveEntryValidation(const fs::path &dir) {
   assert(layouts::LayoutTemplatePackageService::ValidatePortablePackage(
       ToUtf8(directories), &error));
 
-  const fs::path traversal = dir / "traversal.pslayout";
-  entries = MinimalPackageEntries();
-  entries.push_back({"resources/../image.png", "bad"});
-  WritePackageZip(traversal, entries);
-  assert(!layouts::LayoutTemplatePackageService::ValidatePortablePackage(
-      ToUtf8(traversal), &error));
-  assert(error.find("unsafe archive entry") != std::string::npos);
-
-  const fs::path absolute = dir / "absolute.pslayout";
-  entries = MinimalPackageEntries();
-  entries.push_back({"/absolute.png", "bad"});
-  WritePackageZip(absolute, entries);
-  assert(!layouts::LayoutTemplatePackageService::ValidatePortablePackage(
-      ToUtf8(absolute), &error));
-  assert(error.find("unsafe archive entry") != std::string::npos);
-
-  const fs::path backslash = dir / "backslash.pslayout";
-  entries = MinimalPackageEntries();
-  entries.push_back({"resources\\layout_images\\bad.png", "bad"});
-  WritePackageZip(backslash, entries);
-  assert(!layouts::LayoutTemplatePackageService::ValidatePortablePackage(
-      ToUtf8(backslash), &error));
-  assert(error.find("unsafe archive entry") != std::string::npos);
+  AssertUnsafeRawArchiveName(dir, "traversal", "resources/../image.png");
+  AssertUnsafeRawArchiveName(dir, "rooted_unix", "/absolute.png");
+  AssertUnsafeRawArchiveName(dir, "rooted_backslash", "\\absolute.png");
+  AssertUnsafeRawArchiveName(dir, "drive_unix", "C:/absolute.png");
+  AssertUnsafeRawArchiveName(dir, "drive_backslash", "C:\\absolute.png");
+  AssertUnsafeRawArchiveName(dir, "backslash_separator",
+                             "resources\\layout_images\\bad.png");
 
   const fs::path duplicateManifest = dir / "duplicate_manifest.pslayout";
   entries = MinimalPackageEntries();
@@ -258,6 +275,24 @@ void TestArchiveEntryValidation(const fs::path &dir) {
   assert(!layouts::LayoutTemplatePackageService::ValidatePortablePackage(
       ToUtf8(duplicateImage), &error));
   assert(error.find("duplicate archive entry") != std::string::npos);
+
+  const fs::path canonical = dir / "canonical_raw.pslayout";
+  WriteRawPackageZip(canonical, MinimalPackageEntries());
+  assert(layouts::LayoutTemplatePackageService::ValidatePortablePackage(
+      ToUtf8(canonical), &error));
+  layouts::LayoutTemplateImportResult imported;
+  assert(layouts::LayoutTemplatePackageService::ImportFile(
+      ToUtf8(canonical), imported, &error));
+  assert(imported.layout.name == BuildLayout().name);
+
+  const fs::path mismatch = dir / "name_mismatch.pslayout";
+  WriteRawPackageZip(mismatch, MinimalPackageEntries());
+  std::string fixtureError;
+  assert(tests::archive::ReplaceRawLocalHeaderName(
+      ToUtf8(mismatch), 0, "manifesu.json", fixtureError));
+  assert(!layouts::LayoutTemplatePackageService::ValidatePortablePackage(
+      ToUtf8(mismatch), &error));
+  assert(error.find("local/central entry-name mismatch") != std::string::npos);
 }
 
 // Verifies export validation does not import package resources into the registry.

--- a/tests/layout_template_package_service_test.cpp
+++ b/tests/layout_template_package_service_test.cpp
@@ -3,11 +3,12 @@
 #include "LayoutTemplateSerializer.h"
 #include "LayoutImageResourceRegistry.h"
 #include "runtime_storage.h"
+#include "support/zip_test_utils.h"
+#include "json.hpp"
 
 #include <cassert>
 #include <filesystem>
 #include <fstream>
-#include <map>
 #include <memory>
 #include <string>
 #include <vector>
@@ -32,28 +33,6 @@ void WriteFile(const fs::path &path, const std::string &bytes) {
   fs::create_directories(path.parent_path());
   std::ofstream out(path, std::ios::binary);
   out << bytes;
-}
-
-// Reads a package into an entry map for package assertions.
-std::map<std::string, std::string> ReadZipEntries(const fs::path &path) {
-  wxFFileInputStream input(WxPathUtils::WxStringFromFilesystemPath(path));
-  wxZipInputStream zip(input);
-  std::map<std::string, std::string> entries;
-  std::unique_ptr<wxZipEntry> entry;
-  while ((entry.reset(zip.GetNextEntry())), entry) {
-    std::string data;
-    char buffer[4096];
-    while (true) {
-      zip.Read(buffer, sizeof(buffer));
-      const size_t bytes = zip.LastRead();
-      if (bytes == 0)
-        break;
-      data.append(buffer, bytes);
-    }
-    const wxScopedCharBuffer utf8 = entry->GetName(wxPATH_UNIX).utf8_str();
-    entries[utf8.data() == nullptr ? std::string() : std::string(utf8.data())] = data;
-  }
-  return entries;
 }
 
 // Builds a minimal layout definition for package roundtrip tests.
@@ -130,26 +109,43 @@ void TestImagePortabilityAndDeduplication(const fs::path &dir) {
   std::string error;
   assert(layouts::LayoutTemplatePackageService::ExportPackage(
       layout, ToUtf8(package), &error));
-  auto entries = ReadZipEntries(package);
+  const auto entries = tests::zip::ReadEntries(package);
   int imageEntryCount = 0;
   std::string allText;
-  for (const auto &[name, content] : entries) {
-    allText += name + "\n" + content + "\n";
-    if (name.rfind("resources/layout_images/", 0) == 0)
+  std::string packagedImagePath;
+  for (const auto &entry : entries) {
+    allText += entry.name + "\n" + entry.payload + "\n";
+    if (!entry.isDirectory &&
+        entry.name.rfind("resources/layout_images/", 0) == 0) {
       ++imageEntryCount;
-  }
-  assert(imageEntryCount == 1);
-
-  bool foundCanonicalImage = false;
-  for (const auto &[name, content] : entries) {
-    (void)content;
-    assert(name.find('\\') == std::string::npos);
-    if (name.rfind("resources/layout_images/", 0) == 0) {
-      assert(name.find('/') != std::string::npos);
-      foundCanonicalImage = true;
+      packagedImagePath = entry.name;
+      assert(entry.payload == "same-image-bytes");
     }
   }
+  assert(imageEntryCount == 1);
+  assert(packagedImagePath != "resources/layout_images/");
+
+  bool foundCanonicalImage = false;
+  std::string layoutJson;
+  for (const auto &entry : entries) {
+    assert(entry.name.find('\\') == std::string::npos);
+    if (!entry.isDirectory &&
+        entry.name.rfind("resources/layout_images/", 0) == 0) {
+      foundCanonicalImage = true;
+    }
+    if (entry.name == "layout.json" && !entry.isDirectory)
+      layoutJson = entry.payload;
+  }
   assert(foundCanonicalImage);
+  const auto document = nlohmann::json::parse(layoutJson);
+  const auto &images = document.at("layouts").at(0).at("imageViews");
+  assert(images.size() == 2);
+  for (const auto &packagedImage : images) {
+    assert(packagedImage.at("projectResource").get<std::string>() ==
+           packagedImagePath);
+    assert(packagedImage.find("originalPath") == packagedImage.end());
+    assert(packagedImage.dump().find(ToUtf8(imagePath)) == std::string::npos);
+  }
   assert(layouts::LayoutTemplatePackageService::ValidatePortablePackage(
       ToUtf8(package), &error));
   assert(allText.find(ToUtf8(imagePath)) == std::string::npos);
@@ -162,8 +158,18 @@ void TestImagePortabilityAndDeduplication(const fs::path &dir) {
   assert(imported.layout.imageViews.size() == 2);
   for (const auto &importedImage : imported.layout.imageViews) {
     assert(fs::exists(fs::path(importedImage.imagePath)));
-    assert(importedImage.projectResourcePath.rfind("resources/layout_images/", 0) == 0);
+    assert(importedImage.projectResourcePath == packagedImagePath);
   }
+}
+
+// Verifies a layout image directory entry is not treated as an image payload.
+void TestImageDirectoryIsNotAFile(const fs::path &dir) {
+  const fs::path package = dir / "directory_control.zip";
+  WritePackageZip(package, {{"resources/layout_images/", ""}});
+  const auto entries = tests::zip::ReadEntries(package);
+  assert(entries.size() == 1);
+  assert(entries.front().name == "resources/layout_images/");
+  assert(entries.front().isDirectory);
 }
 
 // Verifies export can use registry bytes after a source file disappears.
@@ -268,11 +274,12 @@ void TestExportValidationHasNoImportSideEffects(const fs::path &dir) {
   const fs::path package = dir / "side_effect.pslayout";
   assert(layouts::LayoutTemplatePackageService::ExportPackage(
       layout, ToUtf8(package), &error));
-  auto entries = ReadZipEntries(package);
-  for (const auto &[name, content] : entries) {
-    (void)content;
-    if (name.rfind("resources/layout_images/", 0) == 0)
-      assert(!layouts::LayoutImageResourceRegistry::Get().HasResourceBytes(name));
+  const auto entries = tests::zip::ReadEntries(package);
+  for (const auto &entry : entries) {
+    if (!entry.isDirectory &&
+        entry.name.rfind("resources/layout_images/", 0) == 0)
+      assert(!layouts::LayoutImageResourceRegistry::Get().HasResourceBytes(
+          entry.name));
   }
 }
 
@@ -308,16 +315,23 @@ void TestLegacyJsonWarningsArePreserved(const fs::path &dir) {
 // Runs focused portable layout package service coverage.
 int main() {
   const fs::path dir = fs::temp_directory_path() / "perastage_layout_package_test";
-  fs::remove_all(dir);
-  fs::create_directories(dir);
+  std::error_code ec;
+  fs::remove_all(dir, ec);
+  ec.clear();
+  assert(fs::create_directories(dir, ec) && !ec);
+  layouts::LayoutImageResourceRegistry::Get().Clear();
   runtime_storage::SetRuntimeRootOverrideForTests(dir / "runtime");
   TestRoundTripWithoutImages(dir);
   TestImagePortabilityAndDeduplication(dir);
+  TestImageDirectoryIsNotAFile(dir);
   TestRegistryFallback(dir);
   TestFailedExportPreservesDestination(dir);
   TestArchiveEntryValidation(dir);
   TestExportValidationHasNoImportSideEffects(dir);
   TestLegacyJsonWarningsArePreserved(dir);
-  fs::remove_all(dir);
+  layouts::LayoutImageResourceRegistry::Get().Clear();
+  runtime_storage::SetRuntimeRootOverrideForTests({});
+  fs::remove_all(dir, ec);
+  assert(!ec);
   return 0;
 }

--- a/tests/support/archive_entry_test_utils.h
+++ b/tests/support/archive_entry_test_utils.h
@@ -1,9 +1,13 @@
 #pragma once
 
+#include <algorithm>
+#include <cstddef>
 #include <cstdint>
 #include <fstream>
 #include <iterator>
+#include <limits>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace tests::archive {
@@ -86,6 +90,193 @@ inline std::uint32_t ReadLe32(const std::vector<unsigned char> &bytes,
          (static_cast<std::uint32_t>(bytes[offset + 1]) << 8) |
          (static_cast<std::uint32_t>(bytes[offset + 2]) << 16) |
          (static_cast<std::uint32_t>(bytes[offset + 3]) << 24);
+}
+
+// Appends one little-endian 16-bit value to a ZIP fixture buffer.
+inline void AppendLe16(std::vector<unsigned char> &bytes, std::uint16_t value) {
+  bytes.push_back(static_cast<unsigned char>(value & 0xff));
+  bytes.push_back(static_cast<unsigned char>((value >> 8) & 0xff));
+}
+
+// Appends one little-endian 32-bit value to a ZIP fixture buffer.
+inline void AppendLe32(std::vector<unsigned char> &bytes, std::uint32_t value) {
+  for (int shift = 0; shift < 32; shift += 8)
+    bytes.push_back(static_cast<unsigned char>((value >> shift) & 0xff));
+}
+
+// Computes the standard ZIP CRC-32 for one stored payload.
+inline std::uint32_t ComputeCrc32(const std::string &payload) {
+  std::uint32_t crc = 0xffffffffU;
+  for (const unsigned char byte : payload) {
+    crc ^= byte;
+    for (int bit = 0; bit < 8; ++bit)
+      crc = (crc >> 1) ^ (0xedb88320U & (0U - (crc & 1U)));
+  }
+  return crc ^ 0xffffffffU;
+}
+
+// Writes a deterministic stored ZIP whose entry names remain exact raw bytes.
+inline bool WriteStoredZipWithRawNames(
+    const std::string &archivePath,
+    const std::vector<std::pair<std::string, std::string>> &entries,
+    std::string &error) {
+  if (entries.size() > std::numeric_limits<std::uint16_t>::max()) {
+    error = "ZIP fixture has too many entries";
+    return false;
+  }
+  std::vector<unsigned char> bytes;
+  struct CentralRecord {
+    std::string name;
+    std::string payload;
+    std::uint32_t crc = 0;
+    std::uint32_t localOffset = 0;
+  };
+  std::vector<CentralRecord> records;
+  for (const auto &[name, payload] : entries) {
+    if (name.empty() || name.size() > std::numeric_limits<std::uint16_t>::max() ||
+        payload.size() > std::numeric_limits<std::uint32_t>::max() ||
+        bytes.size() > std::numeric_limits<std::uint32_t>::max()) {
+      error = "ZIP fixture entry exceeds classic ZIP limits";
+      return false;
+    }
+    CentralRecord record{name, payload, ComputeCrc32(payload),
+                         static_cast<std::uint32_t>(bytes.size())};
+    AppendLe32(bytes, 0x04034b50);
+    AppendLe16(bytes, 20);
+    AppendLe16(bytes, 0x0800);
+    AppendLe16(bytes, 0);
+    AppendLe16(bytes, 0);
+    AppendLe16(bytes, 0);
+    AppendLe32(bytes, record.crc);
+    AppendLe32(bytes, static_cast<std::uint32_t>(payload.size()));
+    AppendLe32(bytes, static_cast<std::uint32_t>(payload.size()));
+    AppendLe16(bytes, static_cast<std::uint16_t>(name.size()));
+    AppendLe16(bytes, 0);
+    bytes.insert(bytes.end(), name.begin(), name.end());
+    bytes.insert(bytes.end(), payload.begin(), payload.end());
+    records.push_back(std::move(record));
+  }
+  if (bytes.size() > std::numeric_limits<std::uint32_t>::max()) {
+    error = "ZIP fixture local records exceed classic ZIP limits";
+    return false;
+  }
+  const std::uint32_t centralOffset = static_cast<std::uint32_t>(bytes.size());
+  for (const auto &record : records) {
+    AppendLe32(bytes, 0x02014b50);
+    AppendLe16(bytes, 20);
+    AppendLe16(bytes, 20);
+    AppendLe16(bytes, 0x0800);
+    AppendLe16(bytes, 0);
+    AppendLe16(bytes, 0);
+    AppendLe16(bytes, 0);
+    AppendLe32(bytes, record.crc);
+    AppendLe32(bytes, static_cast<std::uint32_t>(record.payload.size()));
+    AppendLe32(bytes, static_cast<std::uint32_t>(record.payload.size()));
+    AppendLe16(bytes, static_cast<std::uint16_t>(record.name.size()));
+    AppendLe16(bytes, 0);
+    AppendLe16(bytes, 0);
+    AppendLe16(bytes, 0);
+    AppendLe16(bytes, 0);
+    AppendLe32(bytes, !record.name.empty() && record.name.back() == '/' ? 0x10 : 0);
+    AppendLe32(bytes, record.localOffset);
+    bytes.insert(bytes.end(), record.name.begin(), record.name.end());
+  }
+  const std::uint64_t centralSize64 = bytes.size() - centralOffset;
+  if (centralSize64 > std::numeric_limits<std::uint32_t>::max()) {
+    error = "ZIP fixture central directory exceeds classic ZIP limits";
+    return false;
+  }
+  AppendLe32(bytes, 0x06054b50);
+  AppendLe16(bytes, 0);
+  AppendLe16(bytes, 0);
+  AppendLe16(bytes, static_cast<std::uint16_t>(records.size()));
+  AppendLe16(bytes, static_cast<std::uint16_t>(records.size()));
+  AppendLe32(bytes, static_cast<std::uint32_t>(centralSize64));
+  AppendLe32(bytes, centralOffset);
+  AppendLe16(bytes, 0);
+  std::ofstream output(archivePath, std::ios::binary);
+  output.write(reinterpret_cast<const char *>(bytes.data()),
+               static_cast<std::streamsize>(bytes.size()));
+  if (!output.good()) {
+    error = "Could not write raw ZIP fixture";
+    return false;
+  }
+  error.clear();
+  return true;
+}
+
+// Returns local-header entry names exactly as stored in the ZIP archive.
+inline std::vector<std::string> ReadRawLocalHeaderEntryNames(
+    const std::string &archivePath, std::string &error) {
+  const auto bytes = ReadBinaryFile(archivePath);
+  std::vector<std::string> names;
+  std::size_t cursor = 0;
+  while (cursor + 4 <= bytes.size() && ReadLe32(bytes, cursor) == 0x04034b50) {
+    if (cursor + 30 > bytes.size()) {
+      error = "ZIP local header is truncated";
+      return {};
+    }
+    const std::uint16_t nameLength = ReadLe16(bytes, cursor + 26);
+    const std::uint16_t extraLength = ReadLe16(bytes, cursor + 28);
+    const std::uint32_t payloadSize = ReadLe32(bytes, cursor + 18);
+    const std::size_t nameOffset = cursor + 30;
+    const std::uint64_t next = static_cast<std::uint64_t>(nameOffset) +
+                               nameLength + extraLength + payloadSize;
+    if (next > bytes.size()) {
+      error = "ZIP local record exceeds file bounds";
+      return {};
+    }
+    names.emplace_back(reinterpret_cast<const char *>(bytes.data() + nameOffset),
+                       nameLength);
+    cursor = static_cast<std::size_t>(next);
+  }
+  if (names.empty())
+    error = "ZIP contains no local entry headers";
+  return names;
+}
+
+// Replaces one local-header name with same-length bytes to create a mismatch.
+inline bool ReplaceRawLocalHeaderName(const std::string &archivePath,
+                                      std::size_t entryIndex,
+                                      const std::string &replacement,
+                                      std::string &error) {
+  auto bytes = ReadBinaryFile(archivePath);
+  std::size_t cursor = 0;
+  for (std::size_t index = 0; index <= entryIndex; ++index) {
+    if (cursor + 30 > bytes.size() || ReadLe32(bytes, cursor) != 0x04034b50) {
+      error = "Requested ZIP local entry was not found";
+      return false;
+    }
+    const std::uint16_t nameLength = ReadLe16(bytes, cursor + 26);
+    const std::uint16_t extraLength = ReadLe16(bytes, cursor + 28);
+    const std::uint32_t payloadSize = ReadLe32(bytes, cursor + 18);
+    if (index == entryIndex) {
+      if (replacement.size() != nameLength) {
+        error = "Replacement ZIP local name has a different length";
+        return false;
+      }
+      std::copy(replacement.begin(), replacement.end(),
+                bytes.begin() + static_cast<std::ptrdiff_t>(cursor + 30));
+      std::ofstream output(archivePath, std::ios::binary | std::ios::trunc);
+      output.write(reinterpret_cast<const char *>(bytes.data()),
+                   static_cast<std::streamsize>(bytes.size()));
+      if (!output.good()) {
+        error = "Could not update ZIP local entry name";
+        return false;
+      }
+      error.clear();
+      return true;
+    }
+    const std::uint64_t next = static_cast<std::uint64_t>(cursor) + 30 +
+                               nameLength + extraLength + payloadSize;
+    if (next > bytes.size()) {
+      error = "ZIP local record exceeds file bounds";
+      return false;
+    }
+    cursor = static_cast<std::size_t>(next);
+  }
+  error = "Requested ZIP local entry was not found";
+  return false;
 }
 
 // Returns central-directory entry names exactly as stored in the ZIP archive.

--- a/tests/support/zip_test_utils.h
+++ b/tests/support/zip_test_utils.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "wx_path_utils.h"
+
+#include <cassert>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <wx/wfstream.h>
+class wxZipStreamLink;
+#include <wx/zipstrm.h>
+
+namespace tests::zip {
+
+struct Entry {
+  std::string name;
+  std::string payload;
+  bool isDirectory = false;
+};
+
+// Converts a wxString to UTF-8 without using the process locale.
+inline std::string ToUtf8(const wxString &value) {
+  const wxScopedCharBuffer utf8 = value.utf8_str();
+  return utf8.data() == nullptr ? std::string() : std::string(utf8.data());
+}
+
+// Reads ZIP entries with canonical Unix names while retaining directory metadata.
+inline std::vector<Entry> ReadEntries(const std::filesystem::path &archivePath) {
+  wxFFileInputStream input(
+      WxPathUtils::WxStringFromFilesystemPath(archivePath));
+  assert(input.IsOk());
+  wxZipInputStream zip(input);
+  std::vector<Entry> entries;
+  std::unique_ptr<wxZipEntry> entry;
+  while ((entry.reset(zip.GetNextEntry())), entry) {
+    Entry result;
+    result.name = ToUtf8(entry->GetName(wxPATH_UNIX));
+    result.isDirectory = entry->IsDir() ||
+                         (!result.name.empty() && result.name.back() == '/');
+    char buffer[4096];
+    while (!result.isDirectory) {
+      zip.Read(buffer, sizeof(buffer));
+      const size_t bytes = zip.LastRead();
+      if (bytes == 0)
+        break;
+      result.payload.append(buffer, bytes);
+    }
+    entries.push_back(std::move(result));
+  }
+  return entries;
+}
+
+} // namespace tests::zip


### PR DESCRIPTION
### Motivation
- Fix two cross-platform portability failures around layout image packaging and project archive resources by making archive metadata handling canonical and platform-independent.
- Ensure portable `.pslayout` and project archive semantics remain: directory entries must not count as file payloads and archive entry names must be written and compared as UTF-8 Unix-style paths.

### Description
- Add a small, header-only shared test helper `tests/support/zip_test_utils.h` that reads ZIP entries with `wxPATH_UNIX`, converts names explicitly to UTF-8, preserves payload bytes, and exposes an `isDirectory` flag for precise file-vs-directory distinctions.
- Update `tests/layout_template_package_service_test.cpp` to use the new ZIP reader, count only regular payload files under `resources/layout_images/`, assert a single deduplicated payload, verify `layout.json` image entries reference the canonical packaged resource, and add a control proving `resources/layout_images/` directory entries are not counted as image files.
- Update `tests/layout_image_resource_registry_test.cpp` to read canonical Unix entry names, reject backslash-separated presented names, exclude directory entries from payload maps, require the stored resource exists exactly once with exact bytes, and verify the ZIP central-directory stored names remain canonical (via existing `tests/support/archive_entry_test_utils.h`).
- Harden project archive writing in `core/configservices.cpp` by rejecting backslashes and drive-prefixed names in `IsSafeArchiveRelativePath` and by writing optional project resource entries with explicit UTF-8 Unix names via `entry->SetName(..., wxPATH_UNIX)` so portable names are canonical on all platforms.
- Minor test hygiene: clear and reset runtime/test overrides and registry state to avoid cross-test leakage during focused runs; update developer docs to record the canonical ZIP naming contract and Phase 5/E4 → Phase 6A classification; add a brief release-note entry describing the internal packaging/portability stabilization.

### Testing
- Ran repository policy and static checks which succeeded: `tests/check_perastage_tree_modules.sh`, `tests/check_no_configmanager_get_in_gui.sh`, `python3 tests/check_test_targets_no_source_root_includes.py`, `PERASTAGE_TEST_PYTHON="$(command -v python3)" python3 tests/check_wx_filesystem_path_boundaries.py`, `python3 tests/check_bash_test_registration.py`, `PERASTAGE_TEST_PYTHON="$(command -v python3)" bash tests/check_ci_cmake_language_policy.sh`, and `git diff --check` all passed locally.
- Focused native test executables (`layout_template_package_service_test` and `layout_image_resource_registry_test`) could not be executed in this container because CMake configure was blocked by missing system/packaging dependencies in the environment (some native packages had to be installed and further runtime CMake packages were still required); therefore the compiled test run and repeated `--repeat until-fail:5` runs were not performed here and are requested on CI.
- Recommendation: run the two focused tests and a full Linux/Windows Debug CI (and macOS release-gate) on this branch to confirm the expected failure-name delta and reach E5 before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a67b9bcb7648324a4505e38ef4611dd)