### PR TITLE
Preserve UTF-8 paths in GDTF mutation diagnostics

### DIFF
--- a/docs/developer/ci_test_audit.md
+++ b/docs/developer/ci_test_audit.md
@@ -1617,3 +1617,43 @@ Local verification after the complete fixture correction passed
 all four representative UUID-consumer tests. A new exact-head Actions run is
 still required before merge; no final run ID or cross-platform totals are
 available for this commit yet.
+
+### PR #2239 final exact-head evidence
+
+PR #2239 merged after authoritative run `30400595579` verified reviewed head
+`43f778250b9134eaeac3df2c6fd765175edac591`. Every platform built the complete
+target set, ran the complete unfiltered suite, and reported
+`selected_labels = []`. `SaveLoadRoundtrip` passed on Linux, Windows, and
+macOS, confirming the supported canonical fixture-label persistence repair.
+
+Linux reported 160 passed, 5 failed, and 1 skipped of 166. Its remaining
+failures were `EditableFocusUtils`, `GdtfEditorCheckpoint08DStabilization`,
+`Loader3dsNativeDimensions`, `TrussPathEncodingRegression`, and
+`Viewer2DFboCaptureDiagnostics`. Windows reported 162 passed and 6 failed of
+168, retaining those five names plus `GdtfShareSecurity`. macOS reported 161
+passed and 5 failed of 166, retaining the same five names as Linux.
+
+### Checkpoint 08D UTF-8 diagnostic-path audit
+
+The initial cross-platform `GdtfEditorCheckpoint08DStabilization` failure was
+`AssertionError` at Python heredoc line 23. The line resolves to the policy
+prohibition against `.string()` in `gui/fixture_gdtf_apply_services.cpp`.
+`BuildMutationDiagnostic` used `path.string()` while composing a failed GDTF
+publication message, even though the service's operational GDTF calls already
+used `PathUtils::PathToUtf8`. A native narrow path can damage or misrepresent
+non-ASCII text on Windows, so this is a production UTF-8 diagnostic-boundary
+defect rather than a stale policy assertion.
+
+The selected correction preserves the complete diagnostic while converting its
+filesystem path with `PathUtils::PathToUtf8`. The focused policy remains scoped
+to the service file and now identifies the filesystem-path diagnostic contract
+explicitly if native narrow conversion returns. The complete Checkpoint 08D
+script then passed without exposing any later assertion; its nested Checkpoints
+08A, 08B, and 08C also passed. The filesystem-path boundary check, shell-test
+registration check, CI workflow architecture check, Perastage tree check,
+GUI ConfigManager boundary check, and `git diff --check` passed locally.
+
+The local Debug configure could not reach generation because this environment
+lacks the wxWidgets libraries and headers, so no local CTest inventory, compiled
+target set, or complete Debug suite is available from this checkout. Exact-head
+cross-platform CI evidence remains required before merge.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -31,7 +31,8 @@ Changes since **v1.5.0**.
 - Rejected duplicate and case-colliding MVR archive entries consistently across platforms and surfaced tolerant-recovery diagnostics through normal imports.
 - Preserved explicit fixture categories, colors, and valid GDTF mode references across repeated MVR roundtrips while making missing-category inference deterministic.
 - Preserved per-fixture visual color overrides, including intentional empty colors, and meaningful fixture ID text in Perastage projects without leaking project-only instance metadata into normal MVR exports or other fixtures of the same type.
-- Improved GDTF compatibility and safety for Unicode filesystem paths and archive entry names, including deterministic rejection of malformed UTF-8 identities.
+- Preserved per-fixture label settings when fixture identities can be safely canonicalized, including recovery from compatible legacy key spellings without guessing invalid or ambiguous identities.
+- Improved GDTF compatibility and safety for Unicode filesystem paths and archive entry names, including readable publication diagnostics and deterministic rejection of malformed UTF-8 identities.
 
 ## Current limitations
 

--- a/gui/fixture_gdtf_apply_services.cpp
+++ b/gui/fixture_gdtf_apply_services.cpp
@@ -52,7 +52,8 @@ std::string BuildFixtureDocumentRevisionText(
 std::string BuildMutationDiagnostic(const std::filesystem::path &path,
                                     const GdtfDocumentMutationResult &result) {
   std::ostringstream out;
-  out << "Could not publish GDTF document mutation for '" << path.string() << "'";
+  out << "Could not publish GDTF document mutation for '"
+      << PathUtils::PathToUtf8(path) << "'";
   if (!result.errors.empty()) {
     out << ": ";
     for (size_t i = 0; i < result.errors.size(); ++i) {

--- a/tests/check_gdtf_editor_checkpoint08d_stabilization.sh
+++ b/tests/check_gdtf_editor_checkpoint08d_stabilization.sh
@@ -26,7 +26,9 @@ assert '*input.fixtures =' not in adapter_cpp
 assert 'result.updatedFixtures' in adapter_cpp
 assert 'fixtureType' in Path('gui/fixture_gdtf_apply_services.cpp').read_text()
 assert 'CreateOrUpdatePerastageLibraryDerivative(\n        fixtureType' in Path('gui/fixture_gdtf_apply_services.cpp').read_text()
-assert '.string()' not in Path('gui/fixture_gdtf_apply_services.cpp').read_text()
+assert '.string()' not in Path('gui/fixture_gdtf_apply_services.cpp').read_text(), \
+    ('fixture_gdtf_apply_services.cpp must use PathUtils::PathToUtf8 for '
+     'filesystem-path diagnostics')
 
 for path, name in [('gui/fixtureeditdialog.cpp','FixtureEditDialog::ApplyChanges'),('gui/trusseditdialog.cpp','TrussEditDialog::ApplyChanges')]:
     b = body(path, name)


### PR DESCRIPTION
### Motivation

- Fix a production UTF-8 diagnostic-path defect where `BuildMutationDiagnostic` emitted a native-narrow `std::filesystem::path::string()` which can corrupt non-ASCII paths (especially on Windows) while operational GDTF calls already used the UTF-8 boundary helpers.
- Keep the Checkpoint 08D policy guardrail against `.string()` in the service file and make its failure message actionable and explicit about the required `PathUtils::PathToUtf8` contract.
- Record the PR #2239 exact-head evidence and update the release notes to reflect the narrowly scoped fixture-label persistence wording and clarified readable GDTF publication diagnostics.

### Description

- Replaced the unsafe diagnostic conversion in `gui/fixture_gdtf_apply_services.cpp` by using `PathUtils::PathToUtf8(path)` instead of `path.string()` in `BuildMutationDiagnostic` so diagnostic messages preserve non-ASCII characters across platforms.
- Improved the policy test assertion in `tests/check_gdtf_editor_checkpoint08d_stabilization.sh` to keep the prohibition against `.string()` and to provide a clearer failure message: `'fixture_gdtf_apply_services.cpp must use PathUtils::PathToUtf8 for filesystem-path diagnostics'`.
- Updated `docs/developer/ci_test_audit.md` with PR #2239 exact-head evidence and a focused Checkpoint 08D UTF-8 diagnostic-path audit, and updated `docs/release-notes-draft.md` with a narrow release-note entry about preserved fixture-label persistence and readable Unicode GDTF diagnostics.

Files changed: `gui/fixture_gdtf_apply_services.cpp`, `tests/check_gdtf_editor_checkpoint08d_stabilization.sh`, `docs/developer/ci_test_audit.md`, and `docs/release-notes-draft.md`.

### Testing

- Ran the focused policy script: `PERASTAGE_TEST_PYTHON="$(command -v python3)" bash tests/check_gdtf_editor_checkpoint08d_stabilization.sh` and it reported `OK: GDTF editor Checkpoint 08D stabilization checks passed.` (success).
- Ran repository policy checks: `python3 tests/check_wx_filesystem_path_boundaries.py`, `python3 tests/check_bash_test_registration.py`, `python3 tests/check_ci_workflow_architecture.py`, `bash tests/check_perastage_tree_modules.sh`, and `bash tests/check_no_configmanager_get_in_gui.sh`; all returned OK in this environment (success).
- Performed `git diff --check` (OK) and verified the focused code/test/doc changes were committed on branch `codex/repair-gdtf-editor-checkpoint08d-stabilization` (base SHA `55ad5aa68c75e87fbaa245c9ad9521bb73076508`, `VERSION=1.5.26`, commit `dd3dae9fbf9ad822ebcd71ef30fb9d9d250de5ee`).

Notes and limitations:
- Local CMake configure (`cmake --preset wsl-x64-debug`) could not complete in this environment due to missing `wxWidgets` libraries/headers, so no local CTest inventory or full Debug-suite run was produced here; exact-head cross-platform CI runs remain required before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a69250985f883248b12b7c420bd97d4)