### PR TITLE
Repair Viewer2D FBO capture diagnostics guard

### DIFF
--- a/docs/developer/ci_test_audit.md
+++ b/docs/developer/ci_test_audit.md
@@ -1917,3 +1917,24 @@ passed. Direct builds and executions of `ShortcutRegistry`,
 descendant coverage was not added because wxWidgets does not expose a shared,
 portable combo editor-child API that models the native focus hierarchy on all
 supported ports. Corrective exact-head cross-platform evidence remains pending.
+
+### PR #2243 final exact-head evidence
+
+Authoritative run `30443904491` exercised final reviewed head
+`b8a952bb0fffa4991160606ae0f8fd75b143399c` with the `pr` profile. Every
+platform generated the complete CTest inventory, built the complete target
+set, executed the complete unfiltered suite, reported `selected_labels = []`
+and `disabled_not_run = 0`, uploaded result and diagnostic artifacts, and
+retained genuine CTest failure status.
+
+Linux reported 164 passed, 1 failed, and 1 skipped of 166.
+`EditableFocusUtils` passed in 0.56 seconds. The only remaining failure was
+`Viewer2DFboCaptureDiagnostics`, and `CredentialStoreNativeRoundTrip` was the
+only skipped test. Windows reported 166 passed and 2 failed of 168.
+`EditableFocusUtils` passed in 0.14 seconds with no focused normal-exit CRT
+leak; the remaining failures were `Viewer2DFboCaptureDiagnostics` and
+`GdtfShareSecurity`. macOS reported 165 passed and 1 failed of 166.
+`EditableFocusUtils` passed in 0.83 seconds, and the only remaining failure was
+`Viewer2DFboCaptureDiagnostics`.
+
+PR #2243 therefore reached its safe merge gate.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -43,6 +43,9 @@ Changes since **v1.5.0**.
 
 ## Technical and packaging changes
 
+- Updated the internal Viewer2D framebuffer diagnostics verification to track
+  cached capture-target failure reasons accurately after cache acquisition.
+
 - Strengthened internal 3DS loader dimension verification with complete bounds
   validation, actionable failure diagnostics, and reliable temporary-fixture
   cleanup.

--- a/tests/check_viewer2d_fbo_capture_diagnostics.sh
+++ b/tests/check_viewer2d_fbo_capture_diagnostics.sh
@@ -6,12 +6,13 @@ require_ripgrep
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 panel_cpp="$repo_root/viewer2d/viewer2dpanel.cpp"
 panel_h="$repo_root/viewer2d/viewer2dpanel.h"
+framebuffer_cpp="$repo_root/viewer_common/gl_framebuffer_capture_target.cpp"
 report_h="$repo_root/core/diagnostics/DiagnosticReport.h"
 report_cpp="$repo_root/core/diagnostics/DiagnosticReport.cpp"
 offscreen_cpp="$repo_root/viewer2d/viewer2doffscreenrenderer.cpp"
 cmake_tests="$repo_root/tests/CMakeLists.txt"
 
-for required in "$panel_cpp" "$panel_h" "$report_h" "$report_cpp" "$offscreen_cpp"; do
+for required in "$panel_cpp" "$panel_h" "$framebuffer_cpp" "$report_h" "$report_cpp" "$offscreen_cpp"; do
   if [[ ! -f "$required" ]]; then
     echo "Missing required Viewer2D FBO capture diagnostics file: ${required#$repo_root/}" >&2
     exit 1
@@ -42,20 +43,158 @@ print(match.group(0))
 PY
 )"
 
-if [[ "$render_body" != *"RecordViewer2DFboCapture"* || "$render_body" != *"glReadPixels"* ]]; then
-  echo "RenderToRGBA must record FBO success after GL_COLOR_ATTACHMENT0 readback" >&2
-  exit 1
-fi
+run_test_python - "$panel_cpp" "$framebuffer_cpp" "$report_cpp" <<'PY'
+import re
+import sys
 
-if [[ "$render_body" != *"RecordViewer2DBackBufferFallback"* || "$render_body" != *"target.Diagnostic()"* ]]; then
-  echo "RenderToRGBA must record fallback usage with the FBO diagnostic reason" >&2
-  exit 1
-fi
 
-if [[ "$render_body" != *"RecordViewer2DCaptureFailure"* ]]; then
-  echo "RenderToRGBA must record definitive capture failures" >&2
-  exit 1
-fi
+def function_body(path, signature):
+    text = open(path, encoding="utf-8").read()
+    start = text.find(signature)
+    if start < 0:
+        raise SystemExit(f"Could not find bounded function: {signature}")
+    brace = text.find("{", start)
+    if brace < 0:
+        raise SystemExit(f"Could not find function body: {signature}")
+    depth = 0
+    for position in range(brace, len(text)):
+        if text[position] == "{":
+            depth += 1
+        elif text[position] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start : position + 1]
+    raise SystemExit(f"Could not bound function body: {signature}")
+
+
+def require(condition, message):
+    if not condition:
+        raise SystemExit(message)
+
+
+panel = function_body(sys.argv[1], "bool Viewer2DPanel::RenderToRGBA(")
+cache = function_body(
+    sys.argv[2], "FramebufferCaptureTarget *FramebufferCaptureTargetCache::Acquire("
+)
+read_binding = function_body(
+    sys.argv[2], "void FramebufferCaptureTarget::BindForReading() const"
+)
+fallback_recorder = function_body(
+    sys.argv[3], "void DiagnosticReport::RecordViewer2DBackBufferFallback("
+)
+
+acquisition = re.search(
+    r"FramebufferCaptureTarget\s*\*\s*(\w+)\s*=\s*"
+    r"([\w>.\-]+)->Acquire\s*\(\s*w\s*,\s*h\s*\)",
+    panel,
+)
+require(acquisition, "RenderToRGBA must acquire a FramebufferCaptureTarget from the cache")
+target_name, cache_expression = acquisition.groups()
+failure_branch = re.search(
+    rf"if\s*\(\s*!\s*{re.escape(target_name)}\s*\|\|\s*!\s*"
+    rf"{re.escape(target_name)}\s*->\s*IsComplete\s*\(\s*\)\s*\)\s*"
+    r"\{([\s\S]*?)\n\s*\}",
+    panel,
+)
+require(failure_branch, "RenderToRGBA must fall back for null or incomplete cache acquisitions")
+failure = failure_branch.group(1)
+diagnostic_read = re.search(
+    rf"(?:const\s+)?std::string\s+(\w+)\s*=\s*{re.escape(cache_expression)}"
+    r"->Diagnostic\s*\(\s*\)\s*;",
+    failure,
+)
+require(
+    diagnostic_read,
+    "RenderToRGBA must read the framebuffer cache diagnostic after acquisition failure",
+)
+diagnostic_name = diagnostic_read.group(1)
+recorder = re.search(
+    r"RecordViewer2DBackBufferFallback\s*\(([^;]+)\)\s*;", failure
+)
+require(recorder, "RenderToRGBA must record fallback usage before invoking the fallback")
+recorder_arguments = recorder.group(1)
+require(
+    re.search(rf"\b{re.escape(diagnostic_name)}\b", recorder_arguments),
+    "RenderToRGBA must forward the cache diagnostic to the fallback recorder",
+)
+require(
+    re.search(
+        rf"\b{re.escape(diagnostic_name)}\s*\.\s*empty\s*\(\s*\)\s*\?\s*"
+        r'"FBO unavailable"\s*:\s*' + rf"{re.escape(diagnostic_name)}\b",
+        recorder_arguments,
+    ),
+    "RenderToRGBA must retain an explicit default reason for an empty cache diagnostic",
+)
+fallback_call = re.search(r"RenderToRGBABackBufferFallback\s*\(", failure)
+require(
+    fallback_call and recorder.start() < fallback_call.start(),
+    "RenderToRGBA must record fallback usage before invoking the fallback",
+)
+
+failure_path = re.search(
+    r"if\s*\(\s*!\s*(\w+)\.target\.EnsureSize\s*\([^)]*\)\s*\|\|\s*"
+    r"!\s*\1\.target\.IsComplete\s*\(\s*\)\s*\)\s*\{([\s\S]*?)\n\s*\}",
+    cache,
+)
+require(failure_path, "FramebufferCaptureTargetCache::Acquire must reject failed or incomplete targets")
+created_name, failed_creation = failure_path.groups()
+diagnostic_copy = re.search(
+    rf"diagnostic_\s*=\s*{re.escape(created_name)}\.target\.Diagnostic\s*\(\s*\)\s*;",
+    failed_creation,
+)
+null_return = re.search(r"return\s+nullptr\s*;", failed_creation)
+require(
+    diagnostic_copy and null_return and diagnostic_copy.end() <= null_return.start(),
+    "FramebufferCaptureTargetCache::Acquire must preserve the target diagnostic before returning nullptr",
+)
+clear_positions = [match.start() for match in re.finditer(r"diagnostic_\.clear\s*\(\s*\)\s*;", cache)]
+pointer_returns = [match.start() for match in re.finditer(r"return\s+&[^;]+\.target\s*;", cache)]
+require(
+    len(clear_positions) >= 2
+    and len(pointer_returns) >= 2
+    and clear_positions[0] < pointer_returns[0]
+    and pointer_returns[0] < clear_positions[-1] < pointer_returns[-1],
+    "Successful cache acquisition must clear stale failure diagnostics",
+)
+
+for token, message in (
+    ("BindForRendering", "RenderToRGBA must use the dedicated framebuffer helper"),
+    ("BindForReading", "RenderToRGBA must bind the framebuffer helper for reading"),
+    ("glReadPixels", "RenderToRGBA must retain pixel readback in the FBO path"),
+    ("RecordViewer2DFboCapture", "RenderToRGBA must record successful FBO capture"),
+):
+    require(token in panel, message)
+require(
+    panel.index("BindForReading") < panel.index("glReadPixels") < panel.index("RecordViewer2DFboCapture"),
+    "RenderToRGBA must record FBO success after framebuffer readback",
+)
+require("GL_BACK" not in panel, "The main RenderToRGBA FBO path must not read from GL_BACK")
+require(
+    "GL_COLOR_ATTACHMENT0" in read_binding,
+    "FramebufferCaptureTarget::BindForReading must retain GL_COLOR_ATTACHMENT0 as the read source",
+)
+
+for reason in (
+    "Invalid capture target size",
+    "Unable to allocate capture buffer",
+    "OpenGL initialization failed",
+):
+    reason_position = panel.find(f'"{reason}"')
+    require(
+        reason_position >= 0
+        and panel.rfind("RecordViewer2DCaptureFailure", 0, reason_position) >= 0,
+        f'RenderToRGBA must record definitive capture failure: {reason}',
+    )
+
+for token, message in (
+    ("++g_viewer2DCaptureInfo.fallbackCount", "Fallback diagnostics must increment fallbackCount"),
+    ("g_viewer2DCaptureInfo.lastDiagnostic = reason", "Fallback diagnostics must store the fallback reason"),
+    ("g_viewer2DCaptureInfo.fallbackEverUsed = true", "Fallback diagnostics must mark fallbackEverUsed"),
+    ("ShouldLogViewer2DBackendTransition", "Fallback diagnostics must retain low-noise transition logging"),
+    ("DiagnosticLogger::Warning", "Fallback diagnostics must use the local diagnostic logger"),
+):
+    require(token in fallback_recorder, message)
+PY
 
 for token in \
   "Viewer2D RGBA capture backend" \


### PR DESCRIPTION
### Motivation
- The existing static test expected a per-target `target.Diagnostic()` token that became invalid after the framebuffer-target-cache refactor which may return `nullptr` while preserving diagnostics at the cache level.
- Update the structural guard to verify the actual cache-diagnostic propagation chain without altering production rendering or diagnostics behavior.

### Description
- Replaced the brittle string assertions in `tests/check_viewer2d_fbo_capture_diagnostics.sh` with a bounded Python inspection that extracts and validates `Viewer2DPanel::RenderToRGBA`, `FramebufferCaptureTargetCache::Acquire`, `FramebufferCaptureTarget::BindForReading`, and `DiagnosticReport::RecordViewer2DBackBufferFallback` semantics (acquire, failure branch, cache diagnostic read, forwarding the diagnostic to the fallback recorder, default "FBO unavailable", and fallback-before-call ordering).
- Added `viewer_common/gl_framebuffer_capture_target.cpp` to the test file list so the guard can verify cache diagnostic copy/clear behavior and `BindForReading` semantics. The guard also preserves checks for `glReadPixels` + `RecordViewer2DFboCapture`, `GL_COLOR_ATTACHMENT0` read source, `GL_BACK` isolation, and definitive `RecordViewer2DCaptureFailure` paths.
- Appended PR #2243 final exact-head evidence to `docs/developer/ci_test_audit.md` and recorded a small internal verification note in `docs/release-notes-draft.md`; no production C++ code was changed.

### Testing
- Ran syntax and static checks: `bash -n tests/check_viewer2d_fbo_capture_diagnostics.sh` (passed) and `git diff --check` (no issues).
- Executed the focused guard repeatedly: `PERASTAGE_TEST_BASH=/bin/bash PERASTAGE_TEST_PYTHON="$(command -v python3)" bash tests/check_viewer2d_fbo_capture_diagnostics.sh` (5 deterministic runs passed).
- Ran companion Viewer2D guards: `tests/check_viewer2d_render_to_rgba_fbo_boundary.sh`, `tests/check_viewer2d_state_ownership_boundary.sh`, and `tests/check_layout_preview_failure_diagnostics.sh` (all passed).
- Ran repository policy checks: `python3 tests/check_bash_test_registration.py`, `python3 tests/check_ci_workflow_architecture.py`, `bash tests/check_perastage_tree_modules.sh`, and `bash tests/check_no_configmanager_get_in_gui.sh` (all passed).
- Note: no full `ctest` Debug build run was executed in this environment; an exact-head cross-platform CI Debug Tests run is required before merge to confirm final platform totals and residuals.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a69dc79a67083248162dc53c9a121eb)