### PR TITLE
Fix grouped transform targeting and exact table edits

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -67,6 +67,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/rigging_extra_weight_settings.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/riderimporter.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/scene_grouping.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/scene_node_operations.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/scene_transform_integrity.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/scene_object_truss_converter.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/scenedatamanager.cpp

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -67,6 +67,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/rigging_extra_weight_settings.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/riderimporter.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/scene_grouping.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/scene_transform_integrity.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/scene_object_truss_converter.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/scenedatamanager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/simplecrypt.cpp

--- a/core/magnet_snap.cpp
+++ b/core/magnet_snap.cpp
@@ -312,7 +312,7 @@ scene_grouping::SceneTransformTarget SnapTransformTarget(
   if (result.sourceType == ObjectType::Fixture)
     return TargetFor(result.sourceType, result.sourceUuid);
 
-  const auto targets = scene_grouping::BuildTransformTargets(
+  const auto targets = scene_grouping::BuildInteractiveTransformTargets(
       scene, SelectionForSource(result.sourceType, result.sourceUuid));
   if (!targets.empty())
     return targets.front();

--- a/core/scene_grouping.cpp
+++ b/core/scene_grouping.cpp
@@ -924,6 +924,28 @@ BuildInteractiveTransformTargets(const MvrScene &scene,
   return targets;
 }
 
+// Builds selection-preserving feedback for interactive transform scope.
+SelectionFeedback BuildInteractiveSelectionFeedback(
+    const MvrScene &scene, const ObjectSelection &selection) {
+  SelectionFeedback feedback;
+  std::unordered_set<std::string> selectedSeen;
+  for (const auto &object : CollectSelectedObjects(scene, selection))
+    AppendUnique(feedback.selectedUuids, selectedSeen, object.uuid);
+
+  feedback.effectiveTargets =
+      BuildInteractiveTransformTargets(scene, selection);
+  std::unordered_set<std::string> highlightedSeen;
+  for (const auto &target : feedback.effectiveTargets) {
+    if (target.type == MvrNodeType::GroupObject)
+      AppendGroupChildrenForHighlights(scene, target.uuid,
+                                      feedback.highlightedUuids,
+                                      highlightedSeen);
+    else
+      AppendUnique(feedback.highlightedUuids, highlightedSeen, target.uuid);
+  }
+  return feedback;
+}
+
 // Returns the current world transform for one effective transform target.
 Matrix GetTargetWorldTransform(const MvrScene &scene,
                                const SceneTransformTarget &target) {
@@ -1020,7 +1042,8 @@ ExpandSelectionForGroupHighlights(const MvrScene &scene,
                                   const ObjectSelection &selection) {
   std::vector<std::string> expanded;
   std::unordered_set<std::string> seen;
-  for (const auto &target : BuildTransformTargets(scene, selection)) {
+  for (const auto &target :
+       BuildInteractiveSelectionFeedback(scene, selection).effectiveTargets) {
     if (target.type == MvrNodeType::GroupObject) {
       AppendGroupChildrenForHighlights(scene, target.uuid, expanded, seen);
     } else {
@@ -1049,12 +1072,8 @@ ExpandHoverForGroupHighlights(const MvrScene &scene, const std::string &uuid) {
   else
     return expanded;
 
-  std::unordered_set<std::string> seen;
-  for (const auto &target : BuildTransformTargets(scene, selection)) {
-    if (target.type != MvrNodeType::GroupObject)
-      continue;
-    AppendGroupChildrenForHighlights(scene, target.uuid, expanded, seen);
-  }
+  expanded =
+      BuildInteractiveSelectionFeedback(scene, selection).highlightedUuids;
   expanded.erase(std::remove(expanded.begin(), expanded.end(), uuid),
                  expanded.end());
   return expanded;

--- a/core/scene_grouping.cpp
+++ b/core/scene_grouping.cpp
@@ -877,6 +877,53 @@ BuildTransformTargets(const MvrScene &scene, const ObjectSelection &selection) {
   return targets;
 }
 
+// Builds exact transform targets in deterministic selection order.
+std::vector<SceneTransformTarget>
+BuildExactTransformTargets(const MvrScene &scene,
+                           const ObjectSelection &selection) {
+  std::vector<SceneTransformTarget> targets;
+  std::set<std::pair<MvrNodeType, std::string>> seen;
+  for (const auto &object : CollectSelectedObjects(scene, selection)) {
+    if (seen.insert({object.type, object.uuid}).second)
+      targets.push_back({object.type, object.uuid});
+  }
+  return targets;
+}
+
+// Builds interactive targets while promoting grouped trusses only.
+std::vector<SceneTransformTarget>
+BuildInteractiveTransformTargets(const MvrScene &scene,
+                                 const ObjectSelection &selection) {
+  struct Candidate {
+    SceneTransformTarget target;
+    std::string rootGroupUuid;
+  };
+
+  std::vector<Candidate> candidates;
+  std::set<std::string> promotedGroups;
+  for (const auto &object : CollectSelectedObjects(scene, selection)) {
+    const std::string rootUuid = ResolveRootGroupUuid(scene, object);
+    SceneTransformTarget target{object.type, object.uuid};
+    if (object.type == MvrNodeType::Truss && !rootUuid.empty()) {
+      target = {MvrNodeType::GroupObject, rootUuid};
+      promotedGroups.insert(rootUuid);
+    }
+    candidates.push_back({std::move(target), rootUuid});
+  }
+
+  std::vector<SceneTransformTarget> targets;
+  std::set<std::pair<MvrNodeType, std::string>> seen;
+  for (const auto &candidate : candidates) {
+    if (candidate.target.type != MvrNodeType::GroupObject &&
+        !candidate.rootGroupUuid.empty() &&
+        promotedGroups.find(candidate.rootGroupUuid) != promotedGroups.end())
+      continue;
+    if (seen.insert({candidate.target.type, candidate.target.uuid}).second)
+      targets.push_back(candidate.target);
+  }
+  return targets;
+}
+
 // Returns the current world transform for one effective transform target.
 Matrix GetTargetWorldTransform(const MvrScene &scene,
                                const SceneTransformTarget &target) {
@@ -927,7 +974,7 @@ void SetTargetWorldTransform(MvrScene &scene,
 void TranslateSelection(MvrScene &scene, const ObjectSelection &selection,
                         const std::array<float, 3> &deltaMm,
                         transform_space::TransformSpace space) {
-  const auto targets = BuildTransformTargets(scene, selection);
+  const auto targets = BuildInteractiveTransformTargets(scene, selection);
   for (const auto &target : targets) {
     const Matrix transform = GetTargetWorldTransform(scene, target);
     SetTargetWorldTransform(
@@ -950,7 +997,7 @@ void RotateSelectionAroundPivot(MvrScene &scene,
   else
     rotation = MatrixUtils::EulerToMatrix(angleDeg, 0.0f, 0.0f);
 
-  const auto targets = BuildTransformTargets(scene, selection);
+  const auto targets = BuildInteractiveTransformTargets(scene, selection);
   Matrix effectiveRotation = rotation;
   if (space == transform_space::TransformSpace::Local && !targets.empty()) {
     const Matrix reference = transform_space::ExtractOrientation(

--- a/core/scene_grouping.h
+++ b/core/scene_grouping.h
@@ -48,6 +48,12 @@ struct OperationResult {
   std::vector<std::string> affectedSceneObjects;
 };
 
+struct SelectionFeedback {
+  std::vector<std::string> selectedUuids;
+  std::vector<SceneTransformTarget> effectiveTargets;
+  std::vector<std::string> highlightedUuids;
+};
+
 // Synchronizes GroupObject children to the layer owned by their parent group.
 std::size_t SynchronizeGroupObjectLayerOwnership(MvrScene &scene);
 
@@ -82,6 +88,10 @@ BuildExactTransformTargets(const MvrScene &scene,
 std::vector<SceneTransformTarget>
 BuildInteractiveTransformTargets(const MvrScene &scene,
                                  const ObjectSelection &selection);
+
+// Builds selection-preserving feedback for interactive transform scope.
+SelectionFeedback BuildInteractiveSelectionFeedback(
+    const MvrScene &scene, const ObjectSelection &selection);
 
 // Returns the current world transform for one transform target.
 Matrix GetTargetWorldTransform(const MvrScene &scene,

--- a/core/scene_grouping.h
+++ b/core/scene_grouping.h
@@ -69,9 +69,19 @@ OperationResult RemoveSelectionFromGroup(MvrScene &scene,
 OperationResult UngroupSelection(MvrScene &scene,
                                  const ObjectSelection &selection);
 
-// Builds effective transform roots so grouped objects behave as single units.
+// Builds structural group roots for grouping, ungrouping, and highlighting.
 std::vector<SceneTransformTarget>
 BuildTransformTargets(const MvrScene &scene, const ObjectSelection &selection);
+
+// Builds exact node targets without promoting grouped children.
+std::vector<SceneTransformTarget>
+BuildExactTransformTargets(const MvrScene &scene,
+                           const ObjectSelection &selection);
+
+// Builds interactive targets, promoting only grouped trusses to root groups.
+std::vector<SceneTransformTarget>
+BuildInteractiveTransformTargets(const MvrScene &scene,
+                                 const ObjectSelection &selection);
 
 // Returns the current world transform for one transform target.
 Matrix GetTargetWorldTransform(const MvrScene &scene,

--- a/core/scene_node_operations.cpp
+++ b/core/scene_node_operations.cpp
@@ -1,0 +1,177 @@
+#include "scene_node_operations.h"
+
+#include <algorithm>
+#include <set>
+
+namespace scene_node_operations {
+namespace {
+
+// Removes every matching typed child reference from all groups.
+void RemoveChildReferences(MvrScene &scene, MvrNodeType type,
+                           const std::string &uuid) {
+  for (auto &[groupUuid, group] : scene.groupObjects) {
+    std::erase_if(group.children, [&](const GroupObjectChildRef &child) {
+      return child.type == type && child.uuid == uuid;
+    });
+  }
+}
+
+// Returns whether a typed scene node currently exists.
+bool NodeExists(const MvrScene &scene, MvrNodeType type,
+                const std::string &uuid) {
+  switch (type) {
+  case MvrNodeType::Fixture: return scene.fixtures.contains(uuid);
+  case MvrNodeType::Truss: return scene.trusses.contains(uuid);
+  case MvrNodeType::Support: return scene.supports.contains(uuid);
+  case MvrNodeType::SceneObject: return scene.sceneObjects.contains(uuid);
+  case MvrNodeType::GroupObject: return scene.groupObjects.contains(uuid);
+  }
+  return false;
+}
+
+// Removes a node map entry after its hierarchy references have been cleared.
+bool EraseNode(MvrScene &scene, MvrNodeType type, const std::string &uuid) {
+  RemoveChildReferences(scene, type, uuid);
+  switch (type) {
+  case MvrNodeType::Fixture:
+    for (auto &[supportUuid, support] : scene.supports) {
+      if (support.motorFixtureUuid == uuid)
+        support.motorFixtureUuid.clear();
+    }
+    return scene.fixtures.erase(uuid) != 0;
+  case MvrNodeType::Truss: return scene.trusses.erase(uuid) != 0;
+  case MvrNodeType::Support: return scene.supports.erase(uuid) != 0;
+  case MvrNodeType::SceneObject: return scene.sceneObjects.erase(uuid) != 0;
+  case MvrNodeType::GroupObject: return scene.groupObjects.erase(uuid) != 0;
+  }
+  return false;
+}
+
+// Recursively collects a GroupObject subtree in child-first order.
+void CollectGroupSubtree(const MvrScene &scene, const std::string &groupUuid,
+                         std::vector<scene_grouping::SceneTransformTarget> &out,
+                         std::set<std::string> &visited) {
+  if (!visited.insert(groupUuid).second)
+    return;
+  const auto groupIt = scene.groupObjects.find(groupUuid);
+  if (groupIt == scene.groupObjects.end())
+    return;
+  for (const auto &child : groupIt->second.children) {
+    if (child.type == MvrNodeType::GroupObject)
+      CollectGroupSubtree(scene, child.uuid, out, visited);
+    else
+      out.push_back({child.type, child.uuid});
+  }
+  out.push_back({MvrNodeType::GroupObject, groupUuid});
+}
+
+// Prunes empty groups until every remaining group owns at least one child.
+void PruneEmptyGroups(MvrScene &scene, RemovalResult &result) {
+  bool removed = true;
+  while (removed) {
+    removed = false;
+    std::vector<std::string> empty;
+    for (const auto &[uuid, group] : scene.groupObjects) {
+      if (group.children.empty())
+        empty.push_back(uuid);
+    }
+    std::sort(empty.begin(), empty.end());
+    for (const auto &uuid : empty) {
+      if (!scene.groupObjects.contains(uuid))
+        continue;
+      RemoveChildReferences(scene, MvrNodeType::GroupObject, uuid);
+      scene.groupObjects.erase(uuid);
+      result.removedEmptyGroups.push_back(uuid);
+      result.changed = true;
+      removed = true;
+    }
+  }
+}
+
+} // namespace
+
+// Applies an exact world transform while preserving hierarchy-local metadata.
+bool ApplyExactWorldTransform(MvrScene &scene, MvrNodeType type,
+                              const std::string &uuid,
+                              const Matrix &worldTransform) {
+  if (!NodeExists(scene, type, uuid))
+    return false;
+  scene_grouping::SetTargetWorldTransform(scene, {type, uuid}, worldTransform);
+  return true;
+}
+
+// Converts one Fixture to a Support atomically while preserving its identity.
+ConversionResult ConvertFixtureToSupport(MvrScene &scene,
+                                         const std::string &fixtureUuid) {
+  const auto fixtureIt = scene.fixtures.find(fixtureUuid);
+  if (fixtureIt == scene.fixtures.end())
+    return {.error = "fixture not found"};
+  if (scene.supports.contains(fixtureUuid))
+    return {.error = "support UUID already exists"};
+
+  const Fixture &fixture = fixtureIt->second;
+  Support support;
+  support.uuid = fixture.uuid;
+  support.name = fixture.instanceName;
+  support.gdtfSpec = fixture.gdtfSpec;
+  support.gdtfMode = fixture.gdtfMode;
+  support.function = fixture.function.empty() ? "Hoist" : fixture.function;
+  support.position = fixture.position;
+  support.positionName = fixture.positionName;
+  support.layer = fixture.layer;
+  support.loadKg = fixture.weightKg;
+  support.motorName =
+      fixture.instanceName.empty() ? fixture.typeName : fixture.instanceName;
+  support.motorModel = fixture.gdtfMode;
+  support.motorFixtureUuid.clear();
+  support.hoistDataSource = "Manual";
+  support.hoistFunction = NormalizeHoistFunction(support.function);
+  support.transform = fixture.transform;
+  support.localTransform = fixture.localTransform;
+  support.hasLocalTransform = fixture.hasLocalTransform;
+  support.parentGroupUuid = fixture.parentGroupUuid;
+
+  for (auto &[groupUuid, group] : scene.groupObjects) {
+    for (auto &child : group.children) {
+      if (child.type == MvrNodeType::Fixture && child.uuid == fixtureUuid)
+        child.type = MvrNodeType::Support;
+    }
+  }
+  scene.supports.emplace(fixtureUuid, std::move(support));
+  scene.fixtures.erase(fixtureIt);
+  return {.changed = true, .uuid = fixtureUuid};
+}
+
+// Removes typed nodes and recursively prunes empty ancestor groups.
+RemovalResult RemoveNodes(
+    MvrScene &scene,
+    const std::vector<scene_grouping::SceneTransformTarget> &targets) {
+  RemovalResult result;
+  std::vector<scene_grouping::SceneTransformTarget> expanded;
+  std::set<std::pair<MvrNodeType, std::string>> requested;
+  std::set<std::string> visitedGroups;
+  for (const auto &target : targets) {
+    if (!requested.insert({target.type, target.uuid}).second)
+      continue;
+    if (target.type == MvrNodeType::GroupObject)
+      CollectGroupSubtree(scene, target.uuid, expanded, visitedGroups);
+    else
+      expanded.push_back(target);
+  }
+
+  std::set<std::pair<MvrNodeType, std::string>> removed;
+  for (const auto &target : expanded) {
+    if (!removed.insert({target.type, target.uuid}).second)
+      continue;
+    if (EraseNode(scene, target.type, target.uuid)) {
+      result.changed = true;
+      result.removedNodes.push_back(target);
+    } else {
+      result.diagnostics.push_back("node not found: " + target.uuid);
+    }
+  }
+  PruneEmptyGroups(scene, result);
+  return result;
+}
+
+} // namespace scene_node_operations

--- a/core/scene_node_operations.cpp
+++ b/core/scene_node_operations.cpp
@@ -65,26 +65,38 @@ void CollectGroupSubtree(const MvrScene &scene, const std::string &groupUuid,
   out.push_back({MvrNodeType::GroupObject, groupUuid});
 }
 
-// Prunes empty groups until every remaining group owns at least one child.
-void PruneEmptyGroups(MvrScene &scene, RemovalResult &result) {
-  bool removed = true;
-  while (removed) {
-    removed = false;
-    std::vector<std::string> empty;
-    for (const auto &[uuid, group] : scene.groupObjects) {
-      if (group.children.empty())
-        empty.push_back(uuid);
-    }
-    std::sort(empty.begin(), empty.end());
-    for (const auto &uuid : empty) {
-      if (!scene.groupObjects.contains(uuid))
-        continue;
-      RemoveChildReferences(scene, MvrNodeType::GroupObject, uuid);
-      scene.groupObjects.erase(uuid);
-      result.removedEmptyGroups.push_back(uuid);
-      result.changed = true;
-      removed = true;
-    }
+// Returns the direct parent GroupObject UUID for a typed node.
+std::string ParentGroupUuid(const MvrScene &scene, MvrNodeType type,
+                            const std::string &uuid) {
+  switch (type) {
+  case MvrNodeType::Fixture: return scene.fixtures.at(uuid).parentGroupUuid;
+  case MvrNodeType::Truss: return scene.trusses.at(uuid).parentGroupUuid;
+  case MvrNodeType::Support: return scene.supports.at(uuid).parentGroupUuid;
+  case MvrNodeType::SceneObject:
+    return scene.sceneObjects.at(uuid).parentGroupUuid;
+  case MvrNodeType::GroupObject:
+    return scene.groupObjects.at(uuid).parentGroupUuid;
+  }
+  return {};
+}
+
+// Prunes only affected empty groups and newly empty ancestors.
+void PruneAffectedEmptyGroups(MvrScene &scene,
+                              std::set<std::string> affectedGroups,
+                              RemovalResult &result) {
+  while (!affectedGroups.empty()) {
+    const std::string uuid = *affectedGroups.begin();
+    affectedGroups.erase(affectedGroups.begin());
+    const auto groupIt = scene.groupObjects.find(uuid);
+    if (groupIt == scene.groupObjects.end() || !groupIt->second.children.empty())
+      continue;
+    const std::string parentUuid = groupIt->second.parentGroupUuid;
+    RemoveChildReferences(scene, MvrNodeType::GroupObject, uuid);
+    scene.groupObjects.erase(groupIt);
+    result.removedEmptyGroups.push_back(uuid);
+    result.changed = true;
+    if (!parentUuid.empty())
+      affectedGroups.insert(parentUuid);
   }
 }
 
@@ -131,6 +143,15 @@ ConversionResult ConvertFixtureToSupport(MvrScene &scene,
   support.hasLocalTransform = fixture.hasLocalTransform;
   support.parentGroupUuid = fixture.parentGroupUuid;
 
+  std::vector<std::string> clearedReferences;
+  for (auto &[supportUuid, existingSupport] : scene.supports) {
+    if (existingSupport.motorFixtureUuid == fixtureUuid) {
+      existingSupport.motorFixtureUuid.clear();
+      clearedReferences.push_back(supportUuid);
+    }
+  }
+  std::sort(clearedReferences.begin(), clearedReferences.end());
+
   for (auto &[groupUuid, group] : scene.groupObjects) {
     for (auto &child : group.children) {
       if (child.type == MvrNodeType::Fixture && child.uuid == fixtureUuid)
@@ -139,7 +160,9 @@ ConversionResult ConvertFixtureToSupport(MvrScene &scene,
   }
   scene.supports.emplace(fixtureUuid, std::move(support));
   scene.fixtures.erase(fixtureIt);
-  return {.changed = true, .uuid = fixtureUuid};
+  return {.changed = true,
+          .uuid = fixtureUuid,
+          .clearedMotorFixtureReferences = std::move(clearedReferences)};
 }
 
 // Removes typed nodes and recursively prunes empty ancestor groups.
@@ -160,9 +183,16 @@ RemovalResult RemoveNodes(
   }
 
   std::set<std::pair<MvrNodeType, std::string>> removed;
+  std::set<std::string> affectedGroups;
   for (const auto &target : expanded) {
     if (!removed.insert({target.type, target.uuid}).second)
       continue;
+    if (NodeExists(scene, target.type, target.uuid)) {
+      const std::string parentUuid =
+          ParentGroupUuid(scene, target.type, target.uuid);
+      if (!parentUuid.empty())
+        affectedGroups.insert(parentUuid);
+    }
     if (EraseNode(scene, target.type, target.uuid)) {
       result.changed = true;
       result.removedNodes.push_back(target);
@@ -170,7 +200,7 @@ RemovalResult RemoveNodes(
       result.diagnostics.push_back("node not found: " + target.uuid);
     }
   }
-  PruneEmptyGroups(scene, result);
+  PruneAffectedEmptyGroups(scene, std::move(affectedGroups), result);
   return result;
 }
 

--- a/core/scene_node_operations.h
+++ b/core/scene_node_operations.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "scene_grouping.h"
+
+#include <string>
+#include <vector>
+
+namespace scene_node_operations {
+
+struct RemovalResult {
+  bool changed = false;
+  std::vector<scene_grouping::SceneTransformTarget> removedNodes;
+  std::vector<std::string> removedEmptyGroups;
+  std::vector<std::string> diagnostics;
+};
+
+struct ConversionResult {
+  bool changed = false;
+  std::string uuid;
+  std::string error;
+};
+
+// Applies an exact world transform while preserving hierarchy-local metadata.
+bool ApplyExactWorldTransform(MvrScene &scene, MvrNodeType type,
+                              const std::string &uuid,
+                              const Matrix &worldTransform);
+
+// Converts one Fixture to a Support atomically while preserving its identity.
+ConversionResult ConvertFixtureToSupport(MvrScene &scene,
+                                         const std::string &fixtureUuid);
+
+// Removes typed nodes and recursively prunes empty ancestor groups.
+RemovalResult RemoveNodes(
+    MvrScene &scene,
+    const std::vector<scene_grouping::SceneTransformTarget> &targets);
+
+} // namespace scene_node_operations

--- a/core/scene_node_operations.h
+++ b/core/scene_node_operations.h
@@ -17,6 +17,7 @@ struct RemovalResult {
 struct ConversionResult {
   bool changed = false;
   std::string uuid;
+  std::vector<std::string> clearedMotorFixtureReferences;
   std::string error;
 };
 

--- a/core/scene_transform_integrity.cpp
+++ b/core/scene_transform_integrity.cpp
@@ -1,0 +1,302 @@
+#include "scene_transform_integrity.h"
+
+#include "matrixutils.h"
+
+#include <algorithm>
+#include <cmath>
+#include <map>
+#include <set>
+#include <sstream>
+#include <tuple>
+
+namespace scene_transform_integrity {
+namespace {
+
+// Returns a stable display name for an MVR node type.
+const char *TypeName(MvrNodeType type) {
+  switch (type) {
+  case MvrNodeType::Fixture: return "Fixture";
+  case MvrNodeType::Truss: return "Truss";
+  case MvrNodeType::Support: return "Support";
+  case MvrNodeType::SceneObject: return "SceneObject";
+  case MvrNodeType::GroupObject: return "GroupObject";
+  }
+  return "Unknown";
+}
+
+// Returns true when every component of a matrix is finite.
+bool IsFinite(const Matrix &matrix) {
+  for (const auto *axis : {&matrix.u, &matrix.v, &matrix.w, &matrix.o}) {
+    for (float value : *axis) {
+      if (!std::isfinite(value))
+        return false;
+    }
+  }
+  return true;
+}
+
+// Returns true when two complete matrices agree within the supplied tolerance.
+bool NearlyEqual(const Matrix &lhs, const Matrix &rhs, float tolerance) {
+  for (const auto &pair : {std::pair{&lhs.u, &rhs.u},
+                           std::pair{&lhs.v, &rhs.v},
+                           std::pair{&lhs.w, &rhs.w},
+                           std::pair{&lhs.o, &rhs.o}}) {
+    for (size_t index = 0; index < 3; ++index) {
+      if (std::fabs((*pair.first)[index] - (*pair.second)[index]) > tolerance)
+        return false;
+    }
+  }
+  return true;
+}
+
+// Inverts an affine matrix and rejects singular linear components.
+bool Invert(const Matrix &matrix, Matrix &inverse) {
+  const float determinant =
+      matrix.u[0] * (matrix.v[1] * matrix.w[2] - matrix.w[1] * matrix.v[2]) -
+      matrix.v[0] * (matrix.u[1] * matrix.w[2] - matrix.w[1] * matrix.u[2]) +
+      matrix.w[0] * (matrix.u[1] * matrix.v[2] - matrix.v[1] * matrix.u[2]);
+  if (!std::isfinite(determinant) || std::fabs(determinant) < 1.0e-8f)
+    return false;
+
+  const float reciprocal = 1.0f / determinant;
+  inverse = MatrixUtils::Identity();
+  inverse.u = {(matrix.v[1] * matrix.w[2] - matrix.v[2] * matrix.w[1]) * reciprocal,
+               (matrix.u[2] * matrix.w[1] - matrix.u[1] * matrix.w[2]) * reciprocal,
+               (matrix.u[1] * matrix.v[2] - matrix.u[2] * matrix.v[1]) * reciprocal};
+  inverse.v = {(matrix.v[2] * matrix.w[0] - matrix.v[0] * matrix.w[2]) * reciprocal,
+               (matrix.u[0] * matrix.w[2] - matrix.u[2] * matrix.w[0]) * reciprocal,
+               (matrix.u[2] * matrix.v[0] - matrix.u[0] * matrix.v[2]) * reciprocal};
+  inverse.w = {(matrix.v[0] * matrix.w[1] - matrix.v[1] * matrix.w[0]) * reciprocal,
+               (matrix.u[1] * matrix.w[0] - matrix.u[0] * matrix.w[1]) * reciprocal,
+               (matrix.u[0] * matrix.v[1] - matrix.u[1] * matrix.v[0]) * reciprocal};
+  const std::array<float, 3> translation = matrix.o;
+  inverse.o = {
+      -(inverse.u[0] * translation[0] + inverse.v[0] * translation[1] + inverse.w[0] * translation[2]),
+      -(inverse.u[1] * translation[0] + inverse.v[1] * translation[1] + inverse.w[1] * translation[2]),
+      -(inverse.u[2] * translation[0] + inverse.v[2] * translation[1] + inverse.w[2] * translation[2])};
+  return IsFinite(inverse);
+}
+
+// Returns whether a referenced node exists with its declared type.
+bool NodeExists(const MvrScene &scene, MvrNodeType type,
+                const std::string &uuid) {
+  switch (type) {
+  case MvrNodeType::Fixture: return scene.fixtures.contains(uuid);
+  case MvrNodeType::Truss: return scene.trusses.contains(uuid);
+  case MvrNodeType::Support: return scene.supports.contains(uuid);
+  case MvrNodeType::SceneObject: return scene.sceneObjects.contains(uuid);
+  case MvrNodeType::GroupObject: return scene.groupObjects.contains(uuid);
+  }
+  return false;
+}
+
+// Returns the parent metadata stored by a referenced node.
+std::string ParentUuid(const MvrScene &scene, MvrNodeType type,
+                       const std::string &uuid) {
+  switch (type) {
+  case MvrNodeType::Fixture: return scene.fixtures.at(uuid).parentGroupUuid;
+  case MvrNodeType::Truss: return scene.trusses.at(uuid).parentGroupUuid;
+  case MvrNodeType::Support: return scene.supports.at(uuid).parentGroupUuid;
+  case MvrNodeType::SceneObject: return scene.sceneObjects.at(uuid).parentGroupUuid;
+  case MvrNodeType::GroupObject: return scene.groupObjects.at(uuid).parentGroupUuid;
+  }
+  return {};
+}
+
+// Appends a fatal diagnostic and updates the aggregate result.
+void AddFatal(Result &result, MvrNodeType type, const std::string &uuid,
+              const std::string &reason) {
+  result.success = false;
+  result.diagnostics.push_back({Severity::Fatal, type, uuid, reason, {}});
+}
+
+// Appends a deterministic repair diagnostic.
+void AddRepair(Result &result, MvrNodeType type, const std::string &uuid,
+               const std::string &reason) {
+  result.repaired = true;
+  result.diagnostics.push_back(
+      {Severity::Repair, type, uuid, reason, "recalculated local transform from world transform"});
+}
+
+// Sorts diagnostics so map and child insertion order cannot affect output.
+void SortDiagnostics(Result &result) {
+  std::stable_sort(result.diagnostics.begin(), result.diagnostics.end(),
+                   [](const Diagnostic &lhs, const Diagnostic &rhs) {
+                     return std::tie(lhs.severity, lhs.type, lhs.uuid,
+                                     lhs.reason, lhs.action) <
+                            std::tie(rhs.severity, rhs.type, rhs.uuid,
+                                     rhs.reason, rhs.action);
+                   });
+}
+
+} // namespace
+
+// Validates hierarchy transforms and repairs canonical local matrices safely.
+Result ValidateAndRepair(MvrScene &scene, float tolerance) {
+  Result result;
+  using NodeKey = std::pair<MvrNodeType, std::string>;
+  std::map<NodeKey, std::string> ownership;
+
+  std::vector<std::string> groupUuids;
+  for (const auto &[uuid, group] : scene.groupObjects)
+    groupUuids.push_back(uuid);
+  std::sort(groupUuids.begin(), groupUuids.end());
+
+  for (const auto &groupUuid : groupUuids) {
+    const GroupObject &group = scene.groupObjects.at(groupUuid);
+    if (!group.parentGroupUuid.empty() &&
+        !scene.groupObjects.contains(group.parentGroupUuid))
+      AddFatal(result, MvrNodeType::GroupObject, groupUuid, "missing parent group");
+    for (const auto &child : group.children) {
+      if (!NodeExists(scene, child.type, child.uuid)) {
+        AddFatal(result, child.type, child.uuid, "dangling child reference");
+        continue;
+      }
+      const NodeKey key{child.type, child.uuid};
+      const auto [it, inserted] = ownership.emplace(key, groupUuid);
+      if (!inserted)
+        AddFatal(result, child.type, child.uuid, "duplicate or conflicting group ownership");
+      if (ParentUuid(scene, child.type, child.uuid) != groupUuid)
+        AddFatal(result, child.type, child.uuid, "parent metadata disagrees with child reference");
+    }
+  }
+
+  auto validateParentMetadata = [&](MvrNodeType type, const auto &nodes) {
+    std::vector<std::string> uuids;
+    for (const auto &[uuid, node] : nodes)
+      uuids.push_back(uuid);
+    std::sort(uuids.begin(), uuids.end());
+    for (const auto &uuid : uuids) {
+      const auto &node = nodes.at(uuid);
+      if (node.parentGroupUuid.empty())
+        continue;
+      if (!scene.groupObjects.contains(node.parentGroupUuid))
+        AddFatal(result, type, uuid, "missing parent group");
+      else if (!ownership.contains({type, uuid}))
+        AddFatal(result, type, uuid, "parent metadata has no matching child reference");
+    }
+  };
+  validateParentMetadata(MvrNodeType::Fixture, scene.fixtures);
+  validateParentMetadata(MvrNodeType::Truss, scene.trusses);
+  validateParentMetadata(MvrNodeType::Support, scene.supports);
+  validateParentMetadata(MvrNodeType::SceneObject, scene.sceneObjects);
+  validateParentMetadata(MvrNodeType::GroupObject, scene.groupObjects);
+
+  for (const auto &uuid : groupUuids) {
+    std::set<std::string> visited;
+    std::string current = uuid;
+    while (!current.empty() && scene.groupObjects.contains(current)) {
+      if (!visited.insert(current).second) {
+        AddFatal(result, MvrNodeType::GroupObject, uuid, "group ancestry cycle");
+        break;
+      }
+      current = scene.groupObjects.at(current).parentGroupUuid;
+    }
+  }
+
+  auto validateFinite = [&](MvrNodeType type, const auto &nodes) {
+    std::vector<std::string> uuids;
+    for (const auto &[uuid, node] : nodes)
+      uuids.push_back(uuid);
+    std::sort(uuids.begin(), uuids.end());
+    for (const auto &uuid : uuids) {
+      const auto &node = nodes.at(uuid);
+      if (!IsFinite(node.transform))
+        AddFatal(result, type, uuid, "non-finite world transform");
+      if (!node.parentGroupUuid.empty() && node.hasLocalTransform &&
+          !IsFinite(node.localTransform))
+        AddFatal(result, type, uuid, "non-finite local transform");
+    }
+  };
+  validateFinite(MvrNodeType::Fixture, scene.fixtures);
+  validateFinite(MvrNodeType::Truss, scene.trusses);
+  validateFinite(MvrNodeType::Support, scene.supports);
+  validateFinite(MvrNodeType::SceneObject, scene.sceneObjects);
+  for (const auto &uuid : groupUuids) {
+    const auto &group = scene.groupObjects.at(uuid);
+    if (!IsFinite(group.transform))
+      AddFatal(result, MvrNodeType::GroupObject, uuid, "non-finite world transform");
+    if (!IsFinite(group.localTransform))
+      AddFatal(result, MvrNodeType::GroupObject, uuid, "non-finite local transform");
+    Matrix inverse;
+    if (!group.children.empty() && IsFinite(group.transform) &&
+        !Invert(group.transform, inverse))
+      AddFatal(result, MvrNodeType::GroupObject, uuid,
+               "non-invertible parent transform");
+  }
+
+  if (!result.success) {
+    SortDiagnostics(result);
+    return result;
+  }
+
+  auto repairLeaf = [&](MvrNodeType type, auto &nodes) {
+    std::vector<std::string> uuids;
+    for (const auto &[uuid, node] : nodes)
+      uuids.push_back(uuid);
+    std::sort(uuids.begin(), uuids.end());
+    for (const auto &uuid : uuids) {
+      auto &node = nodes.at(uuid);
+      if (node.parentGroupUuid.empty())
+        continue;
+      Matrix inverse;
+      const Matrix &parentWorld = scene.groupObjects.at(node.parentGroupUuid).transform;
+      if (!Invert(parentWorld, inverse)) {
+        AddFatal(result, type, uuid, "non-invertible parent transform");
+        continue;
+      }
+      const Matrix expectedLocal = MatrixUtils::Multiply(inverse, node.transform);
+      if (!node.hasLocalTransform ||
+          !NearlyEqual(MatrixUtils::Multiply(parentWorld, node.localTransform),
+                       node.transform, tolerance)) {
+        AddRepair(result, type, uuid,
+                  node.hasLocalTransform ? "stale local transform" : "missing local transform");
+        node.localTransform = expectedLocal;
+        node.hasLocalTransform = true;
+      }
+    }
+  };
+  repairLeaf(MvrNodeType::Fixture, scene.fixtures);
+  repairLeaf(MvrNodeType::Truss, scene.trusses);
+  repairLeaf(MvrNodeType::Support, scene.supports);
+  repairLeaf(MvrNodeType::SceneObject, scene.sceneObjects);
+
+  for (const auto &uuid : groupUuids) {
+    auto &group = scene.groupObjects.at(uuid);
+    Matrix expectedLocal = group.transform;
+    if (!group.parentGroupUuid.empty()) {
+      Matrix inverse;
+      const Matrix &parentWorld = scene.groupObjects.at(group.parentGroupUuid).transform;
+      if (!Invert(parentWorld, inverse)) {
+        AddFatal(result, MvrNodeType::GroupObject, uuid, "non-invertible parent transform");
+        continue;
+      }
+      expectedLocal = MatrixUtils::Multiply(inverse, group.transform);
+    }
+    const Matrix rebuilt = group.parentGroupUuid.empty()
+                               ? group.localTransform
+                               : MatrixUtils::Multiply(
+                                     scene.groupObjects.at(group.parentGroupUuid).transform,
+                                     group.localTransform);
+    if (!NearlyEqual(rebuilt, group.transform, tolerance)) {
+      AddRepair(result, MvrNodeType::GroupObject, uuid, "stale local transform");
+      group.localTransform = expectedLocal;
+    }
+  }
+
+  SortDiagnostics(result);
+  return result;
+}
+
+// Formats one transform-integrity diagnostic for logs and user warnings.
+std::string FormatDiagnostic(const Diagnostic &diagnostic) {
+  std::ostringstream stream;
+  stream << (diagnostic.severity == Severity::Fatal ? "fatal" : "repair")
+         << ": " << TypeName(diagnostic.type) << " '" << diagnostic.uuid
+         << "': " << diagnostic.reason;
+  if (!diagnostic.action.empty())
+    stream << "; " << diagnostic.action;
+  return stream.str();
+}
+
+} // namespace scene_transform_integrity

--- a/core/scene_transform_integrity.h
+++ b/core/scene_transform_integrity.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "mvrscene.h"
+
+#include <string>
+#include <vector>
+
+namespace scene_transform_integrity {
+
+enum class Severity { Repair, Fatal };
+
+struct Diagnostic {
+  Severity severity = Severity::Fatal;
+  MvrNodeType type = MvrNodeType::SceneObject;
+  std::string uuid;
+  std::string reason;
+  std::string action;
+};
+
+struct Result {
+  bool success = true;
+  bool repaired = false;
+  std::vector<Diagnostic> diagnostics;
+};
+
+// Validates hierarchy transforms and repairs canonical local matrices safely.
+Result ValidateAndRepair(MvrScene &scene, float tolerance = 0.001f);
+
+// Formats one transform-integrity diagnostic for logs and user warnings.
+std::string FormatDiagnostic(const Diagnostic &diagnostic);
+
+} // namespace scene_transform_integrity

--- a/docs/developer/grouped_transform_mutation_audit.md
+++ b/docs/developer/grouped_transform_mutation_audit.md
@@ -1,0 +1,37 @@
+# Grouped transform mutation audit
+
+Perastage treats each scene node's editable world matrix as the visible
+placement and stores a local matrix for MVR hierarchy persistence.
+
+## Corrected user-editing paths
+
+- Fixture, Truss, Support, and SceneObject table transforms use the shared
+  exact-world mutation boundary.
+- Primitive SceneObject placement and object-level scale changes use the same
+  exact-world boundary; geometry-entry scale remains geometry-local.
+- Fixture-to-Support conversion preserves UUID, world/local transforms, parent
+  metadata, and changes the existing GroupObject child-reference type.
+- Table deletion uses the typed core removal service, removes parent child
+  references, and recursively prunes groups that become empty.
+
+Deleting a GroupObject explicitly deletes its complete subtree. Deleting leaf
+nodes preserves non-empty ancestors and prunes empty ancestors. This is a
+Perastage editing policy; it does not change MVR import hierarchy semantics.
+
+## Reviewed-safe paths
+
+- MVR import builds world transforms from parent-world and local matrices.
+- Grouping, ungrouping, and reparenting preserve world placement through the
+  scene-grouping service.
+- selected-Truss replacement preserves world/local/parent metadata.
+- SceneObject-to-Truss conversion preserves transform metadata and repoints the
+  GroupObject child-reference type.
+- Undo and Redo restore complete scene snapshots rather than replaying direct
+  transform writes.
+- Renderer, loader, and view caches contain derived transforms and do not own
+  editable hierarchy state.
+
+## Follow-up review areas
+
+Duplication, paste, and alignment/distribution paths should continue to use the
+exact or interactive core boundaries according to their user-visible intent.

--- a/docs/developer/grouped_transform_mutation_audit.md
+++ b/docs/developer/grouped_transform_mutation_audit.md
@@ -31,7 +31,30 @@ Perastage editing policy; it does not change MVR import hierarchy semantics.
 - Renderer, loader, and view caches contain derived transforms and do not own
   editable hierarchy state.
 
-## Follow-up review areas
+## Additional audited paths
 
-Duplication, paste, and alignment/distribution paths should continue to use the
-exact or interactive core boundaries according to their user-visible intent.
+- Duplication constructs independent top-level nodes and intentionally clears
+  inherited hierarchy ownership before insertion.
+- Clipboard paste restores complete serialized scene records; it does not apply
+  partial world-matrix edits to existing grouped nodes.
+- Alignment and distribution use the interactive scene-grouping boundary, so
+  grouped Trusses promote while other node types remain exact.
+- Fixture and Truss replacement preserve the instance world/local matrices and
+  parent metadata while changing type-level resource fields.
+- Fixture-to-Support and SceneObject-to-Truss conversions now preserve or
+  repoint hierarchy ownership through their owning conversion services.
+- Grouping, ungrouping, Magnet commit/detach, and explicit reparenting use core
+  hierarchy helpers that preserve world placement and rebuild local matrices.
+- Primitive object placement uses the exact transform boundary; geometry-entry
+  transforms are intentionally local geometry data rather than scene-node
+  placement.
+- Direct map erasure remains only in construction/import/reset code or inside
+  the hierarchy-aware removal service. Table deletion no longer erases scene
+  nodes directly.
+- Undo and Redo replace the complete scene snapshot, including both transform
+  matrices and GroupObject ownership, so no incremental hierarchy repair is
+  required during restoration.
+
+Permissive MVR reading, renderer/model-loader transforms, view caches, and
+derived geometry matrices were reviewed but intentionally left unchanged
+because they do not mutate editable scene-node hierarchy state.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -15,7 +15,9 @@ Changes since **v1.5.0**.
   table edits remain exact; compact negative console offsets such as `--1`
   are now accepted, invalid transforms apply atomically without empty undo
   operations, and MVR export validates or safely repairs canonical local
-  hierarchy matrices before serialization.
+  hierarchy matrices before serialization. Fixture-to-hoist conversion and
+  table deletion now preserve valid GroupObject ownership without dangling
+  hierarchy references.
 
 - Fixed global shortcuts being suppressed while a read-only combo box has
   focus on macOS.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -10,6 +10,11 @@ Changes since **v1.5.0**.
 
 ## Important fixes
 
+- Corrected grouped scene transforms so interactive truss moves consistently
+  affect their effective groups while fixtures, supports, scene objects, and
+  table edits remain exact; compact negative console offsets such as `--1`
+  are now accepted without creating empty undo operations for invalid input.
+
 - Fixed global shortcuts being suppressed while a read-only combo box has
   focus on macOS.
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -13,7 +13,9 @@ Changes since **v1.5.0**.
 - Corrected grouped scene transforms so interactive truss moves consistently
   affect their effective groups while fixtures, supports, scene objects, and
   table edits remain exact; compact negative console offsets such as `--1`
-  are now accepted without creating empty undo operations for invalid input.
+  are now accepted, invalid transforms apply atomically without empty undo
+  operations, and MVR export validates or safely repairs canonical local
+  hierarchy matrices before serialization.
 
 - Fixed global shortcuts being suppressed while a read-only combo box has
   focus on macOS.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -17,7 +17,8 @@ Changes since **v1.5.0**.
   operations, and MVR export validates or safely repairs canonical local
   hierarchy matrices before serialization. Fixture-to-hoist conversion and
   table deletion now preserve valid GroupObject ownership without dangling
-  hierarchy references.
+  hierarchy references, leave unrelated empty groups intact, and keep actual
+  selection distinct from the highlighted interactive movement scope.
 
 - Fixed global shortcuts being suppressed while a read-only combo box has
   focus on macOS.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -18,7 +18,9 @@ Changes since **v1.5.0**.
   hierarchy matrices before serialization. Fixture-to-hoist conversion and
   table deletion now preserve valid GroupObject ownership without dangling
   hierarchy references, leave unrelated empty groups intact, and keep actual
-  selection distinct from the highlighted interactive movement scope.
+  selection distinct from the highlighted interactive movement scope. Valid
+  console transforms that are already satisfied no longer add empty Undo
+  entries or trigger unnecessary scene refreshes.
 
 - Fixed global shortcuts being suppressed while a read-only combo box has
   focus on macOS.

--- a/docs/user/shortcuts-and-command-bar.md
+++ b/docs/user/shortcuts-and-command-bar.md
@@ -94,7 +94,11 @@ Notes:
 
 - One value applies to all selected items.
 - Two values distribute linearly from start to end across selection; `t` and `thru` are accepted as optional range separators, so `pos x -7 t 7`, `pos x -7 thru 7`, and `pos x -7 7` are equivalent.
-- Use `++` / `--` for relative offsets (for example `pos x ++ 1.5`).
+- Use `++` / `--` for relative offsets. Compact and spaced values are both
+  accepted, for example `pos x ++1.5`, `pos x ++ 1.5`, `pos z --1`, and
+  `pos z -- 1`.
+- Mouse and console transforms move a grouped truss through its root group.
+  Grouped fixtures, supports, and scene objects remain individual targets.
 - Group rotation pivot defaults to selection bounding-box center.
 - You can override pivot with a trailing `x,y,z` triplet, for example `rot y ++45 --g -2.5,0,0`.
 

--- a/gui/console_command_parser.cpp
+++ b/gui/console_command_parser.cpp
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <cerrno>
 #include <cctype>
+#include <cmath>
 #include <cstdlib>
 #include <sstream>
 
@@ -68,7 +69,8 @@ bool TryParseFloat(const std::string &token, float &value) {
   char *end = nullptr;
   errno = 0;
   const float parsed = std::strtof(token.c_str(), &end);
-  if (errno != 0 || end != token.c_str() + token.size())
+  if (errno != 0 || end != token.c_str() + token.size() ||
+      !std::isfinite(parsed))
     return false;
 
   value = parsed;

--- a/gui/console_command_parser.cpp
+++ b/gui/console_command_parser.cpp
@@ -85,11 +85,18 @@ TransformCommandSegment ParseTransformCommandSegment(const std::string &text) {
   if (remaining.rfind("++", 0) == 0) {
     result.relative = true;
     remaining = Trim(remaining.substr(2));
-  } else if (remaining.rfind("--", 0) == 0 &&
-             (remaining.size() == 2 || std::isspace(static_cast<unsigned char>(remaining[2])))) {
-    result.relative = true;
-    sign = -1.0f;
-    remaining = Trim(remaining.substr(2));
+  } else if (remaining.rfind("--", 0) == 0) {
+    const std::string compactValue = remaining.substr(2);
+    float parsedCompactValue = 0.0f;
+    const size_t tokenEnd = compactValue.find_first_of(" \t\n\r");
+    const std::string firstToken = compactValue.substr(0, tokenEnd);
+    if (remaining.size() == 2 ||
+        std::isspace(static_cast<unsigned char>(remaining[2])) ||
+        TryParseFloat(firstToken, parsedCompactValue)) {
+      result.relative = true;
+      sign = -1.0f;
+      remaining = Trim(remaining.substr(2));
+    }
   }
 
   std::stringstream stream(remaining);

--- a/gui/consolepanel.cpp
+++ b/gui/consolepanel.cpp
@@ -745,13 +745,13 @@ void ConsolePanel::ProcessCommand(const wxString &cmdWx) {
                   .empty();
     };
 
-    auto applyPosEffective = [&](int axis, const std::vector<float> &vals,
+    auto applyPosEffective = [&](MvrScene &scene, int axis,
+                                 const std::vector<float> &vals,
                                  bool relative,
                                  transform_space::TransformSpace space =
                                      transform_space::TransformSpace::World) {
       if (vals.empty())
         return;
-      auto &scene = cfg.GetScene();
       const auto targets = scene_grouping::BuildInteractiveTransformTargets(
           scene, buildEffectiveSelection());
       const size_t n = targets.size();
@@ -776,13 +776,13 @@ void ConsolePanel::ProcessCommand(const wxString &cmdWx) {
       }
     };
 
-    auto applyRotEffective = [&](int axis, const std::vector<float> &vals,
+    auto applyRotEffective = [&](MvrScene &scene, int axis,
+                                 const std::vector<float> &vals,
                                  bool relative,
                                  transform_space::TransformSpace space =
                                      transform_space::TransformSpace::World) {
       if (vals.empty())
         return;
-      auto &scene = cfg.GetScene();
       const auto targets = scene_grouping::BuildInteractiveTransformTargets(
           scene, buildEffectiveSelection());
       const size_t n = targets.size();
@@ -822,12 +822,44 @@ void ConsolePanel::ProcessCommand(const wxString &cmdWx) {
       }
     };
 
-    auto rotateEffectiveAroundPivot = [&](int axis, float angleDeg,
+    auto rotateEffectiveAroundPivot = [&](MvrScene &scene, int axis,
+                                          float angleDeg,
                                           const std::array<float, 3> &pivotMm,
                                           transform_space::TransformSpace space) {
-      scene_grouping::RotateSelectionAroundPivot(cfg.GetScene(),
+      scene_grouping::RotateSelectionAroundPivot(scene,
                                                  buildEffectiveSelection(), axis,
                                                  angleDeg, pivotMm, space);
+    };
+
+    auto executeTransform = [&](const std::string &undoLabel,
+                                const auto &operation) {
+      MvrScene preview = cfg.GetScene();
+      operation(preview);
+      const auto targets = scene_grouping::BuildInteractiveTransformTargets(
+          cfg.GetScene(), buildEffectiveSelection());
+      bool changed = false;
+      for (const auto &target : targets) {
+        const Matrix before =
+            scene_grouping::GetTargetWorldTransform(cfg.GetScene(), target);
+        const Matrix after =
+            scene_grouping::GetTargetWorldTransform(preview, target);
+        for (const auto &pair : {std::pair{&before.u, &after.u},
+                                 std::pair{&before.v, &after.v},
+                                 std::pair{&before.w, &after.w},
+                                 std::pair{&before.o, &after.o}}) {
+          for (size_t component = 0; component < 3; ++component)
+            changed = changed ||
+                      std::fabs((*pair.first)[component] -
+                                (*pair.second)[component]) > 0.0001f;
+        }
+      }
+      if (!changed) {
+        AppendMessage(_("[INFO] Transform is already at the requested value."));
+        return false;
+      }
+      cfg.PushUndoState(undoLabel);
+      operation(cfg.GetScene());
+      return true;
     };
 
 
@@ -960,6 +992,7 @@ void ConsolePanel::ProcessCommand(const wxString &cmdWx) {
         const auto selSupports = cfg.GetSelectedSupports();
         const auto selSceneObjects = cfg.GetSelectedSceneObjects();
         bool validTransform = false;
+        bool appliedTransform = false;
         if (rest.find(',') != std::string::npos) {
           auto parts = split(rest, ',');
           std::vector<gui::console::TransformCommandSegment> segments;
@@ -972,19 +1005,22 @@ void ConsolePanel::ProcessCommand(const wxString &cmdWx) {
                                                 segment.remainder.empty();
                                        });
           validTransform = validTransform && hasEffectiveTargets();
-          if (validTransform)
-            cfg.PushUndoState(std::string("cli ") + lw);
           if (validTransform) {
-            for (size_t idx = 0; idx < segments.size(); ++idx) {
-              const auto &segment = segments[idx];
-              if (isRot) {
-                applyRotEffective((int)idx, segment.values, segment.relative,
-                                  segment.space);
-              } else {
-                applyPosEffective((int)idx, segment.values, segment.relative,
-                                  segment.space);
+            appliedTransform = executeTransform(
+                std::string("cli ") + lw, [&](MvrScene &targetScene) {
+              for (size_t idx = 0; idx < segments.size(); ++idx) {
+                const auto &segment = segments[idx];
+                if (isRot) {
+                  applyRotEffective(targetScene, static_cast<int>(idx),
+                                    segment.values, segment.relative,
+                                    segment.space);
+                } else {
+                  applyPosEffective(targetScene, static_cast<int>(idx),
+                                    segment.values, segment.relative,
+                                    segment.space);
+                }
               }
-            }
+            });
           }
         } else {
           std::stringstream ps(rest);
@@ -1003,24 +1039,35 @@ void ConsolePanel::ProcessCommand(const wxString &cmdWx) {
           useGroupRotation = segment.group;
           validTransform = validAxis && !segment.values.empty() &&
                            segment.remainder.empty() && hasEffectiveTargets();
-          if (validTransform)
-            cfg.PushUndoState(std::string("cli ") + lw);
           if (validTransform && isRot && useGroupRotation) {
             if (!segment.values.empty()) {
               const auto pivotMm =
                   explicitPivotMm.value_or(computeSelectionBoundsCenterMm().value_or(
                       std::array<float, 3>{0.0f, 0.0f, 0.0f}));
               const float angleDeg = segment.values[0];
-              rotateEffectiveAroundPivot(axis, angleDeg, pivotMm, segment.space);
+              appliedTransform = executeTransform(
+                  std::string("cli ") + lw, [&](MvrScene &targetScene) {
+                    rotateEffectiveAroundPivot(targetScene, axis, angleDeg,
+                                               pivotMm, segment.space);
+                  });
             }
           } else if (validTransform && isRot) {
-            applyRotEffective(axis, segment.values, segment.relative, segment.space);
+            appliedTransform = executeTransform(
+                std::string("cli ") + lw, [&](MvrScene &targetScene) {
+                  applyRotEffective(targetScene, axis, segment.values,
+                                    segment.relative, segment.space);
+                });
           } else if (validTransform) {
-            applyPosEffective(axis, segment.values, segment.relative, segment.space);
+            appliedTransform = executeTransform(
+                std::string("cli ") + lw, [&](MvrScene &targetScene) {
+                  applyPosEffective(targetScene, axis, segment.values,
+                                    segment.relative, segment.space);
+                });
           }
         }
         if (validTransform) {
-          refreshSelectionAfterTransform();
+          if (appliedTransform)
+            refreshSelectionAfterTransform();
         } else {
           AppendMessage(_("[ERROR] Invalid transform: provide a valid axis, finite numeric values, valid modifiers, and a non-empty selection."));
           return;
@@ -1040,10 +1087,13 @@ void ConsolePanel::ProcessCommand(const wxString &cmdWx) {
         const auto segment = parseSegment(rest);
         if (!segment.values.empty() && segment.remainder.empty() &&
             hasEffectiveTargets()) {
-          cfg.PushUndoState("cli pos");
-          applyPosEffective(axis, segment.values, segment.relative,
-                            segment.space);
-          refreshSelectionAfterTransform();
+          const bool applied = executeTransform(
+              "cli pos", [&](MvrScene &targetScene) {
+                applyPosEffective(targetScene, axis, segment.values,
+                                  segment.relative, segment.space);
+              });
+          if (applied)
+            refreshSelectionAfterTransform();
         } else {
           AppendMessage(_("[ERROR] Invalid transform: provide finite numeric values, valid modifiers, and a non-empty selection."));
           return;
@@ -1066,11 +1116,16 @@ void ConsolePanel::ProcessCommand(const wxString &cmdWx) {
           AppendMessage(_("[ERROR] Invalid transform triplet: provide three finite numeric components and a non-empty selection."));
           return;
         }
-        cfg.PushUndoState("cli pos");
-        for (size_t idx = 0; idx < segments.size(); ++idx)
-          applyPosEffective(static_cast<int>(idx), segments[idx].values,
-                            segments[idx].relative, segments[idx].space);
-        refreshSelectionAfterTransform();
+        const bool applied = executeTransform(
+            "cli pos", [&](MvrScene &targetScene) {
+              for (size_t idx = 0; idx < segments.size(); ++idx)
+                applyPosEffective(targetScene, static_cast<int>(idx),
+                                  segments[idx].values,
+                                  segments[idx].relative,
+                                  segments[idx].space);
+            });
+        if (applied)
+          refreshSelectionAfterTransform();
       } else if (!lw.empty() && lw[0] == 'f') {
         std::vector<std::string> sub(tokens.begin() + i + 1,
                                      tokens.begin() + j);

--- a/gui/consolepanel.cpp
+++ b/gui/consolepanel.cpp
@@ -154,7 +154,7 @@ wxString ExtractConsoleSection(const wxString &markdown,
 // Builds localized console help while preserving executable command syntax.
 wxString BuildLocalizedConsoleHelpContent() {
   wxString help;
-  help += _("The console works on the current selection. If fixtures are selected, position and rotation commands apply to fixtures; otherwise they apply to trusses.");
+  help += _("The console transforms the current mixed selection. Grouped trusses move through their root group; fixtures, supports, and scene objects remain exact targets.");
   help += "\n\n";
   help += _("Selection");
   help += "\n\n";
@@ -190,7 +190,7 @@ wxString BuildLocalizedConsoleHelpContent() {
   help += "\n\n";
   help += "- " + _("Provide one value to apply it to all selected items.") + "\n";
   help += "- " + _("Provide two values to linearly distribute from start to end across the selection.") + "\n";
-  help += "- " + _("Use `++` / `--` to apply relative offsets.") + "\n";
+  help += "- " + _("Use compact or spaced `++` / `--` relative offsets, such as `++1`, `++ 1`, `--1`, or `-- 1`.") + "\n";
   help += "- " + _("You can also type a comma-separated triplet like `1, 2, 3` as a shortcut for `pos`.") + "\n";
   return help;
 }
@@ -219,7 +219,7 @@ wxString BuildConsoleHelpContent() {
   help += "- x|y|z <values>\n";
   help += "- rot x|y|z <values> [--group|--g] [pivotX,pivotY,pivotZ]\n";
   help += _("Examples:");
-  help += "\n- f 1-5\n- pos x 1 4\n- pos x ++ 1 --local\n- rot z -- 10\n";
+  help += "\n- f 1-5\n- pos x 1 4\n- pos x ++1 --local\n- rot z --10\n";
   help += "- rot y ++45 --g --local -2.5,0,0";
   return help;
 }
@@ -680,129 +680,6 @@ void ConsolePanel::ProcessCommand(const wxString &cmdWx) {
       }
     };
 
-    enum class TransformTarget { Fixtures, Trusses, Supports, SceneObjects };
-
-    auto applyPos = [&](const std::vector<std::string> &sel,
-                        TransformTarget target, int axis,
-                        const std::vector<float> &vals, bool relative) {
-      if (sel.empty() || vals.empty())
-        return;
-      auto &scene = cfg.GetScene();
-      size_t n = sel.size();
-      float start = vals[0];
-      float end = vals.size() > 1 ? vals[1] : vals[0];
-      for (size_t i = 0; i < n; i++) {
-        float v = (vals.size() > 1 && n > 1)
-                      ? start + (end - start) * (float)i / (float)(n - 1)
-                      : start;
-        v *= 1000.0f;
-        if (target == TransformTarget::Fixtures) {
-          auto it = scene.fixtures.find(sel[i]);
-          if (it != scene.fixtures.end()) {
-            if (relative)
-              it->second.transform.o[axis] += v;
-            else
-              it->second.transform.o[axis] = v;
-          }
-        } else if (target == TransformTarget::Trusses) {
-          auto it = scene.trusses.find(sel[i]);
-          if (it != scene.trusses.end()) {
-            if (relative)
-              it->second.transform.o[axis] += v;
-            else
-              it->second.transform.o[axis] = v;
-          }
-        } else if (target == TransformTarget::Supports) {
-          auto it = scene.supports.find(sel[i]);
-          if (it != scene.supports.end()) {
-            if (relative)
-              it->second.transform.o[axis] += v;
-            else
-              it->second.transform.o[axis] = v;
-          }
-        } else {
-          auto it = scene.sceneObjects.find(sel[i]);
-          if (it != scene.sceneObjects.end()) {
-            if (relative)
-              it->second.transform.o[axis] += v;
-            else
-              it->second.transform.o[axis] = v;
-          }
-        }
-      }
-    };
-
-    auto applyRot = [&](const std::vector<std::string> &sel,
-                        TransformTarget target, int axis,
-                        const std::vector<float> &vals, bool relative) {
-      if (sel.empty() || vals.empty())
-        return;
-      auto &scene = cfg.GetScene();
-      size_t n = sel.size();
-      float start = vals[0];
-      float end = vals.size() > 1 ? vals[1] : vals[0];
-      for (size_t i = 0; i < n; i++) {
-        float ang = (vals.size() > 1 && n > 1)
-                        ? start + (end - start) * (float)i / (float)(n - 1)
-                        : start;
-        int eAxis = 0;
-        switch (axis) {
-        case 0: eAxis = 2; break; // roll (X)
-        case 1: eAxis = 1; break; // pitch (Y)
-        default: eAxis = 0; break; // yaw (Z)
-        }
-        if (target == TransformTarget::Fixtures) {
-          auto it = scene.fixtures.find(sel[i]);
-          if (it != scene.fixtures.end()) {
-            auto e = MatrixUtils::MatrixToEuler(it->second.transform);
-            if (relative)
-              e[eAxis] += ang;
-            else
-              e[eAxis] = ang;
-            Matrix m = MatrixUtils::EulerToMatrix(e[0], e[1], e[2]);
-            m.o = it->second.transform.o;
-            it->second.transform = m;
-          }
-        } else if (target == TransformTarget::Trusses) {
-          auto it = scene.trusses.find(sel[i]);
-          if (it != scene.trusses.end()) {
-            auto e = MatrixUtils::MatrixToEuler(it->second.transform);
-            if (relative)
-              e[eAxis] += ang;
-            else
-              e[eAxis] = ang;
-            Matrix m = MatrixUtils::EulerToMatrix(e[0], e[1], e[2]);
-            m.o = it->second.transform.o;
-            it->second.transform = m;
-          }
-        } else if (target == TransformTarget::Supports) {
-          auto it = scene.supports.find(sel[i]);
-          if (it != scene.supports.end()) {
-            auto e = MatrixUtils::MatrixToEuler(it->second.transform);
-            if (relative)
-              e[eAxis] += ang;
-            else
-              e[eAxis] = ang;
-            Matrix m = MatrixUtils::EulerToMatrix(e[0], e[1], e[2]);
-            m.o = it->second.transform.o;
-            it->second.transform = m;
-          }
-        } else {
-          auto it = scene.sceneObjects.find(sel[i]);
-          if (it != scene.sceneObjects.end()) {
-            auto e = MatrixUtils::MatrixToEuler(it->second.transform);
-            if (relative)
-              e[eAxis] += ang;
-            else
-              e[eAxis] = ang;
-            Matrix m = MatrixUtils::EulerToMatrix(e[0], e[1], e[2]);
-            m.o = it->second.transform.o;
-            it->second.transform = m;
-          }
-        }
-      }
-    };
-
     auto parsePivotToken = [&](const std::string &token,
                                std::array<float, 3> &pivotMm) {
       auto parts = split(token, ',');
@@ -815,7 +692,7 @@ void ConsolePanel::ProcessCommand(const wxString &cmdWx) {
         std::stringstream parser(part);
         float valueMeters = 0.0f;
         parser >> valueMeters;
-        if (!parser || !parser.eof())
+        if (!parser || !parser.eof() || !std::isfinite(valueMeters))
           return false;
         pivotMm[idx] = valueMeters * 1000.0f;
       }
@@ -855,68 +732,17 @@ void ConsolePanel::ProcessCommand(const wxString &cmdWx) {
       };
     };
 
-    auto rotateAroundPivot = [&](const std::vector<std::string> &sel,
-                                 TransformTarget target, int axis,
-                                 float angleDeg,
-                                 const std::array<float, 3> &pivotMm) {
-      if (sel.empty())
-        return;
-      auto &scene = cfg.GetScene();
-      Matrix rotation = MatrixUtils::Identity();
-      if (axis == 0)
-        rotation = MatrixUtils::EulerToMatrix(0.0f, 0.0f, angleDeg);
-      else if (axis == 1)
-        rotation = MatrixUtils::EulerToMatrix(0.0f, angleDeg, 0.0f);
-      else
-        rotation = MatrixUtils::EulerToMatrix(angleDeg, 0.0f, 0.0f);
-
-      auto rotatePosition = [&](std::array<float, 3> &positionMm) {
-        const std::array<float, 3> relative = {
-            positionMm[0] - pivotMm[0],
-            positionMm[1] - pivotMm[1],
-            positionMm[2] - pivotMm[2],
-        };
-        const std::array<float, 3> rotated = {
-            rotation.u[0] * relative[0] + rotation.v[0] * relative[1] +
-                rotation.w[0] * relative[2],
-            rotation.u[1] * relative[0] + rotation.v[1] * relative[1] +
-                rotation.w[1] * relative[2],
-            rotation.u[2] * relative[0] + rotation.v[2] * relative[1] +
-                rotation.w[2] * relative[2],
-        };
-        positionMm = {
-            rotated[0] + pivotMm[0],
-            rotated[1] + pivotMm[1],
-            rotated[2] + pivotMm[2],
-        };
-      };
-
-      for (const auto &uuid : sel) {
-        if (target == TransformTarget::Fixtures) {
-          auto it = scene.fixtures.find(uuid);
-          if (it != scene.fixtures.end())
-            rotatePosition(it->second.transform.o);
-        } else if (target == TransformTarget::Trusses) {
-          auto it = scene.trusses.find(uuid);
-          if (it != scene.trusses.end())
-            rotatePosition(it->second.transform.o);
-        } else if (target == TransformTarget::Supports) {
-          auto it = scene.supports.find(uuid);
-          if (it != scene.supports.end())
-            rotatePosition(it->second.transform.o);
-        } else {
-          auto it = scene.sceneObjects.find(uuid);
-          if (it != scene.sceneObjects.end())
-            rotatePosition(it->second.transform.o);
-        }
-      }
-    };
-
     auto buildEffectiveSelection = [&]() {
       return scene_grouping::ObjectSelection{.fixtures = cfg.GetSelectedFixtures(),
                                              .trusses = cfg.GetSelectedTrusses(),
                                              .supports = cfg.GetSelectedSupports(),
                                              .sceneObjects = cfg.GetSelectedSceneObjects()};
+    };
+
+    auto hasEffectiveTargets = [&]() {
+      return !scene_grouping::BuildInteractiveTransformTargets(
+                  cfg.GetScene(), buildEffectiveSelection())
+                  .empty();
     };
 
     auto applyPosEffective = [&](int axis, const std::vector<float> &vals,
@@ -1008,10 +834,6 @@ void ConsolePanel::ProcessCommand(const wxString &cmdWx) {
 
     auto parseSegment = [](const std::string &s) {
       return gui::console::ParseTransformCommandSegment(s);
-    };
-
-    auto parseVals = [](const std::string &s, bool &relative) {
-      return gui::console::ParseTransformValues(s, relative);
     };
 
     auto refreshSelectionAfterTransform = [&]() {
@@ -1149,16 +971,19 @@ void ConsolePanel::ProcessCommand(const wxString &cmdWx) {
                                          return !segment.values.empty() &&
                                                 segment.remainder.empty();
                                        });
+          validTransform = validTransform && hasEffectiveTargets();
           if (validTransform)
             cfg.PushUndoState(std::string("cli ") + lw);
-          for (size_t idx = 0; idx < segments.size(); ++idx) {
-            const auto &segment = segments[idx];
-            if (segment.values.empty() || !segment.remainder.empty())
-              continue;
-            if (isRot) {
-              applyRotEffective((int)idx, segment.values, segment.relative, segment.space);
-            } else {
-              applyPosEffective((int)idx, segment.values, segment.relative, segment.space);
+          if (validTransform) {
+            for (size_t idx = 0; idx < segments.size(); ++idx) {
+              const auto &segment = segments[idx];
+              if (isRot) {
+                applyRotEffective((int)idx, segment.values, segment.relative,
+                                  segment.space);
+              } else {
+                applyPosEffective((int)idx, segment.values, segment.relative,
+                                  segment.space);
+              }
             }
           }
         } else {
@@ -1166,21 +991,18 @@ void ConsolePanel::ProcessCommand(const wxString &cmdWx) {
           std::string ax;
           ps >> ax;
           int axis = 0;
-          if (!ax.empty()) {
-            char c = ax[0];
-            if (c == 'x')
-              axis = 0;
-            else if (c == 'y')
-              axis = 1;
-            else
-              axis = 2;
-          }
+          const bool validAxis = ax == "x" || ax == "y" || ax == "z";
+          if (ax == "y")
+            axis = 1;
+          else if (ax == "z")
+            axis = 2;
           std::string valsStr;
           std::getline(ps, valsStr);
           valsStr = trim(valsStr);
           const auto segment = parseSegment(valsStr);
           useGroupRotation = segment.group;
-          validTransform = !segment.values.empty() && segment.remainder.empty();
+          validTransform = validAxis && !segment.values.empty() &&
+                           segment.remainder.empty() && hasEffectiveTargets();
           if (validTransform)
             cfg.PushUndoState(std::string("cli ") + lw);
           if (validTransform && isRot && useGroupRotation) {
@@ -1200,7 +1022,8 @@ void ConsolePanel::ProcessCommand(const wxString &cmdWx) {
         if (validTransform) {
           refreshSelectionAfterTransform();
         } else {
-          AppendMessage(_("Invalid transform: provide numeric values and valid modifiers."));
+          AppendMessage(_("[ERROR] Invalid transform: provide a valid axis, finite numeric values, valid modifiers, and a non-empty selection."));
+          return;
         }
       } else if (lw == "x" || lw == "y" || lw == "z") {
         std::string rest;
@@ -1215,29 +1038,38 @@ void ConsolePanel::ProcessCommand(const wxString &cmdWx) {
         const auto selSceneObjects = cfg.GetSelectedSceneObjects();
         int axis = (lw == "x") ? 0 : (lw == "y" ? 1 : 2);
         const auto segment = parseSegment(rest);
-        if (!segment.values.empty() && segment.remainder.empty()) {
+        if (!segment.values.empty() && segment.remainder.empty() &&
+            hasEffectiveTargets()) {
           cfg.PushUndoState("cli pos");
           applyPosEffective(axis, segment.values, segment.relative,
                             segment.space);
           refreshSelectionAfterTransform();
         } else {
-          AppendMessage(
-              _("Invalid transform: provide numeric values and valid modifiers."));
+          AppendMessage(_("[ERROR] Invalid transform: provide finite numeric values, valid modifiers, and a non-empty selection."));
+          return;
         }
       } else if (!lw.empty() && (std::isdigit(lw[0]) || lw[0] == '-' ||
                                  lw[0] == '+') &&
                  word.find(',') != std::string::npos) {
-        cfg.PushUndoState("cli pos");
-        const auto selFixtures = cfg.GetSelectedFixtures();
-        const auto selTrusses = cfg.GetSelectedTrusses();
-        const auto selSupports = cfg.GetSelectedSupports();
-        const auto selSceneObjects = cfg.GetSelectedSceneObjects();
         auto parts = split(word, ',');
-        for (size_t idx = 0; idx < parts.size() && idx < 3; ++idx) {
-          bool rel = false;
-          auto vals = parseVals(parts[idx], rel);
-          applyPosEffective((int)idx, vals, rel);
+        std::vector<gui::console::TransformCommandSegment> segments;
+        for (const auto &part : parts)
+          segments.push_back(parseSegment(part));
+        const bool validTriplet =
+            segments.size() == 3 && hasEffectiveTargets() &&
+            std::all_of(segments.begin(), segments.end(),
+                        [](const auto &segment) {
+                          return !segment.values.empty() &&
+                                 segment.remainder.empty() && !segment.group;
+                        });
+        if (!validTriplet) {
+          AppendMessage(_("[ERROR] Invalid transform triplet: provide three finite numeric components and a non-empty selection."));
+          return;
         }
+        cfg.PushUndoState("cli pos");
+        for (size_t idx = 0; idx < segments.size(); ++idx)
+          applyPosEffective(static_cast<int>(idx), segments[idx].values,
+                            segments[idx].relative, segments[idx].space);
         refreshSelectionAfterTransform();
       } else if (!lw.empty() && lw[0] == 'f') {
         std::vector<std::string> sub(tokens.begin() + i + 1,

--- a/gui/consolepanel.cpp
+++ b/gui/consolepanel.cpp
@@ -844,7 +844,7 @@ void ConsolePanel::ProcessCommand(const wxString &cmdWx) {
           .trusses = cfg.GetSelectedTrusses(),
           .supports = cfg.GetSelectedSupports(),
           .sceneObjects = cfg.GetSelectedSceneObjects()};
-      for (const auto &target : scene_grouping::BuildTransformTargets(scene, selection))
+      for (const auto &target : scene_grouping::BuildInteractiveTransformTargets(scene, selection))
         expandBounds(scene_grouping::GetTargetWorldTransform(scene, target).o);
       if (!hasAny)
         return std::nullopt;
@@ -926,8 +926,8 @@ void ConsolePanel::ProcessCommand(const wxString &cmdWx) {
       if (vals.empty())
         return;
       auto &scene = cfg.GetScene();
-      const auto targets = scene_grouping::BuildTransformTargets(scene,
-                                                                 buildEffectiveSelection());
+      const auto targets = scene_grouping::BuildInteractiveTransformTargets(
+          scene, buildEffectiveSelection());
       const size_t n = targets.size();
       if (n == 0)
         return;
@@ -957,8 +957,8 @@ void ConsolePanel::ProcessCommand(const wxString &cmdWx) {
       if (vals.empty())
         return;
       auto &scene = cfg.GetScene();
-      const auto targets = scene_grouping::BuildTransformTargets(scene,
-                                                                 buildEffectiveSelection());
+      const auto targets = scene_grouping::BuildInteractiveTransformTargets(
+          scene, buildEffectiveSelection());
       const size_t n = targets.size();
       if (n == 0)
         return;
@@ -1112,7 +1112,6 @@ void ConsolePanel::ProcessCommand(const wxString &cmdWx) {
           Viewer2DPanel::Instance()->SetSelectedUuids({});
       } else if (lw == "pos" || lw == "rot") {
         bool isRot = (lw == "rot");
-        cfg.PushUndoState(std::string("cli ") + lw);
         std::vector<std::string> segmentTokens;
         for (size_t k = i + 1; k < j; ++k)
           segmentTokens.push_back(tokens[k]);
@@ -1138,10 +1137,24 @@ void ConsolePanel::ProcessCommand(const wxString &cmdWx) {
         const auto selTrusses = cfg.GetSelectedTrusses();
         const auto selSupports = cfg.GetSelectedSupports();
         const auto selSceneObjects = cfg.GetSelectedSceneObjects();
+        bool validTransform = false;
         if (rest.find(',') != std::string::npos) {
           auto parts = split(rest, ',');
-          for (size_t idx = 0; idx < parts.size() && idx < 3; ++idx) {
-            const auto segment = parseSegment(parts[idx]);
+          std::vector<gui::console::TransformCommandSegment> segments;
+          for (size_t idx = 0; idx < parts.size() && idx < 3; ++idx)
+            segments.push_back(parseSegment(parts[idx]));
+          validTransform = !segments.empty() &&
+                           std::all_of(segments.begin(), segments.end(),
+                                       [](const auto &segment) {
+                                         return !segment.values.empty() &&
+                                                segment.remainder.empty();
+                                       });
+          if (validTransform)
+            cfg.PushUndoState(std::string("cli ") + lw);
+          for (size_t idx = 0; idx < segments.size(); ++idx) {
+            const auto &segment = segments[idx];
+            if (segment.values.empty() || !segment.remainder.empty())
+              continue;
             if (isRot) {
               applyRotEffective((int)idx, segment.values, segment.relative, segment.space);
             } else {
@@ -1167,7 +1180,10 @@ void ConsolePanel::ProcessCommand(const wxString &cmdWx) {
           valsStr = trim(valsStr);
           const auto segment = parseSegment(valsStr);
           useGroupRotation = segment.group;
-          if (isRot && useGroupRotation) {
+          validTransform = !segment.values.empty() && segment.remainder.empty();
+          if (validTransform)
+            cfg.PushUndoState(std::string("cli ") + lw);
+          if (validTransform && isRot && useGroupRotation) {
             if (!segment.values.empty()) {
               const auto pivotMm =
                   explicitPivotMm.value_or(computeSelectionBoundsCenterMm().value_or(
@@ -1175,15 +1191,18 @@ void ConsolePanel::ProcessCommand(const wxString &cmdWx) {
               const float angleDeg = segment.values[0];
               rotateEffectiveAroundPivot(axis, angleDeg, pivotMm, segment.space);
             }
-          } else if (isRot) {
+          } else if (validTransform && isRot) {
             applyRotEffective(axis, segment.values, segment.relative, segment.space);
-          } else {
+          } else if (validTransform) {
             applyPosEffective(axis, segment.values, segment.relative, segment.space);
           }
         }
-        refreshSelectionAfterTransform();
+        if (validTransform) {
+          refreshSelectionAfterTransform();
+        } else {
+          AppendMessage(_("Invalid transform: provide numeric values and valid modifiers."));
+        }
       } else if (lw == "x" || lw == "y" || lw == "z") {
-        cfg.PushUndoState("cli pos");
         std::string rest;
         for (size_t k = i + 1; k < j; ++k) {
           if (k > i + 1)
@@ -1196,8 +1215,15 @@ void ConsolePanel::ProcessCommand(const wxString &cmdWx) {
         const auto selSceneObjects = cfg.GetSelectedSceneObjects();
         int axis = (lw == "x") ? 0 : (lw == "y" ? 1 : 2);
         const auto segment = parseSegment(rest);
-        applyPosEffective(axis, segment.values, segment.relative, segment.space);
-        refreshSelectionAfterTransform();
+        if (!segment.values.empty() && segment.remainder.empty()) {
+          cfg.PushUndoState("cli pos");
+          applyPosEffective(axis, segment.values, segment.relative,
+                            segment.space);
+          refreshSelectionAfterTransform();
+        } else {
+          AppendMessage(
+              _("Invalid transform: provide numeric values and valid modifiers."));
+        }
       } else if (!lw.empty() && (std::isdigit(lw[0]) || lw[0] == '-' ||
                                  lw[0] == '+') &&
                  word.find(',') != std::string::npos) {

--- a/gui/fixturetable/fixture_table_edit_service.cpp
+++ b/gui/fixturetable/fixture_table_edit_service.cpp
@@ -11,6 +11,7 @@
 #include "gdtfloader.h"
 #include "matrixutils.h"
 #include "scene_grouping.h"
+#include "scene_node_operations.h"
 
 #include <algorithm>
 #include <cmath>
@@ -454,8 +455,8 @@ void ApplyFullRowChanges(
     next.transform = old.transform;
     it->second = next;
     if (transformChanged) {
-      scene_grouping::SetTargetWorldTransform(
-          scene, {MvrNodeType::Fixture, it->second.uuid},
+      scene_node_operations::ApplyExactWorldTransform(
+          scene, MvrNodeType::Fixture, it->second.uuid,
           requestedWorldTransform);
     }
     if (!next.typeName.empty() && !next.category.empty() &&

--- a/gui/fixturetable/fixture_table_edit_service.cpp
+++ b/gui/fixturetable/fixture_table_edit_service.cpp
@@ -10,6 +10,7 @@
 #include "gdtfdictionary.h"
 #include "gdtfloader.h"
 #include "matrixutils.h"
+#include "scene_grouping.h"
 
 #include <algorithm>
 #include <cmath>
@@ -449,7 +450,14 @@ void ApplyFullRowChanges(
       changedWeightPositions->insert(NormalizePositionName(old.positionName));
       changedWeightPositions->insert(NormalizePositionName(next.positionName));
     }
+    const Matrix requestedWorldTransform = next.transform;
+    next.transform = old.transform;
     it->second = next;
+    if (transformChanged) {
+      scene_grouping::SetTargetWorldTransform(
+          scene, {MvrNodeType::Fixture, it->second.uuid},
+          requestedWorldTransform);
+    }
     if (!next.typeName.empty() && !next.category.empty() &&
         next.categorySource == GdtfFixtureCategory::kManualSource) {
       GdtfDictionary::UpdateCategoryForFile(next.typeName, next.gdtfSpec,

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -41,6 +41,7 @@
 #include "riggingpanel.h"
 #include "selection_origin_token.h"
 #include "scene_view_refresh.h"
+#include "scene_node_operations.h"
 #include "stringutils.h"
 #include "summarypanel.h"
 #include "units/unit_label_utils.h"
@@ -1428,7 +1429,8 @@ void FixtureTablePanel::DeleteSelected(bool pushUndoState) {
     if ((size_t)r < rowUuids.size()) {
       wxDataViewItem rowItem = table->RowToItem(static_cast<unsigned int>(r));
       const wxUIntPtr rowKey = store->GetItemData(rowItem);
-      scene.fixtures.erase(rowUuids[r]);
+      scene_node_operations::RemoveNodes(
+          scene, {{MvrNodeType::Fixture, rowUuids[r]}});
       rowUuids.erase(rowUuids.begin() + r);
       if ((size_t)r < gdtfPaths.size())
         gdtfPaths.erase(gdtfPaths.begin() + r);

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -1425,12 +1425,16 @@ void FixtureTablePanel::DeleteSelected(bool pushUndoState) {
   rows.erase(std::unique(rows.begin(), rows.end()), rows.end());
 
   auto &scene = guiConfigServices->LegacyConfigManager().GetScene();
+  std::vector<scene_grouping::SceneTransformTarget> removalTargets;
+  for (int r : rows) {
+    if (r >= 0 && static_cast<size_t>(r) < rowUuids.size())
+      removalTargets.push_back({MvrNodeType::Fixture, rowUuids[r]});
+  }
+  scene_node_operations::RemoveNodes(scene, removalTargets);
   for (int r : rows) {
     if ((size_t)r < rowUuids.size()) {
       wxDataViewItem rowItem = table->RowToItem(static_cast<unsigned int>(r));
       const wxUIntPtr rowKey = store->GetItemData(rowItem);
-      scene_node_operations::RemoveNodes(
-          scene, {{MvrNodeType::Fixture, rowUuids[r]}});
       rowUuids.erase(rowUuids.begin() + r);
       if ((size_t)r < gdtfPaths.size())
         gdtfPaths.erase(gdtfPaths.begin() + r);

--- a/gui/hoisttablepanel.cpp
+++ b/gui/hoisttablepanel.cpp
@@ -32,6 +32,7 @@
 #include "layerpanel.h"
 #include "matrixutils.h"
 #include "scene_grouping.h"
+#include "scene_node_operations.h"
 #include "riggingpanel.h"
 #include "rigging_extra_weight_settings.h"
 #include "selection_origin_token.h"
@@ -1396,8 +1397,8 @@ void HoistTablePanel::UpdateSceneData(bool logChanges) {
     next.transform = old.transform;
     it->second = next;
     if (transformChanged) {
-      scene_grouping::SetTargetWorldTransform(
-          scene, {MvrNodeType::Support, it->second.uuid},
+      scene_node_operations::ApplyExactWorldTransform(
+          scene, MvrNodeType::Support, it->second.uuid,
           requestedWorldTransform);
     }
     if (!it->second.position.empty())
@@ -1540,7 +1541,8 @@ void HoistTablePanel::DeleteSelected(bool pushUndoState) {
     if ((size_t)r < rowUuids.size()) {
       wxDataViewItem rowItem = table->RowToItem(static_cast<unsigned int>(r));
       const wxUIntPtr rowKey = store->GetItemData(rowItem);
-      scene.supports.erase(rowUuids[r]);
+      scene_node_operations::RemoveNodes(
+          scene, {{MvrNodeType::Support, rowUuids[r]}});
       rowUuids.erase(rowUuids.begin() + r);
       if ((size_t)r < rowLoadStates.size())
         rowLoadStates.erase(rowLoadStates.begin() + r);

--- a/gui/hoisttablepanel.cpp
+++ b/gui/hoisttablepanel.cpp
@@ -1537,12 +1537,16 @@ void HoistTablePanel::DeleteSelected(bool pushUndoState) {
   rows.erase(std::unique(rows.begin(), rows.end()), rows.end());
 
   auto &scene = cfg.GetScene();
+  std::vector<scene_grouping::SceneTransformTarget> removalTargets;
+  for (int r : rows) {
+    if (r >= 0 && static_cast<size_t>(r) < rowUuids.size())
+      removalTargets.push_back({MvrNodeType::Support, rowUuids[r]});
+  }
+  scene_node_operations::RemoveNodes(scene, removalTargets);
   for (int r : rows) {
     if ((size_t)r < rowUuids.size()) {
       wxDataViewItem rowItem = table->RowToItem(static_cast<unsigned int>(r));
       const wxUIntPtr rowKey = store->GetItemData(rowItem);
-      scene_node_operations::RemoveNodes(
-          scene, {{MvrNodeType::Support, rowUuids[r]}});
       rowUuids.erase(rowUuids.begin() + r);
       if ((size_t)r < rowLoadStates.size())
         rowLoadStates.erase(rowLoadStates.begin() + r);

--- a/gui/hoisttablepanel.cpp
+++ b/gui/hoisttablepanel.cpp
@@ -31,6 +31,7 @@
 #include "hoist_weight_distribution.h"
 #include "layerpanel.h"
 #include "matrixutils.h"
+#include "scene_grouping.h"
 #include "riggingpanel.h"
 #include "rigging_extra_weight_settings.h"
 #include "selection_origin_token.h"
@@ -1391,7 +1392,14 @@ void HoistTablePanel::UpdateSceneData(bool logChanges) {
       changedWeightPositions.insert(NormalizePositionName(old.positionName));
       changedWeightPositions.insert(NormalizePositionName(next.positionName));
     }
+    const Matrix requestedWorldTransform = next.transform;
+    next.transform = old.transform;
     it->second = next;
+    if (transformChanged) {
+      scene_grouping::SetTargetWorldTransform(
+          scene, {MvrNodeType::Support, it->second.uuid},
+          requestedWorldTransform);
+    }
     if (!it->second.position.empty())
       scene.positions[it->second.position] = it->second.positionName;
   }

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -904,11 +904,21 @@ void MainWindow::OnConvertToHoist(wxCommandEvent &WXUNUSED(event)) {
     return;
   }
 
-  cfg.PushUndoState("convert fixtures to hoists");
   auto &scene = cfg.GetScene();
+  std::vector<std::string> convertible;
+  for (const auto &uuid : selected) {
+    if (scene.fixtures.contains(uuid) && !scene.supports.contains(uuid))
+      convertible.push_back(uuid);
+  }
+  if (convertible.empty()) {
+    wxMessageBox("The selected fixtures cannot be converted.",
+                 "Convert to Hoist", wxOK | wxICON_INFORMATION);
+    return;
+  }
+  cfg.PushUndoState("convert fixtures to hoists");
 
   std::vector<std::string> newIds;
-  for (const auto &uuid : selected) {
+  for (const auto &uuid : convertible) {
     const auto result =
         scene_node_operations::ConvertFixtureToSupport(scene, uuid);
     if (result.changed)

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -90,6 +90,7 @@
 #include "rigging_extra_weight_settings.h"
 #include "riggingpanel.h"
 #include "scene_grouping.h"
+#include "scene_node_operations.h"
 #include "scene_object_truss_converter.h"
 #include "scene_object_primitive_creation.h"
 #include "scene_object_primitive_dialogs.h"
@@ -906,44 +907,13 @@ void MainWindow::OnConvertToHoist(wxCommandEvent &WXUNUSED(event)) {
   cfg.PushUndoState("convert fixtures to hoists");
   auto &scene = cfg.GetScene();
 
-  auto baseId = std::chrono::steady_clock::now().time_since_epoch().count();
-  int idx = 0;
   std::vector<std::string> newIds;
   for (const auto &uuid : selected) {
-    auto it = scene.fixtures.find(uuid);
-    if (it == scene.fixtures.end())
-      continue;
-
-    const auto &fixture = it->second;
-
-    Support s;
-    (void)idx++;
-    s.uuid = GenerateUuid();
-    s.name = fixture.instanceName;
-    s.gdtfSpec = fixture.gdtfSpec;
-    s.gdtfMode = fixture.gdtfMode;
-    s.function = fixture.function.empty() ? "Hoist" : fixture.function;
-    s.chainLength = 0.0f;
-    s.position = fixture.position;
-    s.positionName = fixture.positionName;
-    s.layer = fixture.layer;
-    s.capacityKg = 0.0f;
-    s.weightKg = 0.0f;
-    s.loadKg = fixture.weightKg;
-    s.motorName =
-        fixture.instanceName.empty() ? fixture.typeName : fixture.instanceName;
-    s.motorModel = fixture.gdtfMode;
-    s.motorFixtureUuid = fixture.uuid;
-    s.hoistDataSource = "Manual";
-    s.hoistFunction = NormalizeHoistFunction(s.function);
-    s.transform = fixture.transform;
-
-    scene.supports[s.uuid] = s;
-    newIds.push_back(s.uuid);
+    const auto result =
+        scene_node_operations::ConvertFixtureToSupport(scene, uuid);
+    if (result.changed)
+      newIds.push_back(result.uuid);
   }
-
-  for (const auto &uuid : selected)
-    scene.fixtures.erase(uuid);
 
   cfg.SetSelectedSupports(newIds);
   cfg.SetSelectedFixtures({});

--- a/gui/scene_object_primitive_editing.cpp
+++ b/gui/scene_object_primitive_editing.cpp
@@ -4,6 +4,7 @@
 #include "scene_object_primitive_dialogs.h"
 #include "sceneobject.h"
 #include "matrixutils.h"
+#include "scene_grouping.h"
 
 #include <algorithm>
 #include <cctype>
@@ -118,13 +119,14 @@ PrimitivePlacementRequest PlacementFromObject(const SceneObject &object) {
   return request;
 }
 
-void ApplyPlacementToObject(SceneObject &object,
-                            const PrimitivePlacementRequest &request) {
+// Builds an exact world placement transform while preserving object scale.
+Matrix BuildPlacementTransform(const SceneObject &object,
+                               const PrimitivePlacementRequest &request) {
   Matrix rotation = MatrixUtils::EulerToMatrix(
       static_cast<float>(request.rotationZDegrees),
       static_cast<float>(request.rotationYDegrees),
       static_cast<float>(request.rotationXDegrees));
-  object.transform = MatrixUtils::ApplyRotationPreservingScale(
+  return MatrixUtils::ApplyRotationPreservingScale(
       object.transform, rotation,
       {static_cast<float>(request.positionXMeters),
        static_cast<float>(request.positionYMeters),
@@ -157,16 +159,21 @@ bool EditPrimitiveObjectByUuid(wxWindow *parent, ConfigManager &cfg,
     if (!ShowScreenEditDialog(parent, request))
       return false;
 
-    const auto oldU = object.transform.u;
-    const auto oldV = object.transform.v;
-    const auto oldW = object.transform.w;
-    object.transform.u = AxisWithLength(object.transform.u, static_cast<float>(request.widthMeters));
-    object.transform.v = AxisWithLength(object.transform.v, kScreenDepthMeters);
-    object.transform.w = AxisWithLength(object.transform.w, static_cast<float>(request.heightMeters));
+    Matrix requestedTransform = object.transform;
+    requestedTransform.u = AxisWithLength(
+        requestedTransform.u, static_cast<float>(request.widthMeters));
+    requestedTransform.v = AxisWithLength(requestedTransform.v,
+                                          kScreenDepthMeters);
+    requestedTransform.w = AxisWithLength(
+        requestedTransform.w, static_cast<float>(request.heightMeters));
 
-    if (object.transform.u == oldU && object.transform.v == oldV && object.transform.w == oldW)
+    if (requestedTransform.u == object.transform.u &&
+        requestedTransform.v == object.transform.v &&
+        requestedTransform.w == object.transform.w)
       return false;
     cfg.PushUndoState("edit screen geometry");
+    scene_grouping::SetTargetWorldTransform(
+        scene, {MvrNodeType::SceneObject, uuid}, requestedTransform);
     return true;
   }
 
@@ -176,11 +183,14 @@ bool EditPrimitiveObjectByUuid(wxWindow *parent, ConfigManager &cfg,
     if (!ShowPipeEditDialog(parent, request))
       return false;
 
-    const auto oldU = object.transform.u;
-    object.transform.u = AxisWithLength(object.transform.u, static_cast<float>(request.lengthMeters));
-    if (object.transform.u == oldU)
+    Matrix requestedTransform = object.transform;
+    requestedTransform.u = AxisWithLength(
+        requestedTransform.u, static_cast<float>(request.lengthMeters));
+    if (requestedTransform.u == object.transform.u)
       return false;
     cfg.PushUndoState("edit pipe geometry");
+    scene_grouping::SetTargetWorldTransform(
+        scene, {MvrNodeType::SceneObject, uuid}, requestedTransform);
     return true;
   }
 
@@ -208,7 +218,9 @@ bool EditPrimitiveObjectByUuid(wxWindow *parent, ConfigManager &cfg,
     accepted = ShowSphereEditDialog(parent, request, placement, [&]() {
       cfg.PushUndoState("apply primitive geometry");
       object.name = request.name;
-      ApplyPlacementToObject(object, placement);
+      scene_grouping::SetTargetWorldTransform(
+          scene, {MvrNodeType::SceneObject, uuid},
+          BuildPlacementTransform(object, placement));
       if (target.usesGeometryEntry && target.geometryIndex < object.geometries.size())
         object.geometries[target.geometryIndex].localTransform =
             BuildSphereScaleTransform(request.radiusMeters);
@@ -229,7 +241,9 @@ bool EditPrimitiveObjectByUuid(wxWindow *parent, ConfigManager &cfg,
     accepted = ShowCubeEditDialog(parent, request, placement, [&]() {
       cfg.PushUndoState("apply primitive geometry");
       object.name = request.name;
-      ApplyPlacementToObject(object, placement);
+      scene_grouping::SetTargetWorldTransform(
+          scene, {MvrNodeType::SceneObject, uuid},
+          BuildPlacementTransform(object, placement));
       if (target.usesGeometryEntry && target.geometryIndex < object.geometries.size())
         object.geometries[target.geometryIndex].localTransform =
             BuildCubeScaleTransform(request.lengthMeters, request.heightMeters,
@@ -251,7 +265,9 @@ bool EditPrimitiveObjectByUuid(wxWindow *parent, ConfigManager &cfg,
     accepted = ShowCylinderEditDialog(parent, request, placement, [&]() {
       cfg.PushUndoState("apply primitive geometry");
       object.name = request.name;
-      ApplyPlacementToObject(object, placement);
+      scene_grouping::SetTargetWorldTransform(
+          scene, {MvrNodeType::SceneObject, uuid},
+          BuildPlacementTransform(object, placement));
       const bool applyRound = std::fabs(request.topRadiusMeters - request.bottomRadiusMeters) <
                               kCylinderRoundToleranceMeters;
       const std::string applyToken =
@@ -297,7 +313,9 @@ bool EditPrimitiveObjectByUuid(wxWindow *parent, ConfigManager &cfg,
   if (!accepted)
     return false;
 
-  ApplyPlacementToObject(object, placement);
+  scene_grouping::SetTargetWorldTransform(
+      scene, {MvrNodeType::SceneObject, uuid},
+      BuildPlacementTransform(object, placement));
 
   if (!primitiveTokenUpdated &&
       updatedTransform.u == currentTransform.u &&

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -27,6 +27,7 @@
 #include "layerpanel.h"
 #include "matrixutils.h"
 #include "scene_grouping.h"
+#include "scene_node_operations.h"
 #include "primitive_model_resources.h"
 #include "projectutils.h"
 #include "resource_reference_sync.h"
@@ -910,8 +911,8 @@ void SceneObjectTablePanel::UpdateSceneData(bool logChanges) {
         next.transform = old.transform;
         it->second = next;
         if (transformChanged) {
-            scene_grouping::SetTargetWorldTransform(
-                scene, {MvrNodeType::SceneObject, it->second.uuid},
+            scene_node_operations::ApplyExactWorldTransform(
+                scene, MvrNodeType::SceneObject, it->second.uuid,
                 requestedWorldTransform);
         }
     }
@@ -1061,7 +1062,8 @@ void SceneObjectTablePanel::DeleteSelected(bool pushUndoState) {
 
     auto& scene = guiConfigServices->LegacyConfigManager().GetScene();
     for (const auto& uuid : uuidsToDelete)
-        scene.sceneObjects.erase(uuid);
+        scene_node_operations::RemoveNodes(
+            scene, {{MvrNodeType::SceneObject, uuid}});
 
     for (int r : rows) {
         if ((size_t)r < rowUuids.size()) {

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -1061,9 +1061,10 @@ void SceneObjectTablePanel::DeleteSelected(bool pushUndoState) {
     }
 
     auto& scene = guiConfigServices->LegacyConfigManager().GetScene();
+    std::vector<scene_grouping::SceneTransformTarget> removalTargets;
     for (const auto& uuid : uuidsToDelete)
-        scene_node_operations::RemoveNodes(
-            scene, {{MvrNodeType::SceneObject, uuid}});
+        removalTargets.push_back({MvrNodeType::SceneObject, uuid});
+    scene_node_operations::RemoveNodes(scene, removalTargets);
 
     for (int r : rows) {
         if ((size_t)r < rowUuids.size()) {

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -26,6 +26,7 @@
 #include "guiconfigservices.h"
 #include "layerpanel.h"
 #include "matrixutils.h"
+#include "scene_grouping.h"
 #include "primitive_model_resources.h"
 #include "projectutils.h"
 #include "resource_reference_sync.h"
@@ -905,7 +906,14 @@ void SceneObjectTablePanel::UpdateSceneData(bool logChanges) {
 
         pushUndoIfNeeded();
         anyChanged = true;
+        const Matrix requestedWorldTransform = next.transform;
+        next.transform = old.transform;
         it->second = next;
+        if (transformChanged) {
+            scene_grouping::SetTargetWorldTransform(
+                scene, {MvrNodeType::SceneObject, it->second.uuid},
+                requestedWorldTransform);
+        }
     }
 
     if (!anyChanged)

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -30,6 +30,7 @@
 #include "layerpanel.h"
 #include "matrixutils.h"
 #include "scene_grouping.h"
+#include "scene_node_operations.h"
 #include "projectutils.h"
 #include "resource_reference_sync.h"
 #include "riggingpanel.h"
@@ -1169,8 +1170,8 @@ void TrussTablePanel::UpdateSceneData(bool logChanges)
             next.transform = old.transform;
             it->second = next;
             if (transformChanged) {
-                scene_grouping::SetTargetWorldTransform(
-                    scene, {MvrNodeType::Truss, it->second.uuid},
+                scene_node_operations::ApplyExactWorldTransform(
+                    scene, MvrNodeType::Truss, it->second.uuid,
                     requestedWorldTransform);
             }
             if (!it->second.position.empty())
@@ -1380,7 +1381,8 @@ void TrussTablePanel::DeleteSelected(bool pushUndoState) {
             const wxUIntPtr rowKey = store->GetItemData(rowItem);
             const std::string uuid = UuidForItem(rowItem);
             if (!uuid.empty())
-                scene.trusses.erase(uuid);
+                scene_node_operations::RemoveNodes(
+                    scene, {{MvrNodeType::Truss, uuid}});
             identityIndex.RemoveKey(rowKey);
             rowUuidByKey.erase(rowKey);
             modelPathByKey.erase(rowKey);

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -29,6 +29,7 @@
 #include "hoist_load_recalculation_prompt.h"
 #include "layerpanel.h"
 #include "matrixutils.h"
+#include "scene_grouping.h"
 #include "projectutils.h"
 #include "resource_reference_sync.h"
 #include "riggingpanel.h"
@@ -1164,7 +1165,14 @@ void TrussTablePanel::UpdateSceneData(bool logChanges)
                 changedWeightPositions.insert(NormalizePositionName(old.positionName));
                 changedWeightPositions.insert(NormalizePositionName(next.positionName));
             }
+            const Matrix requestedWorldTransform = next.transform;
+            next.transform = old.transform;
             it->second = next;
+            if (transformChanged) {
+                scene_grouping::SetTargetWorldTransform(
+                    scene, {MvrNodeType::Truss, it->second.uuid},
+                    requestedWorldTransform);
+            }
             if (!it->second.position.empty())
                 scene.positions[it->second.position] = it->second.positionName;
             changedTrussIds.insert(it->second.uuid);

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -1375,14 +1375,20 @@ void TrussTablePanel::DeleteSelected(bool pushUndoState) {
     const std::vector<wxString> oldSymbolPaths = symbolPaths;
 
     auto& scene = guiConfigServices->LegacyConfigManager().GetScene();
+    std::vector<scene_grouping::SceneTransformTarget> removalTargets;
+    for (int r : rows) {
+        if (r < 0 || static_cast<size_t>(r) >= rowUuids.size())
+            continue;
+        const std::string uuid = UuidForItem(table->RowToItem(
+            static_cast<unsigned int>(r)));
+        if (!uuid.empty())
+            removalTargets.push_back({MvrNodeType::Truss, uuid});
+    }
+    scene_node_operations::RemoveNodes(scene, removalTargets);
     for (int r : rows) {
         if ((size_t)r < rowUuids.size()) {
             wxDataViewItem rowItem = table->RowToItem(static_cast<unsigned int>(r));
             const wxUIntPtr rowKey = store->GetItemData(rowItem);
-            const std::string uuid = UuidForItem(rowItem);
-            if (!uuid.empty())
-                scene_node_operations::RemoveNodes(
-                    scene, {{MvrNodeType::Truss, uuid}});
             identityIndex.RemoveKey(rowKey);
             rowUuidByKey.erase(rowKey);
             modelPathByKey.erase(rowKey);

--- a/help.md
+++ b/help.md
@@ -123,8 +123,9 @@ Release builds keep these entries hidden to reduce risk in production workflows.
 
 ## Console Commands (complete)
 
-The console works on the current selection. If fixtures are selected, position
-and rotation commands apply to fixtures; otherwise they apply to trusses.
+The console transforms the current mixed selection. A grouped truss moves its
+root group, while grouped fixtures, supports, and scene objects remain exact
+targets.
 
 ### Selection
 
@@ -163,7 +164,7 @@ Notes:
 
 - Provide **one value** to apply it to all selected items.
 - Provide **two values** to linearly distribute from start to end across the selection.
-- Use `++` / `--` to apply relative offsets (example: `pos x ++ 1.5`, `rot z -- 10`). Relative CLI transforms use world axes by default; add `--local` or `-l` for local axes, for example `pos x ++ 1 --local`, `rot y ++ 45 -l`, or `rot z ++ 30 --group --local`. Absolute `pos` and `rot` commands keep their existing world-coordinate/Euler semantics. The persistent Local Axes toolbar toggle affects viewport transforms only and does not change CLI defaults.
+- Use compact or spaced `++` / `--` relative offsets (for example `pos x ++1.5`, `pos x ++ 1.5`, `rot z --10`, or `rot z -- 10`). Relative CLI transforms use world axes by default; add `--local` or `-l` for local axes, for example `pos x ++1 --local`, `rot y ++45 -l`, or `rot z ++30 --group --local`. Absolute `pos` and `rot` commands keep their existing world-coordinate/Euler semantics. The persistent Local Axes toolbar toggle affects viewport transforms only and does not change CLI defaults.
 - You can also type a comma-separated triplet like `1, 2, 3` as a shortcut for `pos`.
 - Group rotation (`--group`/`--g`) uses the current selection **bbox center** as default pivot.
 - Add a trailing `x,y,z` triplet (in meters) to override pivot, for example: `rot y ++45 --g -2.5,0,0`.

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -31,6 +31,7 @@
 #include "matrixutils.h"
 #include "mvr_preferences.h"
 #include "mvr_identity_recovery.h"
+#include "scene_transform_integrity.h"
 #include "primitive_model_resources.h"
 #include "runtime_storage.h"
 #include "projectutils.h"
@@ -2374,6 +2375,22 @@ bool MvrExporter::ExportToFile(const std::string &filePath,
     m_exportWarnings.push_back(message);
     Logger::Instance().Log(Logger::Level::Warn, message);
   }
+  const auto transformIntegrity =
+      scene_transform_integrity::ValidateAndRepair(scene);
+  if (transformIntegrity.repaired)
+    ConfigManager::Get().MarkDirty();
+  for (const auto &diagnostic : transformIntegrity.diagnostics) {
+    const std::string message =
+        scene_transform_integrity::FormatDiagnostic(diagnostic);
+    m_exportWarnings.push_back(message);
+    Logger::Instance().Log(
+        diagnostic.severity == scene_transform_integrity::Severity::Fatal
+            ? Logger::Level::Error
+            : Logger::Level::Warn,
+        message);
+  }
+  if (!transformIntegrity.success)
+    return false;
   const TrussGeometryAuthority trussGeometryAuthority =
       GetTrussGeometryAuthoritySetting();
   std::unordered_map<std::string, std::string> positions;
@@ -3304,9 +3321,7 @@ bool MvrExporter::ExportToFile(const std::string &filePath,
                                    fixtureGdtfArchivePath);
 
     const Matrix fixtureMatrixToWrite =
-        f.parentGroupUuid.empty()
-            ? f.transform
-            : (f.hasLocalTransform ? f.localTransform : f.transform);
+        f.parentGroupUuid.empty() ? f.transform : f.localTransform;
     std::string mstr = MatrixUtils::FormatMatrix(fixtureMatrixToWrite);
     tinyxml2::XMLElement *mat = doc.NewElement("Matrix");
     mat->SetText(mstr.c_str());
@@ -3448,11 +3463,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath,
       ov.model = effectiveTruss.model;
     }
 
-    const bool writeWorldTransform = t.parentGroupUuid.empty();
     const Matrix matrixToWrite =
-        writeWorldTransform
-            ? t.transform
-            : (t.hasLocalTransform ? t.localTransform : t.transform);
+        t.parentGroupUuid.empty() ? t.transform : t.localTransform;
     std::string mstr = MatrixUtils::FormatMatrix(matrixToWrite);
     tinyxml2::XMLElement *mat = doc.NewElement("Matrix");
     mat->SetText(mstr.c_str());
@@ -3630,9 +3642,7 @@ bool MvrExporter::ExportToFile(const std::string &filePath,
       se->SetAttribute("name", s.name.c_str());
 
     const Matrix supportMatrixToWrite =
-        s.parentGroupUuid.empty()
-            ? s.transform
-            : (s.hasLocalTransform ? s.localTransform : s.transform);
+        s.parentGroupUuid.empty() ? s.transform : s.localTransform;
     tinyxml2::XMLElement *mat = doc.NewElement("Matrix");
     mat->SetText(MatrixUtils::FormatMatrix(supportMatrixToWrite).c_str());
     se->InsertEndChild(mat);
@@ -3801,10 +3811,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath,
       return true;
     };
 
-    Matrix objectMatrixToWrite =
-        obj.parentGroupUuid.empty()
-            ? obj.transform
-            : (obj.hasLocalTransform ? obj.localTransform : obj.transform);
+    const Matrix objectMatrixToWrite =
+        obj.parentGroupUuid.empty() ? obj.transform : obj.localTransform;
 
     tinyxml2::XMLElement *oe = doc.NewElement("SceneObject");
     oe->SetAttribute("uuid", obj.uuid.c_str());
@@ -3968,8 +3976,16 @@ bool MvrExporter::ExportToFile(const std::string &filePath,
     parent->InsertEndChild(oe);
   };
 
+  std::unordered_set<std::string> exportedGroupUuids;
   auto exportGroupObject = [&](auto &&self, tinyxml2::XMLElement *parent,
                                const GroupObject &group) -> void {
+    if (!exportedGroupUuids.insert(group.uuid).second) {
+      Logger::Instance().Log(
+          Logger::Level::Error,
+          "MVR export stopped recursive GroupObject revisit for uuid=" +
+              group.uuid);
+      return;
+    }
     tinyxml2::XMLElement *go = doc.NewElement("GroupObject");
     go->SetAttribute("uuid", group.uuid.c_str());
     if (!group.name.empty())

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -331,6 +331,13 @@ add_executable(scene_grouping_test scene_grouping_test.cpp
 target_include_directories(scene_grouping_test PRIVATE ../core ../models)
 add_test(NAME SceneGroupingPreservesTransforms COMMAND scene_grouping_test)
 
+add_executable(scene_transform_integrity_test scene_transform_integrity_test.cpp
+    ../core/scene_transform_integrity.cpp
+    ../models/mvrscene.cpp
+)
+target_include_directories(scene_transform_integrity_test PRIVATE ../core ../models)
+add_test(NAME SceneTransformIntegrity COMMAND scene_transform_integrity_test)
+
 add_executable(magnet_snap_test magnet_snap_test.cpp
     ../core/magnet_snap.cpp
     ../core/scene_grouping.cpp
@@ -836,6 +843,7 @@ add_executable(save_load_roundtrip_test save_load_roundtrip_test.cpp
                ../mvr/gdtf_catalog_matcher.cpp
                ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
+               ../core/scene_transform_integrity.cpp
                ../core/mvr_identity_recovery.cpp
                ../mvr/primitive_model_resources.cpp
                ../core/gdtf_canonicalizer.cpp
@@ -870,6 +878,7 @@ add_executable(mvr_project_fixture_metadata_contracts_test
                ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp ../mvr/gdtf_catalog_matcher.cpp
                ../viewer2d/fixture_label_overrides.cpp ../mvr/mvrexporter.cpp
+               ../core/scene_transform_integrity.cpp
                ../core/mvr_identity_recovery.cpp
                ../mvr/primitive_model_resources.cpp
                ../core/gdtf_canonicalizer.cpp ../core/gdtf_mutation_audit.cpp
@@ -907,6 +916,7 @@ add_executable(project_support_userdata_roundtrip_test project_support_userdata_
                ../mvr/gdtf_catalog_matcher.cpp
                ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
+               ../core/scene_transform_integrity.cpp
                ../core/mvr_identity_recovery.cpp
                ../mvr/primitive_model_resources.cpp
                ../core/gdtf_canonicalizer.cpp
@@ -980,6 +990,7 @@ add_executable(rider_truss_dictionary_normalization_test
                ../mvr/gdtf_catalog_matcher.cpp
                ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
+               ../core/scene_transform_integrity.cpp
                ../core/mvr_identity_recovery.cpp
                ../mvr/primitive_model_resources.cpp
                ../core/gdtf_canonicalizer.cpp
@@ -1004,6 +1015,7 @@ add_test(NAME MvrGdtfImportMatching COMMAND mvr_gdtf_import_matching_test)
 add_executable(mvr_dmx_address_test mvr_dmx_address_test.cpp
                build_info_stub.cpp
                ../mvr/mvrexporter.cpp
+               ../core/scene_transform_integrity.cpp
                ../core/mvr_identity_recovery.cpp
                ../mvr/primitive_model_resources.cpp
                ../core/gdtf_canonicalizer.cpp
@@ -1065,6 +1077,7 @@ add_executable(mvr_support_userdata_roundtrip_test mvr_support_userdata_roundtri
                ../mvr/gdtf_catalog_matcher.cpp
                ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
+               ../core/scene_transform_integrity.cpp
                ../core/mvr_identity_recovery.cpp
                ../mvr/primitive_model_resources.cpp
                ../core/gdtf_canonicalizer.cpp
@@ -1098,7 +1111,9 @@ add_executable(mvr_perastage_metadata_recovery_test
                ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp ../mvr/gdtf_catalog_matcher.cpp
                ../viewer2d/fixture_label_overrides.cpp
-               ../mvr/mvrexporter.cpp ../core/mvr_identity_recovery.cpp
+               ../mvr/mvrexporter.cpp
+               ../core/scene_transform_integrity.cpp
+               ../core/mvr_identity_recovery.cpp
                ../mvr/primitive_model_resources.cpp
                ../core/gdtf_canonicalizer.cpp ../core/gdtf_mutation_audit.cpp
                ../core/logger.cpp gdtfloader_stub.cpp consolepanel_stub.cpp
@@ -1136,6 +1151,7 @@ add_executable(mvr_layer_appearance_userdata_test mvr_layer_appearance_userdata_
                ../mvr/gdtf_catalog_matcher.cpp
                ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
+               ../core/scene_transform_integrity.cpp
                ../core/mvr_identity_recovery.cpp
                ../mvr/primitive_model_resources.cpp
                ../core/gdtf_canonicalizer.cpp
@@ -1179,6 +1195,7 @@ add_executable(mvr_fixture_category_roundtrip_test mvr_fixture_category_roundtri
                ../mvr/gdtf_catalog_matcher.cpp
                ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
+               ../core/scene_transform_integrity.cpp
                ../core/mvr_identity_recovery.cpp
                ../mvr/primitive_model_resources.cpp
                ../core/gdtf_canonicalizer.cpp
@@ -1220,6 +1237,7 @@ add_executable(mvr_sceneobject_symbol_identity_test mvr_sceneobject_symbol_ident
                ../mvr/gdtf_catalog_matcher.cpp
                ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
+               ../core/scene_transform_integrity.cpp
                ../core/mvr_identity_recovery.cpp
                ../mvr/primitive_model_resources.cpp
                ../viewer3d/culling/bounds_cache_system.cpp
@@ -1266,6 +1284,7 @@ add_executable(mvr_truss_roundtrip_structure_test mvr_truss_roundtrip_structure_
                ../mvr/gdtf_catalog_matcher.cpp
                ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
+               ../core/scene_transform_integrity.cpp
                ../core/mvr_identity_recovery.cpp
                ../mvr/primitive_model_resources.cpp
                ../core/gdtf_canonicalizer.cpp
@@ -1309,6 +1328,7 @@ add_executable(mvr_exporter_compliance_test mvr_exporter_compliance_test.cpp
                ../mvr/gdtf_catalog_matcher.cpp
                ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
+               ../core/scene_transform_integrity.cpp
                ../core/mvr_identity_recovery.cpp
                ../mvr/primitive_model_resources.cpp
                ../core/gdtf_canonicalizer.cpp
@@ -1358,6 +1378,7 @@ add_executable(rider_save_roundtrip_test rider_save_roundtrip_test.cpp
                ../mvr/gdtf_catalog_matcher.cpp
                ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
+               ../core/scene_transform_integrity.cpp
                ../core/mvr_identity_recovery.cpp
                ../mvr/primitive_model_resources.cpp
                ../core/gdtf_canonicalizer.cpp
@@ -1952,6 +1973,7 @@ add_executable(symbol_fixture_applier_gdtf_test symbol_fixture_applier_gdtf_test
                ../mvr/gdtf_catalog_matcher.cpp
                ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
+               ../core/scene_transform_integrity.cpp
                ../core/mvr_identity_recovery.cpp
                ../mvr/primitive_model_resources.cpp
                consolepanel_stub.cpp
@@ -1966,6 +1988,7 @@ add_executable(mvr_patched_gdtf_export_test mvr_patched_gdtf_export_test.cpp
                support/gdtf_test_fixture_builder.cpp
                build_info_stub.cpp
                ../mvr/mvrexporter.cpp
+               ../core/scene_transform_integrity.cpp
                ../core/mvr_identity_recovery.cpp
                ../mvr/primitive_model_resources.cpp
                ../core/configmanager.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -325,7 +325,7 @@ target_include_directories(matrixutils_test PRIVATE ../models ../core)
 add_test(NAME MatrixUtilsParsingAndComposition COMMAND matrixutils_test)
 
 add_executable(scene_grouping_test scene_grouping_test.cpp
-    ../core/scene_grouping.cpp
+    ../core/scene_grouping.cpp ../core/scene_node_operations.cpp
     ../models/mvrscene.cpp
 )
 target_include_directories(scene_grouping_test PRIVATE ../core ../models)
@@ -338,9 +338,16 @@ add_executable(scene_transform_integrity_test scene_transform_integrity_test.cpp
 target_include_directories(scene_transform_integrity_test PRIVATE ../core ../models)
 add_test(NAME SceneTransformIntegrity COMMAND scene_transform_integrity_test)
 
+add_executable(scene_node_operations_test scene_node_operations_test.cpp
+    ../core/scene_grouping.cpp ../core/scene_node_operations.cpp
+    ../models/mvrscene.cpp
+)
+target_include_directories(scene_node_operations_test PRIVATE ../core ../models)
+add_test(NAME SceneNodeOperations COMMAND scene_node_operations_test)
+
 add_executable(magnet_snap_test magnet_snap_test.cpp
     ../core/magnet_snap.cpp
-    ../core/scene_grouping.cpp
+    ../core/scene_grouping.cpp ../core/scene_node_operations.cpp
     ../models/mvrscene.cpp
 )
 target_include_directories(magnet_snap_test PRIVATE ../core ../models)
@@ -831,7 +838,7 @@ add_executable(save_load_roundtrip_test save_load_roundtrip_test.cpp
                ../core/gdtfdictionary.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/layer_service.cpp
-               ../core/scene_grouping.cpp
+               ../core/scene_grouping.cpp ../core/scene_node_operations.cpp
                ../core/utf8_utils.cpp
                ../core/trussdictionary.cpp
                ../core/trussloader.cpp
@@ -871,7 +878,7 @@ add_executable(mvr_project_fixture_metadata_contracts_test
                ../core/configmanager.cpp ../core/configservices.cpp
                ../core/projectutils.cpp ../core/library/library_bootstrap.cpp
                ../core/gdtfdictionary.cpp ../core/gdtf_fixture_category.cpp
-               ../core/layer_service.cpp ../core/scene_grouping.cpp
+               ../core/layer_service.cpp ../core/scene_grouping.cpp ../core/scene_node_operations.cpp
                ../core/utf8_utils.cpp ../core/trussdictionary.cpp
                ../core/trussloader.cpp ../core/wx_path_utils.cpp
                ../core/runtime_storage.cpp ../core/truss_gdtf_builder.cpp
@@ -904,7 +911,7 @@ add_executable(project_support_userdata_roundtrip_test project_support_userdata_
                ../core/gdtfdictionary.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/layer_service.cpp
-               ../core/scene_grouping.cpp
+               ../core/scene_grouping.cpp ../core/scene_node_operations.cpp
                ../core/utf8_utils.cpp
                ../core/trussdictionary.cpp
                ../core/trussloader.cpp
@@ -978,7 +985,7 @@ add_executable(rider_truss_dictionary_normalization_test
                ../core/gdtfdictionary.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/layer_service.cpp
-               ../core/scene_grouping.cpp
+               ../core/scene_grouping.cpp ../core/scene_node_operations.cpp
                ../core/utf8_utils.cpp
                ../core/trussdictionary.cpp
                ../core/trussloader.cpp
@@ -1027,7 +1034,7 @@ add_executable(mvr_dmx_address_test mvr_dmx_address_test.cpp
                ../core/gdtfdictionary.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/layer_service.cpp
-               ../core/scene_grouping.cpp
+               ../core/scene_grouping.cpp ../core/scene_node_operations.cpp
                ../core/utf8_utils.cpp
                ../core/trussdictionary.cpp
                ../core/trussloader.cpp
@@ -1065,7 +1072,7 @@ add_executable(mvr_support_userdata_roundtrip_test mvr_support_userdata_roundtri
                ../core/gdtfdictionary.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/layer_service.cpp
-               ../core/scene_grouping.cpp
+               ../core/scene_grouping.cpp ../core/scene_node_operations.cpp
                ../core/utf8_utils.cpp
                ../core/trussdictionary.cpp
                ../core/trussloader.cpp
@@ -1104,7 +1111,7 @@ add_executable(mvr_perastage_metadata_recovery_test
                ../core/configmanager.cpp ../core/configservices.cpp
                ../core/projectutils.cpp ../core/library/library_bootstrap.cpp
                ../core/gdtfdictionary.cpp ../core/gdtf_fixture_category.cpp
-               ../core/layer_service.cpp ../core/scene_grouping.cpp
+               ../core/layer_service.cpp ../core/scene_grouping.cpp ../core/scene_node_operations.cpp
                ../core/utf8_utils.cpp ../core/trussdictionary.cpp
                ../core/trussloader.cpp ../core/wx_path_utils.cpp
                ../core/runtime_storage.cpp ../core/truss_gdtf_builder.cpp
@@ -1139,7 +1146,7 @@ add_executable(mvr_layer_appearance_userdata_test mvr_layer_appearance_userdata_
                ../core/gdtfdictionary.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/layer_service.cpp
-               ../core/scene_grouping.cpp
+               ../core/scene_grouping.cpp ../core/scene_node_operations.cpp
                ../core/utf8_utils.cpp
                ../core/trussdictionary.cpp
                ../core/trussloader.cpp
@@ -1183,7 +1190,7 @@ add_executable(mvr_fixture_category_roundtrip_test mvr_fixture_category_roundtri
                ../core/gdtfdictionary.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/layer_service.cpp
-               ../core/scene_grouping.cpp
+               ../core/scene_grouping.cpp ../core/scene_node_operations.cpp
                ../core/utf8_utils.cpp
                ../core/trussdictionary.cpp
                ../core/trussloader.cpp
@@ -1225,7 +1232,7 @@ add_executable(mvr_sceneobject_symbol_identity_test mvr_sceneobject_symbol_ident
                ../core/gdtfdictionary.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/layer_service.cpp
-               ../core/scene_grouping.cpp
+               ../core/scene_grouping.cpp ../core/scene_node_operations.cpp
                ../core/utf8_utils.cpp
                ../core/trussdictionary.cpp
                ../core/trussloader.cpp
@@ -1272,7 +1279,7 @@ add_executable(mvr_truss_roundtrip_structure_test mvr_truss_roundtrip_structure_
                ../core/gdtfdictionary.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/layer_service.cpp
-               ../core/scene_grouping.cpp
+               ../core/scene_grouping.cpp ../core/scene_node_operations.cpp
                ../core/utf8_utils.cpp
                ../core/trussdictionary.cpp
                ../core/trussloader.cpp
@@ -1316,7 +1323,7 @@ add_executable(mvr_exporter_compliance_test mvr_exporter_compliance_test.cpp
                ../core/gdtfdictionary.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/layer_service.cpp
-               ../core/scene_grouping.cpp
+               ../core/scene_grouping.cpp ../core/scene_node_operations.cpp
                ../core/utf8_utils.cpp
                ../core/trussdictionary.cpp
                ../core/trussloader.cpp
@@ -1366,7 +1373,7 @@ add_executable(rider_save_roundtrip_test rider_save_roundtrip_test.cpp
                ../core/gdtfdictionary.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/utf8_utils.cpp
-               ../core/scene_grouping.cpp
+               ../core/scene_grouping.cpp ../core/scene_node_operations.cpp
                ../core/layer_service.cpp
                ../core/trussdictionary.cpp
                ../core/trussloader.cpp
@@ -1947,7 +1954,7 @@ add_executable(symbol_fixture_applier_gdtf_test symbol_fixture_applier_gdtf_test
                ../core/gdtfdictionary.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/utf8_utils.cpp
-               ../core/scene_grouping.cpp
+               ../core/scene_grouping.cpp ../core/scene_node_operations.cpp
                ../core/layer_service.cpp
                ../core/gdtf_canonicalizer.cpp
                ../core/gdtf_mutation_audit.cpp
@@ -1998,7 +2005,7 @@ add_executable(mvr_patched_gdtf_export_test mvr_patched_gdtf_export_test.cpp
                ../core/gdtfdictionary.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/utf8_utils.cpp
-               ../core/scene_grouping.cpp
+               ../core/scene_grouping.cpp ../core/scene_node_operations.cpp
                ../core/layer_service.cpp
                ../core/gdtf_canonicalizer.cpp
                ../core/gdtf_mutation_audit.cpp

--- a/tests/console_command_parser_test.cpp
+++ b/tests/console_command_parser_test.cpp
@@ -74,6 +74,12 @@ int main() {
   assert(!malformed.relative);
   assert(malformed.values.empty());
   assert(malformed.remainder == "--wat");
+  auto notFinite = gui::console::ParseTransformCommandSegment("nan");
+  assert(notFinite.values.empty());
+  assert(notFinite.remainder == "nan");
+  auto infinity = gui::console::ParseTransformCommandSegment("inf");
+  assert(infinity.values.empty());
+  assert(infinity.remainder == "inf");
 
   return 0;
 }

--- a/tests/console_command_parser_test.cpp
+++ b/tests/console_command_parser_test.cpp
@@ -56,6 +56,24 @@ int main() {
   auto relativeNegative = gui::console::ParseTransformCommandSegment("-- 1.5");
   assert(relativeNegative.relative);
   assert(EqualValues(relativeNegative.values, {-1.5f}));
+  auto compactPositive = gui::console::ParseTransformCommandSegment("++1.25");
+  assert(compactPositive.relative);
+  assert(EqualValues(compactPositive.values, {1.25f}));
+  auto compactNegative = gui::console::ParseTransformCommandSegment("--1.25");
+  assert(compactNegative.relative);
+  assert(EqualValues(compactNegative.values, {-1.25f}));
+  auto compactRange =
+      gui::console::ParseTransformCommandSegment("--1.5 thru 3.5 --local");
+  assert(compactRange.relative);
+  assert(compactRange.space == transform_space::TransformSpace::Local);
+  assert(EqualValues(compactRange.values, {-1.5f, -3.5f}));
+  auto modifierOnly = gui::console::ParseTransformCommandSegment("--group");
+  assert(!modifierOnly.relative);
+  assert(modifierOnly.group);
+  auto malformed = gui::console::ParseTransformCommandSegment("--wat");
+  assert(!malformed.relative);
+  assert(malformed.values.empty());
+  assert(malformed.remainder == "--wat");
 
   return 0;
 }

--- a/tests/mvr_truss_roundtrip_structure_test.cpp
+++ b/tests/mvr_truss_roundtrip_structure_test.cpp
@@ -10,6 +10,7 @@
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include <tinyxml2.h>
@@ -22,10 +23,25 @@
 #include "mvrexporter.h"
 #include "mvrimporter.h"
 #include "mvr_preferences.h"
+#include "scene_node_operations.h"
 #include "truss_gdtf_builder.h"
 #include "uuidutils.h"
 
 namespace fs = std::filesystem;
+
+// Compares every matrix component using the MVR transform tolerance.
+static bool MatrixEqual(const Matrix &lhs, const Matrix &rhs) {
+  for (const auto &pair : {std::pair{&lhs.u, &rhs.u},
+                           std::pair{&lhs.v, &rhs.v},
+                           std::pair{&lhs.w, &rhs.w},
+                           std::pair{&lhs.o, &rhs.o}}) {
+    for (size_t index = 0; index < 3; ++index) {
+      if (std::fabs((*pair.first)[index] - (*pair.second)[index]) > 0.02f)
+        return false;
+    }
+  }
+  return true;
+}
 
 static std::string ReadCurrentZipEntry(wxZipInputStream &zip) {
   std::string content;
@@ -239,16 +255,20 @@ int main() {
   group.uuid = "22222222-2222-2222-2222-222222222222";
   group.name = "Imported Group";
   group.layer = DEFAULT_LAYER_NAME;
-  group.localTransform = MatrixUtils::Identity();
-  group.transform = MatrixUtils::Identity();
+  group.transform = MatrixUtils::EulerToMatrix(21.0f, 13.0f, 34.0f);
+  group.transform.o = {1400.0f, -800.0f, 3200.0f};
+  group.localTransform = group.transform;
   scene.groupObjects[group.uuid] = group;
 
   Truss truss;
   truss.uuid = "33333333-3333-3333-3333-333333333333";
   truss.name = "Truss A";
   truss.layer = DEFAULT_LAYER_NAME;
-  truss.localTransform = MatrixUtils::Identity();
-  truss.transform = MatrixUtils::Identity();
+  truss.localTransform = MatrixUtils::EulerToMatrix(8.0f, 17.0f, 6.0f);
+  truss.localTransform.o = {350.0f, 220.0f, -140.0f};
+  truss.hasLocalTransform = true;
+  truss.transform = MatrixUtils::Multiply(group.transform,
+                                          truss.localTransform);
   truss.sourceRepresentation = Truss::GeometryRepresentation::SymbolSymdef;
   truss.sourceSymbolUuid = sourceSymbolUuid;
   truss.sourceSymdefUuid = symdefUuid;
@@ -270,6 +290,30 @@ int main() {
   truss.perastageAuxGdtfArchivePath = auxiliaryGdtf.generic_string();
   scene.trusses[truss.uuid] = truss;
   scene.groupObjects[group.uuid].children.push_back({MvrNodeType::Truss, truss.uuid});
+  SceneObject sibling;
+  sibling.uuid = "77777777-7777-4777-8777-777777777777";
+  sibling.name = "Grouped sibling";
+  sibling.layer = DEFAULT_LAYER_NAME;
+  sibling.modelFile = "primitive:cube";
+  sibling.parentGroupUuid = group.uuid;
+  sibling.localTransform = MatrixUtils::EulerToMatrix(4.0f, 9.0f, 12.0f);
+  sibling.localTransform.o = {-450.0f, 180.0f, 90.0f};
+  sibling.hasLocalTransform = true;
+  sibling.transform = MatrixUtils::Multiply(group.transform,
+                                            sibling.localTransform);
+  scene.sceneObjects[sibling.uuid] = sibling;
+  scene.groupObjects[group.uuid].children.push_back(
+      {MvrNodeType::SceneObject, sibling.uuid});
+  const Matrix originalTrussWorld = truss.transform;
+  const Matrix siblingWorld = sibling.transform;
+  Matrix editedTrussWorld = MatrixUtils::EulerToMatrix(39.0f, 27.0f, 33.0f);
+  editedTrussWorld.o = {4800.0f, 2100.0f, -650.0f};
+  assert(scene_node_operations::ApplyExactWorldTransform(
+      scene, MvrNodeType::Truss, truss.uuid, editedTrussWorld));
+  const Matrix editedTrussLocal = scene.trusses.at(truss.uuid).localTransform;
+  assert(!MatrixEqual(originalTrussWorld, editedTrussWorld));
+  assert(MatrixEqual(scene.sceneObjects.at(sibling.uuid).transform,
+                     siblingWorld));
 
   MvrExporter exporter;
   const fs::path mvrPath = tempDir / "roundtrip.mvr";
@@ -292,6 +336,11 @@ int main() {
   assert(groupChildList != nullptr);
   tinyxml2::XMLElement *trussNode = groupChildList->FirstChildElement("Truss");
   assert(trussNode != nullptr);
+  Matrix serializedTrussLocal;
+  assert(MatrixUtils::ParseMatrix(
+      trussNode->FirstChildElement("Matrix")->GetText(),
+      serializedTrussLocal));
+  assert(MatrixEqual(serializedTrussLocal, editedTrussLocal));
   int matrixOrder = -1;
   int geosOrder = -1;
   int fixtureIdOrder = -1;
@@ -434,6 +483,12 @@ int main() {
   assert(importedScene.groupObjects.size() == 1);
   assert(importedScene.trusses.size() == 1);
   const Truss &importedTruss = importedScene.trusses.begin()->second;
+  assert(importedTruss.parentGroupUuid == group.uuid);
+  assert(MatrixEqual(importedTruss.localTransform, editedTrussLocal));
+  assert(MatrixEqual(importedTruss.transform, editedTrussWorld));
+  assert(!MatrixEqual(importedTruss.transform, originalTrussWorld));
+  assert(MatrixEqual(importedScene.sceneObjects.at(sibling.uuid).transform,
+                     siblingWorld));
   assert(importedTruss.sourceRepresentation == Truss::GeometryRepresentation::SymbolSymdef);
   assert(importedTruss.sourceSymbolUuid == sourceSymbolUuid);
   assert(!importedTruss.perastageAuxGdtfArchivePath.empty());

--- a/tests/save_load_roundtrip_test.cpp
+++ b/tests/save_load_roundtrip_test.cpp
@@ -17,11 +17,13 @@
  */
 #include <algorithm>
 #include <cassert>
+#include <cmath>
 #include <filesystem>
 #include <fstream>
 #include <memory>
 #include <set>
 #include <string>
+#include <utility>
 #include <vector>
 #include <tinyxml2.h>
 #include <wx/init.h>
@@ -35,9 +37,11 @@
 #include "gdtf_test_fixture_builder.h"
 #include "gdtfdictionary.h"
 #include "layer.h"
+#include "matrixutils.h"
 #include "projectutils.h"
 #include "project_fixture_identity.h"
 #include "sceneobject.h"
+#include "scene_node_operations.h"
 #include "support.h"
 #include "truss.h"
 #include "uuidutils.h"
@@ -60,6 +64,20 @@ struct ProjectIdentityPayload {
   std::string configJson;
   std::string sceneXml;
 };
+
+// Compares every component of two persisted scene matrices.
+static bool MatrixEqual(const Matrix &lhs, const Matrix &rhs) {
+  for (const auto &pair : {std::pair{&lhs.u, &rhs.u},
+                           std::pair{&lhs.v, &rhs.v},
+                           std::pair{&lhs.w, &rhs.w},
+                           std::pair{&lhs.o, &rhs.o}}) {
+    for (size_t index = 0; index < 3; ++index) {
+      if (std::fabs((*pair.first)[index] - (*pair.second)[index]) > 0.02f)
+        return false;
+    }
+  }
+  return true;
+}
 
 // Reads the two project payloads that must agree on fixture identity.
 static ProjectIdentityPayload ReadProjectIdentityPayload(
@@ -317,6 +335,44 @@ int main() {
   o.name = "Object";
   o.layer = layer.name;
   scene.sceneObjects[o.uuid] = o;
+  GroupObject groupedTransformRoot;
+  groupedTransformRoot.uuid = "60000000-0000-4000-8000-000000000001";
+  groupedTransformRoot.name = "Grouped transform persistence";
+  groupedTransformRoot.layer = layer.name;
+  groupedTransformRoot.transform =
+      MatrixUtils::EulerToMatrix(23.0f, 11.0f, 37.0f);
+  groupedTransformRoot.transform.o = {1200.0f, -700.0f, 3400.0f};
+  groupedTransformRoot.localTransform = groupedTransformRoot.transform;
+  groupedTransformRoot.children = {{MvrNodeType::Truss, t.uuid},
+                                   {MvrNodeType::SceneObject, o.uuid}};
+  scene.groupObjects[groupedTransformRoot.uuid] = groupedTransformRoot;
+  t.parentGroupUuid = groupedTransformRoot.uuid;
+  t.localTransform = MatrixUtils::EulerToMatrix(7.0f, 19.0f, 5.0f);
+  t.localTransform.o = {400.0f, 300.0f, -200.0f};
+  t.hasLocalTransform = true;
+  t.transform = MatrixUtils::Multiply(groupedTransformRoot.transform,
+                                      t.localTransform);
+  scene.trusses[t.uuid] = t;
+  o.parentGroupUuid = groupedTransformRoot.uuid;
+  o.localTransform = MatrixUtils::EulerToMatrix(3.0f, 13.0f, 17.0f);
+  o.localTransform.o = {-500.0f, 250.0f, 100.0f};
+  o.hasLocalTransform = true;
+  o.transform = MatrixUtils::Multiply(groupedTransformRoot.transform,
+                                      o.localTransform);
+  scene.sceneObjects[o.uuid] = o;
+  const Matrix originalGroupedTrussWorld = t.transform;
+  const Matrix unchangedGroupedSiblingWorld = o.transform;
+  Matrix editedGroupedTrussWorld =
+      MatrixUtils::EulerToMatrix(41.0f, 29.0f, 31.0f);
+  editedGroupedTrussWorld.o = {5100.0f, 2200.0f, -900.0f};
+  assert(scene_node_operations::ApplyExactWorldTransform(
+      scene, MvrNodeType::Truss, t.uuid, editedGroupedTrussWorld));
+  assert(!MatrixEqual(originalGroupedTrussWorld,
+                      scene.trusses.at(t.uuid).transform));
+  assert(MatrixEqual(scene.groupObjects[groupedTransformRoot.uuid].transform,
+                     groupedTransformRoot.transform));
+  assert(MatrixEqual(scene.sceneObjects[o.uuid].transform,
+                     unchangedGroupedSiblingWorld));
     SceneObject cylinderObj;
     cylinderObj.uuid = "40000000-0000-4000-8000-000000000002";
     cylinderObj.name = "Cylinder";
@@ -439,6 +495,15 @@ int main() {
     assert(cfg.LoadProject(temp.string()));
 
     const auto &scene2 = cfg.GetScene();
+    const auto &loadedGroupedTruss = scene2.trusses.at(t.uuid);
+    assert(loadedGroupedTruss.parentGroupUuid == groupedTransformRoot.uuid);
+    assert(MatrixEqual(loadedGroupedTruss.transform, editedGroupedTrussWorld));
+    assert(!MatrixEqual(loadedGroupedTruss.transform,
+                        originalGroupedTrussWorld));
+    assert(MatrixEqual(scene2.sceneObjects.at(o.uuid).transform,
+                       unchangedGroupedSiblingWorld));
+    assert(scene2.groupObjects.at(groupedTransformRoot.uuid).children.size() ==
+           2);
     assert(scene2.fixtures.size() == 4);
     assert(scene2.trusses.size() == 1);
     assert(scene2.sceneObjects.size() == 3);

--- a/tests/scene_grouping_test.cpp
+++ b/tests/scene_grouping_test.cpp
@@ -141,6 +141,74 @@ int main() {
   assert(NearlyEqual(groupedDragScene.trusses[groupedTruss.uuid].transform.o[0],
                      3100.0f));
 
+  Support groupedSupport;
+  groupedSupport.uuid = "grouped-support";
+  groupedSupport.transform = Translated(5000.0f, 0.0f, 0.0f);
+  groupedDragScene.supports[groupedSupport.uuid] = groupedSupport;
+  scene_grouping::ObjectSelection addSupport;
+  addSupport.supports = {groupedSupport.uuid};
+  const std::string dragGroupUuid =
+      groupedDragScene.trusses[groupedTruss.uuid].parentGroupUuid;
+  assert(scene_grouping::AddSelectionToGroup(groupedDragScene, addSupport,
+                                             dragGroupUuid)
+             .changed);
+  scene_grouping::ObjectSelection supportOnly;
+  supportOnly.supports = {groupedSupport.uuid};
+  const auto supportTargets =
+      scene_grouping::BuildInteractiveTransformTargets(groupedDragScene,
+                                                       supportOnly);
+  assert(supportTargets.size() == 1);
+  assert(supportTargets.front().type == MvrNodeType::Support);
+  scene_grouping::TranslateSelection(groupedDragScene, supportOnly,
+                                     {250.0f, 0.0f, 0.0f});
+  assert(NearlyEqual(groupedDragScene.supports[groupedSupport.uuid]
+                         .transform.o[0],
+                     5250.0f));
+  assert(NearlyEqual(groupedDragScene.trusses[groupedTruss.uuid].transform.o[0],
+                     3100.0f));
+
+  scene_grouping::ObjectSelection trussOnly;
+  trussOnly.trusses = {groupedTruss.uuid};
+  const auto trussTargets =
+      scene_grouping::BuildInteractiveTransformTargets(groupedDragScene,
+                                                       trussOnly);
+  assert(trussTargets.size() == 1);
+  assert(trussTargets.front().type == MvrNodeType::GroupObject);
+  scene_grouping::TranslateSelection(groupedDragScene, trussOnly,
+                                     {100.0f, 0.0f, 0.0f});
+  assert(NearlyEqual(groupedDragScene.trusses[groupedTruss.uuid].transform.o[0],
+                     3200.0f));
+  assert(NearlyEqual(groupedDragScene.supports[groupedSupport.uuid]
+                         .transform.o[0],
+                     5350.0f));
+
+  MvrScene exactScene;
+  GroupObject rotatedParent;
+  rotatedParent.uuid = "rotated-parent";
+  rotatedParent.transform = MatrixUtils::EulerToMatrix(25.0f, 10.0f, 35.0f);
+  rotatedParent.transform.o = {700.0f, -300.0f, 1200.0f};
+  rotatedParent.localTransform = rotatedParent.transform;
+  exactScene.groupObjects[rotatedParent.uuid] = rotatedParent;
+  Fixture exactFixture;
+  exactFixture.uuid = "exact-fixture";
+  exactFixture.parentGroupUuid = rotatedParent.uuid;
+  exactFixture.transform = Translated(900.0f, 100.0f, 1400.0f);
+  exactScene.fixtures[exactFixture.uuid] = exactFixture;
+  exactScene.groupObjects[rotatedParent.uuid].children.push_back(
+      {MvrNodeType::Fixture, exactFixture.uuid});
+  const Matrix requestedExact = Translated(1500.0f, 600.0f, 2100.0f);
+  scene_grouping::SetTargetWorldTransform(
+      exactScene, {MvrNodeType::Fixture, exactFixture.uuid}, requestedExact);
+  const Fixture &editedFixture = exactScene.fixtures[exactFixture.uuid];
+  assert(editedFixture.parentGroupUuid == rotatedParent.uuid);
+  assert(editedFixture.hasLocalTransform);
+  const Matrix rebuiltWorld = MatrixUtils::Multiply(
+      exactScene.groupObjects[rotatedParent.uuid].transform,
+      editedFixture.localTransform);
+  assert(NearlyEqual(rebuiltWorld.o[0], requestedExact.o[0]));
+  assert(NearlyEqual(rebuiltWorld.o[1], requestedExact.o[1]));
+  assert(NearlyEqual(rebuiltWorld.o[2], requestedExact.o[2]));
+
   MvrScene existingGroupScene;
   Fixture addedFixture;
   addedFixture.uuid = "added-fixture";

--- a/tests/scene_grouping_test.cpp
+++ b/tests/scene_grouping_test.cpp
@@ -2,6 +2,7 @@
 
 #include "matrixutils.h"
 
+#include <algorithm>
 #include <cassert>
 #include <cmath>
 
@@ -159,6 +160,13 @@ int main() {
                                                        supportOnly);
   assert(supportTargets.size() == 1);
   assert(supportTargets.front().type == MvrNodeType::Support);
+  const auto supportFeedback =
+      scene_grouping::BuildInteractiveSelectionFeedback(groupedDragScene,
+                                                        supportOnly);
+  assert(supportFeedback.selectedUuids ==
+         std::vector<std::string>{groupedSupport.uuid});
+  assert(supportFeedback.highlightedUuids ==
+         std::vector<std::string>{groupedSupport.uuid});
   scene_grouping::TranslateSelection(groupedDragScene, supportOnly,
                                      {250.0f, 0.0f, 0.0f});
   assert(NearlyEqual(groupedDragScene.supports[groupedSupport.uuid]
@@ -174,6 +182,15 @@ int main() {
                                                        trussOnly);
   assert(trussTargets.size() == 1);
   assert(trussTargets.front().type == MvrNodeType::GroupObject);
+  const auto trussFeedback =
+      scene_grouping::BuildInteractiveSelectionFeedback(groupedDragScene,
+                                                        trussOnly);
+  assert(trussFeedback.selectedUuids ==
+         std::vector<std::string>{groupedTruss.uuid});
+  assert(trussFeedback.highlightedUuids.size() == 3);
+  assert(std::find(trussFeedback.highlightedUuids.begin(),
+                   trussFeedback.highlightedUuids.end(),
+                   groupedSupport.uuid) != trussFeedback.highlightedUuids.end());
   scene_grouping::TranslateSelection(groupedDragScene, trussOnly,
                                      {100.0f, 0.0f, 0.0f});
   assert(NearlyEqual(groupedDragScene.trusses[groupedTruss.uuid].transform.o[0],

--- a/tests/scene_node_operations_test.cpp
+++ b/tests/scene_node_operations_test.cpp
@@ -87,17 +87,38 @@ int main() {
 
   const Matrix fixtureWorld = scene.fixtures["fixture"].transform;
   const Matrix fixtureLocal = scene.fixtures["fixture"].localTransform;
+  Support motorLink;
+  motorLink.uuid = "motor-link";
+  motorLink.motorFixtureUuid = "fixture";
+  scene.supports[motorLink.uuid] = motorLink;
   const auto conversion =
       scene_node_operations::ConvertFixtureToSupport(scene, "fixture");
   assert(conversion.changed && conversion.uuid == "fixture");
   assert(!scene.fixtures.contains("fixture"));
   assert(scene.supports.contains("fixture"));
   assert(scene.supports["fixture"].motorFixtureUuid.empty());
+  assert(scene.supports["motor-link"].motorFixtureUuid.empty());
+  assert(conversion.clearedMotorFixtureReferences ==
+         std::vector<std::string>{"motor-link"});
   assert(scene.supports["fixture"].parentGroupUuid == "group");
   assert(MatrixEqual(scene.supports["fixture"].transform, fixtureWorld));
   assert(MatrixEqual(scene.supports["fixture"].localTransform, fixtureLocal));
   assert(scene.groupObjects["group"].children.front().type ==
          MvrNodeType::Support);
+
+  MvrScene collisionScene;
+  Fixture collisionFixture;
+  collisionFixture.uuid = "collision";
+  collisionScene.fixtures[collisionFixture.uuid] = collisionFixture;
+  Support collisionSupport;
+  collisionSupport.uuid = collisionFixture.uuid;
+  collisionScene.supports[collisionSupport.uuid] = collisionSupport;
+  const auto failedConversion =
+      scene_node_operations::ConvertFixtureToSupport(collisionScene,
+                                                     collisionFixture.uuid);
+  assert(!failedConversion.changed);
+  assert(collisionScene.fixtures.contains(collisionFixture.uuid));
+  assert(collisionScene.supports.contains(collisionSupport.uuid));
 
   auto removal = scene_node_operations::RemoveNodes(
       scene, {{MvrNodeType::Support, "fixture"},
@@ -113,6 +134,17 @@ int main() {
   assert(!scene.trusses.contains("truss"));
   assert(!scene.groupObjects.contains("group"));
   assert(removal.removedEmptyGroups.size() == 1);
+
+  MvrScene unrelatedEmptyScene = GroupedScene();
+  GroupObject unrelatedEmpty;
+  unrelatedEmpty.uuid = "unrelated-empty";
+  unrelatedEmptyScene.groupObjects[unrelatedEmpty.uuid] = unrelatedEmpty;
+  removal = scene_node_operations::RemoveNodes(
+      unrelatedEmptyScene, {{MvrNodeType::Fixture, "fixture"},
+                            {MvrNodeType::Truss, "truss"}});
+  assert(removal.changed);
+  assert(unrelatedEmptyScene.groupObjects.contains("unrelated-empty"));
+  assert(!unrelatedEmptyScene.groupObjects.contains("group"));
 
   MvrScene linkedFixtureScene;
   Fixture linkedFixture;

--- a/tests/scene_node_operations_test.cpp
+++ b/tests/scene_node_operations_test.cpp
@@ -1,0 +1,151 @@
+#include "scene_node_operations.h"
+
+#include "matrixutils.h"
+
+#include <cassert>
+#include <cmath>
+#include <utility>
+
+namespace {
+
+// Builds a translated and rotated matrix for node-operation fixtures.
+Matrix Transform(float x, float y, float z, float yaw) {
+  Matrix matrix = MatrixUtils::EulerToMatrix(yaw, 7.0f, 13.0f);
+  matrix.o = {x, y, z};
+  return matrix;
+}
+
+// Compares all matrix components using the transform contract tolerance.
+bool MatrixEqual(const Matrix &lhs, const Matrix &rhs) {
+  for (const auto &pair : {std::pair{&lhs.u, &rhs.u},
+                           std::pair{&lhs.v, &rhs.v},
+                           std::pair{&lhs.w, &rhs.w},
+                           std::pair{&lhs.o, &rhs.o}}) {
+    for (size_t index = 0; index < 3; ++index) {
+      if (std::fabs((*pair.first)[index] - (*pair.second)[index]) > 0.001f)
+        return false;
+    }
+  }
+  return true;
+}
+
+// Creates one canonical group containing all supported leaf node types.
+MvrScene GroupedScene() {
+  MvrScene scene;
+  GroupObject group;
+  group.uuid = "group";
+  group.transform = Transform(100.0f, 200.0f, 300.0f, 25.0f);
+  group.localTransform = group.transform;
+  scene.groupObjects[group.uuid] = group;
+
+  Fixture fixture;
+  fixture.uuid = "fixture";
+  fixture.instanceName = "Motor";
+  fixture.typeName = "Motor Type";
+  fixture.function = "Lighting";
+  fixture.weightKg = 12.0f;
+  fixture.parentGroupUuid = group.uuid;
+  fixture.localTransform = Transform(10.0f, 20.0f, 30.0f, 5.0f);
+  fixture.hasLocalTransform = true;
+  fixture.transform = MatrixUtils::Multiply(group.transform,
+                                            fixture.localTransform);
+  scene.fixtures[fixture.uuid] = fixture;
+  scene.groupObjects[group.uuid].children.push_back(
+      {MvrNodeType::Fixture, fixture.uuid});
+
+  Truss truss;
+  truss.uuid = "truss";
+  truss.parentGroupUuid = group.uuid;
+  truss.localTransform = Transform(40.0f, 50.0f, 60.0f, 15.0f);
+  truss.hasLocalTransform = true;
+  truss.transform = MatrixUtils::Multiply(group.transform,
+                                          truss.localTransform);
+  scene.trusses[truss.uuid] = truss;
+  scene.groupObjects[group.uuid].children.push_back(
+      {MvrNodeType::Truss, truss.uuid});
+  return scene;
+}
+
+} // namespace
+
+// Verifies exact table transforms, conversion, and hierarchy-safe deletion.
+int main() {
+  MvrScene scene = GroupedScene();
+  const Matrix unchangedGroup = scene.groupObjects["group"].transform;
+  const Matrix unchangedFixture = scene.fixtures["fixture"].transform;
+  const Matrix requestedTruss = Transform(900.0f, 800.0f, 700.0f, 42.0f);
+  assert(scene_node_operations::ApplyExactWorldTransform(
+      scene, MvrNodeType::Truss, "truss", requestedTruss));
+  assert(MatrixEqual(scene.trusses["truss"].transform, requestedTruss));
+  assert(MatrixEqual(scene.groupObjects["group"].transform, unchangedGroup));
+  assert(MatrixEqual(scene.fixtures["fixture"].transform, unchangedFixture));
+  assert(scene.trusses["truss"].parentGroupUuid == "group");
+  assert(MatrixEqual(MatrixUtils::Multiply(
+                         scene.groupObjects["group"].transform,
+                         scene.trusses["truss"].localTransform),
+                     requestedTruss));
+
+  const Matrix fixtureWorld = scene.fixtures["fixture"].transform;
+  const Matrix fixtureLocal = scene.fixtures["fixture"].localTransform;
+  const auto conversion =
+      scene_node_operations::ConvertFixtureToSupport(scene, "fixture");
+  assert(conversion.changed && conversion.uuid == "fixture");
+  assert(!scene.fixtures.contains("fixture"));
+  assert(scene.supports.contains("fixture"));
+  assert(scene.supports["fixture"].motorFixtureUuid.empty());
+  assert(scene.supports["fixture"].parentGroupUuid == "group");
+  assert(MatrixEqual(scene.supports["fixture"].transform, fixtureWorld));
+  assert(MatrixEqual(scene.supports["fixture"].localTransform, fixtureLocal));
+  assert(scene.groupObjects["group"].children.front().type ==
+         MvrNodeType::Support);
+
+  auto removal = scene_node_operations::RemoveNodes(
+      scene, {{MvrNodeType::Support, "fixture"},
+              {MvrNodeType::Support, "fixture"}});
+  assert(removal.changed);
+  assert(!scene.supports.contains("fixture"));
+  assert(scene.groupObjects.contains("group"));
+  assert(scene.groupObjects["group"].children.size() == 1);
+
+  removal = scene_node_operations::RemoveNodes(
+      scene, {{MvrNodeType::Truss, "truss"}});
+  assert(removal.changed);
+  assert(!scene.trusses.contains("truss"));
+  assert(!scene.groupObjects.contains("group"));
+  assert(removal.removedEmptyGroups.size() == 1);
+
+  MvrScene linkedFixtureScene;
+  Fixture linkedFixture;
+  linkedFixture.uuid = "linked-fixture";
+  linkedFixtureScene.fixtures[linkedFixture.uuid] = linkedFixture;
+  Support linkedSupport;
+  linkedSupport.uuid = "linked-support";
+  linkedSupport.motorFixtureUuid = linkedFixture.uuid;
+  linkedFixtureScene.supports[linkedSupport.uuid] = linkedSupport;
+  removal = scene_node_operations::RemoveNodes(
+      linkedFixtureScene, {{MvrNodeType::Fixture, linkedFixture.uuid}});
+  assert(removal.changed);
+  assert(linkedFixtureScene.supports[linkedSupport.uuid]
+             .motorFixtureUuid.empty());
+
+  MvrScene nested;
+  GroupObject root;
+  root.uuid = "root";
+  root.children.push_back({MvrNodeType::GroupObject, "child"});
+  GroupObject child;
+  child.uuid = "child";
+  child.parentGroupUuid = "root";
+  SceneObject object;
+  object.uuid = "object";
+  object.parentGroupUuid = "child";
+  child.children.push_back({MvrNodeType::SceneObject, object.uuid});
+  nested.groupObjects[root.uuid] = root;
+  nested.groupObjects[child.uuid] = child;
+  nested.sceneObjects[object.uuid] = object;
+  removal = scene_node_operations::RemoveNodes(
+      nested, {{MvrNodeType::GroupObject, "root"}});
+  assert(removal.changed);
+  assert(nested.groupObjects.empty());
+  assert(nested.sceneObjects.empty());
+  return 0;
+}

--- a/tests/scene_transform_integrity_test.cpp
+++ b/tests/scene_transform_integrity_test.cpp
@@ -1,0 +1,160 @@
+#include "scene_transform_integrity.h"
+
+#include "matrixutils.h"
+
+#include <cassert>
+#include <cmath>
+#include <limits>
+#include <utility>
+
+namespace {
+
+// Builds a translated and rotated matrix for integrity test fixtures.
+Matrix Transform(float x, float y, float z, float yaw = 0.0f) {
+  Matrix matrix = MatrixUtils::EulerToMatrix(yaw, 0.0f, 0.0f);
+  matrix.o = {x, y, z};
+  return matrix;
+}
+
+// Builds one valid grouped fixture scene with canonical local data.
+MvrScene ValidScene() {
+  MvrScene scene;
+  GroupObject group;
+  group.uuid = "group";
+  group.transform = Transform(100.0f, 200.0f, 300.0f, 25.0f);
+  group.localTransform = group.transform;
+  group.children.push_back({MvrNodeType::Fixture, "fixture"});
+  scene.groupObjects[group.uuid] = group;
+
+  Fixture fixture;
+  fixture.uuid = "fixture";
+  fixture.parentGroupUuid = group.uuid;
+  fixture.localTransform = Transform(50.0f, 0.0f, 0.0f, 10.0f);
+  fixture.hasLocalTransform = true;
+  fixture.transform = MatrixUtils::Multiply(group.transform, fixture.localTransform);
+  scene.fixtures[fixture.uuid] = fixture;
+  return scene;
+}
+
+// Finds whether a result contains the requested diagnostic reason.
+bool HasReason(const scene_transform_integrity::Result &result,
+               const std::string &reason) {
+  for (const auto &diagnostic : result.diagnostics) {
+    if (diagnostic.reason == reason)
+      return true;
+  }
+  return false;
+}
+
+// Compares every component of two matrices with the integrity tolerance.
+bool MatrixEqual(const Matrix &lhs, const Matrix &rhs) {
+  for (const auto &pair : {std::pair{&lhs.u, &rhs.u},
+                           std::pair{&lhs.v, &rhs.v},
+                           std::pair{&lhs.w, &rhs.w},
+                           std::pair{&lhs.o, &rhs.o}}) {
+    for (size_t index = 0; index < 3; ++index) {
+      if (std::fabs((*pair.first)[index] - (*pair.second)[index]) >= 0.001f)
+        return false;
+    }
+  }
+  return true;
+}
+
+} // namespace
+
+// Verifies canonical hierarchy validation, safe repairs, and fatal corruption.
+int main() {
+  MvrScene valid = ValidScene();
+  auto result = scene_transform_integrity::ValidateAndRepair(valid);
+  assert(result.success && !result.repaired && result.diagnostics.empty());
+
+  MvrScene stale = ValidScene();
+  stale.fixtures["fixture"].localTransform = MatrixUtils::Identity();
+  result = scene_transform_integrity::ValidateAndRepair(stale);
+  assert(result.success && result.repaired);
+  assert(HasReason(result, "stale local transform"));
+  const Matrix rebuilt = MatrixUtils::Multiply(
+      stale.groupObjects["group"].transform,
+      stale.fixtures["fixture"].localTransform);
+  assert(MatrixEqual(rebuilt, stale.fixtures["fixture"].transform));
+
+  MvrScene missingLocal = ValidScene();
+  missingLocal.fixtures["fixture"].hasLocalTransform = false;
+  result = scene_transform_integrity::ValidateAndRepair(missingLocal);
+  assert(result.success && result.repaired);
+  assert(missingLocal.fixtures["fixture"].hasLocalTransform);
+  assert(HasReason(result, "missing local transform"));
+
+  MvrScene nested = ValidScene();
+  GroupObject childGroup;
+  childGroup.uuid = "nested";
+  childGroup.parentGroupUuid = "group";
+  childGroup.localTransform = Transform(0.0f, 75.0f, 20.0f, 15.0f);
+  childGroup.transform = MatrixUtils::Multiply(
+      nested.groupObjects["group"].transform, childGroup.localTransform);
+  nested.groupObjects["group"].children.push_back(
+      {MvrNodeType::GroupObject, childGroup.uuid});
+  nested.groupObjects[childGroup.uuid] = childGroup;
+  nested.groupObjects["nested"].localTransform = MatrixUtils::Identity();
+  result = scene_transform_integrity::ValidateAndRepair(nested);
+  assert(result.success && result.repaired);
+  assert(nested.groupObjects["nested"].parentGroupUuid == "group");
+
+  MvrScene missingParent = ValidScene();
+  missingParent.fixtures["fixture"].parentGroupUuid = "absent";
+  result = scene_transform_integrity::ValidateAndRepair(missingParent);
+  assert(!result.success && HasReason(result, "missing parent group"));
+
+  MvrScene dangling = ValidScene();
+  dangling.groupObjects["group"].children.push_back(
+      {MvrNodeType::Truss, "absent"});
+  result = scene_transform_integrity::ValidateAndRepair(dangling);
+  assert(!result.success && HasReason(result, "dangling child reference"));
+
+  MvrScene mismatched = ValidScene();
+  mismatched.fixtures["fixture"].parentGroupUuid.clear();
+  result = scene_transform_integrity::ValidateAndRepair(mismatched);
+  assert(!result.success &&
+         HasReason(result, "parent metadata disagrees with child reference"));
+
+  MvrScene duplicate = ValidScene();
+  duplicate.groupObjects["group"].children.push_back(
+      {MvrNodeType::Fixture, "fixture"});
+  result = scene_transform_integrity::ValidateAndRepair(duplicate);
+  assert(!result.success &&
+         HasReason(result, "duplicate or conflicting group ownership"));
+
+  MvrScene cycle;
+  GroupObject first;
+  first.uuid = "a";
+  first.parentGroupUuid = "b";
+  first.children.push_back({MvrNodeType::GroupObject, "b"});
+  GroupObject second;
+  second.uuid = "b";
+  second.parentGroupUuid = "a";
+  second.children.push_back({MvrNodeType::GroupObject, "a"});
+  cycle.groupObjects[first.uuid] = first;
+  cycle.groupObjects[second.uuid] = second;
+  result = scene_transform_integrity::ValidateAndRepair(cycle);
+  assert(!result.success && HasReason(result, "group ancestry cycle"));
+
+  MvrScene nonFinite = ValidScene();
+  nonFinite.fixtures["fixture"].transform.o[0] =
+      std::numeric_limits<float>::infinity();
+  result = scene_transform_integrity::ValidateAndRepair(nonFinite);
+  assert(!result.success && HasReason(result, "non-finite world transform"));
+
+  MvrScene nonFiniteLocal = ValidScene();
+  nonFiniteLocal.fixtures["fixture"].localTransform.o[1] =
+      std::numeric_limits<float>::quiet_NaN();
+  result = scene_transform_integrity::ValidateAndRepair(nonFiniteLocal);
+  assert(!result.success && HasReason(result, "non-finite local transform"));
+
+  MvrScene singular = ValidScene();
+  singular.groupObjects["group"].transform.u = {0.0f, 0.0f, 0.0f};
+  singular.groupObjects["group"].localTransform =
+      singular.groupObjects["group"].transform;
+  result = scene_transform_integrity::ValidateAndRepair(singular);
+  assert(!result.success && HasReason(result, "non-invertible parent transform"));
+  return 0;
+}

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -1775,7 +1775,7 @@ std::optional<magnet_snap::SnapSource> Viewer2DPanel::BuildActiveMagnetSource() 
     scene_grouping::ObjectSelection selection;
     selection.fixtures = m_dragFixtureUuids;
     selection.trusses = m_dragTrussUuids;
-    const auto targets = scene_grouping::BuildTransformTargets(
+    const auto targets = scene_grouping::BuildInteractiveTransformTargets(
         ConfigManager::Get().GetScene(), selection);
     if (targets.size() == 1 && targets.front().type == MvrNodeType::GroupObject)
       return magnet_snap::SnapSource{magnet_snap::ObjectType::TrussGroup,
@@ -1870,7 +1870,8 @@ void Viewer2DPanel::ApplySelectionDelta(
   std::array<float, 3> deltaMm{dxMm, dyMm, dzMm};
   if (m_transformSpace == transform_space::TransformSpace::Local &&
       m_axisConstrainedMovementEnabled && m_dragAxis != DragAxis::None) {
-    const auto targets = scene_grouping::BuildTransformTargets(cfg.GetScene(), selection);
+    const auto targets = scene_grouping::BuildInteractiveTransformTargets(
+        cfg.GetScene(), selection);
     if (!targets.empty()) {
       const Matrix referenceTransform = scene_grouping::GetTargetWorldTransform(
           cfg.GetScene(), targets.front());

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -2663,7 +2663,8 @@ bool Viewer3DPanel::PrepareSelectionDrag(const wxPoint& mousePos)
         .trusses = m_dragTrussUuids,
         .supports = {},
         .sceneObjects = m_dragSceneObjectUuids};
-    const auto dragTargets = scene_grouping::BuildTransformTargets(cfg.GetScene(), dragSelection);
+    const auto dragTargets = scene_grouping::BuildInteractiveTransformTargets(
+        cfg.GetScene(), dragSelection);
     m_selectionDragAnchorMeters = {0.0f, 0.0f, 0.0f};
     if (!dragTargets.empty()) {
         for (const auto& dragTarget : dragTargets) {
@@ -2705,7 +2706,7 @@ std::array<float, 3> Viewer3DPanel::GetSelectionDragAxisVector(
         .trusses = m_dragTrussUuids,
         .supports = {},
         .sceneObjects = m_dragSceneObjectUuids};
-    const auto targets = scene_grouping::BuildTransformTargets(
+    const auto targets = scene_grouping::BuildInteractiveTransformTargets(
         ConfigManager::Get().GetScene(), selection);
     if (targets.empty())
         return worldAxis;
@@ -2849,7 +2850,7 @@ std::optional<magnet_snap::SnapSource> Viewer3DPanel::BuildActiveMagnetSource() 
         scene_grouping::ObjectSelection selection;
         selection.fixtures = m_dragFixtureUuids;
         selection.trusses = m_dragTrussUuids;
-        const auto targets = scene_grouping::BuildTransformTargets(
+        const auto targets = scene_grouping::BuildInteractiveTransformTargets(
             ConfigManager::Get().GetScene(), selection);
         if (targets.size() == 1 &&
             targets.front().type == MvrNodeType::GroupObject)


### PR DESCRIPTION
### Motivation
- Address incorrect grouped-transform promotion and stale local transforms that caused grouped trusses, supports, or scene objects to move or serialize incorrectly. 
- Make interactive (mouse/CLI/Magnet) transforms follow a clear policy that promotes only grouped trusses while table edits remain exact node updates. 
- Fix the CLI to accept compact negative relative tokens like `--1` and ensure malformed transform input does not create empty undo entries. 

### Description
- Introduced explicit target-resolution helpers: `BuildExactTransformTargets` and `BuildInteractiveTransformTargets`, and used the interactive policy in input and viewer paths by replacing ad-hoc calls to `BuildTransformTargets` with `BuildInteractiveTransformTargets`. 
- Kept structural grouping/ungrouping behavior unchanged while promoting only grouped trusses for interactive rigging and deduplicating promoted roots to avoid double-transforms. 
- Routed fixture/truss/support/scene-object table edits to compute and apply the requested world transform via `SetTargetWorldTransform` (preserving non-transform fields and recalculating `localTransform`), instead of overwriting transform metadata directly. 
- Enhanced console parsing in `ParseTransformCommandSegment` to accept compact `++1`/`--1` forms, detect malformed segments, and avoid pushing undo states for invalid transforms; updated `ConsolePanel` to validate segments and emit an actionable message on invalid input. 
- Applied the interactive policy consistently to `Viewer2D`, `Viewer3D`, and Magnet code paths, added focused regression tests, and updated user docs and the release notes draft describing the new behavior. 

### Testing
- Ran the focused unit/regression tests by compiling and executing: `SceneGroupingPreservesTransforms`, `ConsoleCommandParser`, and `MagnetSnapCore`, and they completed successfully. 
- Ran the repository checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both passed. 
- Verified `git diff --check` passed with no whitespace/errors. 
- CMake/CTest full configuration and the wider test matrix were not executed because the build configuration failed in this environment due to missing `wxWidgets` development libraries, so full CTest runs (project-wide) remain unexecuted in this branch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a049eb2708324ba1cbb31de4c4e51)