### PR TITLE
Fix continuous placement coordinate contracts and regression coverage

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -82,6 +82,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/truss_gdtf_builder.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/trussloader.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ui_render_size.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/pixel_coordinate_math.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ui_unit_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/utf8_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/wx_path_utils.cpp

--- a/core/pixel_coordinate_math.cpp
+++ b/core/pixel_coordinate_math.cpp
@@ -43,4 +43,17 @@ FramebufferToLogical(const std::array<double, 2> &framebuffer, double scale) {
   return Convert(framebuffer, 1.0 / scale);
 }
 
+// Converts both logical samples before returning an incremental pixel delta.
+std::optional<std::array<int, 2>>
+IncrementalFramebufferDelta(const std::array<double, 2> &currentLogical,
+                            const std::array<double, 2> &previousLogical,
+                            double scale) {
+  const auto current = LogicalToFramebuffer(currentLogical, scale);
+  const auto previous = LogicalToFramebuffer(previousLogical, scale);
+  if (!current || !previous)
+    return std::nullopt;
+  return std::array<int, 2>{(*current)[0] - (*previous)[0],
+                            (*current)[1] - (*previous)[1]};
+}
+
 } // namespace pixel_coordinates

--- a/core/pixel_coordinate_math.cpp
+++ b/core/pixel_coordinate_math.cpp
@@ -1,0 +1,46 @@
+#include "pixel_coordinate_math.h"
+
+#include <cmath>
+#include <limits>
+
+namespace pixel_coordinates {
+namespace {
+
+// Rounds a finite scaled coordinate when it is representable as an integer.
+std::optional<int> RoundCoordinate(double value) {
+  if (!std::isfinite(value) ||
+      value < static_cast<double>(std::numeric_limits<int>::min()) ||
+      value > static_cast<double>(std::numeric_limits<int>::max()))
+    return std::nullopt;
+  return static_cast<int>(std::lround(value));
+}
+
+// Converts two coordinates using a validated content scale.
+std::optional<std::array<int, 2>> Convert(const std::array<double, 2> &point,
+                                          double scale) {
+  if (!std::isfinite(scale) || scale <= 0.0)
+    return std::nullopt;
+  const auto x = RoundCoordinate(point[0] * scale);
+  const auto y = RoundCoordinate(point[1] * scale);
+  if (!x || !y)
+    return std::nullopt;
+  return std::array<int, 2>{*x, *y};
+}
+
+} // namespace
+
+// Converts logical pixels to rounded physical framebuffer pixels.
+std::optional<std::array<int, 2>>
+LogicalToFramebuffer(const std::array<double, 2> &logical, double scale) {
+  return Convert(logical, scale);
+}
+
+// Converts physical framebuffer pixels to rounded logical pixels.
+std::optional<std::array<int, 2>>
+FramebufferToLogical(const std::array<double, 2> &framebuffer, double scale) {
+  if (!std::isfinite(scale) || scale <= 0.0)
+    return std::nullopt;
+  return Convert(framebuffer, 1.0 / scale);
+}
+
+} // namespace pixel_coordinates

--- a/core/pixel_coordinate_math.h
+++ b/core/pixel_coordinate_math.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <array>
+#include <optional>
+
+namespace pixel_coordinates {
+
+// Converts logical pixels to rounded physical framebuffer pixels.
+std::optional<std::array<int, 2>>
+LogicalToFramebuffer(const std::array<double, 2> &logical, double scale);
+
+// Converts physical framebuffer pixels to rounded logical pixels.
+std::optional<std::array<int, 2>>
+FramebufferToLogical(const std::array<double, 2> &framebuffer, double scale);
+
+} // namespace pixel_coordinates

--- a/core/pixel_coordinate_math.h
+++ b/core/pixel_coordinate_math.h
@@ -13,4 +13,10 @@ LogicalToFramebuffer(const std::array<double, 2> &logical, double scale);
 std::optional<std::array<int, 2>>
 FramebufferToLogical(const std::array<double, 2> &framebuffer, double scale);
 
+// Converts both logical samples before returning an incremental pixel delta.
+std::optional<std::array<int, 2>>
+IncrementalFramebufferDelta(const std::array<double, 2> &currentLogical,
+                            const std::array<double, 2> &previousLogical,
+                            double scale);
+
 } // namespace pixel_coordinates

--- a/docs/developer/viewer_coordinate_contract.md
+++ b/docs/developer/viewer_coordinate_contract.md
@@ -43,6 +43,13 @@ The viewer interaction code uses the following authoritative units and state.
   target, and recomputes the preview even for zero raw translation. Preview
   apply and inverse restoration use the same interactive transform policy;
   neither operation commits grouping or creates a view-only Undo entry.
+- Viewer3D derives the raw anchor by removing pending preview translation from
+  its displayed drag anchor without mutating the scene. Ray intersection uses
+  that raw point as its plane point; only a successful intersection begins the
+  restore, absolute alignment, and fresh-preview transaction.
+- Confirmation preserves the snapped transform of the confirmed element but
+  seeds its next clone from the raw anchor. The new clone remains pending until
+  the normal absolute pointer-alignment path succeeds for the current revision.
 
 The view-dependent hidden-axis Magnet weights are separate from projection and
 remain intentional: 2D ignores the hidden axis, while 3D progressively reduces

--- a/docs/developer/viewer_coordinate_contract.md
+++ b/docs/developer/viewer_coordinate_contract.md
@@ -50,6 +50,12 @@ The viewer interaction code uses the following authoritative units and state.
 - Confirmation preserves the snapped transform of the confirmed element but
   seeds its next clone from the raw anchor. The new clone remains pending until
   the normal absolute pointer-alignment path succeeds for the current revision.
+- Incremental placement uses failure-preserving framebuffer conversion for both
+  pointer samples. Failed conversion or 3D projection retains the newest
+  logical pointer, invalidates alignment, and performs no preview or scene
+  transaction; the next safe update retries by absolute alignment.
+- All 3D placement geometry uses the raw anchor: pointer planes and projected
+  constraint axes never use the displayed preview-adjusted depth.
 
 The view-dependent hidden-axis Magnet weights are separate from projection and
 remain intentional: 2D ignores the hidden axis, while 3D progressively reduces

--- a/docs/developer/viewer_coordinate_contract.md
+++ b/docs/developer/viewer_coordinate_contract.md
@@ -14,6 +14,14 @@ The viewer interaction code uses the following authoritative units and state.
   Top, Bottom, Front, and Side. The hidden coordinate is zero when unprojecting.
   Rendering uses the equivalent orthographic bounds, and overlays and pointer
   interaction call this utility rather than maintaining another formula.
+- The authoritative rendered screen bases are Top `(+X, +Y)`, Bottom
+  `(-X, +Y)`, Front `(+X, +Z)`, and Side `(-Y, +Z)`. These signs follow the
+  right vectors produced by the existing `gluLookAt` cameras. Projection,
+  unprojection, measurement projection, and drag deltas share this basis.
+- Logical/framebuffer conversion uses the window content scale once and rounds
+  to the nearest integer pixel. Non-finite, zero, negative, or overflowing
+  conversions are invalid; callers retain pending alignment until valid
+  framebuffer dimensions and coordinates are available.
 - Viewer3D world coordinates are metres. Pointer placement intersects the ray
   from the current camera matrices with the view plane through the active
   selection-drag anchor. Logical pointer coordinates are scaled to framebuffer
@@ -26,6 +34,15 @@ The viewer interaction code uses the following authoritative units and state.
   invalidate pointer alignment. The next safe update restores any preview and
   aligns from the absolute current pointer under the new mapping; it never
   applies a pixel delta calculated with the old revision.
+- The revision state is the only alignment truth. Failed attempts do not mark
+  the revision aligned. Paint resolves a pending revision before rendering
+  when continuous placement is active and the canvas has received a valid
+  pointer position.
+- Re-anchoring first validates projection prerequisites. It then restores the
+  old Magnet preview, translates the raw anchor from an absolute pointer
+  target, and recomputes the preview even for zero raw translation. Preview
+  apply and inverse restoration use the same interactive transform policy;
+  neither operation commits grouping or creates a view-only Undo entry.
 
 The view-dependent hidden-axis Magnet weights are separate from projection and
 remain intentional: 2D ignores the hidden axis, while 3D progressively reduces

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -26,7 +26,8 @@ Changes since **v1.5.0**.
   conversion, and Magnet preview refresh so continuous placement remains
   visually anchored through view and framebuffer changes without extra Undo
   entries. Confirming snapped elements now keeps each following provisional
-  copy at the raw pointer position without inheriting the previous snap offset.
+  copy at the raw pointer position without inheriting the previous snap offset,
+  including after temporary high-DPI conversion or 3D projection failures.
 
 - Fixed a crash that could occur when opening another project after startup by
   releasing viewer scene caches before the project replaces its scene data.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -22,6 +22,10 @@ Changes since **v1.5.0**.
 - Fixed continuous fixture, truss, and scene-object placement drifting away
   from the pointer after zooming, panning, orbiting, resizing, fitting, or
   changing standard views in the 2D and 3D viewers.
+- Corrected Bottom and Side view pointer orientation, high-DPI coordinate
+  conversion, and Magnet preview refresh so continuous placement remains
+  visually anchored through view and framebuffer changes without extra Undo
+  entries.
 
 - Fixed a crash that could occur when opening another project after startup by
   releasing viewer scene caches before the project replaces its scene data.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -25,7 +25,8 @@ Changes since **v1.5.0**.
 - Corrected Bottom and Side view pointer orientation, high-DPI coordinate
   conversion, and Magnet preview refresh so continuous placement remains
   visually anchored through view and framebuffer changes without extra Undo
-  entries.
+  entries. Confirming snapped elements now keeps each following provisional
+  copy at the raw pointer position without inheriting the previous snap offset.
 
 - Fixed a crash that could occur when opening another project after startup by
   releasing viewer scene caches before the project replaces its scene data.

--- a/models/continuous_placement_scene.cpp
+++ b/models/continuous_placement_scene.cpp
@@ -113,6 +113,32 @@ std::array<float, 3> PositionMeters(const MvrScene &scene,
   return {0.0f, 0.0f, 0.0f};
 }
 
+// Sets the element origin from viewer world units without changing orientation.
+void SetPositionMeters(MvrScene &scene, ContinuousPlacementType type,
+                       const std::string &uuid,
+                       const std::array<float, 3> &positionMeters) {
+  auto setOrigin = [&](auto &elements) {
+    const auto it = elements.find(uuid);
+    if (it != elements.end())
+      it->second.transform.o = {positionMeters[0] * 1000.0f,
+                                positionMeters[1] * 1000.0f,
+                                positionMeters[2] * 1000.0f};
+  };
+  switch (type) {
+  case ContinuousPlacementType::Fixture:
+    setOrigin(scene.fixtures);
+    break;
+  case ContinuousPlacementType::Truss:
+    setOrigin(scene.trusses);
+    break;
+  case ContinuousPlacementType::SceneObject:
+    setOrigin(scene.sceneObjects);
+    break;
+  case ContinuousPlacementType::None:
+    break;
+  }
+}
+
 // Returns a user-facing lowercase name for the placement element type.
 const char *ElementName(ContinuousPlacementType type) {
   switch (type) {

--- a/models/continuous_placement_scene.h
+++ b/models/continuous_placement_scene.h
@@ -18,6 +18,9 @@ void EraseElement(MvrScene &scene, ContinuousPlacementType type,
 std::array<float, 3> PositionMeters(const MvrScene &scene,
                                     ContinuousPlacementType type,
                                     const std::string &uuid);
+void SetPositionMeters(MvrScene &scene, ContinuousPlacementType type,
+                       const std::string &uuid,
+                       const std::array<float, 3> &positionMeters);
 const char *ElementName(ContinuousPlacementType type);
 
 } // namespace continuous_placement

--- a/models/continuous_placement_state.cpp
+++ b/models/continuous_placement_state.cpp
@@ -42,4 +42,13 @@ AbsoluteAlignmentDelta(const std::array<float, 3> &pointerWorld,
           pointerWorld[2] - rawOriginWorld[2]};
 }
 
+// Removes a temporary preview translation from a displayed world anchor.
+std::array<float, 3>
+RawAnchorFromPreview(const std::array<float, 3> &displayedAnchorMeters,
+                     const std::array<float, 3> &previewDeltaMm) {
+  return {displayedAnchorMeters[0] - previewDeltaMm[0] / 1000.0f,
+          displayedAnchorMeters[1] - previewDeltaMm[1] / 1000.0f,
+          displayedAnchorMeters[2] - previewDeltaMm[2] / 1000.0f};
+}
+
 } // namespace continuous_placement

--- a/models/continuous_placement_state.cpp
+++ b/models/continuous_placement_state.cpp
@@ -4,6 +4,10 @@
 
 namespace continuous_placement {
 
+// Creates stale alignment state at a specified nonzero revision.
+ViewRevisionState::ViewRevisionState(std::uint64_t initialRevision)
+    : revision_(initialRevision == 0 ? 1 : initialRevision) {}
+
 // Invalidates pointer alignment after a camera or viewport transformation.
 void ViewRevisionState::Invalidate() {
   if (revision_ == std::numeric_limits<std::uint64_t>::max()) {
@@ -16,6 +20,12 @@ void ViewRevisionState::Invalidate() {
 
 // Records that placement was aligned using the current viewport mapping.
 void ViewRevisionState::MarkAligned() { alignedRevision_ = revision_; }
+
+// Records a completed attempt only when all alignment work succeeded.
+void ViewRevisionState::CompleteAlignmentAttempt(bool succeeded) {
+  if (succeeded)
+    MarkAligned();
+}
 
 // Reports whether placement must be recomputed from the absolute pointer.
 bool ViewRevisionState::NeedsAlignment() const {

--- a/models/continuous_placement_state.h
+++ b/models/continuous_placement_state.h
@@ -37,4 +37,9 @@ std::array<float, 3>
 AbsoluteAlignmentDelta(const std::array<float, 3> &pointerWorld,
                        const std::array<float, 3> &rawOriginWorld);
 
+// Removes a temporary preview translation from a displayed world anchor.
+std::array<float, 3>
+RawAnchorFromPreview(const std::array<float, 3> &displayedAnchorMeters,
+                     const std::array<float, 3> &previewDeltaMm);
+
 } // namespace continuous_placement

--- a/models/continuous_placement_state.h
+++ b/models/continuous_placement_state.h
@@ -8,11 +8,17 @@ namespace continuous_placement {
 // Tracks whether a pointer mapping belongs to the current viewport revision.
 class ViewRevisionState {
 public:
+  // Creates stale alignment state at a specified nonzero revision.
+  explicit ViewRevisionState(std::uint64_t initialRevision = 1);
+
   // Invalidates pointer alignment after a camera or viewport transformation.
   void Invalidate();
 
   // Records that placement was aligned using the current viewport mapping.
   void MarkAligned();
+
+  // Records a completed attempt only when all alignment work succeeded.
+  void CompleteAlignmentAttempt(bool succeeded);
 
   // Reports whether placement must be recomputed from the absolute pointer.
   bool NeedsAlignment() const;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2104,9 +2104,10 @@ add_test(NAME ContinuousPlacementScene COMMAND continuous_placement_scene_test)
 
 add_executable(viewer2d_coordinate_math_test
                viewer2d_coordinate_math_test.cpp
-               ../viewer2d/viewer2d_coordinate_math.cpp)
+               ../viewer2d/viewer2d_coordinate_math.cpp
+               ../core/pixel_coordinate_math.cpp)
 target_include_directories(viewer2d_coordinate_math_test PRIVATE
-                           ../viewer2d ../viewer3d)
+                           ../viewer2d ../viewer3d ../core)
 add_test(NAME Viewer2DCoordinateMath COMMAND viewer2d_coordinate_math_test)
 
 add_executable(layer_visibility_state_test

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2337,3 +2337,10 @@ foreach(perastage_test_target IN LISTS perastage_test_targets)
         target_link_libraries(${perastage_test_target} PRIVATE perastage_uuid)
     endif()
 endforeach()
+
+add_executable(selection_drag_math_test
+               selection_drag_math_test.cpp
+               ../viewer3d/interaction/selection_drag_math.cpp)
+target_include_directories(selection_drag_math_test PRIVATE
+                           ../viewer3d/interaction)
+add_test(NAME SelectionDragMath COMMAND selection_drag_math_test)

--- a/tests/continuous_placement_scene_test.cpp
+++ b/tests/continuous_placement_scene_test.cpp
@@ -45,6 +45,22 @@ int main() {
   assert(rollover.Revision() == 1);
   assert(rollover.NeedsAlignment());
 
+  // Removing a preview component along the camera direction recovers the same
+  // raw projection-plane point through repeated view changes without drift.
+  const std::array<float, 3> rawAnchor{2.0f, 3.0f, 4.0f};
+  const std::array<float, 3> previewMm{250.0f, -500.0f, 750.0f};
+  std::array<float, 3> displayedAnchor{rawAnchor[0] + previewMm[0] / 1000.0f,
+                                       rawAnchor[1] + previewMm[1] / 1000.0f,
+                                       rawAnchor[2] + previewMm[2] / 1000.0f};
+  for (int viewChange = 0; viewChange < 20; ++viewChange) {
+    const auto recovered =
+        continuous_placement::RawAnchorFromPreview(displayedAnchor, previewMm);
+    assert(recovered == rawAnchor);
+    displayedAnchor = {recovered[0] + previewMm[0] / 1000.0f,
+                       recovered[1] + previewMm[1] / 1000.0f,
+                       recovered[2] + previewMm[2] / 1000.0f};
+  }
+
   MvrScene scene;
 
   Fixture fixture;
@@ -70,6 +86,29 @@ int main() {
       scene, ContinuousPlacementType::Truss, "truss-1", "truss-2"));
   assert(continuous_placement::CloneElement(
       scene, ContinuousPlacementType::SceneObject, "object-1", "object-2"));
+
+  // A confirmed snapped source remains snapped while its next clone starts
+  // from the raw pointer anchor rather than inheriting the old preview.
+  for (const auto type :
+       {ContinuousPlacementType::Fixture, ContinuousPlacementType::Truss,
+        ContinuousPlacementType::SceneObject}) {
+    const std::string source =
+        type == ContinuousPlacementType::Fixture ? "fixture-1"
+        : type == ContinuousPlacementType::Truss ? "truss-1"
+                                                 : "object-1";
+    const std::string clone = source + "-raw-clone";
+    const auto snapped =
+        continuous_placement::PositionMeters(scene, type, source);
+    const std::array<float, 3> preview{0.25f, -0.5f, 0.75f};
+    const std::array<float, 3> raw{snapped[0] - preview[0],
+                                   snapped[1] - preview[1],
+                                   snapped[2] - preview[2]};
+    assert(continuous_placement::CloneElement(scene, type, source, clone));
+    continuous_placement::SetPositionMeters(scene, type, clone, raw);
+    assert(continuous_placement::PositionMeters(scene, type, source) ==
+           snapped);
+    assert(continuous_placement::PositionMeters(scene, type, clone) == raw);
+  }
 
   assert(continuous_placement::PositionMeters(
              scene, ContinuousPlacementType::Fixture, "fixture-1") ==

--- a/tests/continuous_placement_scene_test.cpp
+++ b/tests/continuous_placement_scene_test.cpp
@@ -3,15 +3,27 @@
 #include "mvrscene.h"
 
 #include <cassert>
+#include <cstdint>
+#include <limits>
 
 // Verifies cloning and removal for every supported continuous placement type.
 int main() {
   // A camera revision must force absolute re-alignment without retaining a
   // temporary snap preview or adding a stale pointer delta.
   continuous_placement::ViewRevisionState viewState;
+  assert(viewState.NeedsAlignment());
+  viewState.CompleteAlignmentAttempt(false);
+  assert(viewState.NeedsAlignment());
   float rawPosition = 4.0f;
   float displayedPosition = rawPosition + 1.5f;
-  viewState.MarkAligned();
+  viewState.CompleteAlignmentAttempt(true);
+  assert(!viewState.NeedsAlignment());
+  viewState.Invalidate();
+  viewState.Invalidate();
+  assert(viewState.NeedsAlignment());
+  viewState.CompleteAlignmentAttempt(false);
+  assert(viewState.NeedsAlignment());
+  viewState.CompleteAlignmentAttempt(true);
   assert(!viewState.NeedsAlignment());
   for (float pointerWorld : {8.0f, 6.0f, 9.5f}) {
     viewState.Invalidate();
@@ -25,6 +37,13 @@ int main() {
     assert(!viewState.NeedsAlignment());
     assert(displayedPosition == pointerWorld + 1.5f);
   }
+
+  continuous_placement::ViewRevisionState rollover(
+      std::numeric_limits<std::uint64_t>::max());
+  rollover.MarkAligned();
+  rollover.Invalidate();
+  assert(rollover.Revision() == 1);
+  assert(rollover.NeedsAlignment());
 
   MvrScene scene;
 

--- a/tests/selection_drag_math_test.cpp
+++ b/tests/selection_drag_math_test.cpp
@@ -1,0 +1,32 @@
+#include "selection_drag_math.h"
+
+#include <cassert>
+#include <cmath>
+
+// Verifies perspective plane depth and constrained-axis math use explicit data.
+int main() {
+  const std::array<double, 3> origin{0.0, 0.0, 0.0};
+  const std::array<double, 3> previousRay{0.0, 0.0, 1.0};
+  const std::array<double, 3> currentRay{0.2, 0.0, 1.0};
+  const std::array<double, 3> normal{0.0, 0.0, 1.0};
+  const auto previousRaw = viewer3d::IntersectRayWithPlane(
+      origin, previousRay, {0.0, 0.0, 5.0}, normal);
+  const auto currentRaw = viewer3d::IntersectRayWithPlane(
+      origin, currentRay, {0.0, 0.0, 5.0}, normal);
+  const auto currentDisplayed = viewer3d::IntersectRayWithPlane(
+      origin, currentRay, {0.0, 0.0, 8.0}, normal);
+  assert(previousRaw && currentRaw && currentDisplayed);
+  assert(std::abs(((*currentRaw)[0] - (*previousRaw)[0]) - 1.0) < 1e-9);
+  assert(std::abs((*currentDisplayed)[0] - 1.6) < 1e-9);
+  assert(!viewer3d::IntersectRayWithPlane(origin, {1.0, 0.0, 0.0},
+                                          {0.0, 0.0, 5.0}, normal));
+
+  const std::array<viewer3d::ProjectedAxis, 3> axes{
+      {{1.0, 0.0, 10.0, true}, {0.0, 1.0, 20.0, true}, {0.5, 0.5, 5.0, true}}};
+  assert(viewer3d::SelectDragAxisFromMouseDelta(10, 1, axes) ==
+         viewer3d::SelectionDragAxis::X);
+  assert(std::abs(viewer3d::ComputeDragMetersOnAxis(
+                      10, 0, viewer3d::SelectionDragAxis::X, axes) -
+                  1.0) < 1e-9);
+  return 0;
+}

--- a/tests/viewer2d_coordinate_math_test.cpp
+++ b/tests/viewer2d_coordinate_math_test.cpp
@@ -88,6 +88,10 @@ void CheckPixelConversion() {
     assert(!pixel_coordinates::LogicalToFramebuffer({1.0, 1.0}, scale));
     assert(!pixel_coordinates::FramebufferToLogical({1.0, 1.0}, scale));
   }
+  assert(!pixel_coordinates::LogicalToFramebuffer(
+      {std::numeric_limits<double>::max(), 1.0}, 2.0));
+  assert(!pixel_coordinates::FramebufferToLogical(
+      {std::numeric_limits<double>::max(), 1.0}, 0.5));
 }
 
 } // namespace

--- a/tests/viewer2d_coordinate_math_test.cpp
+++ b/tests/viewer2d_coordinate_math_test.cpp
@@ -92,6 +92,16 @@ void CheckPixelConversion() {
       {std::numeric_limits<double>::max(), 1.0}, 2.0));
   assert(!pixel_coordinates::FramebufferToLogical(
       {std::numeric_limits<double>::max(), 1.0}, 0.5));
+  const auto delta = pixel_coordinates::IncrementalFramebufferDelta(
+      {15.0, 18.0}, {10.0, 10.0}, 1.5);
+  assert((delta == std::optional<std::array<int, 2>>{{8, 12}}));
+  for (double scale : {0.0, -1.0, std::numeric_limits<double>::infinity(),
+                       std::numeric_limits<double>::quiet_NaN()}) {
+    assert(!pixel_coordinates::IncrementalFramebufferDelta(
+        {15.0, 18.0}, {10.0, 10.0}, scale));
+  }
+  assert(!pixel_coordinates::IncrementalFramebufferDelta(
+      {std::numeric_limits<double>::max(), 1.0}, {0.0, 0.0}, 2.0));
 }
 
 } // namespace

--- a/tests/viewer2d_coordinate_math_test.cpp
+++ b/tests/viewer2d_coordinate_math_test.cpp
@@ -1,8 +1,10 @@
+#include "pixel_coordinate_math.h"
 #include "viewer2d_coordinate_math.h"
 
 #include <array>
 #include <cassert>
 #include <cmath>
+#include <limits>
 
 namespace {
 
@@ -11,50 +13,99 @@ void ExpectNear(float actual, float expected) {
   assert(std::abs(actual - expected) < 0.0002f);
 }
 
-// Verifies both directions of the coordinate mapping for one view and state.
-void CheckRoundTrip(Viewer2DView view, float zoom, float panX, float panY,
-                    float framebufferScale) {
-  const viewer2d::CoordinateTransform transform{
-      static_cast<int>(800 * framebufferScale),
-      static_cast<int>(600 * framebufferScale),
-      zoom,
-      panX,
-      panY,
-      view};
+// Verifies explicit camera-basis directions rather than only inverse parity.
+void CheckExpectedDirections(Viewer2DView view, int horizontalAxis,
+                             float horizontalSign, int verticalAxis,
+                             float verticalSign) {
+  const viewer2d::CoordinateTransform transform{800,  600,  1.0f,
+                                                0.0f, 0.0f, view};
+  const std::array<float, 3> origin{0.0f, 0.0f, 0.0f};
+  auto horizontal = origin;
+  auto vertical = origin;
+  horizontal[horizontalAxis] = 1.0f;
+  vertical[verticalAxis] = 1.0f;
+  const auto center = viewer2d::WorldToFramebuffer(origin, transform);
+  const auto right = viewer2d::WorldToFramebuffer(horizontal, transform);
+  const auto up = viewer2d::WorldToFramebuffer(vertical, transform);
+  assert(center && right && up);
+  ExpectNear((*right)[0] - (*center)[0], 25.0f * horizontalSign);
+  ExpectNear((*up)[1] - (*center)[1], -25.0f * verticalSign);
+
+  const auto drag = viewer2d::ScreenDeltaToWorld(2.0f, 3.0f, view);
+  ExpectNear(drag[horizontalAxis], 2.0f * horizontalSign);
+  ExpectNear(drag[verticalAxis], 3.0f * verticalSign);
+}
+
+// Verifies projection, unprojection, and bounds under one complete view state.
+void CheckState(Viewer2DView view, float zoom, float panX, float panY,
+                int width, int height) {
+  const viewer2d::CoordinateTransform transform{width, height, zoom,
+                                                panX,  panY,   view};
   const std::array<float, 3> world{2.5f, -1.75f, 4.25f};
   const auto framebuffer = viewer2d::WorldToFramebuffer(world, transform);
-  assert(framebuffer);
-  const auto restored = viewer2d::FramebufferToWorld(*framebuffer, transform);
-  assert(restored);
-  const auto secondFramebuffer =
+  const auto restored =
+      framebuffer ? viewer2d::FramebufferToWorld(*framebuffer, transform)
+                  : std::nullopt;
+  assert(framebuffer && restored);
+  const auto projectedAgain =
       viewer2d::WorldToFramebuffer(*restored, transform);
-  assert(secondFramebuffer);
-  ExpectNear((*secondFramebuffer)[0], (*framebuffer)[0]);
-  ExpectNear((*secondFramebuffer)[1], (*framebuffer)[1]);
+  assert(projectedAgain);
+  ExpectNear((*projectedAgain)[0], (*framebuffer)[0]);
+  ExpectNear((*projectedAgain)[1], (*framebuffer)[1]);
 
-  if (view == Viewer2DView::Top || view == Viewer2DView::Bottom) {
-    ExpectNear((*restored)[0], world[0]);
-    ExpectNear((*restored)[1], world[1]);
-  } else if (view == Viewer2DView::Front) {
-    ExpectNear((*restored)[0], world[0]);
-    ExpectNear((*restored)[2], world[2]);
-  } else {
-    ExpectNear((*restored)[1], world[1]);
-    ExpectNear((*restored)[2], world[2]);
+  const auto bounds = viewer2d::ComputeOrthographicBounds(transform);
+  assert(bounds);
+  const auto lowerLeft = viewer2d::FramebufferToWorld(
+      {0.0f, static_cast<float>(height)}, transform);
+  const auto upperRight = viewer2d::FramebufferToWorld(
+      {static_cast<float>(width), 0.0f}, transform);
+  assert(lowerLeft && upperRight);
+  const auto basis = viewer2d::GetViewBasis(view);
+  ExpectNear((*lowerLeft)[basis.horizontalAxis] * basis.horizontalSign,
+             bounds->left);
+  ExpectNear((*upperRight)[basis.verticalAxis] * basis.verticalSign,
+             bounds->top);
+}
+
+// Verifies logical/framebuffer conversion, rounding, and invalid scales.
+void CheckPixelConversion() {
+  for (double scale : {1.0, 1.25, 2.0}) {
+    const auto framebuffer =
+        pixel_coordinates::LogicalToFramebuffer({17.0, 23.0}, scale);
+    assert(framebuffer);
+    const auto logical = pixel_coordinates::FramebufferToLogical(
+        {static_cast<double>((*framebuffer)[0]),
+         static_cast<double>((*framebuffer)[1])},
+        scale);
+    assert(logical);
+    assert(std::abs((*logical)[0] - 17) <= 1);
+    assert(std::abs((*logical)[1] - 23) <= 1);
+  }
+  assert((pixel_coordinates::LogicalToFramebuffer({1.0, 1.0}, 1.5) ==
+          std::optional<std::array<int, 2>>{{2, 2}}));
+  for (double scale : {0.0, -1.0, std::numeric_limits<double>::infinity(),
+                       std::numeric_limits<double>::quiet_NaN()}) {
+    assert(!pixel_coordinates::LogicalToFramebuffer({1.0, 1.0}, scale));
+    assert(!pixel_coordinates::FramebufferToLogical({1.0, 1.0}, scale));
   }
 }
 
 } // namespace
 
-// Exercises every 2D view under default, zoomed, panned, and scaled states.
+// Exercises the authoritative basis and pixel contract for every 2D view.
 int main() {
+  CheckExpectedDirections(Viewer2DView::Top, 0, 1.0f, 1, 1.0f);
+  CheckExpectedDirections(Viewer2DView::Bottom, 0, -1.0f, 1, 1.0f);
+  CheckExpectedDirections(Viewer2DView::Front, 0, 1.0f, 2, 1.0f);
+  CheckExpectedDirections(Viewer2DView::Side, 1, -1.0f, 2, 1.0f);
   for (Viewer2DView view : {Viewer2DView::Top, Viewer2DView::Bottom,
                             Viewer2DView::Front, Viewer2DView::Side}) {
-    CheckRoundTrip(view, 1.0f, 0.0f, 0.0f, 1.0f);
-    CheckRoundTrip(view, 2.4f, 0.0f, 0.0f, 1.0f);
-    CheckRoundTrip(view, 1.0f, 37.0f, -19.0f, 1.0f);
-    CheckRoundTrip(view, 0.65f, -43.0f, 28.0f, 1.0f);
-    CheckRoundTrip(view, 1.7f, 12.0f, -31.0f, 2.0f);
+    CheckState(view, 1.0f, 0.0f, 0.0f, 800, 600);
+    CheckState(view, 2.4f, 0.0f, 0.0f, 800, 600);
+    CheckState(view, 1.0f, 37.0f, -19.0f, 800, 600);
+    CheckState(view, 0.65f, -43.0f, 28.0f, 1000, 750);
+    CheckState(view, 1.7f, 12.0f, -31.0f, 1600, 1200);
   }
+  CheckPixelConversion();
   return 0;
 }

--- a/viewer2d/viewer2d_coordinate_math.cpp
+++ b/viewer2d/viewer2d_coordinate_math.cpp
@@ -13,22 +13,41 @@ bool IsValid(const CoordinateTransform &transform) {
          std::isfinite(transform.panPixelsY);
 }
 
-// Maps a world position onto the two visible axes of an orthographic view.
+// Maps a world position onto the signed axes of the rendered view camera.
 std::array<float, 2> VisibleAxes(const std::array<float, 3> &world,
                                  Viewer2DView view) {
-  switch (view) {
-  case Viewer2DView::Top:
-  case Viewer2DView::Bottom:
-    return {world[0], world[1]};
-  case Viewer2DView::Front:
-    return {world[0], world[2]};
-  case Viewer2DView::Side:
-    return {world[1], world[2]};
-  }
-  return {world[0], world[1]};
+  const ViewBasis basis = GetViewBasis(view);
+  return {world[basis.horizontalAxis] * basis.horizontalSign,
+          world[basis.verticalAxis] * basis.verticalSign};
 }
 
 } // namespace
+
+// Returns the authoritative screen basis established by the OpenGL camera.
+ViewBasis GetViewBasis(Viewer2DView view) {
+  switch (view) {
+  case Viewer2DView::Top:
+    return {0, 1, 1.0f, 1.0f};
+  case Viewer2DView::Bottom:
+    return {0, 1, -1.0f, 1.0f};
+  case Viewer2DView::Front:
+    return {0, 2, 1.0f, 1.0f};
+  case Viewer2DView::Side:
+    return {1, 2, -1.0f, 1.0f};
+  }
+  return {0, 1, 1.0f, 1.0f};
+}
+
+// Maps a screen-space metre delta onto the visible world axes.
+std::array<float, 3> ScreenDeltaToWorld(float horizontalMeters,
+                                        float verticalMeters,
+                                        Viewer2DView view) {
+  const ViewBasis basis = GetViewBasis(view);
+  std::array<float, 3> world{0.0f, 0.0f, 0.0f};
+  world[basis.horizontalAxis] = horizontalMeters * basis.horizontalSign;
+  world[basis.verticalAxis] = verticalMeters * basis.verticalSign;
+  return world;
+}
 
 // Computes projection bounds from the same transform used for pointer mapping.
 std::optional<OrthographicBounds>
@@ -51,7 +70,6 @@ WorldToFramebuffer(const std::array<float, 3> &world,
   if (!IsValid(transform))
     return std::nullopt;
   const auto visible = VisibleAxes(world, transform.view);
-  const float scale = kPixelsPerMeter * transform.zoom;
   return std::array<float, 2>{
       transform.framebufferWidth * 0.5f +
           (visible[0] * kPixelsPerMeter + transform.panPixelsX) *
@@ -73,16 +91,7 @@ FramebufferToWorld(const std::array<float, 2> &framebuffer,
   const float v =
       (transform.framebufferHeight * 0.5f - framebuffer[1]) / scale -
       transform.panPixelsY / kPixelsPerMeter;
-  switch (transform.view) {
-  case Viewer2DView::Top:
-  case Viewer2DView::Bottom:
-    return std::array<float, 3>{u, v, 0.0f};
-  case Viewer2DView::Front:
-    return std::array<float, 3>{u, 0.0f, v};
-  case Viewer2DView::Side:
-    return std::array<float, 3>{0.0f, u, v};
-  }
-  return std::array<float, 3>{u, v, 0.0f};
+  return ScreenDeltaToWorld(u, v, transform.view);
 }
 
 } // namespace viewer2d

--- a/viewer2d/viewer2d_coordinate_math.h
+++ b/viewer2d/viewer2d_coordinate_math.h
@@ -25,7 +25,23 @@ struct OrthographicBounds {
   float top = 0.0f;
 };
 
+// Defines the visible world axes and their signs on the rendered screen.
+struct ViewBasis {
+  int horizontalAxis = 0;
+  int verticalAxis = 1;
+  float horizontalSign = 1.0f;
+  float verticalSign = 1.0f;
+};
+
 constexpr float kPixelsPerMeter = 25.0f;
+
+// Returns the authoritative screen basis established by the OpenGL camera.
+ViewBasis GetViewBasis(Viewer2DView view);
+
+// Maps a screen-space metre delta onto the visible world axes.
+std::array<float, 3> ScreenDeltaToWorld(float horizontalMeters,
+                                        float verticalMeters,
+                                        Viewer2DView view);
 
 // Computes projection bounds from the same transform used for pointer mapping.
 std::optional<OrthographicBounds>

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -51,6 +51,7 @@
 #include "configmanager.h"
 #include "continuous_placement_scene.h"
 #include "viewer2d_coordinate_math.h"
+#include "../core/pixel_coordinate_math.h"
 #include "diagnostics/DiagnosticReport.h"
 #include "editable_focus_utils.h"
 #include "fixturepatchdialog.h"
@@ -407,12 +408,13 @@ wxPoint ToFramebufferPoint(wxWindow *window, const wxPoint &logicalPoint) {
     return logicalPoint;
   const double contentScale =
       static_cast<double>(window->GetContentScaleFactor());
-  if (!std::isfinite(contentScale) || contentScale <= 0.0)
+  const auto converted = pixel_coordinates::LogicalToFramebuffer(
+      {static_cast<double>(logicalPoint.x),
+       static_cast<double>(logicalPoint.y)},
+      contentScale);
+  if (!converted)
     return logicalPoint;
-  return wxPoint(static_cast<int>(std::lround(
-                     static_cast<double>(logicalPoint.x) * contentScale)),
-                 static_cast<int>(std::lround(
-                     static_cast<double>(logicalPoint.y) * contentScale)));
+  return wxPoint((*converted)[0], (*converted)[1]);
 }
 
 // Converts framebuffer-space mouse coordinates back to logical window
@@ -425,13 +427,15 @@ ToLogicalPointFromFramebuffer(wxWindow *window,
                    static_cast<int>(std::lround(framebufferPoint[1])));
   const double contentScale =
       static_cast<double>(window->GetContentScaleFactor());
-  if (!std::isfinite(contentScale) || contentScale <= 0.0) {
+  const auto converted = pixel_coordinates::FramebufferToLogical(
+      {static_cast<double>(framebufferPoint[0]),
+       static_cast<double>(framebufferPoint[1])},
+      contentScale);
+  if (!converted) {
     return wxPoint(static_cast<int>(std::lround(framebufferPoint[0])),
                    static_cast<int>(std::lround(framebufferPoint[1])));
   }
-  return wxPoint(
-      static_cast<int>(std::lround(framebufferPoint[0] / contentScale)),
-                 static_cast<int>(std::lround(framebufferPoint[1] / contentScale)));
+  return wxPoint((*converted)[0], (*converted)[1]);
 }
 
 // Emit grid primitives to a canvas so the command buffer records the same
@@ -806,7 +810,6 @@ void Viewer2DPanel::SetRenderMode(Viewer2DRenderMode mode) {
 void Viewer2DPanel::SetView(Viewer2DView view) {
   m_view = view;
   m_placementViewRevision.Invalidate();
-  m_continuousPlacementNeedsPointerAlignment = m_continuousPlacementActive;
   m_viewMotionSinceLastHoverHitTest = true;
   InvalidatePickCache();
   RequestRepaint();
@@ -874,7 +877,6 @@ void Viewer2DPanel::ApplyViewState(float offsetX, float offsetY, float zoom,
   m_view = view;
   m_renderMode = renderMode;
   m_placementViewRevision.Invalidate();
-  m_continuousPlacementNeedsPointerAlignment = m_continuousPlacementActive;
   InvalidatePickCache();
 }
 
@@ -892,7 +894,6 @@ bool Viewer2DPanel::FitViewToScene() {
   if (m_zoom < 0.1f)
     m_zoom = 0.1f;
   m_placementViewRevision.Invalidate();
-  m_continuousPlacementNeedsPointerAlignment = m_continuousPlacementActive;
   if (m_persistViewState)
     SaveViewToConfig();
   InvalidatePickCache();
@@ -1675,21 +1676,16 @@ void Viewer2DPanel::OnPaint(wxPaintEvent &WXUNUSED(event)) {
     m_controller.Update();
   }
 
+  if (m_continuousPlacementActive && m_hasLastMousePos &&
+      m_placementViewRevision.NeedsAlignment())
+    AlignContinuousElementToPointer(m_lastMousePos);
+
   Render();
 }
 
 std::array<float, 3> Viewer2DPanel::MapDragDelta(float dxMeters,
                                                  float dyMeters) const {
-  switch (m_view) {
-  case Viewer2DView::Top:
-  case Viewer2DView::Bottom:
-    return {dxMeters, dyMeters, 0.0f};
-  case Viewer2DView::Front:
-    return {dxMeters, 0.0f, dyMeters};
-  case Viewer2DView::Side:
-    return {0.0f, dxMeters, dyMeters};
-  }
-  return {dxMeters, dyMeters, 0.0f};
+  return viewer2d::ScreenDeltaToWorld(dxMeters, dyMeters, m_view);
 }
 
 // Computes the current center point for the dragged 2D selection.
@@ -1899,11 +1895,9 @@ void Viewer2DPanel::ApplySelectionDelta(
   float dxMm = deltaMeters[0] * 1000.0f;
   float dyMm = deltaMeters[1] * 1000.0f;
   float dzMm = deltaMeters[2] * 1000.0f;
-  if (dxMm == 0.0f && dyMm == 0.0f && dzMm == 0.0f)
-    return;
-
   ConfigManager &cfg = ConfigManager::Get();
-  if (!m_dragSelectionPushedUndo) {
+  const bool hasTranslation = dxMm != 0.0f || dyMm != 0.0f || dzMm != 0.0f;
+  if (hasTranslation && !m_dragSelectionPushedUndo) {
     cfg.PushUndoState("move selection");
     m_dragSelectionPushedUndo = true;
   }
@@ -1929,9 +1923,11 @@ void Viewer2DPanel::ApplySelectionDelta(
   }
   const auto policy =
       selection_movement_settings::LoadInteractiveTransformPolicy(cfg);
-  scene_grouping::TranslateSelection(cfg.GetScene(), selection, deltaMm,
-                                     transform_space::TransformSpace::World,
-                                     policy);
+  if (hasTranslation) {
+    scene_grouping::TranslateSelection(cfg.GetScene(), selection, deltaMm,
+                                       transform_space::TransformSpace::World,
+                                       policy);
+  }
   if (auto snap = FindActiveMagnetSnap()) {
     magnet_snap::ApplySnapTransform(cfg.GetScene(), *snap, policy);
     m_pendingMagnetSnap = snap;
@@ -1986,7 +1982,6 @@ void Viewer2DPanel::BeginContinuousPlacement(ContinuousPlacementType type,
   m_continuousPlacementActive = true;
   m_continuousPlacementType = type;
   m_placementViewRevision.Invalidate();
-  m_continuousPlacementNeedsPointerAlignment = true;
   m_continuousPlacementUuid = elementUuid;
   m_continuousPlacedUuids.clear();
   m_dragMode = DragMode::Selection;
@@ -2008,7 +2003,6 @@ void Viewer2DPanel::BeginContinuousPlacement(ContinuousPlacementType type,
   m_dragSelectionMoved = false;
   m_dragSelectionPushedUndo = true;
   m_dragAxis = DragAxis::None;
-  m_lastMousePos = ScreenToClient(wxGetMousePosition());
   m_pendingMagnetSnap.reset();
   SetFocus();
   RequestRepaint();
@@ -2042,8 +2036,7 @@ void Viewer2DPanel::ConfirmContinuousPlacement() {
   const auto placedUuids = m_continuousPlacedUuids;
   BeginContinuousPlacement(m_continuousPlacementType, nextUuid);
   m_continuousPlacedUuids = placedUuids;
-  m_continuousPlacementNeedsPointerAlignment = false;
-  m_placementViewRevision.MarkAligned();
+  m_placementViewRevision.CompleteAlignmentAttempt(true);
   RefreshContinuousPlacementViews();
 }
 
@@ -2117,7 +2110,6 @@ bool Viewer2DPanel::UndoContinuousPlacement() {
 void Viewer2DPanel::EndContinuousPlacementState() {
   m_continuousPlacementActive = false;
   m_continuousPlacementType = ContinuousPlacementType::None;
-  m_continuousPlacementNeedsPointerAlignment = false;
   m_continuousPlacementUuid.clear();
   m_continuousPlacedUuids.clear();
   m_dragMode = DragMode::None;
@@ -3044,6 +3036,7 @@ void Viewer2DPanel::TrackHoverHitTestTelemetry(
 // Handles left-button press setup for view dragging, selection dragging, and
 // rectangle selection.
 void Viewer2DPanel::OnMouseDown(wxMouseEvent &event) {
+  m_hasLastMousePos = true;
   if (m_continuousPlacementActive && event.LeftDown()) {
     CaptureMouse();
     m_draggedSincePress = false;
@@ -3264,7 +3257,6 @@ void Viewer2DPanel::OnMouseUp(wxMouseEvent &event) {
     m_dragMode = DragMode::Selection;
     m_draggedSincePress = false;
     if (navigated) {
-      m_continuousPlacementNeedsPointerAlignment = true;
       AlignContinuousElementToPointer(event.GetPosition());
     } else {
       ConfirmContinuousPlacement();
@@ -3867,17 +3859,21 @@ void Viewer2DPanel::OnCaptureLost(wxMouseCaptureLostEvent &WXUNUSED(event)) {
 
 // Aligns the provisional fixture with the raw world position under the pointer.
 bool Viewer2DPanel::AlignContinuousElementToPointer(const wxPoint &screenPos) {
-  RestorePendingMagnetSnapPreview();
   const auto pointerWorld = ComputeWorldPositionFromScreen(screenPos);
-  const auto currentWorld = ComputeSelectionDragCenterMeters();
-  if (!pointerWorld || !currentWorld)
+  auto rawWorld = ComputeSelectionDragCenterMeters();
+  if (!pointerWorld || !rawWorld)
     return false;
+
+  if (m_pendingMagnetSnap) {
+    for (int axis = 0; axis < 3; ++axis)
+      (*rawWorld)[axis] -=
+          m_pendingMagnetSnap->translationDeltaMm[axis] / 1000.0f;
+  }
 
   ApplySelectionDelta(
       continuous_placement::AbsoluteAlignmentDelta(*pointerWorld,
-                                                   *currentWorld));
-  m_continuousPlacementNeedsPointerAlignment = false;
-  m_placementViewRevision.MarkAligned();
+                                                   *rawWorld));
+  m_placementViewRevision.CompleteAlignmentAttempt(true);
   m_dragAxis = DragAxis::None;
   m_dragSelectionMoved = true;
   m_lastMousePos = screenPos;
@@ -3886,10 +3882,11 @@ bool Viewer2DPanel::AlignContinuousElementToPointer(const wxPoint &screenPos) {
 
 // Handles pointer-following placement, selection movement, and view panning.
 void Viewer2DPanel::OnMouseMove(wxMouseEvent &event) {
+  m_hasLastMousePos = true;
   if (m_continuousPlacementActive &&
       !(m_dragMode == DragMode::View && event.Dragging())) {
     const wxPoint pos = event.GetPosition();
-    if (m_continuousPlacementNeedsPointerAlignment) {
+    if (m_placementViewRevision.NeedsAlignment()) {
       AlignContinuousElementToPointer(pos);
     } else {
       const wxPoint framebufferPos = ToFramebufferPoint(this, pos);
@@ -3998,7 +3995,6 @@ void Viewer2DPanel::OnMouseMove(wxMouseEvent &event) {
     m_offsetX += dx / m_zoom;
     m_offsetY += dy / m_zoom;
     m_placementViewRevision.Invalidate();
-    m_continuousPlacementNeedsPointerAlignment = m_continuousPlacementActive;
     m_viewMotionSinceLastHoverHitTest = true;
     InvalidatePickCache();
     m_lastMousePos = pos;
@@ -4025,6 +4021,7 @@ void Viewer2DPanel::OnMouseMove(wxMouseEvent &event) {
 }
 
 void Viewer2DPanel::OnMouseWheel(wxMouseEvent &event) {
+  m_hasLastMousePos = true;
   MarkInteractionActivity();
 
   int rotation = event.GetWheelRotation();
@@ -4038,7 +4035,6 @@ void Viewer2DPanel::OnMouseWheel(wxMouseEvent &event) {
   if (m_zoom < 0.1f)
     m_zoom = 0.1f;
   m_placementViewRevision.Invalidate();
-  m_continuousPlacementNeedsPointerAlignment = m_continuousPlacementActive;
   if (m_continuousPlacementActive)
     AlignContinuousElementToPointer(event.GetPosition());
   InvalidatePickCache();
@@ -4083,8 +4079,7 @@ bool Viewer2DPanel::TryHandleViewportNavigationKey(int keyCode, bool altDown) {
   if (m_zoom < 0.1f)
     m_zoom = 0.1f;
   m_placementViewRevision.Invalidate();
-  m_continuousPlacementNeedsPointerAlignment = m_continuousPlacementActive;
-  if (m_continuousPlacementActive)
+  if (m_continuousPlacementActive && m_hasLastMousePos)
     AlignContinuousElementToPointer(m_lastMousePos);
   InvalidatePickCache();
   if (m_persistViewState)
@@ -4164,7 +4159,6 @@ void Viewer2DPanel::OnResize(wxSizeEvent &event) {
   }
   InvalidatePickCache();
   m_placementViewRevision.Invalidate();
-  m_continuousPlacementNeedsPointerAlignment = m_continuousPlacementActive;
   RequestRepaint();
   event.Skip();
 }

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -417,6 +417,20 @@ wxPoint ToFramebufferPoint(wxWindow *window, const wxPoint &logicalPoint) {
   return wxPoint((*converted)[0], (*converted)[1]);
 }
 
+// Converts a logical point while preserving conversion failure for placement.
+std::optional<wxPoint> TryToFramebufferPoint(wxWindow *window,
+                                             const wxPoint &logicalPoint) {
+  if (window == nullptr)
+    return std::nullopt;
+  const auto converted = pixel_coordinates::LogicalToFramebuffer(
+      {static_cast<double>(logicalPoint.x),
+       static_cast<double>(logicalPoint.y)},
+      static_cast<double>(window->GetContentScaleFactor()));
+  if (!converted)
+    return std::nullopt;
+  return wxPoint((*converted)[0], (*converted)[1]);
+}
+
 // Converts framebuffer-space mouse coordinates back to logical window
 // coordinates.
 wxPoint
@@ -1031,12 +1045,14 @@ Viewer2DPanel::ComputeWorldPositionFromScreen(const wxPoint &screenPos) const {
     return std::nullopt;
   const int width = renderSize.width;
   const int height = renderSize.height;
-  const wxPoint framebufferPos =
-      ToFramebufferPoint(const_cast<Viewer2DPanel *>(this), screenPos);
+  const auto framebufferPos =
+      TryToFramebufferPoint(const_cast<Viewer2DPanel *>(this), screenPos);
+  if (!framebufferPos)
+    return std::nullopt;
 
   return viewer2d::FramebufferToWorld(
-      {static_cast<float>(framebufferPos.x),
-       static_cast<float>(framebufferPos.y)},
+      {static_cast<float>(framebufferPos->x),
+       static_cast<float>(framebufferPos->y)},
       {width, height, m_zoom, m_offsetX, m_offsetY, m_view});
 }
 
@@ -2017,6 +2033,12 @@ void Viewer2DPanel::ConfirmContinuousPlacement() {
     return;
   }
 
+  auto nextRawPosition = continuous_placement::PositionMeters(
+      cfg.GetScene(), m_continuousPlacementType, m_continuousPlacementUuid);
+  if (m_pendingMagnetSnap) {
+    nextRawPosition = continuous_placement::RawAnchorFromPreview(
+        nextRawPosition, m_pendingMagnetSnap->translationDeltaMm);
+  }
   cfg.PushUndoState(std::string("place ") + continuous_placement::ElementName(
                         m_continuousPlacementType));
   m_continuousPlacedUuids.push_back(m_continuousPlacementUuid);
@@ -2032,11 +2054,14 @@ void Viewer2DPanel::ConfirmContinuousPlacement() {
     CancelContinuousPlacement();
     return;
   }
+  continuous_placement::SetPositionMeters(
+      cfg.GetScene(), m_continuousPlacementType, nextUuid, nextRawPosition);
   CommitActiveMagnetSnap();
   const auto placedUuids = m_continuousPlacedUuids;
   BeginContinuousPlacement(m_continuousPlacementType, nextUuid);
   m_continuousPlacedUuids = placedUuids;
-  m_placementViewRevision.CompleteAlignmentAttempt(true);
+  if (m_hasLastMousePos)
+    AlignContinuousElementToPointer(m_lastMousePos);
   RefreshContinuousPlacementViews();
 }
 
@@ -3865,9 +3890,8 @@ bool Viewer2DPanel::AlignContinuousElementToPointer(const wxPoint &screenPos) {
     return false;
 
   if (m_pendingMagnetSnap) {
-    for (int axis = 0; axis < 3; ++axis)
-      (*rawWorld)[axis] -=
-          m_pendingMagnetSnap->translationDeltaMm[axis] / 1000.0f;
+    *rawWorld = continuous_placement::RawAnchorFromPreview(
+        *rawWorld, m_pendingMagnetSnap->translationDeltaMm);
   }
 
   ApplySelectionDelta(

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -3913,11 +3913,19 @@ void Viewer2DPanel::OnMouseMove(wxMouseEvent &event) {
     if (m_placementViewRevision.NeedsAlignment()) {
       AlignContinuousElementToPointer(pos);
     } else {
-      const wxPoint framebufferPos = ToFramebufferPoint(this, pos);
-      const wxPoint lastFramebufferPos =
-          ToFramebufferPoint(this, m_lastMousePos);
-      int dx = framebufferPos.x - lastFramebufferPos.x;
-      int dy = framebufferPos.y - lastFramebufferPos.y;
+      const auto framebufferDelta = pixel_coordinates::IncrementalFramebufferDelta(
+          {static_cast<double>(pos.x), static_cast<double>(pos.y)},
+          {static_cast<double>(m_lastMousePos.x),
+           static_cast<double>(m_lastMousePos.y)},
+          static_cast<double>(GetContentScaleFactor()));
+      if (!framebufferDelta) {
+        m_lastMousePos = pos;
+        m_placementViewRevision.Invalidate();
+        RequestRepaint();
+        return;
+      }
+      int dx = (*framebufferDelta)[0];
+      int dy = (*framebufferDelta)[1];
       if (m_axisConstrainedMovementEnabled) {
         if (m_dragAxis == DragAxis::None &&
             (std::abs(dx) >= kSelectionDragStartThresholdPx ||

--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -342,7 +342,6 @@ private:
   bool m_continuousPlacementActive = false;
   ContinuousPlacementType m_continuousPlacementType =
       ContinuousPlacementType::None;
-  bool m_continuousPlacementNeedsPointerAlignment = false;
   continuous_placement::ViewRevisionState m_placementViewRevision;
   std::string m_continuousPlacementUuid;
   std::vector<std::string> m_continuousPlacedUuids;
@@ -352,6 +351,7 @@ private:
   wxPoint m_rectSelectStart;
   wxPoint m_rectSelectEnd;
   wxPoint m_lastMousePos;
+  bool m_hasLastMousePos = false;
   float m_offsetX = 0.0f;
   float m_offsetY = 0.0f;
   float m_zoom = 1.0f;

--- a/viewer3d/interaction/selection_drag_math.cpp
+++ b/viewer3d/interaction/selection_drag_math.cpp
@@ -40,9 +40,10 @@ SelectionDragAxis IndexToAxis(size_t index) {
 
 } // namespace
 
-SelectionDragAxis SelectDragAxisFromMouseDelta(
-    int mouseDx, int mouseDy, const std::array<ProjectedAxis, 3> &axes,
-    int activationThresholdPx) {
+SelectionDragAxis
+SelectDragAxisFromMouseDelta(int mouseDx, int mouseDy,
+                             const std::array<ProjectedAxis, 3> &axes,
+                             int activationThresholdPx) {
   if (std::abs(mouseDx) < activationThresholdPx &&
       std::abs(mouseDy) < activationThresholdPx) {
     return SelectionDragAxis::None;
@@ -57,7 +58,8 @@ SelectionDragAxis SelectDragAxisFromMouseDelta(
     const double lenSq = ScreenLengthSquared(axis);
     if (lenSq <= 1e-8)
       continue;
-    const double projected = std::abs(Dot(mouseDx, mouseDy, axis)) / std::sqrt(lenSq);
+    const double projected =
+        std::abs(Dot(mouseDx, mouseDy, axis)) / std::sqrt(lenSq);
     if (projected > bestScore) {
       bestScore = projected;
       bestAxis = IndexToAxis(axisIndex);
@@ -80,6 +82,30 @@ double ComputeDragMetersOnAxis(int mouseDx, int mouseDy, SelectionDragAxis axis,
   const double projectedPixels =
       Dot(mouseDx, mouseDy, projectedAxis) / std::sqrt(lenSq);
   return projectedPixels / projectedAxis.pixelsPerMeter;
+}
+
+// Intersects a world-space ray with a plane for deterministic drag projection.
+std::optional<std::array<double, 3>>
+IntersectRayWithPlane(const std::array<double, 3> &rayOrigin,
+                      const std::array<double, 3> &rayDirection,
+                      const std::array<double, 3> &planePoint,
+                      const std::array<double, 3> &planeNormal) {
+  const double denominator = rayDirection[0] * planeNormal[0] +
+                             rayDirection[1] * planeNormal[1] +
+                             rayDirection[2] * planeNormal[2];
+  if (!std::isfinite(denominator) || std::abs(denominator) <= 1e-12)
+    return std::nullopt;
+  const double t = ((planePoint[0] - rayOrigin[0]) * planeNormal[0] +
+                    (planePoint[1] - rayOrigin[1]) * planeNormal[1] +
+                    (planePoint[2] - rayOrigin[2]) * planeNormal[2]) /
+                   denominator;
+  std::array<double, 3> result{rayOrigin[0] + rayDirection[0] * t,
+                               rayOrigin[1] + rayDirection[1] * t,
+                               rayOrigin[2] + rayDirection[2] * t};
+  if (!std::isfinite(result[0]) || !std::isfinite(result[1]) ||
+      !std::isfinite(result[2]))
+    return std::nullopt;
+  return result;
 }
 
 } // namespace viewer3d

--- a/viewer3d/interaction/selection_drag_math.h
+++ b/viewer3d/interaction/selection_drag_math.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <optional>
 
 namespace viewer3d {
 
@@ -13,11 +14,19 @@ struct ProjectedAxis {
   bool valid = false;
 };
 
-SelectionDragAxis SelectDragAxisFromMouseDelta(
-    int mouseDx, int mouseDy, const std::array<ProjectedAxis, 3> &axes,
-    int activationThresholdPx = 3);
+SelectionDragAxis
+SelectDragAxisFromMouseDelta(int mouseDx, int mouseDy,
+                             const std::array<ProjectedAxis, 3> &axes,
+                             int activationThresholdPx = 3);
 
 double ComputeDragMetersOnAxis(int mouseDx, int mouseDy, SelectionDragAxis axis,
                                const std::array<ProjectedAxis, 3> &axes);
+
+// Intersects a world-space ray with a plane for deterministic drag projection.
+std::optional<std::array<double, 3>>
+IntersectRayWithPlane(const std::array<double, 3> &rayOrigin,
+                      const std::array<double, 3> &rayDirection,
+                      const std::array<double, 3> &planePoint,
+                      const std::array<double, 3> &planeNormal);
 
 } // namespace viewer3d

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -2769,7 +2769,9 @@ std::array<float, 3> Viewer3DPanel::GetSelectionDragAxisVector(
 // Projects the active drag axes into screen space for axis-constrained
 // dragging.
 std::array<viewer3d::ProjectedAxis, 3>
-Viewer3DPanel::BuildProjectedDragAxes(const RenderSize &renderSize) const {
+Viewer3DPanel::BuildProjectedDragAxes(
+    const RenderSize &renderSize,
+    const std::array<float, 3> &anchorMeters) const {
     std::array<viewer3d::ProjectedAxis, 3> axes{};
     if (!renderSize.IsValid())
         return axes;
@@ -2784,8 +2786,7 @@ Viewer3DPanel::BuildProjectedDragAxes(const RenderSize &renderSize) const {
     GLdouble originX = 0.0;
     GLdouble originY = 0.0;
     GLdouble originZ = 0.0;
-    if (gluProject(m_selectionDragAnchorMeters[0], m_selectionDragAnchorMeters[1],
-                 m_selectionDragAnchorMeters[2], modelview, projection,
+    if (gluProject(anchorMeters[0], anchorMeters[1], anchorMeters[2], modelview, projection,
                  viewport, &originX, &originY, &originZ) != GL_TRUE) {
         return axes;
     }
@@ -2801,9 +2802,9 @@ Viewer3DPanel::BuildProjectedDragAxes(const RenderSize &renderSize) const {
         GLdouble tipY = 0.0;
         GLdouble tipZ = 0.0;
         const auto& worldAxis = axisWorldVectors[i];
-        if (gluProject(m_selectionDragAnchorMeters[0] + worldAxis[0],
-                       m_selectionDragAnchorMeters[1] + worldAxis[1],
-                       m_selectionDragAnchorMeters[2] + worldAxis[2], modelview,
+        if (gluProject(anchorMeters[0] + worldAxis[0],
+                       anchorMeters[1] + worldAxis[1],
+                       anchorMeters[2] + worldAxis[2], modelview,
                        projection, viewport, &tipX, &tipY, &tipZ) != GL_TRUE) {
             continue;
         }
@@ -2818,6 +2819,14 @@ Viewer3DPanel::BuildProjectedDragAxes(const RenderSize &renderSize) const {
     }
 
     return axes;
+}
+
+// Returns the unsnapped anchor used by all pointer-movement geometry.
+std::array<float, 3> Viewer3DPanel::CurrentRawSelectionDragAnchor() const {
+    if (!m_pendingMagnetSnap)
+        return m_selectionDragAnchorMeters;
+    return continuous_placement::RawAnchorFromPreview(
+        m_selectionDragAnchorMeters, m_pendingMagnetSnap->translationDeltaMm);
 }
 
 // Projects the mouse position onto the active selection drag view plane.
@@ -2873,22 +2882,16 @@ Viewer3DPanel::ProjectMouseToSelectionDragViewPlane(
     const std::array<double, 3> planeNormal{centerFar[0] - centerNear[0],
                                            centerFar[1] - centerNear[1],
                                            centerFar[2] - centerNear[2]};
-    const double denominator = rayDir[0] * planeNormal[0] +
-                               rayDir[1] * planeNormal[1] +
-                               rayDir[2] * planeNormal[2];
-    if (std::abs(denominator) <= 1e-12)
-        return std::nullopt;
-
   const std::array<double, 3> planePoint{planePointMeters[0],
                                          planePointMeters[1],
                                          planePointMeters[2]};
-    const double t = ((planePoint[0] - nearPoint[0]) * planeNormal[0] +
-                      (planePoint[1] - nearPoint[1]) * planeNormal[1] +
-                      (planePoint[2] - nearPoint[2]) * planeNormal[2]) /
-                     denominator;
-  return std::array<float, 3>{static_cast<float>(nearPoint[0] + rayDir[0] * t),
-        static_cast<float>(nearPoint[1] + rayDir[1] * t),
-        static_cast<float>(nearPoint[2] + rayDir[2] * t)};
+    const auto intersection = viewer3d::IntersectRayWithPlane(
+        nearPoint, rayDir, planePoint, planeNormal);
+    if (!intersection)
+        return std::nullopt;
+  return std::array<float, 3>{static_cast<float>((*intersection)[0]),
+                              static_cast<float>((*intersection)[1]),
+                              static_cast<float>((*intersection)[2])};
 }
 
 // Builds a Magnet snap source for the active single-object 3D drag.
@@ -3353,11 +3356,7 @@ bool Viewer3DPanel::AlignContinuousElementToPointer(const wxPoint &mousePos) {
     }
 
     ApplyCameraMatrices(renderSize);
-    std::array<float, 3> rawAnchor = m_selectionDragAnchorMeters;
-    if (m_pendingMagnetSnap) {
-        rawAnchor = continuous_placement::RawAnchorFromPreview(
-            rawAnchor, m_pendingMagnetSnap->translationDeltaMm);
-    }
+    const auto rawAnchor = CurrentRawSelectionDragAnchor();
     const auto pointer =
         ProjectMouseToSelectionDragViewPlane(mousePos, renderSize, rawAnchor);
     if (!pointer)
@@ -3384,6 +3383,7 @@ void Viewer3DPanel::OnMouseMove(wxMouseEvent &event) {
             return;
         }
         if (m_placementViewRevision.NeedsAlignment()) {
+            m_lastMousePos = pos;
             AlignContinuousElementToPointer(pos);
             Refresh();
             return;
@@ -3392,10 +3392,23 @@ void Viewer3DPanel::OnMouseMove(wxMouseEvent &event) {
         if (renderSize.IsValid() &&
             TryBindGlContextForInteraction("continuous element placement")) {
             ApplyCameraMatrices(renderSize);
+            const auto rawAnchor = CurrentRawSelectionDragAnchor();
             const int dx = pos.x - m_lastMousePos.x;
             const int dy = pos.y - m_lastMousePos.y;
             if (m_axisConstrainedMovementEnabled) {
-                const auto projectedAxes = BuildProjectedDragAxes(renderSize);
+                const auto projectedAxes =
+                    BuildProjectedDragAxes(renderSize, rawAnchor);
+                const bool hasValidAxis = std::any_of(
+                    projectedAxes.begin(), projectedAxes.end(),
+                    [](const viewer3d::ProjectedAxis &axis) {
+                        return axis.valid;
+                    });
+                if (!hasValidAxis) {
+                    m_lastMousePos = pos;
+                    m_placementViewRevision.Invalidate();
+                    Refresh();
+                    return;
+                }
         if (m_selectionDragAxis == viewer3d::SelectionDragAxis::None &&
                     (std::abs(dx) >= kSelectionDragStartThresholdPx ||
                      std::abs(dy) >= kSelectionDragStartThresholdPx)) {
@@ -3416,18 +3429,25 @@ void Viewer3DPanel::OnMouseMove(wxMouseEvent &event) {
         m_selectionDragAxis = viewer3d::SelectionDragAxis::None;
                 const auto lastPoint =
             ProjectMouseToSelectionDragViewPlane(
-                m_lastMousePos, renderSize, m_selectionDragAnchorMeters);
+                m_lastMousePos, renderSize, rawAnchor);
                 const auto currentPoint =
                     ProjectMouseToSelectionDragViewPlane(
-                        pos, renderSize, m_selectionDragAnchorMeters);
+                        pos, renderSize, rawAnchor);
                 if (lastPoint && currentPoint) {
           ApplySelectionDragDelta({(*currentPoint)[0] - (*lastPoint)[0],
                          (*currentPoint)[1] - (*lastPoint)[1],
                          (*currentPoint)[2] - (*lastPoint)[2]});
                     m_selectionDragMoved = true;
+                } else {
+                    m_lastMousePos = pos;
+                    m_placementViewRevision.Invalidate();
+                    Refresh();
+                    return;
                 }
             }
             Refresh();
+        } else {
+            m_placementViewRevision.Invalidate();
         }
         m_lastMousePos = pos;
         return;
@@ -3468,7 +3488,7 @@ void Viewer3DPanel::OnMouseMove(wxMouseEvent &event) {
                 TryBindGlContextForInteraction("OnMouseMove")) {
                 ApplyCameraMatrices(renderSize);
                 if (m_axisConstrainedMovementEnabled) {
-                    const auto projectedAxes = BuildProjectedDragAxes(renderSize);
+                    const auto projectedAxes = BuildProjectedDragAxes(renderSize, CurrentRawSelectionDragAnchor());
                     if (m_selectionDragAxis == viewer3d::SelectionDragAxis::None) {
             m_selectionDragAxis =
                 viewer3d::SelectDragAxisFromMouseDelta(dx, -dy, projectedAxes);

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -346,6 +346,20 @@ wxPoint ToFramebufferPoint(wxWindow* window, const wxPoint& logicalPoint) {
     return wxPoint((*converted)[0], (*converted)[1]);
 }
 
+// Converts a logical point while preserving conversion failure for placement.
+std::optional<wxPoint> TryToFramebufferPoint(wxWindow* window,
+                                             const wxPoint& logicalPoint) {
+    if (window == nullptr)
+        return std::nullopt;
+    const auto converted = pixel_coordinates::LogicalToFramebuffer(
+        {static_cast<double>(logicalPoint.x),
+         static_cast<double>(logicalPoint.y)},
+        static_cast<double>(window->GetContentScaleFactor()));
+    if (!converted)
+        return std::nullopt;
+    return wxPoint((*converted)[0], (*converted)[1]);
+}
+
 // Converts framebuffer pixel coordinates back to logical client-space pixels.
 wxPoint FromFramebufferPoint(wxWindow* window, const wxPoint& framebufferPoint) {
     if (window == nullptr)
@@ -2809,7 +2823,8 @@ Viewer3DPanel::BuildProjectedDragAxes(const RenderSize &renderSize) const {
 // Projects the mouse position onto the active selection drag view plane.
 std::optional<std::array<float, 3>>
 Viewer3DPanel::ProjectMouseToSelectionDragViewPlane(
-    const wxPoint &mousePos, const RenderSize &renderSize) const {
+    const wxPoint &mousePos, const RenderSize &renderSize,
+    const std::array<float, 3> &planePointMeters) const {
     if (!renderSize.IsValid())
         return std::nullopt;
 
@@ -2820,10 +2835,12 @@ Viewer3DPanel::ProjectMouseToSelectionDragViewPlane(
     glGetDoublev(GL_PROJECTION_MATRIX, projection);
     glGetIntegerv(GL_VIEWPORT, viewport);
 
-  const wxPoint framebufferPos =
-      ToFramebufferPoint(const_cast<Viewer3DPanel *>(this), mousePos);
-    const double winX = static_cast<double>(framebufferPos.x);
-    const double winY = static_cast<double>(renderSize.height - framebufferPos.y);
+  const auto framebufferPos =
+      TryToFramebufferPoint(const_cast<Viewer3DPanel *>(this), mousePos);
+    if (!framebufferPos)
+        return std::nullopt;
+    const double winX = static_cast<double>(framebufferPos->x);
+    const double winY = static_cast<double>(renderSize.height - framebufferPos->y);
 
     auto unproject = [&](double x, double y, double z) {
         std::array<double, 3> point{0.0, 0.0, 0.0};
@@ -2862,9 +2879,9 @@ Viewer3DPanel::ProjectMouseToSelectionDragViewPlane(
     if (std::abs(denominator) <= 1e-12)
         return std::nullopt;
 
-  const std::array<double, 3> planePoint{m_selectionDragAnchorMeters[0],
-                                         m_selectionDragAnchorMeters[1],
-        m_selectionDragAnchorMeters[2]};
+  const std::array<double, 3> planePoint{planePointMeters[0],
+                                         planePointMeters[1],
+                                         planePointMeters[2]};
     const double t = ((planePoint[0] - nearPoint[0]) * planeNormal[0] +
                       (planePoint[1] - nearPoint[1]) * planeNormal[1] +
                       (planePoint[2] - nearPoint[2]) * planeNormal[2]) /
@@ -3104,6 +3121,12 @@ void Viewer3DPanel::ConfirmContinuousPlacement()
         return;
     }
 
+    auto nextRawPosition = continuous_placement::PositionMeters(
+        cfg.GetScene(), m_continuousPlacementType, m_continuousPlacementUuid);
+    if (m_pendingMagnetSnap) {
+        nextRawPosition = continuous_placement::RawAnchorFromPreview(
+            nextRawPosition, m_pendingMagnetSnap->translationDeltaMm);
+    }
     cfg.PushUndoState(std::string("place ") +
                       continuous_placement::ElementName(
                           m_continuousPlacementType));
@@ -3118,11 +3141,14 @@ void Viewer3DPanel::ConfirmContinuousPlacement()
         CancelContinuousPlacement();
         return;
     }
+    continuous_placement::SetPositionMeters(
+        cfg.GetScene(), m_continuousPlacementType, nextUuid, nextRawPosition);
     CommitActiveMagnetSnap();
     const auto placedUuids = m_continuousPlacedUuids;
     BeginContinuousPlacement(m_continuousPlacementType, nextUuid);
     m_continuousPlacedUuids = placedUuids;
-    m_placementViewRevision.CompleteAlignmentAttempt(true);
+    if (m_hasLastMousePos)
+        AlignContinuousElementToPointer(m_lastMousePos);
     RefreshContinuousPlacementViews();
 }
 
@@ -3327,8 +3353,13 @@ bool Viewer3DPanel::AlignContinuousElementToPointer(const wxPoint &mousePos) {
     }
 
     ApplyCameraMatrices(renderSize);
+    std::array<float, 3> rawAnchor = m_selectionDragAnchorMeters;
+    if (m_pendingMagnetSnap) {
+        rawAnchor = continuous_placement::RawAnchorFromPreview(
+            rawAnchor, m_pendingMagnetSnap->translationDeltaMm);
+    }
     const auto pointer =
-        ProjectMouseToSelectionDragViewPlane(mousePos, renderSize);
+        ProjectMouseToSelectionDragViewPlane(mousePos, renderSize, rawAnchor);
     if (!pointer)
         return false;
 
@@ -3384,9 +3415,11 @@ void Viewer3DPanel::OnMouseMove(wxMouseEvent &event) {
             } else {
         m_selectionDragAxis = viewer3d::SelectionDragAxis::None;
                 const auto lastPoint =
-            ProjectMouseToSelectionDragViewPlane(m_lastMousePos, renderSize);
+            ProjectMouseToSelectionDragViewPlane(
+                m_lastMousePos, renderSize, m_selectionDragAnchorMeters);
                 const auto currentPoint =
-                    ProjectMouseToSelectionDragViewPlane(pos, renderSize);
+                    ProjectMouseToSelectionDragViewPlane(
+                        pos, renderSize, m_selectionDragAnchorMeters);
                 if (lastPoint && currentPoint) {
           ApplySelectionDragDelta({(*currentPoint)[0] - (*lastPoint)[0],
                          (*currentPoint)[1] - (*lastPoint)[1],
@@ -3456,9 +3489,11 @@ void Viewer3DPanel::OnMouseMove(wxMouseEvent &event) {
                     }
                 } else {
           const auto lastPoint =
-              ProjectMouseToSelectionDragViewPlane(m_lastMousePos, renderSize);
+              ProjectMouseToSelectionDragViewPlane(
+                m_lastMousePos, renderSize, m_selectionDragAnchorMeters);
           const auto currentPoint =
-              ProjectMouseToSelectionDragViewPlane(pos, renderSize);
+              ProjectMouseToSelectionDragViewPlane(
+                        pos, renderSize, m_selectionDragAnchorMeters);
                     if (lastPoint && currentPoint) {
                         const std::array<float, 3> worldDelta{
                             (*currentPoint)[0] - (*lastPoint)[0],

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -40,6 +40,7 @@
 #endif
 
 #include "viewer3dpanel.h"
+#include "../core/pixel_coordinate_math.h"
 #include "mainwindow.h"
 #include "../gui/mainwindow/ids/tools_ids.h"
 #include "editable_focus_utils.h"
@@ -337,12 +338,12 @@ wxPoint ToFramebufferPoint(wxWindow* window, const wxPoint& logicalPoint) {
         return logicalPoint;
     const double contentScale =
         static_cast<double>(window->GetContentScaleFactor());
-    if (!std::isfinite(contentScale) || contentScale <= 0.0)
+    const auto converted = pixel_coordinates::LogicalToFramebuffer(
+        {static_cast<double>(logicalPoint.x),
+         static_cast<double>(logicalPoint.y)}, contentScale);
+    if (!converted)
         return logicalPoint;
-    return wxPoint(static_cast<int>(std::lround(
-                       static_cast<double>(logicalPoint.x) * contentScale)),
-                   static_cast<int>(std::lround(
-                       static_cast<double>(logicalPoint.y) * contentScale)));
+    return wxPoint((*converted)[0], (*converted)[1]);
 }
 
 // Converts framebuffer pixel coordinates back to logical client-space pixels.
@@ -351,12 +352,12 @@ wxPoint FromFramebufferPoint(wxWindow* window, const wxPoint& framebufferPoint) 
         return framebufferPoint;
     const double contentScale =
         static_cast<double>(window->GetContentScaleFactor());
-    if (!std::isfinite(contentScale) || contentScale <= 0.0)
+    const auto converted = pixel_coordinates::FramebufferToLogical(
+        {static_cast<double>(framebufferPoint.x),
+         static_cast<double>(framebufferPoint.y)}, contentScale);
+    if (!converted)
         return framebufferPoint;
-    return wxPoint(static_cast<int>(std::lround(
-                       static_cast<double>(framebufferPoint.x) / contentScale)),
-                   static_cast<int>(std::lround(
-                       static_cast<double>(framebufferPoint.y) / contentScale)));
+    return wxPoint((*converted)[0], (*converted)[1]);
 }
 
 // Normalizes label rotation so text remains readable while staying parallel to the measure line.
@@ -1087,8 +1088,6 @@ void Viewer3DPanel::OnPaint(wxPaintEvent &event) {
     m_camera.Update(dt);
     if (cameraStateBeforeUpdate != m_camera.GetStateForDiagnostics()) {
         m_placementViewRevision.Invalidate();
-        m_continuousPlacementNeedsPointerAlignment =
-            m_continuousPlacementActive;
     }
   wxASSERT_MSG(m_camera.IsValid(),
                "3D camera state became invalid during paint update.");
@@ -1097,8 +1096,8 @@ void Viewer3DPanel::OnPaint(wxPaintEvent &event) {
     if (!renderSize.IsValid()) {
         return;
     }
-    if (m_continuousPlacementActive &&
-        m_continuousPlacementNeedsPointerAlignment)
+    if (m_continuousPlacementActive && m_hasLastMousePos &&
+        m_placementViewRevision.NeedsAlignment())
         AlignContinuousElementToPointer(m_lastMousePos);
 
     wxLogTrace("viewer3d_perf", "Viewer3DPanel frame render mode=full");
@@ -1337,7 +1336,6 @@ void Viewer3DPanel::OnPaint(wxPaintEvent &event) {
 void Viewer3DPanel::OnResize(wxSizeEvent &event) {
     (void)event;
     m_placementViewRevision.Invalidate();
-    m_continuousPlacementNeedsPointerAlignment = m_continuousPlacementActive;
     Refresh();
 }
 
@@ -1766,6 +1764,7 @@ void Viewer3DPanel::DrawMeasureOverlay(const RenderSize &renderSize) {
 
 // Handles mouse button press
 void Viewer3DPanel::OnMouseDown(wxMouseEvent &event) {
+    m_hasLastMousePos = true;
     if (m_continuousPlacementActive && event.LeftDown()) {
     m_mode = event.ShiftDown() ? InteractionMode::Pan : InteractionMode::Orbit;
         m_dragging = true;
@@ -1851,7 +1850,6 @@ void Viewer3DPanel::OnMouseUp(wxMouseEvent &event) {
             ReleaseMouse();
         m_draggedSincePress = false;
         if (navigated) {
-            m_continuousPlacementNeedsPointerAlignment = true;
             AlignContinuousElementToPointer(event.GetPosition());
         } else {
             ConfirmContinuousPlacement();
@@ -2949,7 +2947,10 @@ std::optional<magnet_snap::SnapResult> Viewer3DPanel::RestorePendingMagnetSnapPr
     magnet_snap::SnapResult inverse = previous;
     for (float& component : inverse.translationDeltaMm)
         component = -component;
-    magnet_snap::ApplySnapTransform(ConfigManager::Get().GetScene(), inverse);
+    ConfigManager& cfg = ConfigManager::Get();
+    magnet_snap::ApplySnapTransform(
+        cfg.GetScene(), inverse,
+        selection_movement_settings::LoadInteractiveTransformPolicy(cfg));
     m_selectionDragAnchorMeters[0] += inverse.translationDeltaMm[0] / 1000.0f;
     m_selectionDragAnchorMeters[1] += inverse.translationDeltaMm[1] / 1000.0f;
     m_selectionDragAnchorMeters[2] += inverse.translationDeltaMm[2] / 1000.0f;
@@ -2980,11 +2981,10 @@ void Viewer3DPanel::ApplySelectionDragDelta(
     const float dxMm = deltaMeters[0] * 1000.0f;
     const float dyMm = deltaMeters[1] * 1000.0f;
     const float dzMm = deltaMeters[2] * 1000.0f;
-    if (dxMm == 0.0f && dyMm == 0.0f && dzMm == 0.0f)
-        return;
-
     ConfigManager& cfg = ConfigManager::Get();
-    if (!m_selectionDragUndoPushed) {
+    const bool hasTranslation =
+        dxMm != 0.0f || dyMm != 0.0f || dzMm != 0.0f;
+    if (hasTranslation && !m_selectionDragUndoPushed) {
         cfg.PushUndoState("move selection");
         m_selectionDragUndoPushed = true;
     }
@@ -2996,9 +2996,11 @@ void Viewer3DPanel::ApplySelectionDragDelta(
     const auto previousSnap = RestorePendingMagnetSnapPreview();
   const auto policy =
       selection_movement_settings::LoadInteractiveTransformPolicy(cfg);
-  scene_grouping::TranslateSelection(
-      cfg.GetScene(), selection, {dxMm, dyMm, dzMm},
-      transform_space::TransformSpace::World, policy);
+  if (hasTranslation) {
+    scene_grouping::TranslateSelection(
+        cfg.GetScene(), selection, {dxMm, dyMm, dzMm},
+        transform_space::TransformSpace::World, policy);
+  }
     if (auto snap = FindActiveMagnetSnap()) {
     magnet_snap::ApplySnapTransform(cfg.GetScene(), *snap, policy);
         m_pendingMagnetSnap = snap;
@@ -3066,7 +3068,6 @@ void Viewer3DPanel::BeginContinuousPlacement(
     m_continuousPlacementActive = true;
     m_continuousPlacementType = type;
     m_placementViewRevision.Invalidate();
-    m_continuousPlacementNeedsPointerAlignment = true;
     m_continuousPlacementUuid = elementUuid;
     m_continuousPlacedUuids.clear();
     m_selectionDragArmed = true;
@@ -3085,7 +3086,6 @@ void Viewer3DPanel::BeginContinuousPlacement(
     m_dragSceneObjectUuids = type == ContinuousPlacementType::SceneObject
                                  ? std::vector<std::string>{elementUuid}
                                  : std::vector<std::string>{};
-    m_lastMousePos = ScreenToClient(wxGetMousePosition());
     m_selectionDragAnchorMeters = continuous_placement::PositionMeters(
         cfg.GetScene(), type, elementUuid);
     SetFocus();
@@ -3122,7 +3122,7 @@ void Viewer3DPanel::ConfirmContinuousPlacement()
     const auto placedUuids = m_continuousPlacedUuids;
     BeginContinuousPlacement(m_continuousPlacementType, nextUuid);
     m_continuousPlacedUuids = placedUuids;
-    m_continuousPlacementNeedsPointerAlignment = false;
+    m_placementViewRevision.CompleteAlignmentAttempt(true);
     RefreshContinuousPlacementViews();
 }
 
@@ -3199,7 +3199,6 @@ bool Viewer3DPanel::UndoContinuousPlacement() {
 void Viewer3DPanel::EndContinuousPlacementState() {
     m_continuousPlacementActive = false;
     m_continuousPlacementType = ContinuousPlacementType::None;
-    m_continuousPlacementNeedsPointerAlignment = false;
     m_continuousPlacementUuid.clear();
     m_continuousPlacedUuids.clear();
     ResetSelectionDragState();
@@ -3316,7 +3315,6 @@ void Viewer3DPanel::ApplyCameraDrag(const wxMouseEvent& event,
     }
     m_lastMousePos = mousePos;
     m_placementViewRevision.Invalidate();
-    m_continuousPlacementNeedsPointerAlignment = m_continuousPlacementActive;
 }
 
 // Aligns the provisional fixture with the raw view-plane position under the
@@ -3329,16 +3327,15 @@ bool Viewer3DPanel::AlignContinuousElementToPointer(const wxPoint &mousePos) {
     }
 
     ApplyCameraMatrices(renderSize);
-    RestorePendingMagnetSnapPreview();
     const auto pointer =
         ProjectMouseToSelectionDragViewPlane(mousePos, renderSize);
     if (!pointer)
         return false;
 
+    RestorePendingMagnetSnapPreview();
     ApplySelectionDragDelta(continuous_placement::AbsoluteAlignmentDelta(
         *pointer, m_selectionDragAnchorMeters));
-    m_continuousPlacementNeedsPointerAlignment = false;
-    m_placementViewRevision.MarkAligned();
+    m_placementViewRevision.CompleteAlignmentAttempt(true);
     m_selectionDragAxis = viewer3d::SelectionDragAxis::None;
     m_selectionDragMoved = true;
     m_lastMousePos = mousePos;
@@ -3347,6 +3344,7 @@ bool Viewer3DPanel::AlignContinuousElementToPointer(const wxPoint &mousePos) {
 
 // Handles mouse movement for placement, selection, orbit, and pan.
 void Viewer3DPanel::OnMouseMove(wxMouseEvent &event) {
+    m_hasLastMousePos = true;
     wxPoint pos = event.GetPosition();
     if (m_continuousPlacementActive) {
         if (m_dragging && event.Dragging()) {
@@ -3354,7 +3352,7 @@ void Viewer3DPanel::OnMouseMove(wxMouseEvent &event) {
             Refresh();
             return;
         }
-        if (m_continuousPlacementNeedsPointerAlignment) {
+        if (m_placementViewRevision.NeedsAlignment()) {
             AlignContinuousElementToPointer(pos);
             Refresh();
             return;
@@ -3496,6 +3494,7 @@ void Viewer3DPanel::OnMouseMove(wxMouseEvent &event) {
 
 // Handles mouse wheel (zoom)
 void Viewer3DPanel::OnMouseWheel(wxMouseEvent &event) {
+    m_hasLastMousePos = true;
     viewer3d::diagnostics::Logf("Mouse wheel start rotation=%d delta=%d",
                                 event.GetWheelRotation(), event.GetWheelDelta());
     SetFocus();
@@ -3521,7 +3520,6 @@ void Viewer3DPanel::OnMouseWheel(wxMouseEvent &event) {
 
     m_camera.Zoom(steps);
     m_placementViewRevision.Invalidate();
-    m_continuousPlacementNeedsPointerAlignment = m_continuousPlacementActive;
     if (m_continuousPlacementActive)
         AlignContinuousElementToPointer(event.GetPosition());
     ArmZoomInteractionTimeout();
@@ -3703,8 +3701,7 @@ void Viewer3DPanel::OnKeyDown(wxKeyEvent &event) {
     if (zoomTriggered)
         ArmZoomInteractionTimeout();
     m_placementViewRevision.Invalidate();
-    m_continuousPlacementNeedsPointerAlignment = m_continuousPlacementActive;
-    if (m_continuousPlacementActive)
+    if (m_continuousPlacementActive && m_hasLastMousePos)
         AlignContinuousElementToPointer(m_lastMousePos);
 
     viewer3d::diagnostics::Log("Key interaction end.");
@@ -3715,7 +3712,6 @@ void Viewer3DPanel::OnKeyDown(wxKeyEvent &event) {
 bool Viewer3DPanel::ResetCameraToIsometric() {
     m_camera.Reset();
     m_placementViewRevision.Invalidate();
-    m_continuousPlacementNeedsPointerAlignment = m_continuousPlacementActive;
     Refresh();
     return true;
 }
@@ -3733,7 +3729,6 @@ bool Viewer3DPanel::FrameSceneToFit() {
     m_lastInteractionTime = std::chrono::steady_clock::now();
     m_controller.SetInteracting(true);
     m_placementViewRevision.Invalidate();
-    m_continuousPlacementNeedsPointerAlignment = m_continuousPlacementActive;
     Refresh();
     return true;
 }
@@ -3754,7 +3749,6 @@ void Viewer3DPanel::SetStandardView(Viewer2DView view) {
             return;
     }
     m_placementViewRevision.Invalidate();
-    m_continuousPlacementNeedsPointerAlignment = m_continuousPlacementActive;
     Refresh();
 }
 

--- a/viewer3d/viewer3dpanel.h
+++ b/viewer3d/viewer3dpanel.h
@@ -126,6 +126,7 @@ private:
     bool m_draggedSincePress = false;
     bool m_mouseInside = false;
     wxPoint m_lastMousePos;
+    bool m_hasLastMousePos = false;
     bool m_rectSelecting = false;
     bool m_rectSelectionAcrossAllTables = false;
     wxPoint m_rectSelectStart;
@@ -151,7 +152,6 @@ private:
     bool m_continuousPlacementActive = false;
     ContinuousPlacementType m_continuousPlacementType =
         ContinuousPlacementType::None;
-    bool m_continuousPlacementNeedsPointerAlignment = false;
     continuous_placement::ViewRevisionState m_placementViewRevision;
     std::string m_continuousPlacementUuid;
     std::vector<std::string> m_continuousPlacedUuids;

--- a/viewer3d/viewer3dpanel.h
+++ b/viewer3d/viewer3dpanel.h
@@ -203,7 +203,9 @@ private:
     std::array<float, 3> ComputeSelectionCenterMeters(
         const std::vector<std::string>& uuids, HoverTargetTable target) const;
     std::array<viewer3d::ProjectedAxis, 3> BuildProjectedDragAxes(
-        const RenderSize& renderSize) const;
+        const RenderSize& renderSize,
+        const std::array<float, 3>& anchorMeters) const;
+    std::array<float, 3> CurrentRawSelectionDragAnchor() const;
     std::optional<std::array<float, 3>> ProjectMouseToSelectionDragViewPlane(
         const wxPoint& mousePos, const RenderSize& renderSize,
         const std::array<float, 3>& planePointMeters) const;

--- a/viewer3d/viewer3dpanel.h
+++ b/viewer3d/viewer3dpanel.h
@@ -205,7 +205,8 @@ private:
     std::array<viewer3d::ProjectedAxis, 3> BuildProjectedDragAxes(
         const RenderSize& renderSize) const;
     std::optional<std::array<float, 3>> ProjectMouseToSelectionDragViewPlane(
-        const wxPoint& mousePos, const RenderSize& renderSize) const;
+        const wxPoint& mousePos, const RenderSize& renderSize,
+        const std::array<float, 3>& planePointMeters) const;
     void ApplySelectionDragDelta(const std::array<float, 3>& deltaMeters);
     std::optional<magnet_snap::SnapSource> BuildActiveMagnetSource() const;
     magnet_snap::SnapSettings BuildActiveMagnetSettings(


### PR DESCRIPTION
### Motivation

- Close remaining Checkpoint 01 correctness gaps and implement deterministic Checkpoint 02 regression coverage for coordinate mapping, viewport revision, and Magnet preview lifecycle.
- Ensure the 2D screen basis used by projection/unprojection/drag matches the actual OpenGL `gluLookAt` camera orientations for Top, Bottom, Front and Side views.
- Remove duplicated alignment truth, make the viewport revision the single authoritative alignment state, and make logical→framebuffer conversion deterministic and GUI-independent.

### Description

- Enforce an authoritative 2D view basis by adding `ViewBasis`, `GetViewBasis`, and `ScreenDeltaToWorld` in `viewer2d/viewer2d_coordinate_math.{h,cpp}` and route projection/unprojection/drag math through those helpers so Bottom and Side horizontal signs match the rendered camera.
- Add GUI-independent pixel helpers `core/pixel_coordinate_math.{h,cpp}` with `LogicalToFramebuffer` and `FramebufferToLogical`, integrate them at viewer boundaries (`viewer2d/viewer2dpanel.cpp` and `viewer3d/viewer3dpanel.cpp`), and register the implementation in CMake and the tests harness.
- Make `continuous_placement::ViewRevisionState` the single alignment authority, add `CompleteAlignmentAttempt` and a controlled rollover constructor, remove the duplicated boolean alignment flag, and wire paint/mouse/resize/keyboard paths to resolve pending alignment before the next visible frame only when a valid last pointer exists.
- Improve Magnet preview lifecycle by restoring previews transactionally, recomputing snap candidates even when raw translation is zero, avoiding empty/duplicate Undo entries and grouping commits during preview refresh, and ensuring 3D inverse preview restoration uses the active `InteractiveTransformPolicy`.
- Add and update deterministic regression tests and documentation by extending `tests/viewer2d_coordinate_math_test.cpp` and `tests/continuous_placement_scene_test.cpp` to cover authoritative view-basis directions, framebuffer↔logical pixel behavior (including invalid scales and rounding), revision lifecycle and rollover, and update `docs/developer/viewer_coordinate_contract.md` and `docs/release-notes-draft.md` to reflect the selected contracts and fixes.

### Testing

- Built and executed unit tests via direct g++ runs: the updated `viewer2d_coordinate_math_test` and `continuous_placement_scene_test` were compiled and executed locally and passed with no failures.
- Ran repository policy checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh` and both returned OK.
- Ran formatting and static checks: `clang-format --dry-run --Werror` and `git diff --check` passed after applying formatting adjustments.
- Limitation: an in-container CMake/CTest run of the full repository could not be completed because wxWidgets development libraries and includes are not available in the environment, so the full CTest suite and runtime viewer integration tests (wx/OpenGL) were not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b2bee6b6083249f37bce9ea043a3d)