### PR TITLE
Enable the complete macOS Debug test suite

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -741,23 +741,23 @@ jobs:
         run: |
           ctest --test-dir build/macos-debug -N -V > "$CI_LOG_DIR/ctest-inventory-macos-debug.txt"
           ctest --test-dir build/macos-debug --show-only=json-v1 > "$CI_LOG_DIR/ctest-inventory-macos-debug.json"
-      - name: Build release-gate and macOS tests
+      - name: Build complete macOS test target set
         id: perastage-build
-        run: python3 .github/scripts/run_and_log.py --log "$CI_LOG_DIR/build-macos-debug.log" -- cmake --build build/macos-debug --target gdtf_share_security_test credential_store_native_roundtrip_test --verbose
+        run: python3 .github/scripts/run_and_log.py --log "$CI_LOG_DIR/build-macos-debug.log" -- cmake --build build/macos-debug --target all --verbose
       - name: Capture macOS sccache statistics
         if: ${{ always() }}
         run: |
           "$SCCACHE_PATH" --show-stats > "$CI_LOG_DIR/sccache-macos-debug.txt"
           "$SCCACHE_PATH" --show-stats --stats-format json > "$CI_LOG_DIR/sccache-macos-debug.json"
           python3 .github/scripts/write_sccache_summary.py --stats-json "$CI_LOG_DIR/sccache-macos-debug.json" --compile-commands build/macos-debug/compile_commands.json --platform macos-debug --architecture "${{ runner.arch }}" --backend "$SCCACHE_BACKEND" --cache-scope "$SCCACHE_CACHE_SCOPE" --scope-reason "$SCCACHE_SCOPE_REASON" --namespace "$SCCACHE_NAMESPACE" --compiler-identity "$SCCACHE_COMPILER_IDENTITY" --base-directory "$SCCACHE_BASEDIRS" --launcher-validation "${{ steps.cmake-configure.outcome == 'success' && 'passed' || 'failed' }}" --build-succeeded "${{ steps.perastage-build.outcome == 'success' }}"
-      - name: Run release-gate and macOS tests
-        run: python3 .github/scripts/run_and_log.py --log "$CI_LOG_DIR/ctest-macos-debug.log" -- ctest --test-dir build/macos-debug -L release-gate --output-log "$CI_LOG_DIR/ctest-macos-debug-full.log" --output-junit "$CI_LOG_DIR/ctest-macos-debug.junit.xml" --output-on-failure --verbose
-      - name: Summarize macOS CTest failures
-        if: ${{ always() }}
-        run: python3 .github/scripts/summarize_ctest_failures.py --platform macos --junit "$CI_LOG_DIR/ctest-macos-debug.junit.xml" --log "$CI_LOG_DIR/ctest-macos-debug.log" --last-tests-failed build/macos-debug/Testing/Temporary/LastTestsFailed.log --output "$CI_LOG_DIR/ctest-macos-debug-failures.csv"
-      - name: Summarize macOS CTest results
-        if: ${{ always() }}
-        run: python3 .github/scripts/summarize_ctest_results.py --platform macos --junit "$CI_LOG_DIR/ctest-macos-debug.junit.xml" --output "$CI_LOG_DIR/ctest-macos-debug-results.json" --tested-sha "${{ needs.resolve-source.outputs.source_sha }}" --profile "$PERASTAGE_CI_PROFILE" --labels release-gate
+      - name: Run complete macOS CTest suite
+        run: |
+          set +e
+          ctest --test-dir build/macos-debug --output-log "$CI_LOG_DIR/ctest-macos-debug.log" --output-junit "$CI_LOG_DIR/ctest-macos-debug.junit.xml" --output-on-failure --verbose
+          ctest_exit=$?
+          python3 .github/scripts/summarize_ctest_failures.py --platform macos --junit "$CI_LOG_DIR/ctest-macos-debug.junit.xml" --log "$CI_LOG_DIR/ctest-macos-debug.log" --last-tests-failed build/macos-debug/Testing/Temporary/LastTestsFailed.log --output "$CI_LOG_DIR/ctest-macos-debug-failures.csv"
+          python3 .github/scripts/summarize_ctest_results.py --platform macos --junit "$CI_LOG_DIR/ctest-macos-debug.junit.xml" --output "$CI_LOG_DIR/ctest-macos-debug-results.json" --tested-sha "${{ needs.resolve-source.outputs.source_sha }}" --profile "$PERASTAGE_CI_PROFILE"
+          exit $ctest_exit
       - name: Upload macOS test results
         if: ${{ always() }}
         uses: actions/upload-artifact@v7

--- a/docs/developer/ci_test_audit.md
+++ b/docs/developer/ci_test_audit.md
@@ -1402,3 +1402,27 @@ uniquely named malformed SceneObject recovery fixture. Geometry, matrix,
 archive, and child-order assertions therefore address canonical objects, while
 the independent recovery control verifies canonical output, two-export
 determinism, and identity preservation through reimport and another export.
+
+
+## Phase 8 E7 closure and E8A full macOS suite wiring, 2026-07-28
+
+PR #2236 closed E7 at reviewed head
+`e5e8ac371899032bb3d4bb623aa41ed71232de9a`. Authoritative Debug Tests run
+`30371332821` reported 159 passed, 6 failed, and 1 skipped of 166 on Linux;
+161 passed and 7 failed of 168 on Windows; and 6 passed of 6 in the old reduced
+macOS release gate. `MvrExporterCompliance` was removed from the Linux and
+Windows failure sets, and no new failure name appeared. The retained Linux
+failures were `Viewer2DFboCaptureDiagnostics`, `EditableFocusUtils`,
+`SaveLoadRoundtrip`, `TrussPathEncodingRegression`, `Loader3dsNativeDimensions`,
+and `GdtfEditorCheckpoint08DStabilization`; Windows retained those names plus
+`GdtfFixtureInsertionPreparation`.
+
+Pull-request Debug CI now builds the complete target set and runs the complete,
+unfiltered registered CTest suite on Linux, Windows, and macOS. macOS retains
+`macos-26`, arm64, AppleClang, Ninja, Debug, and the `arm64-osx` vcpkg triplet,
+with its inventory, canonical CTest log, JUnit, failure CSV, compact result
+summary, optional failed/disabled-test records, sccache records, and failure
+diagnostics. The first full macOS run establishes the complete macOS failure
+baseline; the prior 6-of-6 result is only the reduced baseline and does not
+predict the full-suite pass/fail count. E8A validates this full-suite wiring,
+not test greenness.

--- a/docs/developer/github_actions_workflows.md
+++ b/docs/developer/github_actions_workflows.md
@@ -11,9 +11,9 @@ Perastage uses separate workflows for validation, automatic test artifacts, comp
 Pull requests targeting `main` run `CI Debug Tests` from `.github/workflows/ci-tests.yml`.
 
 - The workflow resolves the requested ref to one exact commit SHA and every Debug job checks out that SHA.
-- Linux Debug builds the complete test target set, runs the complete CTest suite, and runs repository policy tests.
+- Linux, Windows, and macOS Debug each build the complete registered test target set and run the complete, unfiltered CTest suite. Linux also runs repository policy tests.
 - Windows Debug initializes Visual Studio Hostx64/x64 explicitly, uses Ninja with MSVC and the `x64-windows` vcpkg triplet, and rejects MinGW, MSYS, or Strawberry toolchain selection.
-- Current macOS Debug uses the explicit current macOS runner, Ninja, arm64, and release-gate secure-store tests.
+- macOS Debug remains on `macos-26` with arm64 AppleClang, Ninja, Debug configuration, and the `arm64-osx` vcpkg triplet. Its test-result artifact retains the complete CTest inventory, canonical CTest log, JUnit report, failure CSV, compact result summary, optional failed/disabled-test records, and sccache diagnostics.
 - Debug jobs configure with `BUILD_TESTING=ON` and do not define `NDEBUG`, because several tests rely on `assert()`.
 - The workflow uploads diagnostics only on failure. Diagnostics include command logs, CMake configure logs, `CMakeCache.txt`, CTest logs, vcpkg failure logs, and a concise environment summary.
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -37,6 +37,8 @@ Changes since **v1.5.0**.
 
 ## Technical and packaging changes
 
+- Expanded macOS Debug continuous integration to build and exercise the complete registered test suite, matching Linux and Windows coverage while preserving diagnostic artifacts.
+
 - Strengthened internal MVR 1.6 compliance coverage by separating primitive
   geometry contracts from malformed SceneObject identity-recovery controls.
 

--- a/tests/check_ci_workflow_architecture.py
+++ b/tests/check_ci_workflow_architecture.py
@@ -152,8 +152,15 @@ for needle in ['$env:GITHUB_ENV', '$env:GITHUB_PATH', 'PERASTAGE_PYTHON', 'Get-C
 assert windows.index('Persist Visual Studio Hostx64 x64 environment') < windows.index('Configure Windows Debug tests') < windows.index('Build Windows Debug tests')
 
 macos = sections['macos']
-for needle in ['sdk-${{ steps.macos-sdk.outputs.identity }}', 'xcrun --sdk macosx --show-sdk-path', '-DCMAKE_OSX_SYSROOT="$current_sdk_path"', '--output-junit', 'ctest-inventory-macos-debug.txt', 'ctest-macos-debug-results.json', 'ci-macos-debug-test-results']:
+for needle in ['sdk-${{ steps.macos-sdk.outputs.identity }}', 'xcrun --sdk macosx --show-sdk-path', '-DCMAKE_OSX_SYSROOT="$current_sdk_path"', 'Build complete macOS test target set', 'Run complete macOS CTest suite', '--output-junit', 'summarize_ctest_failures.py', 'summarize_ctest_results.py', 'ctest-inventory-macos-debug.txt', 'ctest-macos-debug-results.json', 'ci-macos-debug-test-results']:
     assert needle in macos, f'macOS Debug is missing {needle}'
+macos_build = macos[macos.index('      - name: Build complete macOS test target set'):macos.index('      - name: Capture macOS sccache statistics')]
+assert '--target all --verbose' in macos_build, 'macOS Debug must build the complete target set'
+for target in ['gdtf_share_security_test', 'credential_store_native_roundtrip_test']:
+    assert target not in macos_build, f'macOS Debug build must not enumerate {target}'
+macos_test = macos[macos.index('      - name: Run complete macOS CTest suite'):macos.index('      - name: Upload macOS test results')]
+for forbidden in ['-L release-gate', '--labels release-gate', 'Build release-gate and macOS tests', 'Run release-gate and macOS tests', 'continue-on-error']:
+    assert forbidden not in macos_build + macos_test, f'macOS full-suite section must not contain {forbidden}'
 
 sccache_action = 'mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10'
 assert ci.count(sccache_action) == 3, 'each Debug platform must use the reviewed sccache action commit'


### PR DESCRIPTION
### Motivation
- Bring macOS Debug CI to parity with Linux by building the complete registered test target set and running the full, unfiltered CTest suite on macOS.
- Preserve existing logs, JUnit, summaries, artifacts, toolchain, caches, diagnostics, and real CTest exit semantics while avoiding any production/test code or test-selection changes.

### Description
- Replace the macOS build step in `.github/workflows/ci-tests.yml` to run `cmake --build build/macos-debug --target all --verbose` and rename the step to `Build complete macOS test target set` to ensure the entire target set is compiled. 
- Replace the macOS test run step to execute the unfiltered suite with `ctest --test-dir build/macos-debug --output-log "$CI_LOG_DIR/ctest-macos-debug.log" --output-junit "$CI_LOG_DIR/ctest-macos-debug.junit.xml" --output-on-failure --verbose`, preserve the real CTest exit code, and call the existing `summarize_ctest_failures.py` and `summarize_ctest_results.py` reporting tools. 
- Update `tests/check_ci_workflow_architecture.py` with narrow assertions that enforce the new macOS step names, require `--target all --verbose`, require `--output-junit` and the summarize scripts, and forbid the old `-L release-gate` selector, `--labels release-gate`, enumerated macOS test targets, and `continue-on-error` in the macOS build/test section. 
- Update documentation to reflect the change in macOS CI behavior in `docs/developer/github_actions_workflows.md`, record the E7 closure and the authoritative run summary in `docs/developer/ci_test_audit.md`, and add a brief CI-focused entry to `docs/release-notes-draft.md`; do not change `VERSION`. 
- Preserve artifact names `ci-macos-debug-test-results` and `ci-macos-debug-diagnostics` and the set of uploaded logs and summaries; do not alter tests, test registrations, timeouts, CTest labels/properties, production code, or dependency manifests. 

### Testing
- Parsed the workflow YAML with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci-tests.yml')"` and it succeeded. 
- Ran `python3 tests/check_ci_workflow_architecture.py` and it passed after the policy assertions were updated to match the new macOS wiring. 
- Ran `bash tests/check_ci_cmake_language_policy.sh` (with `PERASTAGE_TEST_PYTHON` set) and it passed. 
- Ran `python3 tests/check_bash_test_registration.py`, `bash tests/check_perastage_tree_modules.sh`, and `bash tests/check_no_configmanager_get_in_gui.sh` and they all passed. 
- Ran `git diff --check` and `git diff -- VERSION --exit-code` to confirm no unintended whitespace or `VERSION` changes; both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a68dc19831083249211101ca7139f9c)