### PR TITLE
Normalize fixture-label override keys on project save/load to preserve canonical UUIDs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,6 +228,9 @@ configure_file(
     @ONLY
 )
 
+add_library(perastage_uuid OBJECT core/uuidutils.cpp)
+target_include_directories(perastage_uuid PUBLIC ${CMAKE_SOURCE_DIR}/core)
+
 add_executable(${PROJECT_NAME} main.cpp
     "${PERASTAGE_GENERATED_BUILD_INFO_CPP}"
     models/fixture.cpp
@@ -561,6 +564,7 @@ target_include_directories(${PROJECT_NAME} PRIVATE
 
 # Link required libraries
 target_link_libraries(${PROJECT_NAME} PRIVATE
+    perastage_uuid
     tinyxml2::tinyxml2
     OpenGL::GL
     OpenGL::GLU

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -85,7 +85,6 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/wx_path_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/units/unit_label_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/units/units.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/uuidutils.cpp
 )
 
 target_include_directories(${PROJECT_NAME} PRIVATE

--- a/core/configmanager.cpp
+++ b/core/configmanager.cpp
@@ -23,7 +23,9 @@
 #include "magnet_snap.h"
 #include "mvrexporter.h"
 #include "mvrimporter.h"
+#include "project_fixture_identity.h"
 #include "selection_movement_settings.h"
+#include "uuidutils.h"
 #include <filesystem>
 #include <fstream>
 #include <iostream>
@@ -84,6 +86,36 @@ std::string SerializeHiddenLayerChecks(
   std::vector<std::string> sorted(hiddenLayers.begin(), hiddenLayers.end());
   std::sort(sorted.begin(), sorted.end());
   return nlohmann::json(sorted).dump();
+}
+
+// Collects the canonical fixture identities written by project MVR export.
+std::unordered_set<std::string> CollectSerializedFixtureUuids(
+    const MvrScene &scene) {
+  std::unordered_set<std::string> fixtureUuids;
+  fixtureUuids.reserve(scene.fixtures.size());
+  for (const auto &[key, fixture] : scene.fixtures) {
+    (void)key;
+    const std::string canonical = CanonicalizeUuid(fixture.uuid);
+    if (!canonical.empty())
+      fixtureUuids.insert(canonical);
+  }
+  return fixtureUuids;
+}
+
+// Logs fixture metadata normalization performed at a project persistence boundary.
+void LogFixtureMetadataNormalization(
+    const char *operation,
+    const project_identity::FixtureMetadataNormalizationResult &result) {
+  if (!result.changed)
+    return;
+  std::ostringstream message;
+  message << operation << " fixture metadata normalization: migrated "
+          << result.migratedCount << ", collisions " << result.collisionCount
+          << ", stale entries removed " << result.staleCount;
+  Logger::Instance().Log(result.collisionCount > 0 || result.staleCount > 0
+                             ? Logger::Level::Warn
+                             : Logger::Level::Info,
+                         message.str());
 }
 
 std::unordered_set<std::string>
@@ -513,8 +545,23 @@ bool ConfigManager::SaveProject(const std::string &path) {
            SerializeStringSet(GetHiddenFixtureTypes()));
   bool ok = projectSession.SaveProject(
       path, [this](std::vector<uint8_t> &configBytes) {
+        UserPreferencesStore serializationSnapshot = preferencesStore;
+        const auto normalization =
+            project_identity::NormalizeFixtureLabelOverrides(
+                serializationSnapshot.GetValue(
+                    project_identity::kFixtureLabelOverridesConfigKey),
+                CollectSerializedFixtureUuids(GetScene()));
+        if (normalization.serializedOverrides) {
+          serializationSnapshot.SetValue(
+              project_identity::kFixtureLabelOverridesConfigKey,
+              *normalization.serializedOverrides);
+        } else {
+          serializationSnapshot.RemoveKey(
+              project_identity::kFixtureLabelOverridesConfigKey);
+        }
+        LogFixtureMetadataNormalization("Project save", normalization);
         std::ostringstream configOut;
-        if (!preferencesStore.SaveToStream(configOut))
+        if (!serializationSnapshot.SaveToStream(configOut))
           return false;
         const std::string serializedConfig = configOut.str();
         configBytes.assign(serializedConfig.begin(), serializedConfig.end());
@@ -644,6 +691,20 @@ bool ConfigManager::LoadProject(const std::string &path,
       });
 
   if (ok) {
+    const auto normalization =
+        project_identity::NormalizeFixtureLabelOverrides(
+            GetValue(project_identity::kFixtureLabelOverridesConfigKey),
+            CollectSerializedFixtureUuids(GetScene()));
+    if (normalization.changed) {
+      RevisionGuard guard(*this);
+      if (normalization.serializedOverrides) {
+        SetValue(project_identity::kFixtureLabelOverridesConfigKey,
+                 *normalization.serializedOverrides);
+      } else {
+        RemoveKey(project_identity::kFixtureLabelOverridesConfigKey);
+      }
+    }
+    LogFixtureMetadataNormalization("Project load", normalization);
     layerVisibilityState.SetHiddenLayers(
         DeserializeHiddenLayerChecks(GetValue(kHiddenLayersConfigKey)));
     SetHiddenFixtureTypes(

--- a/core/configmanager.cpp
+++ b/core/configmanager.cpp
@@ -88,20 +88,6 @@ std::string SerializeHiddenLayerChecks(
   return nlohmann::json(sorted).dump();
 }
 
-// Collects the canonical fixture identities written by project MVR export.
-std::unordered_set<std::string> CollectSerializedFixtureUuids(
-    const MvrScene &scene) {
-  std::unordered_set<std::string> fixtureUuids;
-  fixtureUuids.reserve(scene.fixtures.size());
-  for (const auto &[key, fixture] : scene.fixtures) {
-    (void)key;
-    const std::string canonical = CanonicalizeUuid(fixture.uuid);
-    if (!canonical.empty())
-      fixtureUuids.insert(canonical);
-  }
-  return fixtureUuids;
-}
-
 // Logs fixture metadata normalization performed at a project persistence boundary.
 void LogFixtureMetadataNormalization(
     const char *operation,
@@ -550,7 +536,7 @@ bool ConfigManager::SaveProject(const std::string &path) {
             project_identity::NormalizeFixtureLabelOverrides(
                 serializationSnapshot.GetValue(
                     project_identity::kFixtureLabelOverridesConfigKey),
-                CollectSerializedFixtureUuids(GetScene()));
+                project_identity::CollectRecoverableFixtureUuids(GetScene()));
         if (normalization.serializedOverrides) {
           serializationSnapshot.SetValue(
               project_identity::kFixtureLabelOverridesConfigKey,
@@ -694,7 +680,7 @@ bool ConfigManager::LoadProject(const std::string &path,
     const auto normalization =
         project_identity::NormalizeFixtureLabelOverrides(
             GetValue(project_identity::kFixtureLabelOverridesConfigKey),
-            CollectSerializedFixtureUuids(GetScene()));
+            project_identity::CollectRecoverableFixtureUuids(GetScene()));
     if (normalization.changed) {
       RevisionGuard guard(*this);
       if (normalization.serializedOverrides) {

--- a/core/project_fixture_identity.h
+++ b/core/project_fixture_identity.h
@@ -1,11 +1,13 @@
 #pragma once
 
 #include "json.hpp"
+#include "mvrscene.h"
 #include "uuidutils.h"
 
 #include <algorithm>
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
@@ -50,6 +52,27 @@ inline void MergeMissingJsonValues(nlohmann::json &canonical,
 }
 
 } // namespace detail
+
+// Collects unique fixture identities that remain provable after canonicalization.
+inline std::unordered_set<std::string> CollectRecoverableFixtureUuids(
+    const MvrScene &scene) {
+  std::unordered_map<std::string, size_t> canonicalCounts;
+  canonicalCounts.reserve(scene.fixtures.size());
+  for (const auto &[key, fixture] : scene.fixtures) {
+    (void)key;
+    const std::string canonical = CanonicalizeUuid(fixture.uuid);
+    if (!canonical.empty())
+      ++canonicalCounts[canonical];
+  }
+
+  std::unordered_set<std::string> fixtureUuids;
+  fixtureUuids.reserve(canonicalCounts.size());
+  for (const auto &[canonical, count] : canonicalCounts) {
+    if (count == 1)
+      fixtureUuids.insert(canonical);
+  }
+  return fixtureUuids;
+}
 
 // Canonicalizes fixture-keyed project metadata against serialized scene identities.
 inline FixtureMetadataNormalizationResult NormalizeFixtureLabelOverrides(

--- a/core/project_fixture_identity.h
+++ b/core/project_fixture_identity.h
@@ -1,0 +1,119 @@
+#pragma once
+
+#include "json.hpp"
+#include "uuidutils.h"
+
+#include <algorithm>
+#include <optional>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+namespace project_identity {
+
+inline constexpr const char *kFixtureLabelOverridesConfigKey =
+    "label_fixture_overrides";
+
+struct FixtureMetadataNormalizationResult {
+  std::optional<std::string> serializedOverrides;
+  size_t migratedCount = 0;
+  size_t collisionCount = 0;
+  size_t staleCount = 0;
+  bool changed = false;
+};
+
+namespace detail {
+
+// Merges recoverable legacy values without replacing canonical values.
+inline void MergeMissingJsonValues(nlohmann::json &canonical,
+                                   const nlohmann::json &legacy) {
+  if (canonical.is_object() && legacy.is_object()) {
+    for (auto it = legacy.begin(); it != legacy.end(); ++it) {
+      auto canonicalIt = canonical.find(it.key());
+      if (canonicalIt == canonical.end())
+        canonical[it.key()] = it.value();
+      else
+        MergeMissingJsonValues(*canonicalIt, it.value());
+    }
+    return;
+  }
+  if (canonical.is_array() && legacy.is_array()) {
+    for (size_t index = 0; index < legacy.size(); ++index) {
+      if (index >= canonical.size())
+        canonical.push_back(legacy[index]);
+      else if (canonical[index].is_null())
+        canonical[index] = legacy[index];
+      else
+        MergeMissingJsonValues(canonical[index], legacy[index]);
+    }
+  }
+}
+
+} // namespace detail
+
+// Canonicalizes fixture-keyed project metadata against serialized scene identities.
+inline FixtureMetadataNormalizationResult NormalizeFixtureLabelOverrides(
+    const std::optional<std::string> &serializedOverrides,
+    const std::unordered_set<std::string> &sceneFixtureUuids) {
+  FixtureMetadataNormalizationResult result;
+  if (!serializedOverrides || serializedOverrides->empty())
+    return result;
+
+  const nlohmann::json source =
+      nlohmann::json::parse(*serializedOverrides, nullptr, false);
+  if (!source.is_object()) {
+    result.serializedOverrides = serializedOverrides;
+    return result;
+  }
+
+  std::vector<std::string> keys;
+  keys.reserve(source.size());
+  for (auto it = source.begin(); it != source.end(); ++it)
+    keys.push_back(it.key());
+  std::sort(keys.begin(), keys.end());
+
+  nlohmann::json normalized = nlohmann::json::object();
+  std::stable_sort(keys.begin(), keys.end(), [&](const std::string &lhs,
+                                                  const std::string &rhs) {
+    const bool lhsCanonical = sceneFixtureUuids.contains(lhs);
+    const bool rhsCanonical = sceneFixtureUuids.contains(rhs);
+    return lhsCanonical != rhsCanonical ? lhsCanonical : lhs < rhs;
+  });
+
+  for (const std::string &key : keys) {
+    if (!source.at(key).is_object())
+      continue;
+    const std::string canonical = CanonicalizeUuid(key);
+    const std::string target = sceneFixtureUuids.contains(key)
+                                   ? key
+                                   : canonical;
+    if (target.empty() || !sceneFixtureUuids.contains(target)) {
+      ++result.staleCount;
+      result.changed = true;
+      continue;
+    }
+
+    auto existing = normalized.find(target);
+    if (existing == normalized.end()) {
+      normalized[target] = source.at(key);
+    } else {
+      ++result.collisionCount;
+      detail::MergeMissingJsonValues(*existing, source.at(key));
+    }
+    if (key != target) {
+      ++result.migratedCount;
+      result.changed = true;
+    }
+  }
+
+  if (normalized.empty()) {
+    result.changed = result.changed || !source.empty();
+    return result;
+  }
+  result.serializedOverrides = normalized.dump();
+  result.changed = result.changed || result.collisionCount > 0 ||
+                   *result.serializedOverrides != *serializedOverrides;
+  return result;
+}
+
+} // namespace project_identity

--- a/docs/developer/ci_test_audit.md
+++ b/docs/developer/ci_test_audit.md
@@ -1512,3 +1512,62 @@ that `config.json` and `GeneralSceneDescription.xml` both contain
 results remain pending and must replace this paragraph before merge; the gate
 remains removal of `SaveLoadRoundtrip` from every platform failure list without
 hiding any unrelated failure.
+
+### PR #2239 complete-target build correction
+
+PR #2239 at original reviewed head
+`e8672fb084e3ddc5c45b251b37158a0b1a5633f5` failed before CTest in
+cross-platform run `30391083074`. Linux, Windows, and macOS all reported an
+unresolved `CanonicalizeUuid(const std::string&)` from standalone tests that
+compiled `core/configmanager.cpp` without also compiling `core/uuidutils.cpp`.
+The test graph previously compiled `uuidutils.cpp` directly into 39 executable
+targets, while 38 targets compiled `configmanager.cpp`; four ConfigManager
+standalone targets did not happen to own the UUID implementation. Adding the
+source to one more executable therefore fixed only one target and retained
+fragmented ownership.
+
+The corrected graph gives `core/uuidutils.cpp` one compiled owner, the
+`perastage_uuid` object library. The production executable links that target,
+and the standalone-test directory links the same reusable dependency instead
+of compiling 39 private copies. This removes duplicate-definition risk,
+compiles the utility once per configuration, and makes future core consumers
+portable across archive/link ordering differences on MSVC, AppleClang, and
+Linux.
+
+Project metadata recovery is intentionally limited to a unique fixture identity
+that `CanonicalizeUuid` can resolve directly. Invalid or empty fixture IDs need
+MVR export identity recovery and do not have a provable old-to-exported
+association here; canonical collisions are likewise excluded from the safe
+scene identity set. Their metadata is diagnosed as stale rather than guessed.
+An exporter identity map would be required before broadening that contract.
+Within the supported case, canonical metadata wins collisions and compatible
+missing values from a legacy spelling are retained deterministically.
+
+A clean local Debug configuration built and ran the four targets that failed in
+run `30391083074`: `gdtf_dictionary_color_roundtrip_test`,
+`gdtf_dictionary_color_mode_propagation_test`,
+`dictionary_seed_merge_backup_test`, and `active_dictionary_workflow_test`.
+All four tests passed. Complete target-all and focused persistence results are
+recorded below. The corrective head, exact-head
+Actions run ID, cross-platform totals, complete remaining failure names,
+`selected_labels`, and final `SaveLoadRoundtrip` result remain pending; PR #2239
+must not merge until those exact-head artifacts are available.
+
+The repaired local graph built the focused `SaveLoadRoundtrip` executable and
+the exact focused CTest run executed. Its first failure remains the earlier,
+unrelated Support persistence assertion
+`loadedManual.loadKg == 325.0f` (now line 485 after added identity-contract
+coverage), so the test does not yet pass locally and the branch stops short of
+that unrelated repair. The package-coherence and export-identity assertions
+before it passed, but this result is not sufficient to claim complete
+SaveLoadRoundtrip verification or to retain the user-visible release-note fix.
+
+The clean local Debug `target all` build completed successfully after the graph
+correction, including all standalone test executables. The related seven-test
+selector passed six tests:
+`FixtureLabelOverridesReconcile`, `MvrExporterCompliance`,
+`MvrProjectFixtureMetadataContracts`, `MvrFixtureCategoryRoundtrip`,
+`ProjectSupportUserDataRoundtrip`, and `MvrSupportUserDataRoundtrip`;
+`SaveLoadRoundtrip` alone stopped at the Support load assertion described
+above. No exact-head CI run exists yet, so platform totals, remaining failure
+lists, and `selected_labels` cannot be certified from this corrective work.

--- a/docs/developer/ci_test_audit.md
+++ b/docs/developer/ci_test_audit.md
@@ -1571,3 +1571,49 @@ selector passed six tests:
 `SaveLoadRoundtrip` alone stopped at the Support load assertion described
 above. No exact-head CI run exists yet, so platform totals, remaining failure
 lists, and `selected_labels` cannot be certified from this corrective work.
+
+### PR #2239 Support fixture correction and E8C baseline
+
+PR #2239 exact head `97a3909258b23210a98da3f2b34754b504dcbf09`
+restored complete target-all builds and complete unfiltered suites in run
+`30397674152`; every platform reported `selected_labels = []`. Linux reported
+159 passed, 6 failed, and 1 skipped of 166; Windows reported 161 passed and 7
+failed of 168; macOS reported 160 passed and 6 failed of 166. Linux and macOS
+retained `EditableFocusUtils`, `GdtfEditorCheckpoint08DStabilization`,
+`Loader3dsNativeDimensions`, `SaveLoadRoundtrip`,
+`TrussPathEncodingRegression`, and `Viewer2DFboCaptureDiagnostics`. Windows
+retained the same failures plus `GdtfShareSecurity`.
+
+The common `SaveLoadRoundtrip` failure at `loadedManual.loadKg == 325.0f` was a
+test-fixture provenance defect, not a production persistence defect.
+`Support::loadSource` defaults to `Auto`; GUI edits mark a changed load as
+`Manual`, while rigging recalculation writes both the calculated value and
+`Auto`. The exporter persists a `Load` element only for a manual override, and
+the importer marks an explicit `Load` as `Manual`. `hoistDataSource` separately
+describes motor and hoist field provenance and does not imply that the load is
+manual. No project configuration key persists an automatic `loadKg`; automatic
+loads remain derived from current rigging totals. The passing
+`ProjectSupportUserDataRoundtrip` and `MvrSupportUserDataRoundtrip` controls
+already express this contract with explicit manual and automatic fixtures.
+
+The focused correction marks the roundtrip fixture's expected 325 kg value as
+`loadSource = "Manual"` and asserts that provenance after load. Running the test
+to completion then exposed two later stale test-helper assumptions in the same
+save/load checkpoint: canonical GDTF publication correctly changes `orig.gdtf`
+to `Perastage@Original@Perastage.gdtf`, and project fixture metadata may omit
+`visualColorHex` when `hasVisualColorHex` is false. The test now expects the
+canonical resource name and treats the optional XML attribute safely rather
+than constructing `std::string` from a null pointer. Production MVR/GDTF logic
+is unchanged.
+
+The local Debug `SaveLoadRoundtrip` test now passes through first load, legacy
+override recovery, second save, metadata signature comparison, and second
+load. Exact-head cross-platform results for this final corrective commit remain
+pending; the user-visible fixture-label release note must remain withheld until
+that run removes `SaveLoadRoundtrip` from all three failure lists.
+
+Local verification after the complete fixture correction passed
+`SaveLoadRoundtrip` by itself, all seven related identity/persistence tests, and
+all four representative UUID-consumer tests. A new exact-head Actions run is
+still required before merge; no final run ID or cross-platform totals are
+available for this commit yet.

--- a/docs/developer/ci_test_audit.md
+++ b/docs/developer/ci_test_audit.md
@@ -1472,3 +1472,43 @@ script passed a multiline C++ function body through `awk -v`, which BSD awk
 rejected as a newline in a string. E8B remains pending an authoritative
 exact-head run in which the corrected policy test passes without changing the
 six established functional failures.
+
+## Phase 4 SaveLoadRoundtrip project identity persistence repair, 2026-07-28
+
+The merged E8B baseline for PR #2238 is reviewed head
+`49f442ca1898ee6ec6e0156667e134f8263a47a3`, authoritative run
+`30387706435`: Linux passed 159 of 166 with 6 failures and 1 skip; Windows
+passed 161 of 168 with 7 failures; and macOS passed 160 of 166 with 6
+failures. `SaveLoadRoundtrip` failed on all three platforms because
+`scene.mvr` canonized an uppercase fixture UUID while `config.json` retained
+the uppercase key in `label_fixture_overrides`. Project restore imported the
+already-canonical scene before loading configuration, so the importer had no
+old-to-new alias available when the stale project metadata arrived.
+
+Project persistence now normalizes fixture-keyed label metadata at both
+non-GUI persistence boundaries. Save serializes a canonical configuration
+snapshot without mutating live configuration or dirty/undo state. Load
+normalizes restored legacy keys after both the canonical scene and project
+configuration are available. The scene UUID set is authoritative: safely
+canonicalizable aliases migrate, metadata without a scene association is
+removed with a diagnostic, and collisions preserve canonical-key values while
+filling only missing values from legacy aliases in deterministic key order.
+No project-only label metadata is written into standard MVR nodes.
+The project-config audit found no other fixture-UUID-keyed domain; position-keyed rigging weights and scene-owned fixture references have separate identity contracts.
+
+Changed production files are `core/configmanager.cpp`,
+`core/project_fixture_identity.h`, and
+`viewer2d/fixture_label_overrides.cpp`; `tests/CMakeLists.txt` links the existing UUID utility into the related standalone test. Regression coverage in
+`tests/save_load_roundtrip_test.cpp` inspects both nested archives, asserts
+canonical package coherence, exercises a rewritten legacy package, verifies
+second-save stability, and covers deterministic collision merging.
+
+Local Debug compilation of `save_load_roundtrip_test` succeeded. The focused
+CTest run reached the existing Support metadata assertions but stopped at
+`loadedManual.loadKg == 325.0f` in this system-library build before reaching
+the fixture-label assertions; direct archive inspection nevertheless confirmed
+that `config.json` and `GeneralSceneDescription.xml` both contain
+`a0b1c2d3-e4f5-4678-9abc-def012345678`, with no uppercase alias. Exact-head CI
+results remain pending and must replace this paragraph before merge; the gate
+remains removal of `SaveLoadRoundtrip` from every platform failure list without
+hiding any unrelated failure.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -10,6 +10,8 @@ Changes since **v1.5.0**.
 
 ## Important fixes
 
+- Preserved per-fixture label settings when projects canonicalize fixture identities, including deterministic recovery of compatible legacy project files.
+
 - Improved PDF output serialization across platforms and locale settings, and
   added deterministic temporary extraction fixtures while retaining unchanged
   compatibility inputs and pinned-library API coverage for final cross-platform

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -10,8 +10,6 @@ Changes since **v1.5.0**.
 
 ## Important fixes
 
-- Preserved per-fixture label settings when projects canonicalize fixture identities, including deterministic recovery of compatible legacy project files.
-
 - Improved PDF output serialization across platforms and locale settings, and
   added deterministic temporary extraction fixtures while retaining unchanged
   compatibility inputs and pinned-library API coverage for final cross-platform
@@ -38,6 +36,8 @@ Changes since **v1.5.0**.
 ## Current limitations
 
 ## Technical and packaging changes
+
+- Centralized UUID utility build ownership so production and standalone verification targets share one portable compiled implementation.
 
 - Expanded macOS Debug continuous integration to build and exercise the complete registered test suite, matching Linux and Windows coverage while preserving diagnostic artifacts.
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -39,6 +39,8 @@ Changes since **v1.5.0**.
 
 - Centralized UUID utility build ownership so production and standalone verification targets share one portable compiled implementation.
 
+- Aligned save/load verification with the existing distinction between manually overridden hoist loads and automatically calculated rigging loads.
+
 - Expanded macOS Debug continuous integration to build and exercise the complete registered test suite, matching Linux and Windows coverage while preserving diagnostic artifacts.
 
 - Strengthened internal MVR 1.6 compliance coverage by separating primitive

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -317,7 +317,6 @@ add_executable(mvr_merge_analyzer_applier_test
                ../core/filesystem_path_utils.cpp
                ../core/logger.cpp
                ../core/runtime_storage.cpp
-               ../core/uuidutils.cpp
                ../models/mvrscene.cpp)
 add_test(NAME MvrMergeAnalyzerApplier COMMAND mvr_merge_analyzer_applier_test)
 
@@ -327,7 +326,6 @@ add_test(NAME MatrixUtilsParsingAndComposition COMMAND matrixutils_test)
 
 add_executable(scene_grouping_test scene_grouping_test.cpp
     ../core/scene_grouping.cpp
-    ../core/uuidutils.cpp
     ../models/mvrscene.cpp
 )
 target_include_directories(scene_grouping_test PRIVATE ../core ../models)
@@ -336,7 +334,6 @@ add_test(NAME SceneGroupingPreservesTransforms COMMAND scene_grouping_test)
 add_executable(magnet_snap_test magnet_snap_test.cpp
     ../core/magnet_snap.cpp
     ../core/scene_grouping.cpp
-    ../core/uuidutils.cpp
     ../models/mvrscene.cpp
 )
 target_include_directories(magnet_snap_test PRIVATE ../core ../models)
@@ -368,7 +365,6 @@ add_executable(fixture_label_overrides_reconcile_test
                ../core/runtime_storage.cpp
                ../core/library/library_bootstrap.cpp
                ../core/logger.cpp
-               ../core/uuidutils.cpp
                ../models/mvrscene.cpp
                mvr_io_stubs.cpp)
 target_include_directories(fixture_label_overrides_reconcile_test PRIVATE
@@ -835,7 +831,6 @@ add_executable(save_load_roundtrip_test save_load_roundtrip_test.cpp
                ../core/wx_path_utils.cpp
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
-               ../core/uuidutils.cpp
                ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp
                ../mvr/gdtf_catalog_matcher.cpp
@@ -872,7 +867,7 @@ add_executable(mvr_project_fixture_metadata_contracts_test
                ../core/utf8_utils.cpp ../core/trussdictionary.cpp
                ../core/trussloader.cpp ../core/wx_path_utils.cpp
                ../core/runtime_storage.cpp ../core/truss_gdtf_builder.cpp
-               ../core/uuidutils.cpp ../core/dummyprofilelibrary.cpp
+               ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp ../mvr/gdtf_catalog_matcher.cpp
                ../viewer2d/fixture_label_overrides.cpp ../mvr/mvrexporter.cpp
                ../core/mvr_identity_recovery.cpp
@@ -907,7 +902,6 @@ add_executable(project_support_userdata_roundtrip_test project_support_userdata_
                ../core/wx_path_utils.cpp
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
-               ../core/uuidutils.cpp
                ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp
                ../mvr/gdtf_catalog_matcher.cpp
@@ -965,7 +959,6 @@ add_executable(rider_truss_dictionary_normalization_test
                ../core/riderimporter.cpp
                ../core/units/units.cpp
                ../core/hoist_weight_distribution.cpp
-               ../core/uuidutils.cpp
                ../core/autopatcher.cpp
                ../core/patchmanager.cpp
                ../core/configmanager.cpp
@@ -1029,7 +1022,6 @@ add_executable(mvr_dmx_address_test mvr_dmx_address_test.cpp
                ../core/wx_path_utils.cpp
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
-               ../core/uuidutils.cpp
                ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp
                ../mvr/gdtf_catalog_matcher.cpp
@@ -1068,7 +1060,6 @@ add_executable(mvr_support_userdata_roundtrip_test mvr_support_userdata_roundtri
                ../core/wx_path_utils.cpp
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
-               ../core/uuidutils.cpp
                ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp
                ../mvr/gdtf_catalog_matcher.cpp
@@ -1104,7 +1095,7 @@ add_executable(mvr_perastage_metadata_recovery_test
                ../core/utf8_utils.cpp ../core/trussdictionary.cpp
                ../core/trussloader.cpp ../core/wx_path_utils.cpp
                ../core/runtime_storage.cpp ../core/truss_gdtf_builder.cpp
-               ../core/uuidutils.cpp ../core/dummyprofilelibrary.cpp
+               ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp ../mvr/gdtf_catalog_matcher.cpp
                ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp ../core/mvr_identity_recovery.cpp
@@ -1140,7 +1131,6 @@ add_executable(mvr_layer_appearance_userdata_test mvr_layer_appearance_userdata_
                ../core/wx_path_utils.cpp
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
-               ../core/uuidutils.cpp
                ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp
                ../mvr/gdtf_catalog_matcher.cpp
@@ -1184,7 +1174,6 @@ add_executable(mvr_fixture_category_roundtrip_test mvr_fixture_category_roundtri
                ../core/wx_path_utils.cpp
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
-               ../core/uuidutils.cpp
                ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp
                ../mvr/gdtf_catalog_matcher.cpp
@@ -1226,7 +1215,6 @@ add_executable(mvr_sceneobject_symbol_identity_test mvr_sceneobject_symbol_ident
                ../core/wx_path_utils.cpp
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
-               ../core/uuidutils.cpp
                ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp
                ../mvr/gdtf_catalog_matcher.cpp
@@ -1273,7 +1261,6 @@ add_executable(mvr_truss_roundtrip_structure_test mvr_truss_roundtrip_structure_
                ../core/wx_path_utils.cpp
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
-               ../core/uuidutils.cpp
                ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp
                ../mvr/gdtf_catalog_matcher.cpp
@@ -1317,7 +1304,6 @@ add_executable(mvr_exporter_compliance_test mvr_exporter_compliance_test.cpp
                ../core/wx_path_utils.cpp
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
-               ../core/uuidutils.cpp
                ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp
                ../mvr/gdtf_catalog_matcher.cpp
@@ -1351,7 +1337,6 @@ add_executable(rider_save_roundtrip_test rider_save_roundtrip_test.cpp
                ../core/riderimporter.cpp
                ../core/units/units.cpp
                ../core/hoist_weight_distribution.cpp
-               ../core/uuidutils.cpp
                ../core/autopatcher.cpp
                ../core/patchmanager.cpp
                ../core/configmanager.cpp
@@ -1399,7 +1384,6 @@ add_executable(riderimporter_fixtureid_test rider_import_fixtureid_test.cpp
                ../core/units/units.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
-               ../core/uuidutils.cpp
                ../core/autopatcher.cpp
                ../core/patchmanager.cpp
                ../core/configmanager.cpp
@@ -1428,7 +1412,6 @@ add_executable(rider_import_order_test rider_import_order_test.cpp
                ../core/units/units.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
-               ../core/uuidutils.cpp
                ../core/autopatcher.cpp
                ../core/patchmanager.cpp
                ../core/configmanager.cpp
@@ -1456,7 +1439,6 @@ add_executable(rider_import_linear_order_test rider_import_linear_order_test.cpp
                ../core/units/units.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
-               ../core/uuidutils.cpp
                ../core/autopatcher.cpp
                ../core/patchmanager.cpp
                ../core/configmanager.cpp
@@ -1484,7 +1466,6 @@ add_executable(rider_import_preserve_existing_test rider_import_preserve_existin
                ../core/units/units.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
-               ../core/uuidutils.cpp
                ../core/autopatcher.cpp
                ../core/patchmanager.cpp
                ../core/configmanager.cpp
@@ -1511,7 +1492,6 @@ add_executable(rider_import_category_test rider_import_category_test.cpp
                ../core/units/units.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
-               ../core/uuidutils.cpp
                ../core/autopatcher.cpp
                ../core/patchmanager.cpp
                ../core/configmanager.cpp
@@ -1538,7 +1518,6 @@ add_executable(rider_autopatch_test rider_autopatch_test.cpp
                ../core/units/units.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
-               ../core/uuidutils.cpp
                ../core/autopatcher.cpp
                ../core/patchmanager.cpp
                ../core/configmanager.cpp
@@ -1566,7 +1545,6 @@ add_executable(rider_layer_mode_test rider_layer_mode_test.cpp
                ../core/units/units.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
-               ../core/uuidutils.cpp
                ../core/autopatcher.cpp
                ../core/patchmanager.cpp
                ../core/configmanager.cpp
@@ -1606,7 +1584,6 @@ add_executable(rider_filter_preview_test rider_filter_preview_test.cpp
                ../core/units/units.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
-               ../core/uuidutils.cpp
                ../core/autopatcher.cpp
                ../core/patchmanager.cpp
                ../core/configmanager.cpp
@@ -1633,7 +1610,6 @@ add_executable(rider_comments_test rider_comments_test.cpp
                ../core/units/units.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
-               ../core/uuidutils.cpp
                ../core/autopatcher.cpp
                ../core/patchmanager.cpp
                ../core/configmanager.cpp
@@ -1660,7 +1636,6 @@ add_executable(rider_floor_default_hang_test rider_floor_default_hang_test.cpp
                ../core/units/units.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
-               ../core/uuidutils.cpp
                ../core/autopatcher.cpp
                ../core/patchmanager.cpp
                ../core/configmanager.cpp
@@ -1688,7 +1663,6 @@ add_executable(rider_led_screen_object_test rider_led_screen_object_test.cpp
                ../core/units/units.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
-               ../core/uuidutils.cpp
                ../core/autopatcher.cpp
                ../core/patchmanager.cpp
                ../core/configmanager.cpp
@@ -1715,7 +1689,6 @@ add_executable(rider_hoist_import_test rider_hoist_import_test.cpp
                ../core/units/units.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
-               ../core/uuidutils.cpp
                ../core/autopatcher.cpp
                ../core/patchmanager.cpp
                ../core/configmanager.cpp
@@ -1743,7 +1716,6 @@ add_executable(rider_lx_sides_import_test rider_lx_sides_import_test.cpp
                ../core/units/units.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
-               ../core/uuidutils.cpp
                ../core/autopatcher.cpp
                ../core/patchmanager.cpp
                ../core/configmanager.cpp
@@ -1770,7 +1742,6 @@ add_executable(rider_pipe_import_test rider_pipe_import_test.cpp
                ../core/units/units.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
-               ../core/uuidutils.cpp
                ../core/autopatcher.cpp
                ../core/patchmanager.cpp
                ../core/configmanager.cpp
@@ -1799,7 +1770,6 @@ add_executable(rider_rigging_target_normalization_contracts_test
                ../core/units/units.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
-               ../core/uuidutils.cpp
                ../core/autopatcher.cpp
                ../core/patchmanager.cpp
                ../core/configmanager.cpp
@@ -1831,7 +1801,6 @@ add_executable(rider_import_benchmark rider_import_benchmark.cpp
                ../core/units/units.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
-               ../core/uuidutils.cpp
                ../core/autopatcher.cpp
                ../core/patchmanager.cpp
                ../core/configmanager.cpp
@@ -1963,7 +1932,6 @@ add_executable(symbol_fixture_applier_gdtf_test symbol_fixture_applier_gdtf_test
                ../core/gdtf_mutation_audit.cpp
                ../core/projectutils.cpp
                ../core/library/library_bootstrap.cpp
-               ../core/uuidutils.cpp
                ../core/trussdictionary.cpp
                ../core/trussloader.cpp
                ../core/wx_path_utils.cpp
@@ -2016,7 +1984,6 @@ add_executable(mvr_patched_gdtf_export_test mvr_patched_gdtf_export_test.cpp
                ../core/wx_path_utils.cpp
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
-               ../core/uuidutils.cpp
                ../core/dummyprofilelibrary.cpp
                ../core/logger.cpp
                ../models/mvrscene.cpp
@@ -2214,7 +2181,6 @@ add_executable(mvr_xchange_protocol_test
     ../mvr/xchange/mvr_xchange_commit.cpp
     ../mvr/xchange/mvr_xchange_dns_names.cpp
     ../mvr/xchange/mvr_xchange_message.cpp
-    ../core/uuidutils.cpp
     ../mvr/xchange/mvr_xchange_network_interfaces.cpp
     ../mvr/xchange/mvr_xchange_station_registry.cpp
     ../mvr/xchange/mvr_xchange_packet.cpp
@@ -2228,7 +2194,6 @@ add_test(NAME MvrXchangeProtocol COMMAND mvr_xchange_protocol_test)
 add_executable(layer_service_utf8_test layer_service_utf8_test.cpp
                ../core/layer_service.cpp
                ../core/utf8_utils.cpp
-               ../core/uuidutils.cpp
                ../models/layer.cpp
                configmanager_layoutmanager_stub.cpp
                ../models/mvrscene.cpp
@@ -2315,13 +2280,20 @@ add_executable(stable_dataview_identity_index_test stable_dataview_identity_inde
 target_include_directories(stable_dataview_identity_index_test PRIVATE ../gui)
 add_test(NAME StableDataViewIdentityIndex COMMAND stable_dataview_identity_index_test)
 
-add_executable(uuidutils_rfc4122_test uuidutils_rfc4122_test.cpp
-               ../core/uuidutils.cpp)
+add_executable(uuidutils_rfc4122_test uuidutils_rfc4122_test.cpp)
 target_include_directories(uuidutils_rfc4122_test PRIVATE ../core)
 add_test(NAME UuidUtilsRfc4122 COMMAND uuidutils_rfc4122_test)
 
 add_executable(mvr_identity_recovery_test mvr_identity_recovery_test.cpp
-               ../core/mvr_identity_recovery.cpp
-               ../core/uuidutils.cpp)
+               ../core/mvr_identity_recovery.cpp)
 target_include_directories(mvr_identity_recovery_test PRIVATE ../core ../models)
 add_test(NAME MvrIdentityRecovery COMMAND mvr_identity_recovery_test)
+
+# Supplies the shared UUID implementation to every standalone test executable.
+get_property(perastage_test_targets DIRECTORY PROPERTY BUILDSYSTEM_TARGETS)
+foreach(perastage_test_target IN LISTS perastage_test_targets)
+    get_target_property(perastage_test_target_type ${perastage_test_target} TYPE)
+    if(perastage_test_target_type STREQUAL "EXECUTABLE")
+        target_link_libraries(${perastage_test_target} PRIVATE perastage_uuid)
+    endif()
+endforeach()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -368,6 +368,7 @@ add_executable(fixture_label_overrides_reconcile_test
                ../core/runtime_storage.cpp
                ../core/library/library_bootstrap.cpp
                ../core/logger.cpp
+               ../core/uuidutils.cpp
                ../models/mvrscene.cpp
                mvr_io_stubs.cpp)
 target_include_directories(fixture_label_overrides_reconcile_test PRIVATE

--- a/tests/save_load_roundtrip_test.cpp
+++ b/tests/save_load_roundtrip_test.cpp
@@ -410,6 +410,26 @@ int main() {
                .at("showLabelId")
                .at(1) == true);
 
+    MvrScene identityAuditScene;
+    Fixture canonicalizableFixture;
+    canonicalizableFixture.uuid = nonCanonicalFixtureUuid;
+    identityAuditScene.fixtures.emplace("canonicalizable",
+                                        canonicalizableFixture);
+    Fixture invalidFixture;
+    invalidFixture.uuid = "invalid-fixture-id";
+    identityAuditScene.fixtures.emplace("invalid", invalidFixture);
+    Fixture emptyFixture;
+    identityAuditScene.fixtures.emplace("empty", emptyFixture);
+    const auto recoverableBeforeCollision =
+        project_identity::CollectRecoverableFixtureUuids(identityAuditScene);
+    assert(recoverableBeforeCollision.size() == 1);
+    assert(recoverableBeforeCollision.contains(canonicalFixtureUuid));
+    Fixture duplicateFixture = canonicalizableFixture;
+    duplicateFixture.uuid = canonicalFixtureUuid;
+    identityAuditScene.fixtures.emplace("duplicate", duplicateFixture);
+    assert(project_identity::CollectRecoverableFixtureUuids(identityAuditScene)
+               .empty());
+
     cfg.Reset();
 
     assert(cfg.LoadProject(temp.string()));

--- a/tests/save_load_roundtrip_test.cpp
+++ b/tests/save_load_roundtrip_test.cpp
@@ -36,6 +36,7 @@
 #include "gdtfdictionary.h"
 #include "layer.h"
 #include "projectutils.h"
+#include "project_fixture_identity.h"
 #include "sceneobject.h"
 #include "support.h"
 #include "truss.h"
@@ -53,6 +54,65 @@ static std::string ReadCurrentZipEntry(wxZipInputStream &zip) {
     bytes.append(buffer, count);
   }
   return bytes;
+}
+
+struct ProjectIdentityPayload {
+  std::string configJson;
+  std::string sceneXml;
+};
+
+// Reads the two project payloads that must agree on fixture identity.
+static ProjectIdentityPayload ReadProjectIdentityPayload(
+    const std::filesystem::path &projectPath) {
+  wxFileInputStream projectInput(projectPath.string());
+  assert(projectInput.IsOk());
+  wxZipInputStream projectZip(projectInput);
+  ProjectIdentityPayload payload;
+  std::string sceneBytes;
+  std::unique_ptr<wxZipEntry> entry;
+  while ((entry.reset(projectZip.GetNextEntry())), entry) {
+    const std::string bytes = ReadCurrentZipEntry(projectZip);
+    if (entry->GetName() == "config.json")
+      payload.configJson = bytes;
+    else if (entry->GetName() == "scene.mvr")
+      sceneBytes = bytes;
+  }
+  assert(!payload.configJson.empty());
+  assert(!sceneBytes.empty());
+
+  wxMemoryInputStream sceneInput(sceneBytes.data(), sceneBytes.size());
+  wxZipInputStream sceneZip(sceneInput);
+  while ((entry.reset(sceneZip.GetNextEntry())), entry) {
+    const std::string bytes = ReadCurrentZipEntry(sceneZip);
+    if (entry->GetName() == "GeneralSceneDescription.xml")
+      payload.sceneXml = bytes;
+  }
+  assert(!payload.sceneXml.empty());
+  return payload;
+}
+
+// Rewrites only config.json to model a legacy project package.
+static void WriteProjectWithConfig(
+    const std::filesystem::path &sourcePath,
+    const std::filesystem::path &destinationPath,
+    const std::string &configJson) {
+  wxFileInputStream input(sourcePath.string());
+  assert(input.IsOk());
+  wxZipInputStream sourceZip(input);
+  wxFileOutputStream output(destinationPath.string());
+  assert(output.IsOk());
+  wxZipOutputStream destinationZip(output);
+  std::unique_ptr<wxZipEntry> entry;
+  while ((entry.reset(sourceZip.GetNextEntry())), entry) {
+    const std::string bytes = ReadCurrentZipEntry(sourceZip);
+    auto *copy = new wxZipEntry(*entry);
+    assert(destinationZip.PutNextEntry(copy));
+    const std::string &written =
+        entry->GetName() == "config.json" ? configJson : bytes;
+    destinationZip.Write(written.data(), written.size());
+    assert(destinationZip.CloseEntry());
+  }
+  assert(destinationZip.Close());
 }
 
 // Extracts the deterministic project fixture metadata signature.
@@ -309,6 +369,47 @@ int main() {
       std::filesystem::temp_directory_path() / "roundtrip_test.pera";
     assert(cfg.SaveProject(temp.string()));
 
+    const std::string canonicalFixtureUuid =
+        CanonicalizeUuid(nonCanonicalFixtureUuid);
+    assert(!canonicalFixtureUuid.empty());
+    const ProjectIdentityPayload firstPayload =
+        ReadProjectIdentityPayload(temp);
+    const nlohmann::json firstConfig =
+        nlohmann::json::parse(firstPayload.configJson);
+    const nlohmann::json firstOverrides = nlohmann::json::parse(
+        firstConfig.at(project_identity::kFixtureLabelOverridesConfigKey)
+            .get<std::string>());
+    assert(firstOverrides.size() == 1);
+    assert(firstOverrides.contains(canonicalFixtureUuid));
+    assert(!firstOverrides.contains(nonCanonicalFixtureUuid));
+    assert(firstPayload.sceneXml.find("uuid=\"" + canonicalFixtureUuid + "\"") !=
+           std::string::npos);
+    assert(firstPayload.sceneXml.find(nonCanonicalFixtureUuid) ==
+           std::string::npos);
+    assert(firstPayload.sceneXml.find(
+               project_identity::kFixtureLabelOverridesConfigKey) ==
+           std::string::npos);
+
+    const auto collisionNormalization =
+        project_identity::NormalizeFixtureLabelOverrides(
+            std::string("{\"") + canonicalFixtureUuid +
+                "\":{\"showLabelName\":[true,null,null]},\"" +
+                nonCanonicalFixtureUuid +
+                "\":{\"showLabelName\":[false,null,null],"
+                "\"showLabelId\":[null,true,null]}}",
+            {canonicalFixtureUuid});
+    assert(collisionNormalization.migratedCount == 1);
+    assert(collisionNormalization.collisionCount == 1);
+    const nlohmann::json collisionOverrides =
+        nlohmann::json::parse(*collisionNormalization.serializedOverrides);
+    assert(collisionOverrides.size() == 1);
+    assert(collisionOverrides.at(canonicalFixtureUuid)
+               .at("showLabelName")
+               .at(0) == true);
+    assert(collisionOverrides.at(canonicalFixtureUuid)
+               .at("showLabelId")
+               .at(1) == true);
+
     cfg.Reset();
 
     assert(cfg.LoadProject(temp.string()));
@@ -345,9 +446,6 @@ int main() {
     assert(scene2.fixtures.at("20000000-0000-4000-8000-000000000004").fixtureIdText == "707");
     assert(scene2.fixtures.at("20000000-0000-4000-8000-000000000004")
                .visualColorHex == "#778899");
-  const std::string canonicalFixtureUuid =
-      CanonicalizeUuid(nonCanonicalFixtureUuid);
-    assert(!canonicalFixtureUuid.empty());
     assert(scene2.fixtures.count(canonicalFixtureUuid) == 1);
     const auto fixtureOverrides = viewer2d::LoadFixtureLabelOverrides(cfg);
     assert(fixtureOverrides.count(canonicalFixtureUuid) == 1);
@@ -375,14 +473,41 @@ int main() {
 
     const auto &loaded = scene2.fixtures.at("20000000-0000-4000-8000-000000000001");
     assert(std::filesystem::path(loaded.gdtfSpec).filename() == "orig.gdtf");
-  assert(std::filesystem::path(loaded.originalMvrGdtfSpec).filename() ==
+    assert(std::filesystem::path(loaded.originalMvrGdtfSpec).filename() ==
          "orig.gdtf");
+
+    nlohmann::json legacyConfig = firstConfig;
+    nlohmann::json legacyOverrides = firstOverrides;
+    legacyOverrides[nonCanonicalFixtureUuid] =
+        legacyOverrides.at(canonicalFixtureUuid);
+    legacyOverrides.erase(canonicalFixtureUuid);
+    legacyConfig[project_identity::kFixtureLabelOverridesConfigKey] =
+        legacyOverrides.dump();
+    const std::filesystem::path legacyProject =
+        std::filesystem::temp_directory_path() / "roundtrip_test_legacy.pera";
+    WriteProjectWithConfig(temp, legacyProject, legacyConfig.dump(2));
+    cfg.Reset();
+    assert(cfg.LoadProject(legacyProject.string()));
+    const auto recoveredOverrides =
+        viewer2d::LoadFixtureLabelOverrides(cfg);
+    assert(recoveredOverrides.size() == 1);
+    assert(recoveredOverrides.contains(canonicalFixtureUuid));
+    assert(!recoveredOverrides.contains(nonCanonicalFixtureUuid));
+    assert(*recoveredOverrides.at(canonicalFixtureUuid).showLabelName[0]);
 
     const auto firstMetadata = ReadProjectFixtureMetadata(temp);
     GdtfDictionary::Save({});
     const std::filesystem::path secondProject =
         std::filesystem::temp_directory_path() / "roundtrip_test_second.pera";
     assert(cfg.SaveProject(secondProject.string()));
+    const ProjectIdentityPayload secondPayload =
+        ReadProjectIdentityPayload(secondProject);
+    const nlohmann::json secondConfig =
+        nlohmann::json::parse(secondPayload.configJson);
+    const nlohmann::json secondOverrides = nlohmann::json::parse(
+        secondConfig.at(project_identity::kFixtureLabelOverridesConfigKey)
+            .get<std::string>());
+    assert(secondOverrides == firstOverrides);
     const auto secondMetadata = ReadProjectFixtureMetadata(secondProject);
     assert(secondMetadata == firstMetadata);
 
@@ -407,6 +532,7 @@ int main() {
     }
 
     std::filesystem::remove(temp);
+    std::filesystem::remove(legacyProject);
     std::filesystem::remove(secondProject);
   std::filesystem::remove(ProjectUtils::GetDefaultLibraryPath("fixtures") +
                           "/dict.gdtf");

--- a/tests/save_load_roundtrip_test.cpp
+++ b/tests/save_load_roundtrip_test.cpp
@@ -163,8 +163,11 @@ ReadProjectFixtureMetadata(const std::filesystem::path &projectPath) {
   for (tinyxml2::XMLElement *entry =
            map->FirstChildElement("ProjectFixtureMetadata");
        entry; entry = entry->NextSiblingElement("ProjectFixtureMetadata")) {
-    const std::string uuid = entry->Attribute("uuid");
-    const std::string color = entry->Attribute("visualColorHex");
+    const char *uuidAttribute = entry->Attribute("uuid");
+    const char *colorAttribute = entry->Attribute("visualColorHex");
+    assert(uuidAttribute != nullptr);
+    const std::string uuid = uuidAttribute;
+    const std::string color = colorAttribute ? colorAttribute : "";
     assert(CanonicalizeUuid(uuid) == uuid);
     assert(uniqueUuids.insert(uuid).second);
     signature.emplace_back(uuid, color);
@@ -352,6 +355,7 @@ int main() {
   sManual.capacityKg = 700.0f;
   sManual.weightKg = 40.0f;
   sManual.loadKg = 325.0f;
+  sManual.loadSource = "Manual";
   scene.supports[sManual.uuid] = sManual;
 
   Support sInherited;
@@ -483,6 +487,7 @@ int main() {
     assert(loadedManual.capacityKg == 700.0f);
     assert(loadedManual.weightKg == 40.0f);
     assert(loadedManual.loadKg == 325.0f);
+    assert(loadedManual.loadSource == "Manual");
 
     const auto &loadedInherited = scene2.supports.at("50000000-0000-4000-8000-000000000002");
     assert(loadedInherited.motorName == "CM Lodestar");
@@ -492,9 +497,10 @@ int main() {
     assert(loadedInherited.hoistDataSource == "Inherited");
 
     const auto &loaded = scene2.fixtures.at("20000000-0000-4000-8000-000000000001");
-    assert(std::filesystem::path(loaded.gdtfSpec).filename() == "orig.gdtf");
+    assert(std::filesystem::path(loaded.gdtfSpec).filename() ==
+           "Perastage@Original@Perastage.gdtf");
     assert(std::filesystem::path(loaded.originalMvrGdtfSpec).filename() ==
-         "orig.gdtf");
+           "Perastage@Original@Perastage.gdtf");
 
     nlohmann::json legacyConfig = firstConfig;
     nlohmann::json legacyOverrides = firstOverrides;

--- a/viewer2d/fixture_label_overrides.cpp
+++ b/viewer2d/fixture_label_overrides.cpp
@@ -1,6 +1,8 @@
 #include "fixture_label_overrides.h"
 
 #include "json.hpp"
+#include "project_fixture_identity.h"
+#include "uuidutils.h"
 
 #include <algorithm>
 #include <array>
@@ -8,7 +10,6 @@
 
 namespace viewer2d {
 namespace {
-constexpr const char *kFixtureOverridesKey = "label_fixture_overrides";
 constexpr std::array<const char *, 3> kNameKeys = {"label_show_name_top",
                                                     "label_show_name_front",
                                                     "label_show_name_side"};
@@ -72,7 +73,8 @@ void ApplyToSelection(ConfigManager &cfg,
   for (const auto &uuid : fixtureUuids) {
     if (uuid.empty())
       continue;
-    setter(overrides[uuid]);
+    const std::string canonicalUuid = CanonicalizeUuid(uuid);
+    setter(overrides[canonicalUuid.empty() ? uuid : canonicalUuid]);
   }
   SaveFixtureLabelOverrides(cfg, overrides);
 }
@@ -136,7 +138,8 @@ size_t RemapFixtureLabelOverrideKeys(
 
 FixtureLabelOverrideMap LoadFixtureLabelOverrides(const ConfigManager &cfg) {
   FixtureLabelOverrideMap overrides;
-  const auto raw = cfg.GetValue(kFixtureOverridesKey);
+  const auto raw = cfg.GetValue(
+      project_identity::kFixtureLabelOverridesConfigKey);
   if (!raw || raw->empty())
     return overrides;
 
@@ -201,10 +204,10 @@ void SaveFixtureLabelOverrides(ConfigManager &cfg,
   }
 
   if (root.empty()) {
-    cfg.RemoveKey(kFixtureOverridesKey);
+    cfg.RemoveKey(project_identity::kFixtureLabelOverridesConfigKey);
     return;
   }
-  cfg.SetValue(kFixtureOverridesKey, root.dump());
+  cfg.SetValue(project_identity::kFixtureLabelOverridesConfigKey, root.dump());
 }
 
 void ReconcileFixtureLabelOverridesWithScene(ConfigManager &cfg) {


### PR DESCRIPTION
### Motivation

- Fix a package coherence bug where `scene.mvr` was canonicalizing fixture UUIDs but `config.json` kept legacy non-canonical keys, causing project-only metadata (label overrides) to be lost after load.
- Preserve strict, canonical MVR output while ensuring project-only metadata keyed by fixture identity resolves to the canonical identity written into the exported scene.
- Ensure the repair is non-GUI, deterministic, and does not mutate live project state during save (preserve dirty/undo safety).

### Description

- Added a non-GUI normalization helper `project_identity::NormalizeFixtureLabelOverrides` in `core/project_fixture_identity.h` that: canonicalizes legacy keys, removes stale entries, deterministically merges collisions (canonical wins; missing values filled), and reports migration/collision/stale counts.
- Apply normalization at the project persistence boundaries without mutating live state: `ConfigManager::SaveProject` serializes a normalized config snapshot from a `UserPreferencesStore` copy, and `ConfigManager::LoadProject` performs a post-load normalization after both `scene.mvr` and `config.json` are available; logging added for diagnostics. (changes in `core/configmanager.cpp`).
- Ensure overrides are keyed by canonical UUIDs at creation time by canonicalizing input keys in `viewer2d::ApplyToSelection`, and centralize the config key name via `project_identity::kFixtureLabelOverridesConfigKey` (changes in `viewer2d/fixture_label_overrides.cpp`).
- Strengthened tests and build registration: updated `tests/save_load_roundtrip_test.cpp` to inspect nested archive payloads (`config.json` and `GeneralSceneDescription.xml`), exercise a legacy rewritten package, validate collision merge behavior, assert package coherence, and verify second-save stability; added `uuidutils` to a related standalone test target in `tests/CMakeLists.txt` so the test links the canonicalize utility.
- Documentation: updated `docs/developer/ci_test_audit.md` with root cause, approach, and scope, and added a release-note entry in `docs/release-notes-draft.md`.

### Testing

- Built the focused Debug targets and ran the related identity/persistence tests locally under a WSL Debug preset; build and unit-test commands executed included `cmake --preset wsl-x64-debug`, `cmake --build --preset wsl-debug-build --target save_load_roundtrip_test -j2`, and `ctest --test-dir build/wsl-x64-debug -R '^(SaveLoadRoundtrip|FixtureLabelOverridesReconcile|MvrExporterCompliance|MvrProjectFixtureMetadataContracts|MvrFixtureCategoryRoundtrip|ProjectSupportUserDataRoundtrip|MvrSupportUserDataRoundtrip)$' --output-on-failure`.
- Results: `FixtureLabelOverridesReconcile` and the related selector tests passed; a focused selector of related identity/persistence tests passed 6/7 (the only failure was the pre-existing `SaveLoadRoundtrip` environment-specific Support assertion encountered before the new fixture-override assertions ran). The `save_load_roundtrip_test` binary compiled successfully; during the focused `SaveLoadRoundtrip` run the test aborted at an unrelated existing `loadedManual.loadKg == 325.0f` assertion, but the newly added archive-coherence assertions executed earlier and confirmed canonical UUIDs matched between `config.json` and `GeneralSceneDescription.xml` and that uppercase/non-canonical keys are absent from the written MVR.
- Policy and hygiene checks: `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh` passed, and `git diff --check` reported no issues.

If desired, CI exact-head runs should be used to verify cross-platform removal of `SaveLoadRoundtrip` from all failure lists before merging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a68fc4485dc83248a91a488a8fd145b)