### PR TITLE
Preserve UTF-8 truss dictionary asset references

### DIFF
--- a/core/active_dictionary_storage.cpp
+++ b/core/active_dictionary_storage.cpp
@@ -50,7 +50,9 @@ fs::path GetOwnedAssetDirectory(const fs::path &dictionaryPath,
                                 const fs::path &defaultDictionaryPath) {
   if (IsDefaultManagedDictionary(dictionaryPath, defaultDictionaryPath))
     return defaultDictionaryPath.parent_path();
-  return dictionaryPath.parent_path() / (dictionaryPath.stem().string() + "_assets");
+  fs::path assetDirectoryName = dictionaryPath.stem();
+  assetDirectoryName += "_assets";
+  return dictionaryPath.parent_path() / assetDirectoryName;
 }
 
 // Builds the storage layout for an active dictionary.
@@ -79,8 +81,9 @@ fs::path ResolveReference(const fs::path &dictionaryPath,
   if (fs::exists(directPath))
     return directPath;
 
-  const fs::path assetPath =
-      jsonDir / (dictionaryPath.stem().string() + "_assets") / parsedPath;
+  fs::path assetDirectoryName = dictionaryPath.stem();
+  assetDirectoryName += "_assets";
+  const fs::path assetPath = jsonDir / assetDirectoryName / parsedPath;
   if (fs::exists(assetPath))
     return assetPath;
   return directPath;
@@ -93,11 +96,11 @@ std::string MakeSerializedReference(const AssetStorageLayout &layout,
     return {};
   if (!layout.isDefaultManagedDictionary &&
       PathsEquivalentOrEqual(assetPath.parent_path(), layout.ownedAssetDirectory))
-    return assetPath.filename().string();
+    return PathUtils::PathToUtf8(assetPath.filename());
   if (layout.isDefaultManagedDictionary &&
       PathsEquivalentOrEqual(assetPath.parent_path(), layout.ownedAssetDirectory))
-    return assetPath.filename().string();
-  return assetPath.string();
+    return PathUtils::PathToUtf8(assetPath.filename());
+  return PathUtils::PathToUtf8(assetPath);
 }
 
 // Returns the deterministic destination path for importing an owned asset.

--- a/core/trussdictionary.cpp
+++ b/core/trussdictionary.cpp
@@ -47,9 +47,9 @@ size_t g_saveCallCountForTesting = 0;
 constexpr const char *kTrussDictionaryPathConfigKey =
     "trusses_dictionary_active_path";
 
+// Converts a filesystem path to UTF-8 for string-based application boundaries.
 static std::string ToUtf8String(const fs::path &path) {
-  std::u8string utf8 = path.u8string();
-  return std::string(utf8.begin(), utf8.end());
+  return PathUtils::PathToUtf8(path);
 }
 
 static std::string LowerExt(const fs::path &path) {
@@ -99,6 +99,7 @@ static fs::path GetUserDictFile() {
   return dir / "truss_dictionary.json";
 }
 
+// Resolves a configured dictionary path against the managed default location.
 static fs::path ResolveConfiguredDictionaryPath(
     const fs::path &defaultPath, const std::string &rawConfiguredPath,
     std::string *warningOut = nullptr) {
@@ -120,7 +121,7 @@ static fs::path ResolveConfiguredDictionaryPath(
     if (warningOut) {
       *warningOut =
           "Could not create dictionary directory for configured path: " +
-          configuredPath.parent_path().string();
+          PathUtils::PathToUtf8(configuredPath.parent_path());
     }
     return defaultPath;
   }
@@ -188,7 +189,7 @@ static bool CopySeedAssetsIntoCustomDictionary(
          seedPath, {}, FileImportUtils::ConflictPolicy::Rename});
     if (!copied.success)
       continue;
-    targetDict[key] = copied.finalPath.string();
+    targetDict[key] = PathUtils::PathToUtf8(copied.finalPath);
     changed = true;
   }
   return changed;
@@ -209,6 +210,7 @@ static fs::path ResolveImportedPath(const fs::path &jsonFile,
   return ActiveDictionaryStorage::ResolveReference(jsonFile, rawPathText);
 }
 
+// Converts supported legacy truss resources to the current GDTF container.
 static bool EnsureMigratedToGdtf(fs::path &pathInOut, std::string &error) {
   std::string ext = LowerExt(pathInOut);
   if (ext == ".gdtf")
@@ -231,7 +233,7 @@ static bool EnsureMigratedToGdtf(fs::path &pathInOut, std::string &error) {
     if (!fs::exists(converted)) {
       Truss truss;
       truss.modelFile = ToUtf8String(pathInOut);
-      truss.model = pathInOut.stem().string();
+      truss.model = PathUtils::PathToUtf8(pathInOut.stem());
       if (!BuildTrussGdtfFromInstance(truss, converted, &error))
         return false;
     }
@@ -243,6 +245,7 @@ static bool EnsureMigratedToGdtf(fs::path &pathInOut, std::string &error) {
   return false;
 }
 
+// Loads and resolves all entries from a truss dictionary file.
 static std::optional<std::unordered_map<std::string, std::string>>
 LoadFromFile(const fs::path &file, std::string &error) {
   std::unordered_map<std::string, std::string> dict;
@@ -320,7 +323,7 @@ LoadFromFile(const fs::path &file, std::string &error) {
     if (!fs::exists(path) && !PathUtils::PathFromUtf8(rawPath).is_absolute()) {
       std::cerr << "Warning: trusses dictionary " << sourceLabel
                 << " references missing relative path '" << rawPath
-                << "' resolved from '" << file.string() << "'."
+                << "' resolved from '" << PathUtils::PathToUtf8(file) << "'."
                 << std::endl;
     }
     dict[normalizedKey] = ToUtf8String(path);
@@ -503,7 +506,7 @@ bool CreateEmptyDictionaryFile(const std::string &path, std::string *errorOut) {
   }
   out << DictionaryJsonContract::MakeRoot("trusses", nlohmann::json::object()).dump(4);
   out.close();
-  return ValidateDictionaryFile(target.string(), errorOut);
+  return ValidateDictionaryFile(PathUtils::PathToUtf8(target), errorOut);
 }
 
 // Creates a trusses dictionary from application defaults with copied assets.
@@ -534,7 +537,8 @@ bool CreateDictionaryFileFromDefaults(const std::string &path,
   CopySeedAssetsIntoCustomDictionary(target, *baseDict, customDict);
   const auto previousValue =
       ConfigManager::Get().GetValue(kTrussDictionaryPathConfigKey);
-  ConfigManager::Get().SetValue(kTrussDictionaryPathConfigKey, target.string());
+  ConfigManager::Get().SetValue(kTrussDictionaryPathConfigKey,
+                                PathUtils::PathToUtf8(target));
   std::string saveError;
   const bool saved = Save(customDict, &saveError);
   if (previousValue)
@@ -546,13 +550,13 @@ bool CreateDictionaryFileFromDefaults(const std::string &path,
       *errorOut = "Could not create dictionary from defaults: " + saveError;
     return false;
   }
-  return ValidateDictionaryFile(target.string(), errorOut);
+  return ValidateDictionaryFile(PathUtils::PathToUtf8(target), errorOut);
 }
 
 // Returns the active trusses dictionary path.
 std::string GetActiveDictionaryFilePath() {
   std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
-  return GetConfiguredUserDictFile().string();
+  return PathUtils::PathToUtf8(GetConfiguredUserDictFile());
 }
 
 // Returns the active trusses dictionary file name.
@@ -561,7 +565,7 @@ std::string GetActiveDictionaryFileName() {
   const fs::path path = GetConfiguredUserDictFile();
   if (path.empty())
     return {};
-  return path.filename().string();
+  return PathUtils::PathToUtf8(path.filename());
 }
 
 // Changes the active trusses dictionary after validating the selected file.
@@ -581,7 +585,8 @@ bool SetActiveDictionaryFilePath(const std::string &path, std::string *errorOut)
   const fs::path resolvedPath =
       ResolveConfiguredDictionaryPath(defaultPath, path, &warning);
   if (!warning.empty() &&
-      TrimAsciiWhitespace(path) != TrimAsciiWhitespace(defaultPath.string())) {
+      TrimAsciiWhitespace(path) !=
+          TrimAsciiWhitespace(PathUtils::PathToUtf8(defaultPath))) {
     if (errorOut)
       *errorOut = warning;
     return false;
@@ -604,7 +609,8 @@ bool SetActiveDictionaryFilePath(const std::string &path, std::string *errorOut)
   if (trimmedInput.empty() || resolvedPath == defaultPath) {
     ConfigManager::Get().RemoveKey(kTrussDictionaryPathConfigKey);
   } else {
-    ConfigManager::Get().SetValue(kTrussDictionaryPathConfigKey, resolvedPath.string());
+    ConfigManager::Get().SetValue(kTrussDictionaryPathConfigKey,
+                                  PathUtils::PathToUtf8(resolvedPath));
   }
 
   if (!ConfigManager::Get().SaveUserConfig()) {
@@ -627,8 +633,8 @@ std::optional<std::unordered_map<std::string, std::string>> Load() {
   const fs::path defaultFile = GetUserDictFile();
   const fs::path baseFile = GetBaseDictFile();
   const bool isManagedDefault = userFile == defaultFile;
-  g_lastLoadStatus.activePath = userFile.string();
-  g_lastLoadStatus.fallbackPath = baseFile.string();
+  g_lastLoadStatus.activePath = PathUtils::PathToUtf8(userFile);
+  g_lastLoadStatus.fallbackPath = PathUtils::PathToUtf8(baseFile);
 
   std::error_code ec;
   if (!fs::exists(userFile, ec)) {
@@ -673,7 +679,7 @@ std::optional<std::unordered_map<std::string, std::string>> Load() {
   }
 
   g_lastLoadStatus.error += ". Failed to load base truss dictionary ('" +
-                            baseFile.string() + "'): " + baseError;
+                            PathUtils::PathToUtf8(baseFile) + "'): " + baseError;
   std::cerr << "Error: " << g_lastLoadStatus.error << std::endl;
   return std::nullopt;
 }
@@ -728,21 +734,21 @@ bool Save(const std::unordered_map<std::string, std::string> &dict,
   if (!out.is_open()) {
     if (errorOut)
       *errorOut = "Could not open user trusses dictionary for writing: " +
-                  file.string();
+                  PathUtils::PathToUtf8(file);
     return false;
   }
   out << root.dump(4);
   if (!out.good()) {
     if (errorOut)
       *errorOut = "Failed while writing user trusses dictionary: " +
-                  file.string();
+                  PathUtils::PathToUtf8(file);
     return false;
   }
   out.flush();
   if (!out.good()) {
     if (errorOut)
       *errorOut = "Failed to flush user trusses dictionary to disk: " +
-                  file.string();
+                  PathUtils::PathToUtf8(file);
     return false;
   }
   ++g_saveCallCountForTesting;

--- a/docs/developer/ci_test_audit.md
+++ b/docs/developer/ci_test_audit.md
@@ -1657,3 +1657,61 @@ The local Debug configure could not reach generation because this environment
 lacks the wxWidgets libraries and headers, so no local CTest inventory, compiled
 target set, or complete Debug suite is available from this checkout. Exact-head
 cross-platform CI evidence remains required before merge.
+
+### PR #2240 final exact-head evidence
+
+PR #2240 merged after authoritative run `30402918582` verified reviewed head
+`e98f1297de5f262f0b16e2301be3ca944e33ecef`. Every platform reported
+`selected_labels = []`, and `GdtfEditorCheckpoint08DStabilization` passed on
+Linux, Windows, and macOS.
+
+Linux reported 161 passed, 4 failed, and 1 skipped of 166. Its residual failures
+were `EditableFocusUtils`, `Loader3dsNativeDimensions`,
+`TrussPathEncodingRegression`, and `Viewer2DFboCaptureDiagnostics`. Windows
+reported 163 passed and 5 failed of 168; its residual failures were
+`EditableFocusUtils`, `GdtfShareSecurity`, `Loader3dsNativeDimensions`,
+`TrussPathEncodingRegression`, and `Viewer2DFboCaptureDiagnostics`. macOS
+reported 162 passed and 4 failed of 166; its residual failures matched Linux.
+
+### Truss path encoding and shared dictionary storage audit
+
+The original Linux and macOS failure parsed the archive and recovered its
+3000 x 300 x 300 mm dimensions, but left `symbolFile` empty. The regression
+fixture contained only `models/svg/main.svg`, while the production loader's
+renderable-resource contract resolves `models/gltf/<model>.glb` and
+`models/3ds/<model>.3ds`. This was a stale SVG-only test fixture, not a Unicode
+resolution failure. The fixture now follows `TrussLoaderValidation` by providing
+`models/gltf/main.glb`; production loader semantics remain unchanged.
+
+On Windows, the observed exception was nlohmann JSON
+`type_error.316` (`invalid UTF-8 byte`) at `nlohmann::json::dump` during
+`TrussDictionary::Save`. The first invalid-byte producer in that save path was
+`ActiveDictionaryStorage::MakeSerializedReference`: it returned
+`std::filesystem::path::filename().string()` for an owned Unicode filename, a
+native narrow string that is not guaranteed to be UTF-8 on Windows. The shared
+storage helper now uses `PathUtils::PathToUtf8` for owned filenames and external
+absolute references. Custom `<dictionary-stem>_assets` paths are assembled with
+filesystem-native path operations, so Unicode dictionary stems are not narrowed.
+Owned references remain portable filenames, while absolute legacy references,
+files beside a dictionary, and relative references in the owned asset directory
+retain their existing resolution behavior.
+
+Target-relevant truss dictionary boundaries were classified individually.
+Extension-only `.string()` handling remains an ASCII-only internal operation;
+copied paths, model stems, configured paths, load-status paths, public path
+results, and path diagnostics now cross their serialized, API, or user-visible
+boundaries as UTF-8. Shared-storage coverage now exercises a Unicode custom
+dictionary stem, a Unicode owned filename, portable JSON serialization and
+dump, exact owned-reference resolution, and an external absolute Unicode
+reference without changing the JSON schema or existing ASCII and legacy cases.
+The truss regression also retains its Unicode and spaced source cases,
+dictionary ownership and lookup, extracted-resource checks, canonical
+last-project write, tolerated legacy mojibake read, restoration, empty save, and
+cleanup.
+
+A direct local build and run of `ActiveDictionaryStorage` passed. The repository
+Debug configure could not complete in this environment because wxWidgets
+libraries and headers are unavailable, so the compiled truss/loader controls,
+complete local suite, Windows CRT completion, and exact-head cross-platform CI
+evidence remain pending. No CI run ID or final platform totals are claimed by
+this local audit.

--- a/docs/developer/ci_test_audit.md
+++ b/docs/developer/ci_test_audit.md
@@ -1715,3 +1715,54 @@ libraries and headers are unavailable, so the compiled truss/loader controls,
 complete local suite, Windows CRT completion, and exact-head cross-platform CI
 evidence remain pending. No CI run ID or final platform totals are claimed by
 this local audit.
+
+### PR #2241 first exact-head cross-platform evidence
+
+Authoritative run `30405753117` exercised reviewed head
+`ce7534b9063888ec218d6e8472cdf84926d04b7a`. All three platforms completed
+configuration, generated their complete inventories, built the complete target
+set, ran the unfiltered suites, and reported `selected_labels = []`. This run
+did not complete PR #2241.
+
+Linux reported 161 passed, 4 failed, and 1 skipped of 166. Its failures were
+`EditableFocusUtils`, `Loader3dsNativeDimensions`,
+`TrussPathEncodingRegression`, and `Viewer2DFboCaptureDiagnostics`. Windows
+reported 162 passed and 6 failed of 168. Its failures were
+`ActiveDictionaryStorage`, `EditableFocusUtils`, `GdtfShareSecurity`,
+`Loader3dsNativeDimensions`, `TrussPathEncodingRegression`, and
+`Viewer2DFboCaptureDiagnostics`. macOS reported 162 passed and 4 failed of 166;
+its failures matched Linux.
+
+The run positively verified that both truss archive cases load, resolve
+`models/gltf/main.glb`, and retain 3000 x 300 x 300 mm dimensions on every
+platform. The original Windows nlohmann `type_error.316` / `invalid UTF-8 byte`
+exception is absent, so the production UTF-8 serialization correction remains
+valid and is retained.
+
+Two follow-up test-contract defects remain. The last-project helper creates an
+invalid-byte pseudo-Latin-1 fixture instead of valid UTF-8 mojibake, obscuring
+whether canonical or legacy recovery failed behind duplicate raw assertions.
+The Windows shared-storage test searches dumped JSON for an unescaped absolute
+path even though JSON correctly escapes native backslashes. The Windows CRT
+leak output occurs after an assertion abort and remains pending normal-exit
+confirmation; it is not yet classified as a genuine leak.
+
+The corrective test audit identifies the legacy stage as the failing
+last-project stage: the canonical save writes UTF-8 and its load resolves the
+existing file, while the old legacy helper decoded the path and emitted each
+Unicode code point as one byte. For `ñ` it therefore wrote `F1`, which is an
+invalid standalone UTF-8 byte, instead of valid UTF-8 mojibake `C3 83 C2 B1`
+(`Ã±`). The replacement deterministically treats every original UTF-8 byte as a
+Latin-1 code point and UTF-8-encodes that code point. It validates the fixture,
+reports canonical and legacy failures separately with bounded path-specific
+diagnostics, and restores the exact prior last-project file state through RAII.
+No production change was required.
+
+The shared-storage correction retains `dump()`, reparses the serialized JSON,
+and compares both application values exactly. This classifies Windows JSON
+backslash escaping as reversible syntax rather than a production path change.
+A direct local C++20 build and execution of `ActiveDictionaryStorage` passed,
+and the corrected truss regression translation unit compiled with the system
+wxWidgets headers. Full CMake configuration remains unavailable because this
+container lacks GLEW; exact-head cross-platform completion and Windows
+normal-exit CRT evidence are still required and are not claimed here.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -10,6 +10,8 @@ Changes since **v1.5.0**.
 
 ## Important fixes
 
+- Fixed Unicode truss dictionary paths and filenames on Windows while keeping managed asset references portable across platforms.
+
 - Improved PDF output serialization across platforms and locale settings, and
   added deterministic temporary extraction fixtures while retaining unchanged
   compatibility inputs and pinned-library API coverage for final cross-platform

--- a/tests/active_dictionary_storage_test.cpp
+++ b/tests/active_dictionary_storage_test.cpp
@@ -96,8 +96,9 @@ static void TestUnicodeReferenceRoundtrip(const fs::path &root) {
   nlohmann::json serialized = {
       {"owned", ownedReference}, {"external", externalReference}};
   const std::string dumped = serialized.dump();
-  assert(dumped.find(ownedReference) != std::string::npos);
-  assert(dumped.find(externalReference) != std::string::npos);
+  const nlohmann::json reparsed = nlohmann::json::parse(dumped);
+  assert(reparsed.at("owned").get<std::string>() == ownedReference);
+  assert(reparsed.at("external").get<std::string>() == externalReference);
 }
 
 // Verifies deterministic same-name conflict handling for copied assets.

--- a/tests/active_dictionary_storage_test.cpp
+++ b/tests/active_dictionary_storage_test.cpp
@@ -1,5 +1,6 @@
 #include "active_dictionary_storage.h"
 #include "filesystem_path_utils.h"
+#include "json.hpp"
 
 #include <cassert>
 #include <filesystem>
@@ -58,7 +59,45 @@ static void TestReferenceResolution(const fs::path &root) {
 
   assert(ActiveDictionaryStorage::ResolveReference(dict, "beside.gdtf") == beside);
   assert(ActiveDictionaryStorage::ResolveReference(dict, "owned.gdtf") == asset);
-  assert(ActiveDictionaryStorage::ResolveReference(dict, absolute.string()) == absolute);
+  assert(ActiveDictionaryStorage::ResolveReference(
+             dict, PathUtils::PathToUtf8(absolute)) == absolute);
+}
+
+// Verifies Unicode dictionary layouts and JSON-safe portable asset references.
+static void TestUnicodeReferenceRoundtrip(const fs::path &root) {
+  const fs::path defaultDict = root / "fixtures" / "gdtf_dictionary.json";
+  const fs::path dictionary =
+      root / PathUtils::PathFromUtf8("shows/diccionario_niño.json");
+  const fs::path expectedAssetDirectory =
+      root / PathUtils::PathFromUtf8("shows/diccionario_niño_assets");
+  const auto layout = ActiveDictionaryStorage::BuildLayout(
+      ActiveDictionaryStorage::DictionaryKind::Fixtures, dictionary, defaultDict);
+  assert(layout.ownedAssetDirectory == expectedAssetDirectory);
+
+  const fs::path ownedAsset =
+      expectedAssetDirectory / PathUtils::PathFromUtf8("cabeza_móvil_á.gdtf");
+  WriteText(ownedAsset, "owned");
+  const std::string ownedReference =
+      ActiveDictionaryStorage::MakeSerializedReference(layout, ownedAsset);
+  assert(ownedReference == "cabeza_móvil_á.gdtf");
+  assert(PathUtils::PathFromUtf8(ownedReference).is_relative());
+  assert(ActiveDictionaryStorage::ResolveReference(dictionary, ownedReference) ==
+         ownedAsset);
+
+  const fs::path externalAsset =
+      fs::absolute(root / PathUtils::PathFromUtf8("externo/estructura_ñ.gdtf"));
+  WriteText(externalAsset, "external");
+  const std::string externalReference =
+      ActiveDictionaryStorage::MakeSerializedReference(layout, externalAsset);
+  assert(externalReference == PathUtils::PathToUtf8(externalAsset));
+  assert(ActiveDictionaryStorage::ResolveReference(dictionary, externalReference) ==
+         externalAsset);
+
+  nlohmann::json serialized = {
+      {"owned", ownedReference}, {"external", externalReference}};
+  const std::string dumped = serialized.dump();
+  assert(dumped.find(ownedReference) != std::string::npos);
+  assert(dumped.find(externalReference) != std::string::npos);
 }
 
 // Verifies deterministic same-name conflict handling for copied assets.
@@ -93,6 +132,7 @@ int main() {
 
   TestStorageLayouts(root);
   TestReferenceResolution(root);
+  TestUnicodeReferenceRoundtrip(root);
   TestConflictHandling(root);
 
   fs::remove_all(root, ec);

--- a/tests/truss_path_encoding_regression_test.cpp
+++ b/tests/truss_path_encoding_regression_test.cpp
@@ -24,7 +24,6 @@
 #include <fstream>
 #include <string>
 
-#include <wx/filename.h>
 #include <wx/init.h>
 #include <wx/wfstream.h>
 #include <wx/zipstrm.h>
@@ -37,9 +36,9 @@ namespace fs = std::filesystem;
 
 namespace {
 
+// Converts a filesystem path to UTF-8 for string-based application APIs.
 std::string ToUtf8String(const fs::path &path) {
-  std::u8string utf8 = path.u8string();
-  return std::string(utf8.begin(), utf8.end());
+  return PathUtils::PathToUtf8(path);
 }
 
 void SetLibraryPathEnv(const std::string &value) {
@@ -50,10 +49,8 @@ void SetLibraryPathEnv(const std::string &value) {
 #endif
 }
 
+// Writes a minimal truss archive with a supported GLB model resource.
 bool WriteArchive(const fs::path &archivePath) {
-  wxFileName::Mkdir(archivePath.parent_path().string(), wxS_DIR_DEFAULT,
-                    wxPATH_MKDIR_FULL);
-
   wxFileOutputStream output(WxPathUtils::WxStringFromFilesystemPath(archivePath));
   if (!output.IsOk())
     return false;
@@ -66,16 +63,15 @@ bool WriteArchive(const fs::path &archivePath) {
       "<GDTF><FixtureType Manufacturer=\"Perastage\" Name=\"FK40Q\">"
       "<Models><Model Name=\"main\" File=\"main\" Length=\"3.0\" Width=\"0.3\" Height=\"0.3\"/>"
       "</Models></FixtureType></GDTF>";
-  static const char *kSvg =
-      "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"10\" height=\"10\"></svg>";
+  static const char *kGlb = "glTF";
 
   if (!zip.PutNextEntry("description.xml"))
     return false;
   zip.Write(kDescriptionXml, std::strlen(kDescriptionXml));
 
-  if (!zip.PutNextEntry("models/svg/main.svg"))
+  if (!zip.PutNextEntry("models/gltf/main.glb"))
     return false;
-  zip.Write(kSvg, std::strlen(kSvg));
+  zip.Write(kGlb, std::strlen(kGlb));
 
   zip.Close();
   return output.IsOk();
@@ -123,6 +119,7 @@ void RunLastProjectPathCase(const fs::path &tempRoot) {
   restoreOut << previousLastProject;
 }
 
+// Exercises dictionary import and model extraction for one archive path.
 void RunPathCase(const fs::path &sourceDir, const std::string &modelName,
                  const std::string &fileName) {
   fs::create_directories(sourceDir);
@@ -137,7 +134,7 @@ void RunPathCase(const fs::path &sourceDir, const std::string &modelName,
   assert(LoadTrussDefinition(*storedPath, truss));
   assert(!truss.symbolFile.empty());
   assert(fs::exists(PathUtils::PathFromUtf8(truss.symbolFile)));
-  assert(fs::path(PathUtils::PathFromUtf8(truss.symbolFile)).filename() == "main.svg");
+  assert(fs::path(PathUtils::PathFromUtf8(truss.symbolFile)).filename() == "main.glb");
   assert(truss.symbolFile != *storedPath);
 }
 

--- a/tests/truss_path_encoding_regression_test.cpp
+++ b/tests/truss_path_encoding_regression_test.cpp
@@ -22,6 +22,8 @@
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <iostream>
+#include <optional>
 #include <string>
 
 #include <wx/init.h>
@@ -36,11 +38,44 @@ namespace fs = std::filesystem;
 
 namespace {
 
+// Restores the exact prior last-project file state when the test scope ends.
+class LastProjectFileGuard {
+public:
+  // Captures the existing file state for later restoration.
+  explicit LastProjectFileGuard(const fs::path &path) : path_(path) {
+    std::error_code ec;
+    existed_ = fs::exists(path_, ec) && !ec;
+    if (!existed_)
+      return;
+    std::ifstream input(path_, std::ios::binary);
+    previousBytes_.assign(std::istreambuf_iterator<char>(input),
+                          std::istreambuf_iterator<char>());
+  }
+
+  // Restores the previous bytes or removes the test-created file.
+  ~LastProjectFileGuard() {
+    if (existed_) {
+      std::ofstream output(path_, std::ios::binary | std::ios::trunc);
+      output.write(previousBytes_.data(),
+                   static_cast<std::streamsize>(previousBytes_.size()));
+      return;
+    }
+    std::error_code ec;
+    fs::remove(path_, ec);
+  }
+
+private:
+  fs::path path_;
+  bool existed_ = false;
+  std::string previousBytes_;
+};
+
 // Converts a filesystem path to UTF-8 for string-based application APIs.
 std::string ToUtf8String(const fs::path &path) {
   return PathUtils::PathToUtf8(path);
 }
 
+// Sets the writable library override for the current process.
 void SetLibraryPathEnv(const std::string &value) {
 #ifdef _WIN32
   _putenv_s("PERASTAGE_LIBRARY_PATH", value.c_str());
@@ -77,21 +112,88 @@ bool WriteArchive(const fs::path &archivePath) {
   return output.IsOk();
 }
 
-// Simulates legacy mojibake by treating UTF-8 bytes as Latin-1 text.
-std::string MangleUtf8AsLatin1(const std::string &text) {
-  wxString decodedAsUtf8 = wxString::FromUTF8(text.c_str(), text.size());
-  std::string latin1Bytes;
-  latin1Bytes.reserve(decodedAsUtf8.length());
-  for (size_t index = 0; index < decodedAsUtf8.length(); ++index) {
-    const unsigned int value = decodedAsUtf8[index].GetValue();
-    assert(value <= 0xFF);
-    latin1Bytes.push_back(static_cast<char>(value));
+// Reports whether text is structurally valid UTF-8.
+bool IsValidUtf8(const std::string &text) {
+  size_t index = 0;
+  while (index < text.size()) {
+    const unsigned char lead = static_cast<unsigned char>(text[index]);
+    if (lead < 0x80) {
+      ++index;
+      continue;
+    }
+    size_t continuationCount = 0;
+    unsigned int codePoint = 0;
+    if (lead >= 0xC2 && lead <= 0xDF) {
+      continuationCount = 1;
+      codePoint = lead & 0x1F;
+    } else if (lead >= 0xE0 && lead <= 0xEF) {
+      continuationCount = 2;
+      codePoint = lead & 0x0F;
+    } else if (lead >= 0xF0 && lead <= 0xF4) {
+      continuationCount = 3;
+      codePoint = lead & 0x07;
+    } else {
+      return false;
+    }
+    if (index + continuationCount >= text.size())
+      return false;
+    for (size_t offset = 1; offset <= continuationCount; ++offset) {
+      const unsigned char continuation =
+          static_cast<unsigned char>(text[index + offset]);
+      if ((continuation & 0xC0) != 0x80)
+        return false;
+      codePoint = (codePoint << 6) | (continuation & 0x3F);
+    }
+    if ((continuationCount == 2 && codePoint < 0x800) ||
+        (continuationCount == 3 && codePoint < 0x10000) ||
+        codePoint > 0x10FFFF || (codePoint >= 0xD800 && codePoint <= 0xDFFF))
+      return false;
+    index += continuationCount + 1;
   }
-  return latin1Bytes;
+  return true;
+}
+
+// Encodes each original UTF-8 byte as its corresponding Latin-1 code point.
+std::string EncodeUtf8BytesAsLatin1Mojibake(const std::string &text) {
+  std::string mojibake;
+  mojibake.reserve(text.size() * 2);
+  for (const unsigned char byte : text) {
+    if (byte < 0x80) {
+      mojibake.push_back(static_cast<char>(byte));
+      continue;
+    }
+    mojibake.push_back(static_cast<char>(0xC0 | (byte >> 6)));
+    mojibake.push_back(static_cast<char>(0x80 | (byte & 0x3F)));
+  }
+  return mojibake;
+}
+
+// Reads the exact stored last-project bytes for diagnostics.
+std::string ReadStoredBytes(const fs::path &path) {
+  std::ifstream input(path, std::ios::binary);
+  return {std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>()};
+}
+
+// Validates and reports one last-project load stage.
+bool CheckLastProjectStage(const char *stage, const std::string &expected,
+                           const std::optional<std::string> &actual,
+                           const fs::path &storagePath) {
+  if (actual && *actual == expected)
+    return true;
+  const std::string stored = ReadStoredBytes(storagePath);
+  std::cerr << "TrussPathEncodingRegression: last-project " << stage
+            << " stage failed; returned=" << (actual ? "yes" : "no")
+            << "; expected='" << expected << "'";
+  if (actual)
+    std::cerr << "; actual='" << *actual << "'";
+  std::cerr << "; stored_bytes=" << stored.size()
+            << "; stored_valid_utf8=" << (IsValidUtf8(stored) ? "yes" : "no")
+            << '\n';
+  return false;
 }
 
 // Verifies last-project paths survive Unicode and legacy mojibake storage.
-void RunLastProjectPathCase(const fs::path &tempRoot) {
+bool RunLastProjectPathCase(const fs::path &tempRoot) {
   const fs::path projectPath =
       tempRoot / PathUtils::PathFromUtf8("Escenaro_Metal_ViñaRock_1.pstg");
   std::ofstream project(projectPath, std::ios::binary);
@@ -99,24 +201,34 @@ void RunLastProjectPathCase(const fs::path &tempRoot) {
   project.close();
 
   const std::string expectedPath = ToUtf8String(projectPath);
-  const std::string lastProjectPath = ProjectUtils::GetLastProjectPathFile();
-  std::string previousLastProject;
-  {
-    std::ifstream previousIn(lastProjectPath, std::ios::binary);
-    previousLastProject.assign(std::istreambuf_iterator<char>(previousIn),
-                               std::istreambuf_iterator<char>());
+  const fs::path lastProjectPath =
+      PathUtils::PathFromUtf8(ProjectUtils::GetLastProjectPathFile());
+  LastProjectFileGuard restoreLastProject(lastProjectPath);
+
+  if (!ProjectUtils::SaveLastProjectPath(expectedPath)) {
+    std::cerr << "TrussPathEncodingRegression: canonical last-project save failed\n";
+    return false;
+  }
+  const auto canonicalResult = ProjectUtils::LoadLastProjectPath();
+  if (!CheckLastProjectStage("canonical", expectedPath, canonicalResult,
+                             lastProjectPath))
+    return false;
+
+  const std::string mojibake = EncodeUtf8BytesAsLatin1Mojibake(expectedPath);
+  const std::string transformedEnye = "\xC3\x83\xC2\xB1";
+  if (mojibake == expectedPath || !IsValidUtf8(mojibake) ||
+      mojibake.find(transformedEnye) == std::string::npos ||
+      !fs::exists(projectPath)) {
+    std::cerr << "TrussPathEncodingRegression: legacy fixture validation failed\n";
+    return false;
   }
 
-  assert(ProjectUtils::SaveLastProjectPath(expectedPath));
-  assert(ProjectUtils::LoadLastProjectPath() == expectedPath);
-
   std::ofstream legacyOut(lastProjectPath, std::ios::binary | std::ios::trunc);
-  legacyOut << MangleUtf8AsLatin1(expectedPath);
+  legacyOut << mojibake;
   legacyOut.close();
-  assert(ProjectUtils::LoadLastProjectPath() == expectedPath);
-
-  std::ofstream restoreOut(lastProjectPath, std::ios::binary | std::ios::trunc);
-  restoreOut << previousLastProject;
+  const auto legacyResult = ProjectUtils::LoadLastProjectPath();
+  return CheckLastProjectStage("legacy", expectedPath, legacyResult,
+                               lastProjectPath);
 }
 
 // Exercises dictionary import and model extraction for one archive path.
@@ -140,6 +252,7 @@ void RunPathCase(const fs::path &sourceDir, const std::string &modelName,
 
 } // namespace
 
+// Runs the complete Unicode truss and last-project regression sequence.
 int main() {
   wxInitializer initializer;
   assert(initializer.IsOk());
@@ -157,9 +270,9 @@ int main() {
               "Tramo_áéíóú.gdtf");
   RunPathCase(tempRoot / PathUtils::PathFromUtf8("source with spaces"), "FK40Q-Spaces",
               "FK40Q H-300.gdtf");
-  RunLastProjectPathCase(tempRoot);
+  const bool lastProjectPassed = RunLastProjectPathCase(tempRoot);
 
   TrussDictionary::Save({});
   fs::remove_all(tempRoot, ec);
-  return 0;
+  return lastProjectPassed ? 0 : 1;
 }


### PR DESCRIPTION
### Motivation

- Fix a Windows-side `nlohmann::json::dump` `invalid UTF-8 byte` exception caused by serializing native narrow `std::filesystem::path` strings into dictionary JSON; the root cause was `path::string()`/`.filename().string()` producing non-UTF-8 bytes on Windows.
- Repair a stale regression fixture that contained only an SVG (non-renderable for the loader) so the truss loader and test exercise a supported GLB model resource as production expects.
- Keep portable, UTF-8 serialized dictionary references while preserving existing relative/legacy resolution semantics and last-project mojibake recovery.

### Description

- ActiveDictionaryStorage: construct custom `<stem>_assets` directories using native `std::filesystem::path` operations and serialize owned filenames and absolute references with `PathUtils::PathToUtf8` instead of `path::string()`. (changed `MakeSerializedReference`, `GetOwnedAssetDirectory`, `ResolveReference`) Files: `core/active_dictionary_storage.cpp`.
- Truss dictionary boundaries: convert public/config/status/diagnostic path outputs and saved dictionary entries to UTF-8 at API/serialization boundaries by using `PathUtils::PathToUtf8`, and avoid unnecessary `.string()` narrowing for user-visible data. Files: `core/trussdictionary.cpp`.
- Tests and fixtures: update `tests/truss_path_encoding_regression_test.cpp` to include a supported `models/gltf/main.glb` in the archive and use `PathUtils::PathToUtf8` for path text used by APIs, and extend `tests/active_dictionary_storage_test.cpp` with `TestUnicodeReferenceRoundtrip` covering a Unicode dictionary stem, a Unicode owned asset, external absolute Unicode reference, `MakeSerializedReference` UTF-8 output, resolution round-trip, and JSON dumping. Files: `tests/truss_path_encoding_regression_test.cpp`, `tests/active_dictionary_storage_test.cpp`.
- Documentation: appended the PR #2240 exact-head audit evidence and added a narrow user-facing release-note entry describing reliable Unicode truss dictionary paths on Windows. Files: `docs/developer/ci_test_audit.md`, `docs/release-notes-draft.md`.
- Branch and metadata: changes were prepared on branch `codex/repair-truss-path-encoding-regression` from repository `VERSION` `1.5.27` and committed under the message `fix: preserve UTF-8 truss dictionary paths`.

### Testing

- Built and executed the focused `ActiveDictionaryStorage` test binary with `g++` locally and the test passed, validating layout construction, resolution and copy conflict semantics and the new Unicode round-trip coverage.
- Ran repository policy checks which passed: `python3 tests/check_wx_filesystem_path_boundaries.py`, `python3 tests/check_bash_test_registration.py`, `python3 tests/check_ci_workflow_architecture.py`, `bash tests/check_perastage_tree_modules.sh`, and `bash tests/check_no_configmanager_get_in_gui.sh` all returned OK; `git diff --check` also passed.
- Per the audit, the original Linux/macOS symptom was a stale fixture (SVG-only) and is fixed by providing `models/gltf/main.glb` in the regression archive, so symbol-path assertions remain meaningful and preserved.
- Environmental limitation: `cmake --preset wsl-x64-debug` could not configure in this container because wxWidgets libraries/headers are not available, so the full compiled truss/loader test set and exact-head cross-platform CTest run remain to be validated in CI before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a692f4204a08324992cec00f3d58783)