### PR TITLE
Repair Loader3ds native-dimensions test bounds

### DIFF
--- a/docs/developer/ci_test_audit.md
+++ b/docs/developer/ci_test_audit.md
@@ -1766,3 +1766,56 @@ and the corrected truss regression translation unit compiled with the system
 wxWidgets headers. Full CMake configuration remains unavailable because this
 container lacks GLEW; exact-head cross-platform completion and Windows
 normal-exit CRT evidence are still required and are not claimed here.
+
+### PR #2241 final exact-head evidence
+
+PR #2241 merged after authoritative run `30433985589` verified reviewed head
+`9e51750a938dbc5bfbbe42f4f3ca6eb2e30081d2`. Every platform built and ran the
+complete unfiltered suite with `selected_labels = []`.
+
+Linux reported 162 passed, 3 failed, and 1 skipped of 166. Its residual
+failures were `EditableFocusUtils`, `Loader3dsNativeDimensions`, and
+`Viewer2DFboCaptureDiagnostics`. Windows reported 164 passed and 4 failed of
+168; its residual failures were `EditableFocusUtils`, `GdtfShareSecurity`,
+`Loader3dsNativeDimensions`, and `Viewer2DFboCaptureDiagnostics`. macOS
+reported 163 passed and 3 failed of 166; its residual failures matched Linux.
+
+`TrussPathEncodingRegression` and `ActiveDictionaryStorage` passed on all
+three platforms. Both Unicode and spaced truss archives resolved
+`models/gltf/main.glb`, the original Windows nlohmann `type_error.316` /
+invalid UTF-8 exception remained absent, and the focused Windows tests exited
+normally without a CRT leak report associated with
+`TrussPathEncodingRegression`. No new failure was introduced.
+
+### Loader3ds native-dimensions test-helper audit
+
+The original `Loader3dsNativeDimensions` failure occurred on Linux, Windows,
+and macOS at the native Z assertion expecting 290. The interleaved XYZ bounds
+helper iterated while `i + 2 < vertices.size()`. For axis Z and 12 floats, that
+condition visited indices 2, 5, and 8 but rejected index 11, which held the
+only non-zero Z value. X and Y happened to pass because their extrema were at
+indices 3 and 7. This is a test-helper off-by-axis bounds defect; the production
+loader correctly keeps chunk `0x4110` vertices unchanged when local transforms
+are disabled and applies the separately recorded non-identity `0x4160` basis
+only when requested.
+
+The corrected helper validates the axis, non-empty XYZ layout, finite component
+values, and complete vertex triples, exposes invalid input as an explicit
+failure state, and visits every requested component with
+`i < vertices.size()`. The regression now diagnoses the stage, axis, expected
+and actual dimensions, topology counts, and loader error. It also validates
+fixture creation, uses scope-bound temporary-directory cleanup, and checks that
+the transformed dimensions are 0.1 times the native dimensions.
+
+Local Debug configuration and the focused target build completed successfully.
+`Loader3dsNativeDimensions` passed and recovered 12 vertex floats (4 vertices)
+and 6 indices for both meshes. Native dimensions were 290 x 2500 x 290, and
+transformed dimensions were 29 x 250 x 29. The registered controls
+`MeshPrimitivesCubeNormals`, `GdtfLoaderPrimitiveFallback`,
+`GdtfLoaderChannelModeSummaries`, `GdtfLoaderGeometryRoots`, and
+`GdtfLoaderSetPropertiesMutation` also passed. Repository registration,
+workflow architecture, module-tree, GUI configuration-boundary, and diff
+checks passed. No production change was required. The complete 1,968-step
+local target build was stopped after the focused and related targets passed;
+the complete suite was consequently not run. Exact-head cross-platform CI
+totals and normal-exit Windows CRT evidence for this correction remain pending.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -40,6 +40,10 @@ Changes since **v1.5.0**.
 
 ## Technical and packaging changes
 
+- Strengthened internal 3DS loader dimension verification with complete bounds
+  validation, actionable failure diagnostics, and reliable temporary-fixture
+  cleanup.
+
 - Centralized UUID utility build ownership so production and standalone verification targets share one portable compiled implementation.
 
 - Aligned save/load verification with the existing distinction between manually overridden hoist loads and automatically calculated rigging loads.

--- a/tests/loader3ds_native_dimensions_test.cpp
+++ b/tests/loader3ds_native_dimensions_test.cpp
@@ -2,17 +2,21 @@
  * This file is part of Perastage.
  */
 #include <algorithm>
-#include <cassert>
+#include <array>
 #include <cmath>
 #include <cstdint>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <iostream>
 #include <limits>
+#include <optional>
+#include <string>
 #include <vector>
 
 #include <wx/init.h>
 
+#include "filesystem_path_utils.h"
 #include "loader3ds.h"
 
 namespace fs = std::filesystem;
@@ -51,7 +55,7 @@ static void AppendChunk(std::vector<uint8_t> &out, uint16_t id,
 
 // Writes a minimal 3DS mesh with native millimeter vertices and a scaled object
 // basis.
-static void WriteScaledBasis3ds(const fs::path &path) {
+static bool WriteScaledBasis3ds(const fs::path &path) {
   std::vector<uint8_t> vertices;
   AppendValue<uint16_t>(vertices, 4);
   const float points[] = {0.0f, 0.0f,    0.0f, 290.0f, 0.0f, 0.0f,
@@ -90,7 +94,7 @@ static void WriteScaledBasis3ds(const fs::path &path) {
   std::ofstream out(path, std::ios::binary | std::ios::trunc);
   out.write(reinterpret_cast<const char *>(root.data()),
             static_cast<std::streamsize>(root.size()));
-  assert(out.good());
+  return out.good();
 }
 
 // Compares floats with a small tolerance for binary mesh data.
@@ -98,42 +102,169 @@ static bool NearlyEqual(float lhs, float rhs) {
   return std::abs(lhs - rhs) <= 1e-4f;
 }
 
-// Returns one axis size from a loaded mesh bounding box.
-static float MeshAxisSize(const Mesh &mesh, size_t axis) {
+// Removes a temporary directory when its owner leaves scope.
+class TemporaryDirectoryGuard {
+public:
+  // Stores the temporary directory that this guard owns.
+  explicit TemporaryDirectoryGuard(fs::path path) : path_(std::move(path)) {}
+
+  // Removes the owned directory without throwing during scope cleanup.
+  ~TemporaryDirectoryGuard() {
+    std::error_code cleanupError;
+    fs::remove_all(path_, cleanupError);
+  }
+
+  TemporaryDirectoryGuard(const TemporaryDirectoryGuard &) = delete;
+  TemporaryDirectoryGuard &operator=(const TemporaryDirectoryGuard &) = delete;
+
+private:
+  fs::path path_;
+};
+
+// Returns one validated axis size from a loaded mesh bounding box.
+static std::optional<float> MeshAxisSize(const Mesh &mesh, size_t axis,
+                                         std::string &error) {
+  if (axis >= 3) {
+    error = "axis is outside the XYZ range";
+    return std::nullopt;
+  }
+  if (mesh.vertices.empty()) {
+    error = "vertex vector is empty";
+    return std::nullopt;
+  }
+  if (mesh.vertices.size() % 3 != 0) {
+    error = "vertex float count is not divisible by three";
+    return std::nullopt;
+  }
+
   float minValue = std::numeric_limits<float>::max();
   float maxValue = -std::numeric_limits<float>::max();
-  for (size_t i = axis; i + 2 < mesh.vertices.size(); i += 3) {
-    minValue = std::min(minValue, mesh.vertices[i]);
-    maxValue = std::max(maxValue, mesh.vertices[i]);
+  for (size_t i = axis; i < mesh.vertices.size(); i += 3) {
+    const float component = mesh.vertices[i];
+    if (!std::isfinite(component)) {
+      error = "vertex component at float index " + std::to_string(i) +
+              " is not finite";
+      return std::nullopt;
+    }
+    minValue = std::min(minValue, component);
+    maxValue = std::max(maxValue, component);
   }
   return maxValue - minValue;
+}
+
+// Checks mesh topology and dimensions while emitting actionable diagnostics.
+static bool CheckMesh(const char *stage, const Mesh &mesh,
+                      const std::array<float, 3> &expected,
+                      const std::string &loadError,
+                      std::array<float, 3> &actual) {
+  bool valid = true;
+  if (mesh.vertices.size() != 12 || mesh.vertices.size() / 3 != 4 ||
+      mesh.indices.size() != 6) {
+    std::cerr << stage << " mesh topology mismatch: vertex float count="
+              << mesh.vertices.size() << ", vertex count="
+              << mesh.vertices.size() / 3 << ", index count="
+              << mesh.indices.size() << ", load error=" << loadError << '\n';
+    valid = false;
+  }
+
+  constexpr std::array<const char *, 3> axisNames = {"X", "Y", "Z"};
+  for (size_t axis = 0; axis < axisNames.size(); ++axis) {
+    std::string boundsError;
+    const std::optional<float> dimension =
+        MeshAxisSize(mesh, axis, boundsError);
+    if (!dimension || !std::isfinite(*dimension) ||
+        !NearlyEqual(*dimension, expected[axis])) {
+      std::cerr << stage << " dimension mismatch: axis=" << axisNames[axis]
+                << ", expected=" << expected[axis] << ", actual=";
+      if (dimension)
+        std::cerr << *dimension;
+      else
+        std::cerr << "unavailable (" << boundsError << ')';
+      std::cerr << ", vertex float count=" << mesh.vertices.size()
+                << ", vertex count=" << mesh.vertices.size() / 3
+                << ", index count=" << mesh.indices.size()
+                << ", load error=" << loadError << '\n';
+      valid = false;
+    } else {
+      actual[axis] = *dimension;
+    }
+  }
+  return valid;
 }
 
 // Runs the 3DS native-dimensions loader regression test.
 int main() {
   wxInitializer initializer;
-  assert(initializer.IsOk());
+  if (!initializer.IsOk()) {
+    std::cerr << "Failed to initialize wxWidgets.\n";
+    return 1;
+  }
 
   const fs::path tempDir =
       fs::temp_directory_path() / "loader3ds_native_dimensions_test";
   fs::remove_all(tempDir);
-  fs::create_directories(tempDir);
-  const fs::path modelPath = tempDir / "eurotruss_FD34-250.3ds";
-  WriteScaledBasis3ds(modelPath);
+  int result = 0;
+  {
+    TemporaryDirectoryGuard cleanup(tempDir);
+    std::error_code directoryError;
+    if (!fs::create_directories(tempDir, directoryError) || directoryError) {
+      std::cerr << "Failed to create fixture directory: "
+                << directoryError.message() << '\n';
+      result = 1;
+    } else {
+      const fs::path modelPath = tempDir / "eurotruss_FD34-250.3ds";
+      if (!WriteScaledBasis3ds(modelPath) || !fs::is_regular_file(modelPath)) {
+        std::cerr << "Failed to create the 3DS source fixture.\n";
+        result = 1;
+      } else {
+        Mesh nativeMesh;
+        std::string nativeError;
+        const std::string modelPathUtf8 = PathUtils::PathToUtf8(modelPath);
+        if (!Load3DS(modelPathUtf8, nativeMesh, false,
+                     &nativeError)) {
+          std::cerr << "native Load3DS failed: " << nativeError << '\n';
+          result = 1;
+        }
 
-  Mesh nativeMesh;
-  std::string error;
-  assert(Load3DS(modelPath.generic_string(), nativeMesh, false, &error));
-  assert(NearlyEqual(MeshAxisSize(nativeMesh, 0), 290.0f));
-  assert(NearlyEqual(MeshAxisSize(nativeMesh, 1), 2500.0f));
-  assert(NearlyEqual(MeshAxisSize(nativeMesh, 2), 290.0f));
+        Mesh transformedMesh;
+        std::string transformedError;
+        if (!Load3DS(modelPathUtf8, transformedMesh, true,
+                     &transformedError)) {
+          std::cerr << "transformed Load3DS failed: " << transformedError
+                    << '\n';
+          result = 1;
+        }
 
-  Mesh transformedMesh;
-  assert(Load3DS(modelPath.generic_string(), transformedMesh, true, &error));
-  assert(NearlyEqual(MeshAxisSize(transformedMesh, 0), 29.0f));
-  assert(NearlyEqual(MeshAxisSize(transformedMesh, 1), 250.0f));
-  assert(NearlyEqual(MeshAxisSize(transformedMesh, 2), 29.0f));
+        std::array<float, 3> nativeDimensions{};
+        std::array<float, 3> transformedDimensions{};
+        const bool nativeValid =
+            CheckMesh("native", nativeMesh, {290.0f, 2500.0f, 290.0f},
+                      nativeError, nativeDimensions);
+        const bool transformedValid =
+            CheckMesh("transformed", transformedMesh,
+                      {29.0f, 250.0f, 29.0f}, transformedError,
+                      transformedDimensions);
+        if (!nativeValid || !transformedValid) {
+          result = 1;
+        }
 
-  fs::remove_all(tempDir);
-  return 0;
+        for (size_t axis = 0; axis < nativeDimensions.size(); ++axis) {
+          if (!NearlyEqual(transformedDimensions[axis],
+                           nativeDimensions[axis] * 0.1f)) {
+            std::cerr << "transformed scale mismatch at axis " << axis
+                      << ": native=" << nativeDimensions[axis]
+                      << ", transformed=" << transformedDimensions[axis]
+                      << '\n';
+            result = 1;
+          }
+        }
+      }
+    }
+  }
+
+  if (fs::exists(tempDir)) {
+    std::cerr << "Temporary fixture directory was not removed.\n";
+    result = 1;
+  }
+  return result;
 }


### PR DESCRIPTION
### Motivation

- Fix a test-helper off-by-axis traversal bug that caused Z extents to be computed incorrectly for interleaved XYZ vertex buffers.
- Make the native/transformed-dimension checks actionable and robust so failures report stage, axis, expected/actual values, and topology counts instead of aborting with an unhelpful assertion.
- Preserve production loader behavior (no geometry/loader changes) while ensuring the fixture lifecycle and temporary resources are cleaned reliably.

### Description

- Replaced the fragile helper with a validated bounds helper that returns `std::optional<float>`, rejects `axis >= 3`, empty vertex vectors, and vertex-float counts not divisible by 3, iterates using `i < vertices.size()`, and rejects non-finite components; it visits every requested component for the given axis. (modified `tests/loader3ds_native_dimensions_test.cpp`).
- Added `TemporaryDirectoryGuard` RAII cleanup for the temporary fixture and made `WriteScaledBasis3ds` return success so fixture creation is validated before loading. (modified `tests/loader3ds_native_dimensions_test.cpp`).
- Added `CheckMesh` diagnostics that print stage (native/transformed), axis name, expected/actual dimension, vertex float count, vertex count, index count, and loader error to produce actionable failure messages. (modified `tests/loader3ds_native_dimensions_test.cpp`).
- Ensure `Load3DS` is called with UTF-8 path using `PathUtils::PathToUtf8` at the test boundary and preserved the loader contract (no production change). (modified `tests/loader3ds_native_dimensions_test.cpp`).
- Recorded PR #2241 final exact-head run evidence and added a concise internal release-note entry about the strengthened 3DS loader test verification. (modified `docs/developer/ci_test_audit.md` and `docs/release-notes-draft.md`).
- Files changed: `tests/loader3ds_native_dimensions_test.cpp`, `docs/developer/ci_test_audit.md`, and `docs/release-notes-draft.md`.
- Base branch metadata recorded during preparation: main SHA `d7404c0e3d3886acb6044c592e5a72f0714a3f46`, `VERSION` `1.5.28`.

### Testing

- Configured and built focused Debug targets: `cmake -S . -B build/wsl-x64-debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON -DPERASTAGE_ENABLE_COMPILER_CACHE=OFF -DPERASTAGE_ENABLE_MVR_XCHANGE_MDNS=OFF` succeeded in this environment.
- Built and ran the focused test: `cmake --build build/wsl-x64-debug --target loader3ds_native_dimensions_test -j2` and `ctest --test-dir build/wsl-x64-debug -R '^Loader3dsNativeDimensions$' --output-on-failure` — `Loader3dsNativeDimensions` passed.
- Built and ran five related registered controls and they passed: `MeshPrimitivesCubeNormals`, `GdtfLoaderPrimitiveFallback`, `GdtfLoaderChannelModeSummaries`, `GdtfLoaderGeometryRoots`, and `GdtfLoaderSetPropertiesMutation`.
- Repository policy checks passed: `python3 tests/check_bash_test_registration.py`, `python3 tests/check_ci_workflow_architecture.py`, `bash tests/check_perastage_tree_modules.sh`, `bash tests/check_no_configmanager_get_in_gui.sh`, and `git diff --check`.
- Observed results from focused verification: native mesh has 12 vertex floats (4 vertices) and 6 indices with native dimensions 290 × 2500 × 290 and transformed dimensions 29 × 250 × 29; transformed dimensions are verified to be exactly 0.1× native within existing tolerance.
- Note: a complete local build of all targets (1,968 Ninja steps) was started but intentionally stopped after focused and related targets completed, so a full local-suite run was not finished here; a new exact-head cross-platform Debug CI run is still required before merge to confirm the change on Linux, Windows, and macOS and to verify no focused normal-exit CRT leak remains.

DO NOT MERGE: wait for the requested cross-platform CI run confirming `Loader3dsNativeDimensions` passes on all platforms and that no new failures or focused Windows CRT leak remain.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a69ba44b83483249d69deed67fa2d6e)