### PR TITLE
ci: stabilize complete macOS test harness

### DIFF
--- a/.github/scripts/install_vcpkg_build_prerequisites.sh
+++ b/.github/scripts/install_vcpkg_build_prerequisites.sh
@@ -17,7 +17,7 @@ case "$platform" in
     ;;
   macos)
     brew update
-    brew install autoconf autoconf-archive automake gettext libtool ninja
+    brew install autoconf autoconf-archive automake gettext libtool ninja ripgrep
     command -v mono >/dev/null || brew install mono
     ;;
   *)

--- a/docs/developer/ci_test_audit.md
+++ b/docs/developer/ci_test_audit.md
@@ -1415,7 +1415,7 @@ Windows failure sets, and no new failure name appeared. The retained Linux
 failures were `Viewer2DFboCaptureDiagnostics`, `EditableFocusUtils`,
 `SaveLoadRoundtrip`, `TrussPathEncodingRegression`, `Loader3dsNativeDimensions`,
 and `GdtfEditorCheckpoint08DStabilization`; Windows retained those names plus
-`GdtfFixtureInsertionPreparation`.
+`GdtfShareSecurity`.
 
 Pull-request Debug CI now builds the complete target set and runs the complete,
 unfiltered registered CTest suite on Linux, Windows, and macOS. macOS retains
@@ -1426,3 +1426,37 @@ diagnostics. The first full macOS run establishes the complete macOS failure
 baseline; the prior 6-of-6 result is only the reduced baseline and does not
 predict the full-suite pass/fail count. E8A validates this full-suite wiring,
 not test greenness.
+
+PR #2237 was reviewed at head
+`46dcef5c5d38061f79e1bed0d14243eb66ee5438`. Its authoritative first complete
+suite run, `30379890796`, reported 156 passed, 9 failed, and 1 skipped of 166 on
+Linux; 158 passed and 10 failed of 168 on Windows; and 136 passed and 30 failed
+of 166 on macOS. The macOS result recorded `selected_labels` as empty, the
+target-all build succeeded, and all 166 registered macOS tests executed. This
+reached E8A as an infrastructure gate while preserving real CTest exit
+semantics and the complete diagnostic artifact set.
+
+Twenty-three macOS failures were immediate missing-tool failures because `rg`
+was absent: `DictionaryPathsPolicy`, `DocsPerastageTreeModules`,
+`GdtfEditorCheckpoint08ABinding`, `GdtfEditorCheckpoint08DStabilization`,
+`GdtfEditorCheckpoint08E2ModeBrowser`,
+`GdtfEditorCheckpoint08E3WheelAttributeInspector`, `GdtfEditorCoreBoundary`,
+`GdtfEditorPanelBoundary`, `GdtfMetadataPanelBoundary`,
+`GdtfMetadataSummaryBoundary`, `GdtfReusablePanelsBoundary`,
+`GuiNoConfigManagerGet`, `Layout2DRasterizationBoundary`,
+`Layout2DViewCaptureBoundary`, `LayoutPreviewFailureDiagnostics`,
+`LayoutProjectLoadCacheReset`, `LayoutViewerFitLifecycle`,
+`LibraryUserDataPolicy`, `OpenGLLifecycleCentralized`,
+`ProjectRestoreImportOptions`, `Viewer2DFboCaptureDiagnostics`,
+`Viewer2DRenderToRGBAFboBoundary`, and `Viewer2DStateOwnershipBoundary`.
+Three further cross-platform policy failures, `SecureStoreBuildPolicy`,
+`ReleaseGatePolicyPortability`, and `PolicyWorkingDirectories`, shared a stale
+assertion that Debug CI still selected `-L release-gate` after PR #2237 had
+intentionally made every platform suite complete and unfiltered.
+
+The visible macOS functional failures were `EditableFocusUtils`,
+`Loader3dsNativeDimensions`, `SaveLoadRoundtrip`, and
+`TrussPathEncodingRegression`. `GdtfEditorCheckpoint08DStabilization` and
+`Viewer2DFboCaptureDiagnostics` were masked by the missing `rg` prerequisite and
+may expose their existing functional failures once the infrastructure gate is
+removed.

--- a/docs/developer/ci_test_audit.md
+++ b/docs/developer/ci_test_audit.md
@@ -1460,3 +1460,15 @@ The visible macOS functional failures were `EditableFocusUtils`,
 `Viewer2DFboCaptureDiagnostics` were masked by the missing `rg` prerequisite and
 may expose their existing functional failures once the infrastructure gate is
 removed.
+
+PR #2238 authoritative run `30383307145` at reviewed head
+`342497920b293eded38268669cebbcfb4abf8aa9` reported 159 passed, 6 failed, and 1
+skipped of 166 on Linux; 161 passed and 7 failed of 168 on Windows; and 159
+passed and 7 failed of 166 on macOS. All 23 missing-`rg` failures and the three
+stale release-gate policy failures were resolved. macOS continued to build
+target `all` and execute all 166 tests unfiltered, but
+`LayoutProjectLoadCacheReset` exposed a BSD awk portability defect: its policy
+script passed a multiline C++ function body through `awk -v`, which BSD awk
+rejected as a newline in a string. E8B remains pending an authoritative
+exact-head run in which the corrected policy test passes without changing the
+six established functional failures.

--- a/docs/developer/github_actions_workflows.md
+++ b/docs/developer/github_actions_workflows.md
@@ -13,7 +13,7 @@ Pull requests targeting `main` run `CI Debug Tests` from `.github/workflows/ci-t
 - The workflow resolves the requested ref to one exact commit SHA and every Debug job checks out that SHA.
 - Linux, Windows, and macOS Debug each build the complete registered test target set and run the complete, unfiltered CTest suite. Linux also runs repository policy tests.
 - Windows Debug initializes Visual Studio Hostx64/x64 explicitly, uses Ninja with MSVC and the `x64-windows` vcpkg triplet, and rejects MinGW, MSYS, or Strawberry toolchain selection.
-- macOS Debug remains on `macos-26` with arm64 AppleClang, Ninja, Debug configuration, and the `arm64-osx` vcpkg triplet. Its test-result artifact retains the complete CTest inventory, canonical CTest log, JUnit report, failure CSV, compact result summary, optional failed/disabled-test records, and sccache diagnostics.
+- macOS Debug remains on `macos-26` with arm64 AppleClang, Ninja, Debug configuration, and the `arm64-osx` vcpkg triplet. The shared Homebrew prerequisite path installs ripgrep for fail-closed policy tests. Its test-result artifact retains the complete CTest inventory, canonical CTest log, JUnit report, failure CSV, compact result summary, optional failed/disabled-test records, and sccache diagnostics.
 - Debug jobs configure with `BUILD_TESTING=ON` and do not define `NDEBUG`, because several tests rely on `assert()`.
 - The workflow uploads diagnostics only on failure. Diagnostics include command logs, CMake configure logs, `CMakeCache.txt`, CTest logs, vcpkg failure logs, and a concise environment summary.
 

--- a/tests/check_ci_workflow_architecture.py
+++ b/tests/check_ci_workflow_architecture.py
@@ -49,7 +49,7 @@ linux_packages = [
 ]
 for package in linux_packages:
     assert package in prerequisites, f'shared Linux vcpkg prerequisites are missing {package}'
-for tool in ['autoconf', 'autoconf-archive', 'automake', 'gettext', 'libtool', 'ninja']:
+for tool in ['autoconf', 'autoconf-archive', 'automake', 'gettext', 'libtool', 'ninja', 'ripgrep']:
     assert re.search(rf'brew install[^\n]*\b{re.escape(tool)}\b', prerequisites), f'shared macOS vcpkg prerequisites are missing {tool}'
 assert 'command -v mono >/dev/null || brew install mono' in prerequisites
 diagnostic_section = remote[remote.index('Upload vcpkg failure diagnostics'):remote.index('Save vcpkg downloads cache')]

--- a/tests/check_layout_project_load_cache_reset.sh
+++ b/tests/check_layout_project_load_cache_reset.sh
@@ -53,30 +53,23 @@ for token in \
   fi
 done
 
-load_body="$(run_test_python - "$mainwindow_cpp" <<'PY'
+run_test_python - "$mainwindow_cpp" <<'PY'
 import re
 import sys
 text = open(sys.argv[1], encoding='utf-8').read()
 match = re.search(r'bool MainWindow::LoadProjectFromPath\([\s\S]*?ApplySavedLayout\(\);', text)
 if not match:
-    sys.exit(1)
-print(match.group(0))
+    raise SystemExit('MainWindow::LoadProjectFromPath must be locatable through ApplySavedLayout')
+
+load_body = match.group(0)
+reset_index = load_body.find('ResetPreviewCachesForProjectLoad')
+load_cache_index = load_body.find('LoadPersistentViewCacheFromProject')
+apply_index = load_body.find('ApplySavedLayout')
+
+if reset_index < 0:
+    raise SystemExit('Project load must reset Layout preview caches before applying the saved layout')
+if load_cache_index < 0 or reset_index >= load_cache_index:
+    raise SystemExit("Project load must reset stale Layout preview caches before loading the new project's persistent cache")
+if apply_index < 0 or reset_index >= apply_index:
+    raise SystemExit('Project load must reset Layout preview caches before ApplySavedLayout')
 PY
-)"
-
-reset_index=$(awk -v body="$load_body" 'BEGIN { print index(body, "ResetPreviewCachesForProjectLoad") }')
-load_cache_index=$(awk -v body="$load_body" 'BEGIN { print index(body, "LoadPersistentViewCacheFromProject") }')
-apply_index=$(awk -v body="$load_body" 'BEGIN { print index(body, "ApplySavedLayout") }')
-
-if (( reset_index <= 0 )); then
-  echo "Project load must reset Layout preview caches before applying the saved layout" >&2
-  exit 1
-fi
-if (( load_cache_index <= 0 || reset_index >= load_cache_index )); then
-  echo "Project load must reset stale Layout preview caches before loading the new project's persistent cache" >&2
-  exit 1
-fi
-if (( apply_index <= 0 || reset_index >= apply_index )); then
-  echo "Project load must reset Layout preview caches before ApplySavedLayout" >&2
-  exit 1
-fi

--- a/tests/check_securestore_build_policy.sh
+++ b/tests/check_securestore_build_policy.sh
@@ -58,9 +58,27 @@ require(r'VCPKG_MANIFEST_MODE=OFF|VCPKG_MANIFEST_MODE.*OFF', 'setup_windows.ps1'
 require(r'securestore-v2', '.github/workflows/windows-installer.yml', '.github/workflows/linux-installer.yml', '.github/workflows/arch-package.yml', '.github/workflows/macos-installer.yml', '.github/workflows/macos-15-manual-installer.yml')
 require(r'0878b5224d4a4968940ee296a2e7fae2d3b62983', 'vcpkg.json')
 require(r'get_vcpkg_baseline\.py vcpkg\.json', '.github/workflows/windows-installer.yml', '.github/workflows/linux-installer.yml', '.github/workflows/arch-package.yml', '.github/workflows/macos-installer.yml', '.github/workflows/macos-15-manual-installer.yml')
-require(r'ctest --test-dir .* -L release-gate', '.github/workflows/ci-tests.yml')
-require(r'gdtf_share_security_test', '.github/workflows/ci-tests.yml', 'tests/CMakeLists.txt')
-require(r'credential_store_native_roundtrip_test', '.github/workflows/ci-tests.yml', 'tests/CMakeLists.txt')
+ci_workflow = read('.github/workflows/ci-tests.yml')
+for platform, build_dir in (
+    ('Linux', 'build/linux-debug'),
+    ('Windows', 'build-windows-debug'),
+    ('macOS', 'build/macos-debug'),
+):
+    commands = [
+        line.strip()
+        for line in ci_workflow.splitlines()
+        if re.search(rf'\bctest\s+--test-dir\s+{re.escape(build_dir)}\b', line)
+        and '--output-on-failure' in line
+    ]
+    assert len(commands) == 1, f'{platform} Debug CI must have one canonical complete-suite CTest command'
+    assert not re.search(r'(?:^|\s)(?:-L|--label-regex|-R|--tests-regex|-E|--exclude-regex)(?:\s|=)', commands[0]), (
+        f'{platform} Debug CI canonical CTest command must remain unfiltered: {commands[0]}'
+    )
+require(r'cmake\s+--build\s+build/macos-debug\s+--target\s+all\s+--verbose', '.github/workflows/ci-tests.yml')
+require(r'add_executable\(gdtf_share_security_test\b', 'tests/CMakeLists.txt')
+require(r'add_test\(NAME\s+GdtfShareSecurity\s+COMMAND\s+gdtf_share_security_test\)', 'tests/CMakeLists.txt')
+require(r'add_executable\(credential_store_native_roundtrip_test\b', 'tests/CMakeLists.txt')
+require(r'add_test\(NAME\s+CredentialStoreNativeRoundTrip\s+COMMAND\s+credential_store_native_roundtrip_test\)', 'tests/CMakeLists.txt')
 require(r'libsecret-1-dev', '.github/workflows/linux-installer.yml')
 require(r"'libsecret'", 'packaging/arch/PKGBUILD')
 require(r'--manifest-root', '.github/workflows/macos-installer.yml', '.github/workflows/macos-15-manual-installer.yml')


### PR DESCRIPTION
### Motivation
- Ensure the complete macOS Debug CTest suite can run unfiltered by installing the missing `rg` test tool on macOS and making the CI prerequisite path authoritative. 
- Remove a stale secure-store policy assumption that required a `-L release-gate` selector and replace it with a portable, stronger check that the canonical unfiltered CTest commands exist and secure-store tests are built and registered.

### Description
- Add `ripgrep` to the shared macOS Homebrew prerequisite invocation in `.github/scripts/install_vcpkg_build_prerequisites.sh` so `rg` is available to macOS Debug jobs. 
- Extend `tests/check_ci_workflow_architecture.py` to require `ripgrep` among the macOS Homebrew prerequisites. 
- Replace the obsolete `ctest --test-dir .* -L release-gate` assertion in `tests/check_securestore_build_policy.sh` with a focused validation that each canonical platform Debug job has exactly one unfiltered complete-suite `ctest` command, that macOS builds `--target all`, and that the secure-store tests are registered and test executables exist. 
- Update `docs/developer/ci_test_audit.md` to record the authoritative run details (PR #2237 head and run `30379890796`), correct the retained Windows failure name to `GdtfShareSecurity`, and enumerate the missing-`rg` macOS failures observed. 
- Document the macOS prereq requirement for `ripgrep` in `docs/developer/github_actions_workflows.md` without changing workflow behavior.

### Testing
- Ran `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci-tests.yml')"` and it completed successfully. 
- Ran `python3 tests/check_ci_workflow_architecture.py` and it reported `OK: GitHub Actions architecture policies are enforced.` 
- Ran `PERASTAGE_TEST_PYTHON="$(command -v python3)" bash tests/check_securestore_build_policy.sh` and it reported `OK: secure-store build, manifest, workflow, and Debug CI and Release builder policies are enforced.` 
- Ran `PERASTAGE_TEST_PYTHON="$(command -v python3)" bash tests/check_release_gate_policy_portability.sh` and it reported success for the portable invocation. 
- Ran `python3 tests/check_policy_working_directories.py --bash "$(command -v bash)"` and it reported success. 
- `bash tests/check_ci_cmake_language_policy.sh` correctly failed when `PERASTAGE_TEST_PYTHON` was not provided and passed when invoked with `PERASTAGE_TEST_PYTHON` set, demonstrating correct harness behavior. 
- Performed `python3 -m py_compile tests/check_ci_workflow_architecture.py`, `python3 tests/check_bash_test_registration.py`, `bash tests/check_perastage_tree_modules.sh`, `bash tests/check_no_configmanager_get_in_gui.sh`, and `git diff --check`, all of which passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a68e63aaf70832487599ccc2d69c77d)