### PR TITLE
Implement prioritized truss Magnet candidates

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -79,6 +79,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/symbols/PerastageSvgSymbol.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/trussdictionary.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/truss_asset_ingestion.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/truss_attachment_candidates.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/truss_gdtf_builder.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/trussloader.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ui_render_size.cpp

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -80,6 +80,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/trussdictionary.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/truss_asset_ingestion.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/truss_attachment_candidates.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/truss_screen_snap.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/truss_gdtf_builder.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/trussloader.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ui_render_size.cpp

--- a/core/magnet_snap.cpp
+++ b/core/magnet_snap.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <cmath>
 #include <limits>
+#include <tuple>
 #include <vector>
 
 namespace magnet_snap {
@@ -336,19 +337,64 @@ bool GroupContainsTruss(const MvrScene &scene, const std::string &groupUuid,
   return false;
 }
 
+struct CandidateRank {
+  double primary = std::numeric_limits<double>::max();
+  double depthDifference = std::numeric_limits<double>::max();
+  double worldDistance = std::numeric_limits<double>::max();
+  std::string targetUuid;
+  std::string sourceCandidateId;
+  std::string targetCandidateId;
+};
+
+// Returns whether the left candidate rank wins the deterministic ordering.
+bool IsBetterRank(const CandidateRank &left, const CandidateRank &right) {
+  return std::tie(left.primary, left.depthDifference, left.worldDistance,
+                  left.targetUuid, left.sourceCandidateId,
+                  left.targetCandidateId) <
+         std::tie(right.primary, right.depthDifference, right.worldDistance,
+                  right.targetUuid, right.sourceCandidateId,
+                  right.targetCandidateId);
+}
+
 // Tests a source and target attachment point and stores the closest snap.
 void ConsiderCandidatePair(const SnapSource &source, ObjectType targetType,
                            const std::string &targetUuid, SnapKind kind,
                            const truss_attachment::Candidate &sourceCandidate,
                            const truss_attachment::Candidate &targetCandidate,
-                           const SnapSettings &settings, float &bestDistance,
+                           const SnapSettings &settings,
+                           CandidateRank &bestRank,
                            std::optional<SnapResult> &best) {
   const std::array<float, 3> delta = Subtract(targetCandidate.worldTransform.o,
                                               sourceCandidate.worldTransform.o);
-  const float distance = WeightedLength(delta, settings.axisWeights);
-  if (distance > settings.thresholdMm || distance >= bestDistance)
+  const double worldDistance = Length(delta);
+  CandidateRank rank;
+  rank.targetUuid = targetUuid;
+  rank.sourceCandidateId = sourceCandidate.stableId;
+  rank.targetCandidateId = targetCandidate.stableId;
+  rank.worldDistance = worldDistance;
+  if (settings.trussProjection) {
+    const auto sourceProjected = truss_screen_snap::Project(
+        *settings.trussProjection, sourceCandidate.worldTransform.o);
+    const auto targetProjected = truss_screen_snap::Project(
+        *settings.trussProjection, targetCandidate.worldTransform.o);
+    if (!sourceProjected || !targetProjected)
+      return;
+    const double dx = targetProjected->logicalX - sourceProjected->logicalX;
+    const double dy = targetProjected->logicalY - sourceProjected->logicalY;
+    rank.primary = std::sqrt(dx * dx + dy * dy);
+    rank.depthDifference =
+        std::fabs(targetProjected->depth - sourceProjected->depth);
+    if (rank.primary > settings.trussScreenApertureLogicalPx)
+      return;
+  } else {
+    rank.primary = WeightedLength(delta, settings.axisWeights);
+    rank.depthDifference = 0.0;
+    if (rank.primary > settings.thresholdMm)
+      return;
+  }
+  if (!IsBetterRank(rank, bestRank))
     return;
-  bestDistance = distance;
+  bestRank = rank;
   SnapResult result;
   result.snapped = true;
   result.kind = kind;
@@ -358,6 +404,8 @@ void ConsiderCandidatePair(const SnapSource &source, ObjectType targetType,
   result.targetType = targetType;
   result.translationDeltaMm = delta;
   result.needsGrouping = kind == SnapKind::TrussToTruss;
+  result.sourceCandidateId = sourceCandidate.stableId;
+  result.targetCandidateId = targetCandidate.stableId;
   best = result;
 }
 
@@ -379,9 +427,58 @@ void ConsiderFacePair(const SnapSource &source, ObjectType targetType,
       source.type, targetType, delta,       kind == SnapKind::TrussToTruss};
 }
 
+constexpr float kGroupParallelDotTolerance = 0.996f;
+constexpr float kGroupCenterlineToleranceMm = 25.0f;
+constexpr float kGroupContinuityToleranceMm = 25.0f;
+
+// Conservatively verifies that grouped truss bounds form one collinear chain.
+bool IsCollinearChain(const std::vector<Bounds> &members) {
+  if (members.empty())
+    return false;
+  const auto firstAxis =
+      truss_attachment::ClassifyLongitudinalAxis(members.front().size);
+  if (!firstAxis)
+    return false;
+  const std::array<std::array<float, 3>, 3> firstBasis = {
+      Normalize(members.front().transform.u),
+      Normalize(members.front().transform.v),
+      Normalize(members.front().transform.w)};
+  const auto referenceAxis = firstBasis[*firstAxis];
+  const auto referenceCenter = members.front().transform.o;
+  std::vector<std::array<float, 2>> intervals;
+  for (const Bounds &member : members) {
+    const auto dominant =
+        truss_attachment::ClassifyLongitudinalAxis(member.size);
+    if (!dominant)
+      return false;
+    const std::array<std::array<float, 3>, 3> basis = {
+        Normalize(member.transform.u), Normalize(member.transform.v),
+        Normalize(member.transform.w)};
+    if (std::fabs(Dot(referenceAxis, basis[*dominant])) <
+        kGroupParallelDotTolerance)
+      return false;
+    const auto offset = Subtract(member.transform.o, referenceCenter);
+    const float along = Dot(offset, referenceAxis);
+    const auto cross = Subtract(offset, Scale(referenceAxis, along));
+    if (Length(cross) > kGroupCenterlineToleranceMm)
+      return false;
+    intervals.push_back({along - member.size[*dominant] * 0.5f,
+                         along + member.size[*dominant] * 0.5f});
+  }
+  std::sort(intervals.begin(), intervals.end());
+  float coveredEnd = intervals.front()[1];
+  for (std::size_t index = 1; index < intervals.size(); ++index) {
+    if (intervals[index][0] > coveredEnd + kGroupContinuityToleranceMm)
+      return false;
+    coveredEnd = std::max(coveredEnd, intervals[index][1]);
+  }
+  return true;
+}
+
 // Builds conservative attachment points for aggregate truss-group bounds.
 std::vector<truss_attachment::Candidate>
-BuildGroupCandidates(const Bounds &bounds, const std::string &groupUuid) {
+BuildGroupCandidatesImpl(const MvrScene &scene, const Bounds &bounds,
+                         const std::string &groupUuid) {
   Matrix insertionTransform = bounds.transform;
   insertionTransform.o =
       Add(insertionTransform.o,
@@ -389,11 +486,24 @@ BuildGroupCandidates(const Bounds &bounds, const std::string &groupUuid) {
   insertionTransform.o =
       Add(insertionTransform.o,
           Scale(Normalize(insertionTransform.w), -bounds.size[2] * 0.5f));
-  return truss_attachment::BuildInferredCandidates(
+  std::vector<Bounds> members;
+  CollectGroupTrussBounds(scene, groupUuid, members);
+  if (IsCollinearChain(members))
+    return truss_attachment::BuildInferredCandidates(
+        bounds.size, insertionTransform, groupUuid);
+  return truss_attachment::BuildAmbiguousCandidates(
       bounds.size, insertionTransform, groupUuid);
 }
 
 } // namespace
+
+// Builds deterministic exterior or conservative aggregate group candidates.
+std::vector<truss_attachment::Candidate>
+BuildTrussGroupCandidates(const MvrScene &scene, const std::string &groupUuid) {
+  const auto bounds = MakeTrussGroupBounds(scene, groupUuid);
+  return bounds ? BuildGroupCandidatesImpl(scene, *bounds, groupUuid)
+                : std::vector<truss_attachment::Candidate>{};
+}
 
 // Finds the best non-destructive Magnet snap candidate for the source object.
 std::optional<SnapResult> FindSnap(const MvrScene &scene,
@@ -404,14 +514,20 @@ std::optional<SnapResult> FindSnap(const MvrScene &scene,
     return std::nullopt;
 
   float bestDistance = std::numeric_limits<float>::max();
+  CandidateRank bestCandidateRank;
   std::optional<SnapResult> best;
 
   if (source.type == ObjectType::Truss ||
       source.type == ObjectType::TrussGroup) {
+    truss_attachment::CandidateResolver localResolver;
+    auto &resolver = settings.candidateResolver ? *settings.candidateResolver
+                                                : localResolver;
     const auto sourceCandidates =
         source.type == ObjectType::Truss
-            ? truss_attachment::BuildCandidates(scene.trusses.at(source.uuid))
-            : BuildGroupCandidates(*sourceBounds, source.uuid);
+            ? truss_attachment::BuildCandidates(
+                  scene, scene.trusses.at(source.uuid), resolver)
+                  .candidates
+            : BuildGroupCandidatesImpl(scene, *sourceBounds, source.uuid);
     auto considerTrussTarget = [&](ObjectType targetType,
                                    const std::string &uuid,
                                    const Bounds &targetBounds) {
@@ -422,13 +538,15 @@ std::optional<SnapResult> FindSnap(const MvrScene &scene,
         return;
       const auto targetCandidates =
           targetType == ObjectType::Truss
-              ? truss_attachment::BuildCandidates(scene.trusses.at(uuid))
-              : BuildGroupCandidates(targetBounds, uuid);
+              ? truss_attachment::BuildCandidates(scene, scene.trusses.at(uuid),
+                                                  resolver)
+                    .candidates
+              : BuildGroupCandidatesImpl(scene, targetBounds, uuid);
       for (const auto &sourceCandidate : sourceCandidates) {
         for (const auto &targetCandidate : targetCandidates)
-          ConsiderCandidatePair(source, targetType, uuid,
-                                SnapKind::TrussToTruss, sourceCandidate,
-                                targetCandidate, settings, bestDistance, best);
+          ConsiderCandidatePair(
+              source, targetType, uuid, SnapKind::TrussToTruss, sourceCandidate,
+              targetCandidate, settings, bestCandidateRank, best);
       }
     };
     for (const auto &[uuid, group] : scene.groupObjects) {

--- a/core/magnet_snap.cpp
+++ b/core/magnet_snap.cpp
@@ -2,6 +2,7 @@
 
 #include "matrixutils.h"
 #include "scene_grouping.h"
+#include "truss_attachment_candidates.h"
 
 #include <algorithm>
 #include <cmath>
@@ -150,7 +151,7 @@ std::optional<Bounds> MakeTrussGroupBounds(const MvrScene &scene,
     aggregate.size[axis] = std::max(maxLocal[axis] - minLocal[axis], 1.0f);
     aggregate.transform.o =
         Add(aggregate.transform.o,
-        Scale(basis[axis], (minLocal[axis] + maxLocal[axis]) * 0.5f));
+            Scale(basis[axis], (minLocal[axis] + maxLocal[axis]) * 0.5f));
   }
   return aggregate;
 }
@@ -335,15 +336,15 @@ bool GroupContainsTruss(const MvrScene &scene, const std::string &groupUuid,
   return false;
 }
 
-// Tests a source and target face pair and stores the closest snap result.
-void ConsiderFacePair(const SnapSource &source, ObjectType targetType,
-                      const std::string &targetUuid, SnapKind kind,
-                      const Face &sourceFace, const Bounds &targetBounds,
-                      const Face &targetFace, const SnapSettings &settings,
-                      float &bestDistance, std::optional<SnapResult> &best) {
-  const auto targetPoint =
-      ClosestPointOnFace(targetBounds, targetFace, sourceFace.center);
-  const std::array<float, 3> delta = Subtract(targetPoint, sourceFace.center);
+// Tests a source and target attachment point and stores the closest snap.
+void ConsiderCandidatePair(const SnapSource &source, ObjectType targetType,
+                           const std::string &targetUuid, SnapKind kind,
+                           const truss_attachment::Candidate &sourceCandidate,
+                           const truss_attachment::Candidate &targetCandidate,
+                           const SnapSettings &settings, float &bestDistance,
+                           std::optional<SnapResult> &best) {
+  const std::array<float, 3> delta = Subtract(targetCandidate.worldTransform.o,
+                                              sourceCandidate.worldTransform.o);
   const float distance = WeightedLength(delta, settings.axisWeights);
   if (distance > settings.thresholdMm || distance >= bestDistance)
     return;
@@ -358,6 +359,38 @@ void ConsiderFacePair(const SnapSource &source, ObjectType targetType,
   result.translationDeltaMm = delta;
   result.needsGrouping = kind == SnapKind::TrussToTruss;
   best = result;
+}
+
+// Tests a generic object face pair and stores the closest snap result.
+void ConsiderFacePair(const SnapSource &source, ObjectType targetType,
+                      const std::string &targetUuid, SnapKind kind,
+                      const Face &sourceFace, const Bounds &targetBounds,
+                      const Face &targetFace, const SnapSettings &settings,
+                      float &bestDistance, std::optional<SnapResult> &best) {
+  const auto targetPoint =
+      ClosestPointOnFace(targetBounds, targetFace, sourceFace.center);
+  const auto delta = Subtract(targetPoint, sourceFace.center);
+  const float distance = WeightedLength(delta, settings.axisWeights);
+  if (distance > settings.thresholdMm || distance >= bestDistance)
+    return;
+  bestDistance = distance;
+  best = SnapResult{
+      true,        kind,       source.uuid, targetUuid,
+      source.type, targetType, delta,       kind == SnapKind::TrussToTruss};
+}
+
+// Builds conservative attachment points for aggregate truss-group bounds.
+std::vector<truss_attachment::Candidate>
+BuildGroupCandidates(const Bounds &bounds, const std::string &groupUuid) {
+  Matrix insertionTransform = bounds.transform;
+  insertionTransform.o =
+      Add(insertionTransform.o,
+          Scale(Normalize(insertionTransform.u), -bounds.size[0] * 0.5f));
+  insertionTransform.o =
+      Add(insertionTransform.o,
+          Scale(Normalize(insertionTransform.w), -bounds.size[2] * 0.5f));
+  return truss_attachment::BuildInferredCandidates(
+      bounds.size, insertionTransform, groupUuid);
 }
 
 } // namespace
@@ -375,7 +408,10 @@ std::optional<SnapResult> FindSnap(const MvrScene &scene,
 
   if (source.type == ObjectType::Truss ||
       source.type == ObjectType::TrussGroup) {
-    const auto sourceFaces = BuildFaces(*sourceBounds, true);
+    const auto sourceCandidates =
+        source.type == ObjectType::Truss
+            ? truss_attachment::BuildCandidates(scene.trusses.at(source.uuid))
+            : BuildGroupCandidates(*sourceBounds, source.uuid);
     auto considerTrussTarget = [&](ObjectType targetType,
                                    const std::string &uuid,
                                    const Bounds &targetBounds) {
@@ -384,11 +420,15 @@ std::optional<SnapResult> FindSnap(const MvrScene &scene,
       if (targetType == ObjectType::TrussGroup &&
           BoundsContainsPoint(targetBounds, sourceBounds->transform.o))
         return;
-      for (const auto &sourceFace : sourceFaces) {
-        for (const auto &targetFace : BuildFaces(targetBounds, true))
-          ConsiderFacePair(source, targetType, uuid, SnapKind::TrussToTruss,
-                           sourceFace, targetBounds, targetFace, settings,
-                           bestDistance, best);
+      const auto targetCandidates =
+          targetType == ObjectType::Truss
+              ? truss_attachment::BuildCandidates(scene.trusses.at(uuid))
+              : BuildGroupCandidates(targetBounds, uuid);
+      for (const auto &sourceCandidate : sourceCandidates) {
+        for (const auto &targetCandidate : targetCandidates)
+          ConsiderCandidatePair(source, targetType, uuid,
+                                SnapKind::TrussToTruss, sourceCandidate,
+                                targetCandidate, settings, bestDistance, best);
       }
     };
     for (const auto &[uuid, group] : scene.groupObjects) {

--- a/core/magnet_snap.cpp
+++ b/core/magnet_snap.cpp
@@ -157,21 +157,6 @@ std::optional<Bounds> MakeTrussGroupBounds(const MvrScene &scene,
   return aggregate;
 }
 
-// Returns whether a point lies inside an oriented bounds volume.
-bool BoundsContainsPoint(const Bounds &bounds,
-                         const std::array<float, 3> &point) {
-  const std::array<std::array<float, 3>, 3> basis = {
-      Normalize(bounds.transform.u), Normalize(bounds.transform.v),
-      Normalize(bounds.transform.w)};
-  const auto relative = Subtract(point, bounds.transform.o);
-  for (int axis = 0; axis < 3; ++axis) {
-    const float projected = Dot(relative, basis[axis]);
-    if (std::fabs(projected) > bounds.size[axis] * 0.5f)
-      return false;
-  }
-  return true;
-}
-
 // Returns transformed bounds for objects with known dimensions.
 std::optional<Bounds> GetBounds(const MvrScene &scene, ObjectType type,
                                 const std::string &uuid) {
@@ -344,33 +329,180 @@ struct CandidateRank {
   std::string targetUuid;
   std::string sourceCandidateId;
   std::string targetCandidateId;
+  std::string sourceMemberUuid;
+  std::string targetMemberUuid;
 };
+
+// Returns whether two candidate directions face one another.
+bool DirectionsOppose(const truss_attachment::Candidate &source,
+                      const truss_attachment::Candidate &target) {
+  return source.worldDirection && target.worldDirection &&
+         Dot(*source.worldDirection, *target.worldDirection) <= -0.996f;
+}
+
+// Returns whether two oriented bounds have substantial volumetric overlap.
+bool SubstantiallyOverlaps(const Bounds &moving, const Bounds &target) {
+  constexpr float kAxisEpsilon = 1e-5f;
+  constexpr float kSubstantialPenetrationMm = 50.0f;
+  const std::array<std::array<float, 3>, 3> a = {Normalize(moving.transform.u),
+                                                 Normalize(moving.transform.v),
+                                                 Normalize(moving.transform.w)};
+  const std::array<std::array<float, 3>, 3> b = {Normalize(target.transform.u),
+                                                 Normalize(target.transform.v),
+                                                 Normalize(target.transform.w)};
+  const std::array<float, 3> aHalf = {
+      moving.size[0] * 0.5f, moving.size[1] * 0.5f, moving.size[2] * 0.5f};
+  const std::array<float, 3> bHalf = {
+      target.size[0] * 0.5f, target.size[1] * 0.5f, target.size[2] * 0.5f};
+  float rotation[3][3]{};
+  float absoluteRotation[3][3]{};
+  for (int row = 0; row < 3; ++row) {
+    for (int column = 0; column < 3; ++column) {
+      rotation[row][column] = Dot(a[row], b[column]);
+      absoluteRotation[row][column] =
+          std::fabs(rotation[row][column]) + kAxisEpsilon;
+    }
+  }
+  const auto centerDelta = Subtract(target.transform.o, moving.transform.o);
+  const std::array<float, 3> translated = {
+      Dot(centerDelta, a[0]), Dot(centerDelta, a[1]), Dot(centerDelta, a[2])};
+  float minimumFacePenetration = std::numeric_limits<float>::max();
+  for (int row = 0; row < 3; ++row) {
+    float targetRadius = 0.0f;
+    for (int column = 0; column < 3; ++column)
+      targetRadius += bHalf[column] * absoluteRotation[row][column];
+    const float penetration =
+        aHalf[row] + targetRadius - std::fabs(translated[row]);
+    if (penetration <= 0.0f)
+      return false;
+    minimumFacePenetration = std::min(minimumFacePenetration, penetration);
+  }
+  for (int column = 0; column < 3; ++column) {
+    float movingRadius = 0.0f;
+    for (int row = 0; row < 3; ++row)
+      movingRadius += aHalf[row] * absoluteRotation[row][column];
+    const float projectedCenter =
+        std::fabs(translated[0] * rotation[0][column] +
+                  translated[1] * rotation[1][column] +
+                  translated[2] * rotation[2][column]);
+    const float penetration = movingRadius + bHalf[column] - projectedCenter;
+    if (penetration <= 0.0f)
+      return false;
+    minimumFacePenetration = std::min(minimumFacePenetration, penetration);
+  }
+  for (int row = 0; row < 3; ++row) {
+    for (int column = 0; column < 3; ++column) {
+      const float movingRadius =
+          aHalf[(row + 1) % 3] * absoluteRotation[(row + 2) % 3][column] +
+          aHalf[(row + 2) % 3] * absoluteRotation[(row + 1) % 3][column];
+      const float targetRadius =
+          bHalf[(column + 1) % 3] * absoluteRotation[row][(column + 2) % 3] +
+          bHalf[(column + 2) % 3] * absoluteRotation[row][(column + 1) % 3];
+      const float separation = std::fabs(
+          translated[(row + 2) % 3] * rotation[(row + 1) % 3][column] -
+          translated[(row + 1) % 3] * rotation[(row + 2) % 3][column]);
+      if (separation >= movingRadius + targetRadius)
+        return false;
+    }
+  }
+  return minimumFacePenetration > kSubstantialPenetrationMm;
+}
+
+// Returns bounds translated by a candidate alignment delta.
+Bounds TranslatedBounds(Bounds bounds, const std::array<float, 3> &delta) {
+  bounds.transform.o = Add(bounds.transform.o, delta);
+  return bounds;
+}
+
+// Returns the actual target member bounds for overlap evaluation.
+std::optional<Bounds>
+TargetMemberBounds(const MvrScene &scene, ObjectType targetType,
+                   const std::string &targetUuid,
+                   const truss_attachment::Candidate &targetCandidate) {
+  const std::string ownerUuid = targetType == ObjectType::Truss
+                                    ? targetUuid
+                                    : targetCandidate.ownerTrussUuid;
+  const auto targetIt = scene.trusses.find(ownerUuid);
+  return targetIt == scene.trusses.end()
+             ? std::nullopt
+             : std::optional<Bounds>(MakeTrussBounds(targetIt->second));
+}
+
+// Chooses an alternate inferred source end only to avoid substantial overlap.
+const truss_attachment::Candidate &ChooseSourceEndpoint(
+    const MvrScene &scene, const SnapSource &source, ObjectType targetType,
+    const std::string &targetUuid, const Bounds &sourceBounds,
+    const std::vector<truss_attachment::Candidate> &sourceCandidates,
+    const truss_attachment::Candidate &acquiredSource,
+    const truss_attachment::Candidate &targetCandidate) {
+  if (source.type != ObjectType::Truss || sourceCandidates.size() != 2 ||
+      acquiredSource.kind !=
+          truss_attachment::CandidateKind::InferredLongitudinalEnd ||
+      sourceCandidates[0].kind !=
+          truss_attachment::CandidateKind::InferredLongitudinalEnd ||
+      sourceCandidates[1].kind !=
+          truss_attachment::CandidateKind::InferredLongitudinalEnd)
+    return acquiredSource;
+  const auto targetBounds =
+      TargetMemberBounds(scene, targetType, targetUuid, targetCandidate);
+  if (!targetBounds)
+    return acquiredSource;
+  const auto &alternate = &sourceCandidates[0] == &acquiredSource
+                              ? sourceCandidates[1]
+                              : sourceCandidates[0];
+  const auto acquiredDelta = Subtract(targetCandidate.worldTransform.o,
+                                      acquiredSource.worldTransform.o);
+  const auto alternateDelta =
+      Subtract(targetCandidate.worldTransform.o, alternate.worldTransform.o);
+  const bool acquiredOverlap = SubstantiallyOverlaps(
+      TranslatedBounds(sourceBounds, acquiredDelta), *targetBounds);
+  const bool alternateOverlap = SubstantiallyOverlaps(
+      TranslatedBounds(sourceBounds, alternateDelta), *targetBounds);
+  if (acquiredOverlap != alternateOverlap)
+    return acquiredOverlap ? alternate : acquiredSource;
+  if (acquiredOverlap && DirectionsOppose(alternate, targetCandidate) !=
+                             DirectionsOppose(acquiredSource, targetCandidate))
+    return DirectionsOppose(alternate, targetCandidate) ? alternate
+                                                        : acquiredSource;
+  return acquiredSource;
+}
 
 // Returns whether the left candidate rank wins the deterministic ordering.
 bool IsBetterRank(const CandidateRank &left, const CandidateRank &right) {
   return std::tie(left.primary, left.depthDifference, left.worldDistance,
                   left.targetUuid, left.sourceCandidateId,
-                  left.targetCandidateId) <
+                  left.targetCandidateId, left.sourceMemberUuid,
+                  left.targetMemberUuid) <
          std::tie(right.primary, right.depthDifference, right.worldDistance,
                   right.targetUuid, right.sourceCandidateId,
-                  right.targetCandidateId);
+                  right.targetCandidateId, right.sourceMemberUuid,
+                  right.targetMemberUuid);
 }
 
 // Tests a source and target attachment point and stores the closest snap.
-void ConsiderCandidatePair(const SnapSource &source, ObjectType targetType,
-                           const std::string &targetUuid, SnapKind kind,
-                           const truss_attachment::Candidate &sourceCandidate,
-                           const truss_attachment::Candidate &targetCandidate,
-                           const SnapSettings &settings,
-                           CandidateRank &bestRank,
-                           std::optional<SnapResult> &best) {
+void ConsiderCandidatePair(
+    const SnapSource &source, ObjectType targetType,
+    const std::string &targetUuid, SnapKind kind,
+    const truss_attachment::Candidate &sourceCandidate,
+    const truss_attachment::Candidate &targetCandidate, const MvrScene &scene,
+    const Bounds &sourceBounds,
+    const std::vector<truss_attachment::Candidate> &sourceCandidates,
+    const SnapSettings &settings, CandidateRank &bestRank,
+    std::optional<SnapResult> &best) {
+  const std::array<float, 3> acquisitionDelta = Subtract(
+      targetCandidate.worldTransform.o, sourceCandidate.worldTransform.o);
+  const auto &resolvedSource =
+      ChooseSourceEndpoint(scene, source, targetType, targetUuid, sourceBounds,
+                           sourceCandidates, sourceCandidate, targetCandidate);
   const std::array<float, 3> delta = Subtract(targetCandidate.worldTransform.o,
-                                              sourceCandidate.worldTransform.o);
-  const double worldDistance = Length(delta);
+                                              resolvedSource.worldTransform.o);
+  const double worldDistance = Length(acquisitionDelta);
   CandidateRank rank;
   rank.targetUuid = targetUuid;
   rank.sourceCandidateId = sourceCandidate.stableId;
   rank.targetCandidateId = targetCandidate.stableId;
+  rank.sourceMemberUuid = sourceCandidate.ownerTrussUuid;
+  rank.targetMemberUuid = targetCandidate.ownerTrussUuid;
   rank.worldDistance = worldDistance;
   if (settings.trussProjection) {
     const auto sourceProjected = truss_screen_snap::Project(
@@ -387,7 +519,7 @@ void ConsiderCandidatePair(const SnapSource &source, ObjectType targetType,
     if (rank.primary > settings.trussScreenApertureLogicalPx)
       return;
   } else {
-    rank.primary = WeightedLength(delta, settings.axisWeights);
+    rank.primary = WeightedLength(acquisitionDelta, settings.axisWeights);
     rank.depthDifference = 0.0;
     if (rank.primary > settings.thresholdMm)
       return;
@@ -404,8 +536,10 @@ void ConsiderCandidatePair(const SnapSource &source, ObjectType targetType,
   result.targetType = targetType;
   result.translationDeltaMm = delta;
   result.needsGrouping = kind == SnapKind::TrussToTruss;
-  result.sourceCandidateId = sourceCandidate.stableId;
+  result.sourceCandidateId = resolvedSource.stableId;
   result.targetCandidateId = targetCandidate.stableId;
+  result.sourceMemberTrussUuid = resolvedSource.ownerTrussUuid;
+  result.targetMemberTrussUuid = targetCandidate.ownerTrussUuid;
   best = result;
 }
 
@@ -427,58 +561,101 @@ void ConsiderFacePair(const SnapSource &source, ObjectType targetType,
       source.type, targetType, delta,       kind == SnapKind::TrussToTruss};
 }
 
-constexpr float kGroupParallelDotTolerance = 0.996f;
-constexpr float kGroupCenterlineToleranceMm = 25.0f;
-constexpr float kGroupContinuityToleranceMm = 25.0f;
+constexpr float kOccupiedJointPositionToleranceMm = 25.0f;
+constexpr float kOccupiedJointOpposingDirectionDot = -0.996f;
 
-// Conservatively verifies that grouped truss bounds form one collinear chain.
-bool IsCollinearChain(const std::vector<Bounds> &members) {
-  if (members.empty())
-    return false;
-  const auto firstAxis =
-      truss_attachment::ClassifyLongitudinalAxis(members.front().size);
-  if (!firstAxis)
-    return false;
-  const std::array<std::array<float, 3>, 3> firstBasis = {
-      Normalize(members.front().transform.u),
-      Normalize(members.front().transform.v),
-      Normalize(members.front().transform.w)};
-  const auto referenceAxis = firstBasis[*firstAxis];
-  const auto referenceCenter = members.front().transform.o;
-  std::vector<std::array<float, 2>> intervals;
-  for (const Bounds &member : members) {
-    const auto dominant =
-        truss_attachment::ClassifyLongitudinalAxis(member.size);
-    if (!dominant)
-      return false;
-    const std::array<std::array<float, 3>, 3> basis = {
-        Normalize(member.transform.u), Normalize(member.transform.v),
-        Normalize(member.transform.w)};
-    if (std::fabs(Dot(referenceAxis, basis[*dominant])) <
-        kGroupParallelDotTolerance)
-      return false;
-    const auto offset = Subtract(member.transform.o, referenceCenter);
-    const float along = Dot(offset, referenceAxis);
-    const auto cross = Subtract(offset, Scale(referenceAxis, along));
-    if (Length(cross) > kGroupCenterlineToleranceMm)
-      return false;
-    intervals.push_back({along - member.size[*dominant] * 0.5f,
-                         along + member.size[*dominant] * 0.5f});
+// Collects truss UUIDs recursively from a GroupObject hierarchy.
+void CollectGroupTrussUuids(const MvrScene &scene, const std::string &groupUuid,
+                            std::vector<std::string> &uuids) {
+  const auto groupIt = scene.groupObjects.find(groupUuid);
+  if (groupIt == scene.groupObjects.end())
+    return;
+  for (const auto &child : groupIt->second.children) {
+    if (child.type == MvrNodeType::Truss)
+      uuids.push_back(child.uuid);
+    else if (child.type == MvrNodeType::GroupObject)
+      CollectGroupTrussUuids(scene, child.uuid, uuids);
   }
-  std::sort(intervals.begin(), intervals.end());
-  float coveredEnd = intervals.front()[1];
-  for (std::size_t index = 1; index < intervals.size(); ++index) {
-    if (intervals[index][0] > coveredEnd + kGroupContinuityToleranceMm)
-      return false;
-    coveredEnd = std::max(coveredEnd, intervals[index][1]);
-  }
-  return true;
 }
 
-// Builds conservative attachment points for aggregate truss-group bounds.
+struct JointMatch {
+  float distance = 0.0f;
+  std::size_t first = 0;
+  std::size_t second = 0;
+};
+
+// Builds real unoccupied member candidates for a truss group.
 std::vector<truss_attachment::Candidate>
 BuildGroupCandidatesImpl(const MvrScene &scene, const Bounds &bounds,
-                         const std::string &groupUuid) {
+                         const std::string &groupUuid,
+                         truss_attachment::CandidateResolver &resolver) {
+  std::vector<std::string> memberUuids;
+  CollectGroupTrussUuids(scene, groupUuid, memberUuids);
+  std::sort(memberUuids.begin(), memberUuids.end());
+  memberUuids.erase(std::unique(memberUuids.begin(), memberUuids.end()),
+                    memberUuids.end());
+  std::vector<truss_attachment::Candidate> candidates;
+  for (const std::string &uuid : memberUuids) {
+    const auto trussIt = scene.trusses.find(uuid);
+    if (trussIt == scene.trusses.end())
+      continue;
+    auto memberCandidates =
+        truss_attachment::BuildCandidates(scene, trussIt->second, resolver)
+            .candidates;
+    candidates.insert(candidates.end(), memberCandidates.begin(),
+                      memberCandidates.end());
+  }
+  std::sort(candidates.begin(), candidates.end(),
+            [](const auto &left, const auto &right) {
+              return std::tie(left.ownerTrussUuid, left.stableId) <
+                     std::tie(right.ownerTrussUuid, right.stableId);
+            });
+  std::vector<JointMatch> matches;
+  for (std::size_t first = 0; first < candidates.size(); ++first) {
+    for (std::size_t second = first + 1; second < candidates.size(); ++second) {
+      if (candidates[first].ownerTrussUuid == candidates[second].ownerTrussUuid)
+        continue;
+      const float distance =
+          Length(Subtract(candidates[first].worldTransform.o,
+                          candidates[second].worldTransform.o));
+      if (distance > kOccupiedJointPositionToleranceMm)
+        continue;
+      if (candidates[first].worldDirection &&
+          candidates[second].worldDirection &&
+          Dot(*candidates[first].worldDirection,
+              *candidates[second].worldDirection) >
+              kOccupiedJointOpposingDirectionDot)
+        continue;
+      matches.push_back({distance, first, second});
+    }
+  }
+  std::sort(
+      matches.begin(), matches.end(),
+      [&](const JointMatch &left, const JointMatch &right) {
+        return std::tie(left.distance, candidates[left.first].ownerTrussUuid,
+                        candidates[left.first].stableId,
+                        candidates[left.second].ownerTrussUuid,
+                        candidates[left.second].stableId) <
+               std::tie(right.distance, candidates[right.first].ownerTrussUuid,
+                        candidates[right.first].stableId,
+                        candidates[right.second].ownerTrussUuid,
+                        candidates[right.second].stableId);
+      });
+  std::vector<bool> occupied(candidates.size(), false);
+  for (const JointMatch &match : matches) {
+    if (occupied[match.first] || occupied[match.second])
+      continue;
+    occupied[match.first] = true;
+    occupied[match.second] = true;
+  }
+  std::vector<truss_attachment::Candidate> exposed;
+  for (std::size_t index = 0; index < candidates.size(); ++index) {
+    if (!occupied[index])
+      exposed.push_back(candidates[index]);
+  }
+  if (!candidates.empty())
+    return exposed;
+
   Matrix insertionTransform = bounds.transform;
   insertionTransform.o =
       Add(insertionTransform.o,
@@ -486,11 +663,6 @@ BuildGroupCandidatesImpl(const MvrScene &scene, const Bounds &bounds,
   insertionTransform.o =
       Add(insertionTransform.o,
           Scale(Normalize(insertionTransform.w), -bounds.size[2] * 0.5f));
-  std::vector<Bounds> members;
-  CollectGroupTrussBounds(scene, groupUuid, members);
-  if (IsCollinearChain(members))
-    return truss_attachment::BuildInferredCandidates(
-        bounds.size, insertionTransform, groupUuid);
   return truss_attachment::BuildAmbiguousCandidates(
       bounds.size, insertionTransform, groupUuid);
 }
@@ -501,7 +673,8 @@ BuildGroupCandidatesImpl(const MvrScene &scene, const Bounds &bounds,
 std::vector<truss_attachment::Candidate>
 BuildTrussGroupCandidates(const MvrScene &scene, const std::string &groupUuid) {
   const auto bounds = MakeTrussGroupBounds(scene, groupUuid);
-  return bounds ? BuildGroupCandidatesImpl(scene, *bounds, groupUuid)
+  truss_attachment::CandidateResolver resolver;
+  return bounds ? BuildGroupCandidatesImpl(scene, *bounds, groupUuid, resolver)
                 : std::vector<truss_attachment::Candidate>{};
 }
 
@@ -527,26 +700,25 @@ std::optional<SnapResult> FindSnap(const MvrScene &scene,
             ? truss_attachment::BuildCandidates(
                   scene, scene.trusses.at(source.uuid), resolver)
                   .candidates
-            : BuildGroupCandidatesImpl(scene, *sourceBounds, source.uuid);
+            : BuildGroupCandidatesImpl(scene, *sourceBounds, source.uuid,
+                                       resolver);
     auto considerTrussTarget = [&](ObjectType targetType,
                                    const std::string &uuid,
                                    const Bounds &targetBounds) {
       if (uuid == source.uuid)
-        return;
-      if (targetType == ObjectType::TrussGroup &&
-          BoundsContainsPoint(targetBounds, sourceBounds->transform.o))
         return;
       const auto targetCandidates =
           targetType == ObjectType::Truss
               ? truss_attachment::BuildCandidates(scene, scene.trusses.at(uuid),
                                                   resolver)
                     .candidates
-              : BuildGroupCandidatesImpl(scene, targetBounds, uuid);
+              : BuildGroupCandidatesImpl(scene, targetBounds, uuid, resolver);
       for (const auto &sourceCandidate : sourceCandidates) {
         for (const auto &targetCandidate : targetCandidates)
           ConsiderCandidatePair(
               source, targetType, uuid, SnapKind::TrussToTruss, sourceCandidate,
-              targetCandidate, settings, bestCandidateRank, best);
+              targetCandidate, scene, *sourceBounds, sourceCandidates, settings,
+              bestCandidateRank, best);
       }
     };
     for (const auto &[uuid, group] : scene.groupObjects) {

--- a/core/magnet_snap.h
+++ b/core/magnet_snap.h
@@ -43,6 +43,8 @@ struct SnapResult {
   bool needsGrouping = false;
   std::string sourceCandidateId;
   std::string targetCandidateId;
+  std::string sourceMemberTrussUuid;
+  std::string targetMemberTrussUuid;
 };
 
 // Builds deterministic exterior or conservative aggregate group candidates.

--- a/core/magnet_snap.h
+++ b/core/magnet_snap.h
@@ -2,6 +2,8 @@
 
 #include "interactive_transform_policy.h"
 #include "mvrscene.h"
+#include "truss_attachment_candidates.h"
+#include "truss_screen_snap.h"
 
 #include <array>
 #include <optional>
@@ -24,6 +26,10 @@ struct SnapSource {
 struct SnapSettings {
   float thresholdMm = kDefaultSnapDistanceMm;
   std::array<float, 3> axisWeights{1.0f, 1.0f, 1.0f};
+  truss_attachment::CandidateResolver *candidateResolver = nullptr;
+  std::optional<truss_screen_snap::ProjectionSnapshot> trussProjection;
+  double trussScreenApertureLogicalPx =
+      truss_screen_snap::kDefaultTrussScreenSnapApertureLogicalPx;
 };
 
 struct SnapResult {
@@ -35,7 +41,13 @@ struct SnapResult {
   ObjectType targetType = ObjectType::SceneObject;
   std::array<float, 3> translationDeltaMm{0.0f, 0.0f, 0.0f};
   bool needsGrouping = false;
+  std::string sourceCandidateId;
+  std::string targetCandidateId;
 };
+
+// Builds deterministic exterior or conservative aggregate group candidates.
+std::vector<truss_attachment::Candidate>
+BuildTrussGroupCandidates(const MvrScene &scene, const std::string &groupUuid);
 
 // Finds the best non-destructive Magnet snap candidate for the source object.
 std::optional<SnapResult> FindSnap(const MvrScene &scene,

--- a/core/truss_attachment_candidates.cpp
+++ b/core/truss_attachment_candidates.cpp
@@ -5,7 +5,9 @@
 #include "matrixutils.h"
 
 #include <algorithm>
+#include <chrono>
 #include <cmath>
+#include <cstdint>
 #include <filesystem>
 #include <system_error>
 #include <tinyxml2.h>
@@ -23,13 +25,33 @@ Matrix ToMillimetres(Matrix transform) {
 // Appends one deterministic candidate at a local transform.
 void AppendCandidate(std::vector<Candidate> &out, CandidateKind kind,
                      std::string stableId, const Matrix &local,
-                     const Matrix &ownerTransform, std::string sourceId) {
+                     const Matrix &ownerTransform, std::string sourceId,
+                     std::optional<std::array<float, 3>> localDirection) {
   Candidate candidate;
   candidate.stableId = std::move(stableId);
   candidate.kind = kind;
+  candidate.ownerTrussUuid = sourceId;
   candidate.localTransform = local;
   candidate.worldTransform = MatrixUtils::Multiply(ownerTransform, local);
   candidate.sourcePath = std::move(sourceId);
+  candidate.localDirection = localDirection;
+  if (localDirection) {
+    std::array<float, 3> direction{};
+    for (int component = 0; component < 3; ++component) {
+      direction[component] =
+          ownerTransform.u[component] * (*localDirection)[0] +
+          ownerTransform.v[component] * (*localDirection)[1] +
+          ownerTransform.w[component] * (*localDirection)[2];
+    }
+    const float length =
+        std::sqrt(direction[0] * direction[0] + direction[1] * direction[1] +
+                  direction[2] * direction[2]);
+    if (length > 1e-6f) {
+      for (float &value : direction)
+        value /= length;
+      candidate.worldDirection = direction;
+    }
+  }
   out.push_back(std::move(candidate));
 }
 
@@ -161,10 +183,12 @@ BuildInferredCandidates(const std::array<float, 3> &dimensionsMm,
       Matrix local = MatrixUtils::Identity();
       local.o = center;
       local.o[*dominant] += sign * safeDimensions[*dominant] * 0.5f;
+      std::array<float, 3> direction{};
+      direction[*dominant] = static_cast<float>(sign);
       AppendCandidate(result, CandidateKind::InferredLongitudinalEnd,
                       "longitudinal-axis-" + std::to_string(*dominant) +
                           (sign < 0 ? "-negative" : "-positive"),
-                      local, trussTransform, sourceId);
+                      local, trussTransform, sourceId, direction);
     }
     return result;
   }
@@ -189,10 +213,12 @@ BuildAmbiguousCandidates(const std::array<float, 3> &dimensionsMm,
       Matrix local = MatrixUtils::Identity();
       local.o = center;
       local.o[axis] += sign * safeDimensions[axis] * 0.5f;
+      std::array<float, 3> direction{};
+      direction[axis] = static_cast<float>(sign);
       AppendCandidate(result, CandidateKind::InferredFaceCenter,
                       "face-axis-" + std::to_string(axis) +
                           (sign < 0 ? "-negative" : "-positive"),
-                      local, trussTransform, sourceId);
+                      local, trussTransform, sourceId, direction);
     }
   }
   return result;
@@ -219,21 +245,45 @@ std::string BuildArchiveVersionKey(const std::filesystem::path &path) {
   const auto modified = std::filesystem::last_write_time(path, ec);
   if (ec)
     return {};
+  using PortableFileTicks = std::chrono::duration<std::int64_t, std::nano>;
+  const std::int64_t modifiedTicks =
+      std::chrono::duration_cast<PortableFileTicks>(modified.time_since_epoch())
+          .count();
   return PathUtils::BuildFilesystemIdentityKey(path) + "|" +
-         std::to_string(size) + "|" +
-         std::to_string(modified.time_since_epoch().count());
+         std::to_string(static_cast<std::uintmax_t>(size)) + "|" +
+         std::to_string(modifiedTicks);
 }
 
 // Applies an instance transform to cached local candidate definitions.
 CandidateResolution Instantiate(const CandidateResolver::CacheEntry &entry,
-                                const Matrix &transform) {
+                                const Matrix &transform,
+                                const std::string &ownerTrussUuid) {
   CandidateResolution result;
   result.candidates = entry.localCandidates;
   result.diagnostics = entry.diagnostics;
   result.resolvedSourceIdentity = entry.resolvedSourceIdentity;
-  for (Candidate &candidate : result.candidates)
+  for (Candidate &candidate : result.candidates) {
     candidate.worldTransform =
         MatrixUtils::Multiply(transform, candidate.localTransform);
+    candidate.ownerTrussUuid = ownerTrussUuid;
+    if (candidate.localDirection) {
+      std::array<float, 3> direction{};
+      for (int component = 0; component < 3; ++component) {
+        direction[component] =
+            transform.u[component] * (*candidate.localDirection)[0] +
+            transform.v[component] * (*candidate.localDirection)[1] +
+            transform.w[component] * (*candidate.localDirection)[2];
+      }
+      const float length =
+          std::sqrt(direction[0] * direction[0] + direction[1] * direction[1] +
+                    direction[2] * direction[2]);
+      if (length > 1e-6f) {
+        for (float &value : direction)
+          value /= length;
+        candidate.worldDirection = direction;
+      }
+    }
+  }
   return result;
 }
 
@@ -260,7 +310,8 @@ CandidateResolution CandidateResolver::Resolve(const MvrScene &scene,
       continue;
     }
     if (const auto found = m_cache.find(versionKey); found != m_cache.end()) {
-      CandidateResolution result = Instantiate(found->second, truss.transform);
+      CandidateResolution result =
+          Instantiate(found->second, truss.transform, truss.uuid);
       result.diagnostics.insert(result.diagnostics.begin(),
                                 resolutionDiagnostics.begin(),
                                 resolutionDiagnostics.end());
@@ -293,7 +344,8 @@ CandidateResolution CandidateResolver::Resolve(const MvrScene &scene,
     }
     auto [inserted, unused] = m_cache.emplace(versionKey, std::move(entry));
     (void)unused;
-    CandidateResolution result = Instantiate(inserted->second, truss.transform);
+    CandidateResolution result =
+        Instantiate(inserted->second, truss.transform, truss.uuid);
     result.diagnostics.insert(result.diagnostics.begin(),
                               resolutionDiagnostics.begin(),
                               resolutionDiagnostics.end());

--- a/core/truss_attachment_candidates.cpp
+++ b/core/truss_attachment_candidates.cpp
@@ -1,0 +1,185 @@
+#include "truss_attachment_candidates.h"
+
+#include "gdtf_archive_reader.h"
+#include "matrixutils.h"
+
+#include <algorithm>
+#include <cmath>
+#include <tinyxml2.h>
+
+namespace truss_attachment {
+namespace {
+
+// Returns a GDTF transform converted from metres to scene millimetres.
+Matrix ToMillimetres(Matrix transform) {
+  for (float &component : transform.o)
+    component *= 1000.0f;
+  return transform;
+}
+
+// Appends one deterministic candidate at a local transform.
+void AppendCandidate(std::vector<Candidate> &out, CandidateKind kind,
+                     std::string stableId, const Matrix &local,
+                     const Matrix &ownerTransform, std::string sourceId) {
+  Candidate candidate;
+  candidate.stableId = std::move(stableId);
+  candidate.kind = kind;
+  candidate.localTransform = local;
+  candidate.worldTransform = MatrixUtils::Multiply(ownerTransform, local);
+  candidate.sourcePath = std::move(sourceId);
+  out.push_back(std::move(candidate));
+}
+
+// Traverses a GDTF geometry subtree while composing parent transforms.
+void ReadGeometry(const tinyxml2::XMLElement *node, const Matrix &parent,
+                  const Matrix &trussTransform, const std::string &path,
+                  ExplicitReadResult &result, size_t &magnetIndex) {
+  for (const tinyxml2::XMLElement *current = node; current;
+       current = current->NextSiblingElement()) {
+    const std::string elementName = current->Name() ? current->Name() : "";
+    const std::string name =
+        current->Attribute("Name") ? current->Attribute("Name") : "";
+    const std::string currentPath =
+        path + "/" + elementName + (name.empty() ? "" : "[" + name + "]");
+    Matrix local = MatrixUtils::Identity();
+    const char *position = current->Attribute("Position");
+    const bool positionValid =
+        !position || MatrixUtils::ParseMatrix(position, local);
+    if (elementName == "Magnet" && !positionValid) {
+      result.diagnostics.push_back(
+          {currentPath, "Magnet Position is malformed and was skipped."});
+    } else {
+      const Matrix composed = MatrixUtils::Multiply(parent, local);
+      if (elementName == "Magnet") {
+        Candidate candidate;
+        candidate.stableId = "gdtf-magnet-" + std::to_string(magnetIndex++);
+        candidate.kind = CandidateKind::ExplicitGdtfMagnet;
+        candidate.name = name;
+        candidate.model =
+            current->Attribute("Model") ? current->Attribute("Model") : "";
+        candidate.localTransform = ToMillimetres(composed);
+        candidate.worldTransform =
+            MatrixUtils::Multiply(trussTransform, candidate.localTransform);
+        candidate.sourcePath = currentPath;
+        result.candidates.push_back(std::move(candidate));
+      }
+      ReadGeometry(current->FirstChildElement(), composed, trussTransform,
+                   currentPath, result, magnetIndex);
+    }
+  }
+}
+
+} // namespace
+
+// Reads Magnet nodes from immutable GDTF description XML.
+ExplicitReadResult ReadExplicitGdtfMagnets(const std::string &descriptionXml,
+                                           const Matrix &trussTransform) {
+  ExplicitReadResult result;
+  tinyxml2::XMLDocument document;
+  if (document.Parse(descriptionXml.c_str(), descriptionXml.size()) !=
+      tinyxml2::XML_SUCCESS) {
+    result.diagnostics.push_back({"/", "GDTF description XML is malformed."});
+    return result;
+  }
+  const auto *fixtureType =
+      document.FirstChildElement("GDTF")
+          ? document.FirstChildElement("GDTF")->FirstChildElement("FixtureType")
+          : nullptr;
+  const auto *geometries =
+      fixtureType ? fixtureType->FirstChildElement("Geometries") : nullptr;
+  size_t index = 0;
+  ReadGeometry(geometries ? geometries->FirstChildElement() : nullptr,
+               MatrixUtils::Identity(), trussTransform,
+               "/GDTF/FixtureType/Geometries", result, index);
+  return result;
+}
+
+// Reads Magnet nodes from a GDTF archive without modifying it.
+ExplicitReadResult
+ReadExplicitGdtfMagnetsFromArchive(const std::string &archivePath,
+                                   const Matrix &trussTransform) {
+  if (archivePath.empty())
+    return {};
+  const gdtf::ArchiveReadResult archive = gdtf::ReadGdtfArchive(archivePath);
+  if (!archive.Success())
+    return {};
+  return ReadExplicitGdtfMagnets(archive.descriptionXml, trussTransform);
+}
+
+// Returns the clearly dominant local dimension, if one exists.
+std::optional<int>
+ClassifyLongitudinalAxis(const std::array<float, 3> &dimensionsMm) {
+  for (float dimension : dimensionsMm) {
+    if (!std::isfinite(dimension) || dimension <= 0.0f)
+      return std::nullopt;
+  }
+  int largest = 0;
+  for (int axis = 1; axis < 3; ++axis) {
+    if (dimensionsMm[axis] > dimensionsMm[largest])
+      largest = axis;
+  }
+  float secondLargest = 0.0f;
+  for (int axis = 0; axis < 3; ++axis) {
+    if (axis != largest)
+      secondLargest = std::max(secondLargest, dimensionsMm[axis]);
+  }
+  // Equality is deliberately ambiguous; dominance must be clear.
+  return dimensionsMm[largest] / secondLargest > kLongitudinalDominanceRatio
+             ? std::optional<int>(largest)
+             : std::nullopt;
+}
+
+// Builds inferred terminal or face-center candidates from local bounds.
+std::vector<Candidate>
+BuildInferredCandidates(const std::array<float, 3> &dimensionsMm,
+                        const Matrix &trussTransform,
+                        const std::string &sourceId) {
+  std::vector<Candidate> result;
+  std::array<float, 3> safeDimensions = dimensionsMm;
+  for (float &dimension : safeDimensions) {
+    if (!std::isfinite(dimension) || dimension <= 0.0f)
+      dimension = 1.0f;
+  }
+  const std::array<float, 3> center{safeDimensions[0] * 0.5f, 0.0f,
+                                    safeDimensions[2] * 0.5f};
+  if (const auto dominant = ClassifyLongitudinalAxis(dimensionsMm)) {
+    for (int sign : {-1, 1}) {
+      Matrix local = MatrixUtils::Identity();
+      local.o = center;
+      local.o[*dominant] += sign * safeDimensions[*dominant] * 0.5f;
+      AppendCandidate(result, CandidateKind::InferredLongitudinalEnd,
+                      "longitudinal-axis-" + std::to_string(*dominant) +
+                          (sign < 0 ? "-negative" : "-positive"),
+                      local, trussTransform, sourceId);
+    }
+    return result;
+  }
+  for (int axis = 0; axis < 3; ++axis) {
+    for (int sign : {-1, 1}) {
+      Matrix local = MatrixUtils::Identity();
+      local.o = center;
+      local.o[axis] += sign * safeDimensions[axis] * 0.5f;
+      AppendCandidate(result, CandidateKind::InferredFaceCenter,
+                      "face-axis-" + std::to_string(axis) +
+                          (sign < 0 ? "-negative" : "-positive"),
+                      local, trussTransform, sourceId);
+    }
+  }
+  return result;
+}
+
+// Resolves explicit candidates first and otherwise returns inferred candidates.
+std::vector<Candidate> BuildCandidates(const Truss &truss,
+                                       std::vector<Diagnostic> *diagnostics) {
+  ExplicitReadResult explicitResult =
+      ReadExplicitGdtfMagnetsFromArchive(truss.gdtfSpec, truss.transform);
+  if (diagnostics)
+    *diagnostics = explicitResult.diagnostics;
+  if (!explicitResult.candidates.empty())
+    return explicitResult.candidates;
+  return BuildInferredCandidates(
+      {truss.lengthMm, truss.widthMm, truss.heightMm}, truss.transform,
+      truss.uuid);
+}
+
+} // namespace truss_attachment

--- a/core/truss_attachment_candidates.cpp
+++ b/core/truss_attachment_candidates.cpp
@@ -1,10 +1,13 @@
 #include "truss_attachment_candidates.h"
 
+#include "filesystem_path_utils.h"
 #include "gdtf_archive_reader.h"
 #include "matrixutils.h"
 
 #include <algorithm>
 #include <cmath>
+#include <filesystem>
+#include <system_error>
 #include <tinyxml2.h>
 
 namespace truss_attachment {
@@ -101,9 +104,20 @@ ReadExplicitGdtfMagnetsFromArchive(const std::string &archivePath,
   if (archivePath.empty())
     return {};
   const gdtf::ArchiveReadResult archive = gdtf::ReadGdtfArchive(archivePath);
-  if (!archive.Success())
-    return {};
-  return ReadExplicitGdtfMagnets(archive.descriptionXml, trussTransform);
+  ExplicitReadResult result;
+  if (!archive.Success()) {
+    result.sourceReadable = false;
+    for (const auto &diagnostic : archive.diagnostics)
+      result.diagnostics.push_back({diagnostic.entryPath, diagnostic.message});
+    if (result.diagnostics.empty())
+      result.diagnostics.push_back(
+          {archivePath, "GDTF archive could not be read."});
+    return result;
+  }
+  result = ReadExplicitGdtfMagnets(archive.descriptionXml, trussTransform);
+  for (const auto &diagnostic : archive.diagnostics)
+    result.diagnostics.push_back({diagnostic.entryPath, diagnostic.message});
+  return result;
 }
 
 // Returns the clearly dominant local dimension, if one exists.
@@ -154,6 +168,22 @@ BuildInferredCandidates(const std::array<float, 3> &dimensionsMm,
     }
     return result;
   }
+  return BuildAmbiguousCandidates(safeDimensions, trussTransform, sourceId);
+}
+
+// Builds exactly six deterministic face-center candidates.
+std::vector<Candidate>
+BuildAmbiguousCandidates(const std::array<float, 3> &dimensionsMm,
+                         const Matrix &trussTransform,
+                         const std::string &sourceId) {
+  std::vector<Candidate> result;
+  std::array<float, 3> safeDimensions = dimensionsMm;
+  for (float &dimension : safeDimensions) {
+    if (!std::isfinite(dimension) || dimension <= 0.0f)
+      dimension = 1.0f;
+  }
+  const std::array<float, 3> center{safeDimensions[0] * 0.5f, 0.0f,
+                                    safeDimensions[2] * 0.5f};
   for (int axis = 0; axis < 3; ++axis) {
     for (int sign : {-1, 1}) {
       Matrix local = MatrixUtils::Identity();
@@ -168,18 +198,136 @@ BuildInferredCandidates(const std::array<float, 3> &dimensionsMm,
   return result;
 }
 
-// Resolves explicit candidates first and otherwise returns inferred candidates.
-std::vector<Candidate> BuildCandidates(const Truss &truss,
-                                       std::vector<Diagnostic> *diagnostics) {
-  ExplicitReadResult explicitResult =
-      ReadExplicitGdtfMagnetsFromArchive(truss.gdtfSpec, truss.transform);
-  if (diagnostics)
-    *diagnostics = explicitResult.diagnostics;
-  if (!explicitResult.candidates.empty())
-    return explicitResult.candidates;
-  return BuildInferredCandidates(
-      {truss.lengthMm, truss.widthMm, truss.heightMm}, truss.transform,
-      truss.uuid);
+// Resolves one scene resource reference without consulting the working
+// directory.
+std::filesystem::path ResolveSceneResource(const MvrScene &scene,
+                                           const std::string &reference) {
+  const auto path = PathUtils::PathFromUtf8(reference);
+  if (path.empty() || path.is_absolute())
+    return path;
+  if (scene.basePath.empty())
+    return {};
+  return PathUtils::PathFromUtf8(scene.basePath) / path;
+}
+
+// Builds the versioned cache identity for an existing archive.
+std::string BuildArchiveVersionKey(const std::filesystem::path &path) {
+  std::error_code ec;
+  const auto size = std::filesystem::file_size(path, ec);
+  if (ec)
+    return {};
+  const auto modified = std::filesystem::last_write_time(path, ec);
+  if (ec)
+    return {};
+  return PathUtils::BuildFilesystemIdentityKey(path) + "|" +
+         std::to_string(size) + "|" +
+         std::to_string(modified.time_since_epoch().count());
+}
+
+// Applies an instance transform to cached local candidate definitions.
+CandidateResolution Instantiate(const CandidateResolver::CacheEntry &entry,
+                                const Matrix &transform) {
+  CandidateResolution result;
+  result.candidates = entry.localCandidates;
+  result.diagnostics = entry.diagnostics;
+  result.resolvedSourceIdentity = entry.resolvedSourceIdentity;
+  for (Candidate &candidate : result.candidates)
+    candidate.worldTransform =
+        MatrixUtils::Multiply(transform, candidate.localTransform);
+  return result;
+}
+
+// Resolves prioritized archive sources and caches immutable local definitions.
+CandidateResolution CandidateResolver::Resolve(const MvrScene &scene,
+                                               const Truss &truss) {
+  std::vector<Diagnostic> resolutionDiagnostics;
+  for (const std::string *reference :
+       {&truss.gdtfSpec, &truss.perastageAuxGdtfArchivePath}) {
+    if (reference->empty())
+      continue;
+    const std::filesystem::path resolved =
+        ResolveSceneResource(scene, *reference);
+    if (resolved.empty()) {
+      resolutionDiagnostics.push_back(
+          {*reference, "Relative GDTF resource has no scene base path."});
+      continue;
+    }
+    const std::string versionKey = BuildArchiveVersionKey(resolved);
+    if (versionKey.empty()) {
+      resolutionDiagnostics.push_back(
+          {PathUtils::PathToUtf8(resolved),
+           "GDTF resource is missing or unreadable."});
+      continue;
+    }
+    if (const auto found = m_cache.find(versionKey); found != m_cache.end()) {
+      CandidateResolution result = Instantiate(found->second, truss.transform);
+      result.diagnostics.insert(result.diagnostics.begin(),
+                                resolutionDiagnostics.begin(),
+                                resolutionDiagnostics.end());
+      if (!found->second.sourceReadable) {
+        resolutionDiagnostics = std::move(result.diagnostics);
+        continue;
+      }
+      if (result.candidates.empty())
+        result.candidates = BuildInferredCandidates(
+            {truss.lengthMm, truss.widthMm, truss.heightMm}, truss.transform,
+            truss.uuid);
+      return result;
+    }
+
+    ++m_archiveParseCount;
+    const std::string resolvedText = PathUtils::PathToUtf8(resolved);
+    ExplicitReadResult explicitResult = ReadExplicitGdtfMagnetsFromArchive(
+        resolvedText, MatrixUtils::Identity());
+    CacheEntry entry;
+    entry.localCandidates = std::move(explicitResult.candidates);
+    entry.diagnostics = std::move(explicitResult.diagnostics);
+    entry.resolvedSourceIdentity =
+        PathUtils::BuildFilesystemIdentityKey(resolved);
+    entry.sourceReadable = explicitResult.sourceReadable;
+    for (auto cached = m_cache.begin(); cached != m_cache.end();) {
+      if (cached->second.resolvedSourceIdentity == entry.resolvedSourceIdentity)
+        cached = m_cache.erase(cached);
+      else
+        ++cached;
+    }
+    auto [inserted, unused] = m_cache.emplace(versionKey, std::move(entry));
+    (void)unused;
+    CandidateResolution result = Instantiate(inserted->second, truss.transform);
+    result.diagnostics.insert(result.diagnostics.begin(),
+                              resolutionDiagnostics.begin(),
+                              resolutionDiagnostics.end());
+    if (!inserted->second.sourceReadable) {
+      resolutionDiagnostics = std::move(result.diagnostics);
+      continue;
+    }
+    if (result.candidates.empty())
+      result.candidates = BuildInferredCandidates(
+          {truss.lengthMm, truss.widthMm, truss.heightMm}, truss.transform,
+          truss.uuid);
+    return result;
+  }
+
+  CandidateResolution fallback;
+  fallback.diagnostics = std::move(resolutionDiagnostics);
+  fallback.candidates =
+      BuildInferredCandidates({truss.lengthMm, truss.widthMm, truss.heightMm},
+                              truss.transform, truss.uuid);
+  return fallback;
+}
+
+// Clears all cached type-level attachment definitions.
+void CandidateResolver::Clear() { m_cache.clear(); }
+
+// Returns the number of archive parses performed by this resolver.
+std::size_t CandidateResolver::ArchiveParseCount() const {
+  return m_archiveParseCount;
+}
+
+// Resolves cached local definitions and applies the current instance transform.
+CandidateResolution BuildCandidates(const MvrScene &scene, const Truss &truss,
+                                    CandidateResolver &resolver) {
+  return resolver.Resolve(scene, truss);
 }
 
 } // namespace truss_attachment

--- a/core/truss_attachment_candidates.h
+++ b/core/truss_attachment_candidates.h
@@ -1,8 +1,11 @@
 #pragma once
 
-#include "truss.h"
+#include "mvrscene.h"
 
 #include <array>
+#include <cstddef>
+#include <filesystem>
+#include <map>
 #include <optional>
 #include <string>
 #include <vector>
@@ -35,6 +38,32 @@ struct Diagnostic {
 struct ExplicitReadResult {
   std::vector<Candidate> candidates;
   std::vector<Diagnostic> diagnostics;
+  bool sourceReadable = true;
+};
+
+struct CandidateResolution {
+  std::vector<Candidate> candidates;
+  std::vector<Diagnostic> diagnostics;
+  std::string resolvedSourceIdentity;
+};
+
+// Caches immutable local attachment definitions by resolved archive version.
+class CandidateResolver {
+public:
+  struct CacheEntry {
+    std::vector<Candidate> localCandidates;
+    std::vector<Diagnostic> diagnostics;
+    std::string resolvedSourceIdentity;
+    bool sourceReadable = true;
+  };
+
+  CandidateResolution Resolve(const MvrScene &scene, const Truss &truss);
+  void Clear();
+  std::size_t ArchiveParseCount() const;
+
+private:
+  std::map<std::string, CacheEntry> m_cache;
+  std::size_t m_archiveParseCount = 0;
 };
 
 // Reads Magnet nodes from immutable GDTF description XML.
@@ -56,9 +85,14 @@ BuildInferredCandidates(const std::array<float, 3> &dimensionsMm,
                         const Matrix &trussTransform,
                         const std::string &sourceId = {});
 
-// Resolves explicit candidates first and otherwise returns inferred candidates.
+// Builds exactly six deterministic face-center candidates.
 std::vector<Candidate>
-BuildCandidates(const Truss &truss,
-                std::vector<Diagnostic> *diagnostics = nullptr);
+BuildAmbiguousCandidates(const std::array<float, 3> &dimensionsMm,
+                         const Matrix &trussTransform,
+                         const std::string &sourceId = {});
+
+// Resolves cached local definitions and applies the current instance transform.
+CandidateResolution BuildCandidates(const MvrScene &scene, const Truss &truss,
+                                    CandidateResolver &resolver);
 
 } // namespace truss_attachment

--- a/core/truss_attachment_candidates.h
+++ b/core/truss_attachment_candidates.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include "truss.h"
+
+#include <array>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace truss_attachment {
+
+constexpr float kLongitudinalDominanceRatio = 2.0f;
+
+enum class CandidateKind {
+  ExplicitGdtfMagnet,
+  InferredLongitudinalEnd,
+  InferredFaceCenter
+};
+
+struct Candidate {
+  std::string stableId;
+  CandidateKind kind = CandidateKind::InferredFaceCenter;
+  std::string name;
+  std::string model;
+  Matrix localTransform{};
+  Matrix worldTransform{};
+  std::string sourcePath;
+};
+
+struct Diagnostic {
+  std::string path;
+  std::string message;
+};
+
+struct ExplicitReadResult {
+  std::vector<Candidate> candidates;
+  std::vector<Diagnostic> diagnostics;
+};
+
+// Reads Magnet nodes from immutable GDTF description XML.
+ExplicitReadResult ReadExplicitGdtfMagnets(const std::string &descriptionXml,
+                                           const Matrix &trussTransform);
+
+// Reads Magnet nodes from a GDTF archive without modifying it.
+ExplicitReadResult
+ReadExplicitGdtfMagnetsFromArchive(const std::string &archivePath,
+                                   const Matrix &trussTransform);
+
+// Returns the clearly dominant local dimension, if one exists.
+std::optional<int>
+ClassifyLongitudinalAxis(const std::array<float, 3> &dimensionsMm);
+
+// Builds inferred terminal or face-center candidates from local bounds.
+std::vector<Candidate>
+BuildInferredCandidates(const std::array<float, 3> &dimensionsMm,
+                        const Matrix &trussTransform,
+                        const std::string &sourceId = {});
+
+// Resolves explicit candidates first and otherwise returns inferred candidates.
+std::vector<Candidate>
+BuildCandidates(const Truss &truss,
+                std::vector<Diagnostic> *diagnostics = nullptr);
+
+} // namespace truss_attachment

--- a/core/truss_attachment_candidates.h
+++ b/core/truss_attachment_candidates.h
@@ -22,11 +22,14 @@ enum class CandidateKind {
 
 struct Candidate {
   std::string stableId;
+  std::string ownerTrussUuid;
   CandidateKind kind = CandidateKind::InferredFaceCenter;
   std::string name;
   std::string model;
   Matrix localTransform{};
   Matrix worldTransform{};
+  std::optional<std::array<float, 3>> localDirection;
+  std::optional<std::array<float, 3>> worldDirection;
   std::string sourcePath;
 };
 

--- a/core/truss_screen_snap.cpp
+++ b/core/truss_screen_snap.cpp
@@ -1,0 +1,49 @@
+#include "truss_screen_snap.h"
+
+#include <cmath>
+
+namespace truss_screen_snap {
+namespace {
+
+// Multiplies an OpenGL column-major matrix by a homogeneous vector.
+std::array<double, 4> Multiply(const std::array<double, 16> &matrix,
+                               const std::array<double, 4> &vector) {
+  std::array<double, 4> result{};
+  for (int row = 0; row < 4; ++row) {
+    for (int column = 0; column < 4; ++column)
+      result[row] += matrix[column * 4 + row] * vector[column];
+  }
+  return result;
+}
+
+} // namespace
+
+// Projects a scene-millimetre point using an immutable OpenGL-style snapshot.
+std::optional<ProjectedPoint>
+Project(const ProjectionSnapshot &snapshot,
+        const std::array<float, 3> &worldPointMm) {
+  if (!std::isfinite(snapshot.contentScale) || snapshot.contentScale <= 0.0 ||
+      snapshot.viewport[2] <= 0 || snapshot.viewport[3] <= 0)
+    return std::nullopt;
+  const std::array<double, 4> world{worldPointMm[0] / 1000.0,
+                                    worldPointMm[1] / 1000.0,
+                                    worldPointMm[2] / 1000.0, 1.0};
+  const auto eye = Multiply(snapshot.modelView, world);
+  const auto clip = Multiply(snapshot.projection, eye);
+  if (!std::isfinite(clip[0]) || !std::isfinite(clip[1]) ||
+      !std::isfinite(clip[2]) || !std::isfinite(clip[3]) || clip[3] <= 0.0)
+    return std::nullopt;
+  const double x = clip[0] / clip[3];
+  const double y = clip[1] / clip[3];
+  const double z = clip[2] / clip[3];
+  if (x < -1.0 || x > 1.0 || y < -1.0 || y > 1.0 || z < -1.0 || z > 1.0)
+    return std::nullopt;
+  return ProjectedPoint{
+      (snapshot.viewport[0] + (x + 1.0) * snapshot.viewport[2] * 0.5) /
+          snapshot.contentScale,
+      (snapshot.viewport[1] + (y + 1.0) * snapshot.viewport[3] * 0.5) /
+          snapshot.contentScale,
+      eye[2]};
+}
+
+} // namespace truss_screen_snap

--- a/core/truss_screen_snap.h
+++ b/core/truss_screen_snap.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <array>
+#include <optional>
+
+namespace truss_screen_snap {
+
+constexpr double kDefaultTrussScreenSnapApertureLogicalPx = 16.0;
+
+struct ProjectionSnapshot {
+  std::array<double, 16> modelView{};
+  std::array<double, 16> projection{};
+  std::array<int, 4> viewport{};
+  double contentScale = 1.0;
+};
+
+struct ProjectedPoint {
+  double logicalX = 0.0;
+  double logicalY = 0.0;
+  double depth = 0.0;
+};
+
+// Projects a scene-millimetre point using an immutable OpenGL-style snapshot.
+std::optional<ProjectedPoint> Project(const ProjectionSnapshot &snapshot,
+                                      const std::array<float, 3> &worldPointMm);
+
+} // namespace truss_screen_snap

--- a/docs/developer/truss_attachment_candidates.md
+++ b/docs/developer/truss_attachment_candidates.md
@@ -13,6 +13,19 @@ diagnostic path are retained by a read-only core service. Malformed positions
 are diagnosed and skipped. If no usable explicit point remains, inference is
 used without writing to the GDTF or MVR data.
 
+Public `GDTFSpec` is resolved first, relative to `MvrScene::basePath` when it is
+not absolute. If that reference is absent or cannot be resolved, the Perastage
+auxiliary GDTF archive reference is resolved the same way. `modelFile` is never
+treated as a GDTF source. Missing and unreadable sources remain visible as
+structured diagnostics before conservative inference is used.
+
+An explicit resolver caches type-level local candidates by normalized absolute
+archive identity, file size, and last-write timestamp. Instance transforms are
+applied after lookup, so dragging or rotating a truss does not reopen its
+archive. Replacing an archive changes the version key and reparses its local
+definition. Viewers own their resolver lifetime; the core has no static
+resource-owning cache.
+
 ## Inference
 
 Dimensions are evaluated in truss-local X, Y, and Z. A shape is longitudinal
@@ -31,9 +44,23 @@ internal joints are not normal candidates. Other aggregates use the six-point
 ambiguous fallback. Existing hierarchy rejection prevents self and descendant
 snaps.
 
+The two-end group result additionally requires every member to be
+longitudinal, member axes to have an absolute dot product of at least 0.996,
+center lines to be within 25 mm, and consecutive projected member intervals to
+have no gap greater than 25 mm. A group that fails any check uses six aggregate
+face centers.
+
 ## View weighting
 
 Top and Bottom ignore Z in scoring, Front ignores Y, and Side ignores X. The
-3D viewer continues to reduce weights progressively from the camera direction.
-Weighting changes selection only; it never removes a component from the final
-translation.
+3D camera-direction weights remain available to the existing non-screen-space
+paths. Weighting changes selection only; it never removes a component from the
+final translation.
+
+Viewer3D truss-to-truss acquisition instead projects both candidates from one
+captured camera snapshot and accepts a separation of at most 16 logical pixels.
+Framebuffer coordinates are divided by the content scale, so the aperture is
+DPI-independent. Accepted pairs rank by screen separation, absolute view-depth
+difference, full world translation length, target UUID, source candidate ID,
+and target candidate ID. The 250 mm world threshold is not an eligibility cap
+for this Viewer3D path.

--- a/docs/developer/truss_attachment_candidates.md
+++ b/docs/developer/truss_attachment_candidates.md
@@ -20,7 +20,8 @@ treated as a GDTF source. Missing and unreadable sources remain visible as
 structured diagnostics before conservative inference is used.
 
 An explicit resolver caches type-level local candidates by normalized absolute
-archive identity, file size, and last-write timestamp. Instance transforms are
+archive identity, file size, and a fixed-width nanosecond last-write timestamp.
+Instance transforms are
 applied after lookup, so dragging or rotating a truss does not reopen its
 archive. Replacing an archive changes the version key and reparses its local
 definition. Viewers own their resolver lifetime; the core has no static
@@ -38,17 +39,31 @@ dominant-axis terminal planes. Ambiguous shapes, including invalid-dimension
 fallbacks, expose the six oriented bounds face centers. These inferred points
 are conservative snapping aids, not verified mechanical connectors.
 
-Groups aggregate their truss bounds in the first truss's local basis. Clearly
-longitudinal collinear aggregates expose only the two exterior ends, so
-internal joints are not normal candidates. Other aggregates use the six-point
-ambiguous fallback. Existing hierarchy rejection prevents self and descendant
-snaps.
+Groups expose candidates resolved from their actual member trusses. Candidate
+pairs from different members are treated as occupied internal joints when
+their positions are within 25 mm and, when both have inferred directions,
+their direction dot product is at most -0.996. Deterministic one-to-one
+matching removes occupied candidates. Every remaining member candidate is
+exposed with its member UUID and original stable identity. Aggregate face
+centers are used only if no member candidates can be built.
 
-The two-end group result additionally requires every member to be
-longitudinal, member axes to have an absolute dot product of at least 0.996,
-center lines to be within 25 mm, and consecutive projected member intervals to
-have no gap greater than 25 mm. A group that fails any check uses six aggregate
-face centers.
+Inferred longitudinal ends and ambiguous face centers carry runtime-only
+outward directions transformed into world space. Explicit GDTF Magnets do not
+receive an invented direction because GDTF does not standardize one.
+
+For a moving truss with exactly two inferred longitudinal ends, target
+acquisition remains view-driven. After acquiring one target candidate, both
+source ends are evaluated against that same target. If the nearby end would
+produce more than 50 mm of substantial oriented-bounds penetration into the
+actual target truss or owning group member and the opposite end would not, the
+opposite end is selected. Opposing inferred directions break only an
+all-overlapping tie. This correction changes translation only and never
+rotates or flips the truss.
+
+Cache invalidation normally uses normalized identity, size, and timestamp.
+Project/resource lifecycle owners may call `Clear()` when replacing a resource
+while deliberately preserving both metadata values; the interactive path does
+not hash archives on every query.
 
 ## View weighting
 

--- a/docs/developer/truss_attachment_candidates.md
+++ b/docs/developer/truss_attachment_candidates.md
@@ -1,0 +1,39 @@
+# Truss attachment candidates
+
+Truss-to-truss Magnet snapping is translation-only and uses deterministic
+attachment points. Candidate scoring applies the active view's axis weights,
+but the selected translation always retains all three components.
+
+## Priority and data
+
+Each truss resolves candidates independently. Usable `Magnet` geometry nodes
+from its GDTF archive suppress all inferred points. Their `Name`, optional
+`Model`, complete composed `Position` transform, stable traversal identity, and
+diagnostic path are retained by a read-only core service. Malformed positions
+are diagnosed and skipped. If no usable explicit point remains, inference is
+used without writing to the GDTF or MVR data.
+
+## Inference
+
+Dimensions are evaluated in truss-local X, Y, and Z. A shape is longitudinal
+only when its largest positive finite dimension is **strictly greater than
+twice** the second-largest dimension. The strict comparison makes the 2:1
+boundary ambiguous while classifying 3000 x 400 x 400 mm as longitudinal.
+
+Longitudinal shapes expose exactly the negative and positive centers of the
+dominant-axis terminal planes. Ambiguous shapes, including invalid-dimension
+fallbacks, expose the six oriented bounds face centers. These inferred points
+are conservative snapping aids, not verified mechanical connectors.
+
+Groups aggregate their truss bounds in the first truss's local basis. Clearly
+longitudinal collinear aggregates expose only the two exterior ends, so
+internal joints are not normal candidates. Other aggregates use the six-point
+ambiguous fallback. Existing hierarchy rejection prevents self and descendant
+snaps.
+
+## View weighting
+
+Top and Bottom ignore Z in scoring, Front ignores Y, and Side ignores X. The
+3D viewer continues to reduce weights progressively from the camera direction.
+Weighting changes selection only; it never removes a component from the final
+translation.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -6,6 +6,10 @@ Changes since **v1.5.0**.
 
 ## New features and workflow improvements
 
+- Improved truss Magnet placement by preferring connector points declared in
+  GDTF files, using terminal points for clearly straight trusses, and retaining
+  conservative face-center snapping for ambiguous truss shapes and groups.
+
 - Added **Selection & Movement** preferences for choosing, independently for
   fixtures, trusses, supports/hoists, and scene objects, whether mouse,
   command-bar, and Magnet transforms move an exact grouped object or its
@@ -18,6 +22,9 @@ Changes since **v1.5.0**.
   ensuring the GLEW header is initialized before platform OpenGL headers.
 
 ## Important fixes
+
+- Corrected unconstrained 3D selection dragging after a Magnet preview so both
+  pointer projections use the same unsnapped drag anchor.
 
 - Fixed continuous fixture, truss, and scene-object placement drifting away
   from the pointer after zooming, panning, orbiting, resizing, fitting, or

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -28,6 +28,10 @@ Changes since **v1.5.0**.
 
 ## Important fixes
 
+- Improved Windows test reliability for truss Magnet archive and cache
+  validation by initializing its native file services explicitly and reporting
+  failures without modal dialogs.
+
 - Corrected unconstrained 3D selection dragging after a Magnet preview so both
   pointer projections use the same unsnapped drag anchor.
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -11,7 +11,9 @@ Changes since **v1.5.0**.
   conservative face-center snapping for ambiguous truss shapes and groups.
   Project-relative connector resources are cached safely, while 3D assembly
   now acquires visually overlapping endpoints with a DPI-independent screen
-  aperture for more predictable perspective-view placement.
+  aperture for more predictable perspective-view placement. Truss groups now
+  expose their real unoccupied member connectors, and straight extensions
+  choose the non-overlapping end when approaching an assembly from either side.
 
 - Added **Selection & Movement** preferences for choosing, independently for
   fixtures, trusses, supports/hoists, and scene objects, whether mouse,

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -9,6 +9,9 @@ Changes since **v1.5.0**.
 - Improved truss Magnet placement by preferring connector points declared in
   GDTF files, using terminal points for clearly straight trusses, and retaining
   conservative face-center snapping for ambiguous truss shapes and groups.
+  Project-relative connector resources are cached safely, while 3D assembly
+  now acquires visually overlapping endpoints with a DPI-independent screen
+  aperture for more predictable perspective-view placement.
 
 - Added **Selection & Movement** preferences for choosing, independently for
   fixtures, trusses, supports/hoists, and scene objects, whether mouse,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -110,6 +110,7 @@ if(BASH_EXECUTABLE)
     add_bash_policy_test(OpenGLLifecycleCentralized ${CMAKE_CURRENT_SOURCE_DIR}/check_opengl_lifecycle_centralized.sh)
     add_bash_policy_test(ViewerSceneReplacementLifecycle ${CMAKE_CURRENT_SOURCE_DIR}/check_viewer_scene_replacement_lifecycle.sh)
     add_bash_policy_test(Viewer3DRawDragAnchor ${CMAKE_CURRENT_SOURCE_DIR}/check_viewer3d_raw_drag_anchor.sh)
+    add_bash_policy_test(TrussAttachmentCoreBoundary ${CMAKE_CURRENT_SOURCE_DIR}/check_truss_attachment_core_boundary.sh)
     add_bash_policy_test(Layout2DRasterizationBoundary ${CMAKE_CURRENT_SOURCE_DIR}/check_layout_2d_rasterization_boundary.sh)
     add_bash_policy_test(Layout2DViewCaptureBoundary ${CMAKE_CURRENT_SOURCE_DIR}/check_layout_2d_view_capture_boundary.sh)
     add_bash_policy_test(Viewer2DStateOwnershipBoundary ${CMAKE_CURRENT_SOURCE_DIR}/check_viewer2d_state_ownership_boundary.sh)
@@ -350,13 +351,20 @@ add_test(NAME SceneNodeOperations COMMAND scene_node_operations_test)
 add_executable(magnet_snap_test magnet_snap_test.cpp
     ../core/magnet_snap.cpp
     ../core/truss_attachment_candidates.cpp
+    ../core/truss_screen_snap.cpp
     ../core/gdtf_archive_reader.cpp
+    ../core/filesystem_path_utils.cpp
     ../core/scene_grouping.cpp ../core/scene_node_operations.cpp
     ../models/mvrscene.cpp
 )
 target_include_directories(magnet_snap_test PRIVATE ../core ../models)
 target_link_libraries(magnet_snap_test PRIVATE tinyxml2::tinyxml2 ${wxWidgets_LIBRARIES})
 add_test(NAME MagnetSnapCore COMMAND magnet_snap_test)
+
+add_executable(truss_screen_snap_test truss_screen_snap_test.cpp
+    ../core/truss_screen_snap.cpp)
+target_include_directories(truss_screen_snap_test PRIVATE ../core)
+add_test(NAME TrussScreenSnapMath COMMAND truss_screen_snap_test)
 
 add_executable(rdp_simplifier_test
                rdp_simplifier_test.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -109,6 +109,7 @@ if(BASH_EXECUTABLE)
     add_bash_policy_test(GuiNoConfigManagerGet ${CMAKE_CURRENT_SOURCE_DIR}/check_no_configmanager_get_in_gui.sh)
     add_bash_policy_test(OpenGLLifecycleCentralized ${CMAKE_CURRENT_SOURCE_DIR}/check_opengl_lifecycle_centralized.sh)
     add_bash_policy_test(ViewerSceneReplacementLifecycle ${CMAKE_CURRENT_SOURCE_DIR}/check_viewer_scene_replacement_lifecycle.sh)
+    add_bash_policy_test(Viewer3DRawDragAnchor ${CMAKE_CURRENT_SOURCE_DIR}/check_viewer3d_raw_drag_anchor.sh)
     add_bash_policy_test(Layout2DRasterizationBoundary ${CMAKE_CURRENT_SOURCE_DIR}/check_layout_2d_rasterization_boundary.sh)
     add_bash_policy_test(Layout2DViewCaptureBoundary ${CMAKE_CURRENT_SOURCE_DIR}/check_layout_2d_view_capture_boundary.sh)
     add_bash_policy_test(Viewer2DStateOwnershipBoundary ${CMAKE_CURRENT_SOURCE_DIR}/check_viewer2d_state_ownership_boundary.sh)
@@ -348,10 +349,13 @@ add_test(NAME SceneNodeOperations COMMAND scene_node_operations_test)
 
 add_executable(magnet_snap_test magnet_snap_test.cpp
     ../core/magnet_snap.cpp
+    ../core/truss_attachment_candidates.cpp
+    ../core/gdtf_archive_reader.cpp
     ../core/scene_grouping.cpp ../core/scene_node_operations.cpp
     ../models/mvrscene.cpp
 )
 target_include_directories(magnet_snap_test PRIVATE ../core ../models)
+target_link_libraries(magnet_snap_test PRIVATE tinyxml2::tinyxml2 ${wxWidgets_LIBRARIES})
 add_test(NAME MagnetSnapCore COMMAND magnet_snap_test)
 
 add_executable(rdp_simplifier_test

--- a/tests/check_truss_attachment_core_boundary.sh
+++ b/tests/check_truss_attachment_core_boundary.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+files=(
+  core/truss_attachment_candidates.cpp
+  core/truss_attachment_candidates.h
+  core/truss_screen_snap.cpp
+  core/truss_screen_snap.h
+)
+
+if rg -n '#include <(GL|OpenGL)|#include "(gui|viewer2d|viewer3d|configmanager)' "${files[@]}"; then
+  echo "Truss attachment core services must remain GUI and OpenGL independent." >&2
+  exit 1
+fi

--- a/tests/check_viewer3d_raw_drag_anchor.sh
+++ b/tests/check_viewer3d_raw_drag_anchor.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source_file="viewer3d/viewer3dpanel.cpp"
+block="$(sed -n '3505,3522p' "$source_file")"
+
+if [[ "$(printf '%s' "$block" | rg -c 'ProjectMouseToSelectionDragViewPlane')" -ne 2 ]]; then
+  echo "Expected both unconstrained pointer projections in the checked block." >&2
+  exit 1
+fi
+if [[ "$(printf '%s' "$block" | rg -c 'renderSize, rawAnchor')" -ne 2 ]]; then
+  echo "Unconstrained pointer projections must share CurrentRawSelectionDragAnchor()." >&2
+  exit 1
+fi

--- a/tests/check_viewer3d_raw_drag_anchor.sh
+++ b/tests/check_viewer3d_raw_drag_anchor.sh
@@ -2,13 +2,13 @@
 set -euo pipefail
 
 source_file="viewer3d/viewer3dpanel.cpp"
-block="$(sed -n '3505,3522p' "$source_file")"
+block="$(sed -n '/void Viewer3DPanel::OnMouseMove/,/void Viewer3DPanel::OnMouseWheel/p' "$source_file")"
 
-if [[ "$(printf '%s' "$block" | rg -c 'ProjectMouseToSelectionDragViewPlane')" -ne 2 ]]; then
-  echo "Expected both unconstrained pointer projections in the checked block." >&2
+if [[ "$(printf '%s' "$block" | rg -c 'renderSize, rawAnchor')" -lt 2 ]]; then
+  echo "Expected unconstrained pointer projections to use the raw anchor." >&2
   exit 1
 fi
-if [[ "$(printf '%s' "$block" | rg -c 'renderSize, rawAnchor')" -ne 2 ]]; then
-  echo "Unconstrained pointer projections must share CurrentRawSelectionDragAnchor()." >&2
+if printf '%s' "$block" | rg -q 'renderSize, m_selectionDragAnchorMeters'; then
+  echo "Pointer projections must not use the snapped selection anchor directly." >&2
   exit 1
 fi

--- a/tests/magnet_snap_test.cpp
+++ b/tests/magnet_snap_test.cpp
@@ -2,6 +2,7 @@
 
 #include "matrixutils.h"
 #include "scene_grouping.h"
+#include "truss_attachment_candidates.h"
 
 #include <cassert>
 #include <cmath>
@@ -31,22 +32,72 @@ void AddTruss(MvrScene &scene, const std::string &uuid, float x) {
 
 } // namespace
 
-// Verifies Magnet snap candidates, metadata preservation, and committed grouping.
+// Verifies Magnet snap candidates, metadata preservation, and committed
+// grouping.
 int main() {
+  using truss_attachment::CandidateKind;
+  const auto longitudinal = truss_attachment::BuildInferredCandidates(
+      {3000.0f, 400.0f, 400.0f}, Translated(100.0f, 200.0f, 300.0f), "long");
+  assert(longitudinal.size() == 2);
+  assert(longitudinal[0].kind == CandidateKind::InferredLongitudinalEnd);
+  assert(longitudinal[0].localTransform.o[0] == 0.0f);
+  assert(longitudinal[1].localTransform.o[0] == 3000.0f);
+  assert(longitudinal[0].worldTransform.o[0] == 100.0f);
+  assert(longitudinal[1].worldTransform.o[0] == 3100.0f);
+  assert(truss_attachment::ClassifyLongitudinalAxis({3000, 400, 400}) == 0);
+  assert(truss_attachment::ClassifyLongitudinalAxis({400, 3000, 400}) == 1);
+  assert(truss_attachment::ClassifyLongitudinalAxis({400, 400, 3000}) == 2);
+  assert(!truss_attachment::ClassifyLongitudinalAxis({800, 400, 400}));
+  assert(truss_attachment::ClassifyLongitudinalAxis({801, 400, 400}) == 0);
+
+  const auto ambiguous = truss_attachment::BuildInferredCandidates(
+      {400.0f, 400.0f, 400.0f}, MatrixUtils::Identity(), "cube");
+  assert(ambiguous.size() == 6);
+  assert(ambiguous.front().stableId == "face-axis-0-negative");
+  assert(ambiguous.back().stableId == "face-axis-2-positive");
+  for (const auto &candidate : ambiguous)
+    assert(candidate.kind == CandidateKind::InferredFaceCenter);
+  assert(truss_attachment::BuildInferredCandidates({0.0f, 400.0f, 400.0f},
+                                                   MatrixUtils::Identity())
+             .size() == 6);
+
+  const std::string magnetXml =
+      "<GDTF><FixtureType><Geometries>"
+      "<Geometry Name='Root' Position='{1,0,0,1}{0,1,0,2}{0,0,1,3}{0,0,0,1}'>"
+      "<Magnet Name='A' Model='Connector' "
+      "Position='{1,0,0,0.5}{0,1,0,0}{0,0,1,0}{0,0,0,1}'/>"
+      "<Geometry><Magnet Name='B'/></Geometry>"
+      "<Magnet Name='Bad' Position='invalid'/></Geometry>"
+      "</Geometries></FixtureType></GDTF>";
+  const auto explicitMagnets = truss_attachment::ReadExplicitGdtfMagnets(
+      magnetXml, Translated(100.0f, 0.0f, 0.0f));
+  assert(explicitMagnets.candidates.size() == 2);
+  assert(explicitMagnets.diagnostics.size() == 1);
+  assert(explicitMagnets.candidates[0].name == "A");
+  assert(explicitMagnets.candidates[0].model == "Connector");
+  assert(explicitMagnets.candidates[1].model.empty());
+  assert(explicitMagnets.candidates[0].localTransform.o[0] == 1500.0f);
+  assert(explicitMagnets.candidates[0].localTransform.o[1] == 2000.0f);
+  assert(explicitMagnets.candidates[0].worldTransform.o[0] == 1600.0f);
+  assert(truss_attachment::ReadExplicitGdtfMagnets(
+             "<GDTF><FixtureType><Geometries/></FixtureType></GDTF>",
+             MatrixUtils::Identity())
+             .candidates.empty());
+
   MvrScene scene;
   AddTruss(scene, "target", 0.0f);
   AddTruss(scene, "source", 3250.0f);
 
-  auto snap = magnet_snap::FindSnap(
-      scene, {magnet_snap::ObjectType::Truss, "source"});
+  auto snap =
+      magnet_snap::FindSnap(scene, {magnet_snap::ObjectType::Truss, "source"});
   assert(snap);
   assert(snap->kind == magnet_snap::SnapKind::TrussToTruss);
   assert(snap->needsGrouping);
   assert(std::fabs(snap->translationDeltaMm[0] + 250.0f) < 0.001f);
 
   scene.trusses["source"].transform.o[0] = 4000.0f;
-  assert(!magnet_snap::FindSnap(
-      scene, {magnet_snap::ObjectType::Truss, "source"}));
+  assert(!magnet_snap::FindSnap(scene,
+                                {magnet_snap::ObjectType::Truss, "source"}));
 
   MvrScene sideSurfaceScene;
   AddTruss(sideSurfaceScene, "target", 0.0f);
@@ -57,13 +108,11 @@ int main() {
   auto sideSurfaceSnap = magnet_snap::FindSnap(
       sideSurfaceScene, {magnet_snap::ObjectType::Truss, "source"},
       topSideSettings);
-  assert(sideSurfaceSnap);
-  assert(std::fabs(sideSurfaceSnap->translationDeltaMm[1] + 250.0f) < 0.001f);
-  assert(std::fabs(sideSurfaceSnap->translationDeltaMm[2]) < 0.001f);
+  assert(!sideSurfaceSnap);
 
   scene.trusses["source"].transform.o[0] = 3250.0f;
-  snap = magnet_snap::FindSnap(scene,
-                               {magnet_snap::ObjectType::Truss, "source"});
+  snap =
+      magnet_snap::FindSnap(scene, {magnet_snap::ObjectType::Truss, "source"});
   assert(snap);
   const std::string hang = scene.trusses["source"].positionName;
   assert(magnet_snap::ApplySnapTransform(scene, *snap));
@@ -127,9 +176,10 @@ int main() {
          0.001f);
   assert(magnet_snap::ApplySnapTransform(elevatedFixtureScene,
                                          *elevatedFixtureSnap));
-  assert(std::fabs(elevatedFixtureScene.fixtures[elevatedFixture.uuid]
-                       .transform.o[2] -
-                   10000.0f) < 0.001f);
+  assert(
+      std::fabs(
+          elevatedFixtureScene.fixtures[elevatedFixture.uuid].transform.o[2] -
+          10000.0f) < 0.001f);
 
   Fixture fixture;
   fixture.uuid = "fixture";

--- a/tests/magnet_snap_test.cpp
+++ b/tests/magnet_snap_test.cpp
@@ -9,7 +9,7 @@
 #include <cmath>
 #include <filesystem>
 #include <fstream>
-#include <thread>
+#include <iostream>
 
 #include <wx/wfstream.h>
 #include <wx/zipstrm.h>
@@ -38,25 +38,44 @@ void AddTruss(MvrScene &scene, const std::string &uuid, float x) {
 }
 
 // Writes a minimal GDTF ZIP archive for production resolver tests.
-void WriteGdtf(const std::filesystem::path &path, const std::string &xml) {
+bool WriteGdtf(const std::filesystem::path &path, const std::string &xml) {
   wxFFileOutputStream file(path.string());
+  if (!file.IsOk())
+    return false;
   wxZipOutputStream zip(file);
-  zip.PutNextEntry("description.xml");
+  if (!zip.PutNextEntry("description.xml"))
+    return false;
   zip.Write(xml.data(), xml.size());
-  zip.CloseEntry();
-  zip.Close();
+  if (!zip.IsOk() || !zip.CloseEntry() || !zip.Close())
+    return false;
+  return file.IsOk();
 }
 
 // Returns a minimal GDTF description with an optional Magnet.
-std::string ArchiveXml(bool withMagnet, float xMeters = 0.0f) {
+std::string ArchiveXml(bool withMagnet, float xMeters = 0.0f,
+                       const std::string &padding = {}) {
   const std::string magnet =
       withMagnet
           ? "<Magnet Name='ArchiveMagnet' Position='{1,0,0," +
                 std::to_string(xMeters) + "}{0,1,0,0}{0,0,1,0}{0,0,0,1}'/>"
           : "";
   return "<GDTF><FixtureType><Geometries><Geometry Name='Root'>" + magnet +
-         "</Geometry></Geometries></FixtureType></GDTF>";
+         padding + "</Geometry></Geometries></FixtureType></GDTF>";
 }
+
+// Reports a non-modal test failure with its source location.
+bool Check(bool condition, const char *expression, int line) {
+  if (condition)
+    return true;
+  std::cerr << "CHECK failed at line " << line << ": " << expression << '\n';
+  return false;
+}
+
+#define CHECK_OR_RETURN(expression)                                            \
+  do {                                                                         \
+    if (!Check(static_cast<bool>(expression), #expression, __LINE__))          \
+      return 1;                                                                \
+  } while (false)
 
 } // namespace
 
@@ -72,6 +91,10 @@ int main() {
   assert(longitudinal[1].localTransform.o[0] == 3000.0f);
   assert(longitudinal[0].worldTransform.o[0] == 100.0f);
   assert(longitudinal[1].worldTransform.o[0] == 3100.0f);
+  assert(longitudinal[0].worldDirection &&
+         (*longitudinal[0].worldDirection)[0] == -1.0f);
+  assert(longitudinal[1].worldDirection &&
+         (*longitudinal[1].worldDirection)[0] == 1.0f);
   assert(truss_attachment::ClassifyLongitudinalAxis({3000, 400, 400}) == 0);
   assert(truss_attachment::ClassifyLongitudinalAxis({400, 3000, 400}) == 1);
   assert(truss_attachment::ClassifyLongitudinalAxis({400, 400, 3000}) == 2);
@@ -107,19 +130,24 @@ int main() {
   assert(explicitMagnets.candidates[0].localTransform.o[0] == 1500.0f);
   assert(explicitMagnets.candidates[0].localTransform.o[1] == 2000.0f);
   assert(explicitMagnets.candidates[0].worldTransform.o[0] == 1600.0f);
+  assert(!explicitMagnets.candidates[0].worldDirection);
   assert(truss_attachment::ReadExplicitGdtfMagnets(
              "<GDTF><FixtureType><Geometries/></FixtureType></GDTF>",
              MatrixUtils::Identity())
              .candidates.empty());
 
-  const auto tempRoot = std::filesystem::temp_directory_path() /
-                        "perastage-truss-attachment-test";
-  std::filesystem::remove_all(tempRoot);
-  std::filesystem::create_directories(tempRoot / "resources");
+  const auto tempRoot =
+      std::filesystem::temp_directory_path() /
+      ("perastage-truss-attachment-test-" +
+       std::to_string(
+           std::chrono::steady_clock::now().time_since_epoch().count()));
+  std::error_code filesystemError;
+  std::filesystem::create_directories(tempRoot / "resources", filesystemError);
+  CHECK_OR_RETURN(!filesystemError);
   const auto publicArchive = tempRoot / "resources" / "public.gdtf";
   const auto auxiliaryArchive = tempRoot / "resources" / "auxiliary.gdtf";
-  WriteGdtf(publicArchive, ArchiveXml(true, 0.25f));
-  WriteGdtf(auxiliaryArchive, ArchiveXml(true, 0.5f));
+  CHECK_OR_RETURN(WriteGdtf(publicArchive, ArchiveXml(true, 0.25f)));
+  CHECK_OR_RETURN(WriteGdtf(auxiliaryArchive, ArchiveXml(true, 0.5f)));
   MvrScene resourceScene;
   resourceScene.basePath = tempRoot.string();
   Truss resourceTruss;
@@ -156,15 +184,47 @@ int main() {
       truss_attachment::BuildCandidates(resourceScene, resourceTruss, resolver);
   assert(resolved.candidates.size() == 1);
   assert(resolver.ArchiveParseCount() == 2);
-  std::this_thread::sleep_for(std::chrono::milliseconds(10));
-  WriteGdtf(publicArchive, ArchiveXml(true, 0.75f));
+  const auto previousWriteTime =
+      std::filesystem::last_write_time(publicArchive, filesystemError);
+  CHECK_OR_RETURN(!filesystemError);
+  const auto previousSize =
+      std::filesystem::file_size(publicArchive, filesystemError);
+  CHECK_OR_RETURN(!filesystemError);
+  CHECK_OR_RETURN(WriteGdtf(publicArchive, ArchiveXml(true, 0.35f)));
+  CHECK_OR_RETURN(std::filesystem::file_size(publicArchive, filesystemError) ==
+                  previousSize);
+  std::filesystem::last_write_time(publicArchive, previousWriteTime,
+                                   filesystemError);
+  CHECK_OR_RETURN(!filesystemError);
   resolved =
       truss_attachment::BuildCandidates(resourceScene, resourceTruss, resolver);
-  assert(resolver.ArchiveParseCount() == 3);
+  CHECK_OR_RETURN(resolver.ArchiveParseCount() == 2);
+  CHECK_OR_RETURN(resolved.candidates[0].localTransform.o[0] == 250.0f);
+  resolver.Clear();
+  resolved =
+      truss_attachment::BuildCandidates(resourceScene, resourceTruss, resolver);
+  CHECK_OR_RETURN(resolver.ArchiveParseCount() == 3);
+  CHECK_OR_RETURN(resolved.candidates[0].localTransform.o[0] == 350.0f);
+
+  CHECK_OR_RETURN(WriteGdtf(
+      publicArchive, ArchiveXml(true, 0.75f, "<Geometry Name='Padding'/>")));
+  std::filesystem::last_write_time(publicArchive,
+                                   previousWriteTime + std::chrono::seconds(2),
+                                   filesystemError);
+  CHECK_OR_RETURN(!filesystemError);
+  resolved =
+      truss_attachment::BuildCandidates(resourceScene, resourceTruss, resolver);
+  assert(resolver.ArchiveParseCount() == 4);
   assert(resolved.candidates[0].localTransform.o[0] == 750.0f);
 
   const auto malformedArchive = tempRoot / "resources" / "malformed.gdtf";
-  std::ofstream(malformedArchive) << "not a zip";
+  {
+    std::ofstream malformedOutput(malformedArchive, std::ios::binary);
+    CHECK_OR_RETURN(malformedOutput.is_open());
+    malformedOutput << "not a zip";
+    malformedOutput.close();
+    CHECK_OR_RETURN(!malformedOutput.fail());
+  }
   resourceTruss.gdtfSpec = malformedArchive.string();
   resolved =
       truss_attachment::BuildCandidates(resourceScene, resourceTruss, resolver);
@@ -172,7 +232,7 @@ int main() {
   assert(!resolved.diagnostics.empty());
 
   const auto noMagnetArchive = tempRoot / "resources" / "no-magnet.gdtf";
-  WriteGdtf(noMagnetArchive, ArchiveXml(false));
+  CHECK_OR_RETURN(WriteGdtf(noMagnetArchive, ArchiveXml(false)));
   resourceTruss.gdtfSpec = noMagnetArchive.string();
   resolved =
       truss_attachment::BuildCandidates(resourceScene, resourceTruss, resolver);
@@ -221,6 +281,8 @@ int main() {
   assert(straightCandidates.size() == 2);
   assert(straightCandidates[0].worldTransform.o[0] == 0.0f);
   assert(straightCandidates[1].worldTransform.o[0] == 9000.0f);
+  assert(straightCandidates[0].ownerTrussUuid == "straight-0");
+  assert(straightCandidates[1].ownerTrussUuid == "straight-2");
 
   MvrScene rotatedGroupScene;
   GroupObject rotatedGroup;
@@ -252,9 +314,37 @@ int main() {
   bentGroupScene.groupObjects[bentGroup.uuid] = bentGroup;
   const auto bentCandidates =
       magnet_snap::BuildTrussGroupCandidates(bentGroupScene, bentGroup.uuid);
-  assert(bentCandidates.size() == 6);
-  for (const auto &candidate : bentCandidates)
-    assert(candidate.kind == CandidateKind::InferredFaceCenter);
+  assert(bentCandidates.size() == 4);
+  for (const auto &candidate : bentCandidates) {
+    assert(candidate.kind == CandidateKind::InferredLongitudinalEnd);
+    assert(candidate.ownerTrussUuid == "bent-x" ||
+           candidate.ownerTrussUuid == "bent-y");
+  }
+  AddTruss(bentGroupScene, "bent-moving", 250.0f);
+  auto bentGroupSnap = magnet_snap::FindSnap(
+      bentGroupScene, {magnet_snap::ObjectType::Truss, "bent-moving"});
+  assert(bentGroupSnap);
+  assert(bentGroupSnap->targetUuid == bentGroup.uuid);
+  assert(bentGroupSnap->targetMemberTrussUuid == "bent-x");
+  assert(bentGroupSnap->sourceCandidateId == "longitudinal-axis-0-positive");
+  assert(std::fabs(bentGroupSnap->translationDeltaMm[0] + 3250.0f) < 0.001f);
+
+  MvrScene explicitGroupScene;
+  explicitGroupScene.basePath = tempRoot.string();
+  GroupObject explicitGroup;
+  explicitGroup.uuid = "explicit-group";
+  AddTruss(explicitGroupScene, "explicit-member", 0.0f);
+  explicitGroupScene.trusses["explicit-member"].gdtfSpec =
+      "resources/auxiliary.gdtf";
+  explicitGroupScene.trusses["explicit-member"].parentGroupUuid =
+      explicitGroup.uuid;
+  explicitGroup.children.push_back({MvrNodeType::Truss, "explicit-member"});
+  explicitGroupScene.groupObjects[explicitGroup.uuid] = explicitGroup;
+  const auto explicitGroupCandidates = magnet_snap::BuildTrussGroupCandidates(
+      explicitGroupScene, explicitGroup.uuid);
+  assert(explicitGroupCandidates.size() == 1);
+  assert(explicitGroupCandidates[0].kind == CandidateKind::ExplicitGdtfMagnet);
+  assert(explicitGroupCandidates[0].ownerTrussUuid == "explicit-member");
 
   MvrScene scene;
   AddTruss(scene, "target", 0.0f);
@@ -266,6 +356,73 @@ int main() {
   assert(snap->kind == magnet_snap::SnapKind::TrussToTruss);
   assert(snap->needsGrouping);
   assert(std::fabs(snap->translationDeltaMm[0] + 250.0f) < 0.001f);
+  assert(snap->sourceCandidateId == "longitudinal-axis-0-negative");
+
+  MvrScene leftExtensionScene;
+  AddTruss(leftExtensionScene, "target", 0.0f);
+  AddTruss(leftExtensionScene, "source", 250.0f);
+  const Matrix leftSourceBefore =
+      leftExtensionScene.trusses["source"].transform;
+  auto leftSnap = magnet_snap::FindSnap(
+      leftExtensionScene, {magnet_snap::ObjectType::Truss, "source"});
+  assert(leftSnap);
+  assert(leftSnap->sourceCandidateId == "longitudinal-axis-0-positive");
+  assert(std::fabs(leftSnap->translationDeltaMm[0] + 3250.0f) < 0.001f);
+  assert(magnet_snap::ApplySnapTransform(leftExtensionScene, *leftSnap));
+  assert(leftExtensionScene.trusses["source"].transform.u ==
+         leftSourceBefore.u);
+  assert(leftExtensionScene.trusses["source"].transform.v ==
+         leftSourceBefore.v);
+  assert(leftExtensionScene.trusses["source"].transform.w ==
+         leftSourceBefore.w);
+  assert(leftExtensionScene.trusses["source"].transform.o[0] == -3000.0f);
+
+  MvrScene ambiguousSourceScene;
+  AddTruss(ambiguousSourceScene, "target", 0.0f);
+  AddTruss(ambiguousSourceScene, "source", 240.0f);
+  ambiguousSourceScene.trusses["source"].lengthMm = 400.0f;
+  ambiguousSourceScene.trusses["source"].widthMm = 400.0f;
+  ambiguousSourceScene.trusses["source"].heightMm = 400.0f;
+  auto ambiguousSourceSnap = magnet_snap::FindSnap(
+      ambiguousSourceScene, {magnet_snap::ObjectType::Truss, "source"});
+  assert(ambiguousSourceSnap);
+  assert(ambiguousSourceSnap->sourceCandidateId.rfind("face-axis-", 0) == 0);
+
+  MvrScene rotatedExtensionScene;
+  AddTruss(rotatedExtensionScene, "target", 0.0f);
+  AddTruss(rotatedExtensionScene, "source", 0.0f);
+  rotatedExtensionScene.trusses["target"].transform = rotated;
+  rotatedExtensionScene.trusses["source"].transform = rotated;
+  for (int component = 0; component < 3; ++component)
+    rotatedExtensionScene.trusses["source"].transform.o[component] =
+        rotated.u[component] * 250.0f;
+  auto rotatedLeftSnap = magnet_snap::FindSnap(
+      rotatedExtensionScene, {magnet_snap::ObjectType::Truss, "source"});
+  assert(rotatedLeftSnap);
+  assert(rotatedLeftSnap->sourceCandidateId == "longitudinal-axis-0-positive");
+  for (int component = 0; component < 3; ++component)
+    assert(std::fabs(rotatedLeftSnap->translationDeltaMm[component] +
+                     rotated.u[component] * 3250.0f) < 0.001f);
+
+  MvrScene groupExtensionScene;
+  GroupObject targetGroup;
+  targetGroup.uuid = "target-group";
+  for (int index = 0; index < 2; ++index) {
+    const std::string uuid = "target-member-" + std::to_string(index);
+    AddTruss(groupExtensionScene, uuid, index * 3000.0f);
+    groupExtensionScene.trusses[uuid].parentGroupUuid = targetGroup.uuid;
+    targetGroup.children.push_back({MvrNodeType::Truss, uuid});
+  }
+  groupExtensionScene.groupObjects[targetGroup.uuid] = targetGroup;
+  AddTruss(groupExtensionScene, "moving", 250.0f);
+  auto groupLeftSnap = magnet_snap::FindSnap(
+      groupExtensionScene, {magnet_snap::ObjectType::Truss, "moving"});
+  assert(groupLeftSnap);
+  assert(groupLeftSnap->targetUuid == targetGroup.uuid);
+  assert(groupLeftSnap->targetMemberTrussUuid == "target-member-0");
+  assert(groupLeftSnap->targetCandidateId == "longitudinal-axis-0-negative");
+  assert(groupLeftSnap->sourceCandidateId == "longitudinal-axis-0-positive");
+  assert(std::fabs(groupLeftSnap->translationDeltaMm[0] + 3250.0f) < 0.001f);
 
   scene.trusses["source"].transform.o[0] = 4000.0f;
   assert(!magnet_snap::FindSnap(scene,
@@ -300,6 +457,18 @@ int main() {
       screenSettings);
   assert(screenSnap);
   assert(std::fabs(screenSnap->translationDeltaMm[2] - 500.0f) < 0.001f);
+
+  MvrScene screenLeftScene;
+  AddTruss(screenLeftScene, "target", 0.0f);
+  AddTruss(screenLeftScene, "source", 250.0f);
+  auto screenLeftSettings = screenSettings;
+  screenLeftSettings.trussProjection->viewport = {0, 0, 100, 100};
+  auto screenLeftSnap = magnet_snap::FindSnap(
+      screenLeftScene, {magnet_snap::ObjectType::Truss, "source"},
+      screenLeftSettings);
+  assert(screenLeftSnap);
+  assert(screenLeftSnap->sourceCandidateId == "longitudinal-axis-0-positive");
+  assert(std::fabs(screenLeftSnap->translationDeltaMm[0] + 3250.0f) < 0.001f);
   screenScene.trusses["screen-target"].transform.o[1] = 100.0f;
   assert(!magnet_snap::FindSnap(
       screenScene, {magnet_snap::ObjectType::Truss, "screen-source"},
@@ -365,6 +534,7 @@ int main() {
   assert(groupSnap);
   assert(groupSnap->kind == magnet_snap::SnapKind::TrussToTruss);
   assert(groupSnap->sourceUuid == groupUuid);
+  assert(groupSnap->sourceMemberTrussUuid == "source");
   assert(groupSnap->targetUuid == "loose");
   assert(std::fabs(groupSnap->translationDeltaMm[0] - 250.0f) < 0.001f);
   scene.trusses.erase("loose");
@@ -374,6 +544,7 @@ int main() {
       scene, {magnet_snap::ObjectType::Truss, "source-2"});
   assert(snap2);
   assert(snap2->targetUuid == groupUuid);
+  assert(magnet_snap::ApplySnapTransform(scene, *snap2));
   assert(magnet_snap::ApplyCommittedSnapGrouping(scene, *snap2));
   assert(scene.trusses["source-2"].parentGroupUuid == groupUuid);
   assert(scene.groupObjects.size() == 1);
@@ -490,6 +661,9 @@ int main() {
   assert(magnet_snap::DetachSnapSourceFromGroup(scene, *fixtureSnap));
   assert(scene.fixtures[fixture.uuid].parentGroupUuid.empty());
   assert(scene.trusses["target"].parentGroupUuid == groupUuid);
+
+  std::filesystem::remove_all(tempRoot, filesystemError);
+  CHECK_OR_RETURN(!filesystemError);
 
   return 0;
 }

--- a/tests/magnet_snap_test.cpp
+++ b/tests/magnet_snap_test.cpp
@@ -5,7 +5,14 @@
 #include "truss_attachment_candidates.h"
 
 #include <cassert>
+#include <chrono>
 #include <cmath>
+#include <filesystem>
+#include <fstream>
+#include <thread>
+
+#include <wx/wfstream.h>
+#include <wx/zipstrm.h>
 
 namespace {
 
@@ -28,6 +35,27 @@ void AddTruss(MvrScene &scene, const std::string &uuid, float x) {
   truss.positionName = "LX1";
   truss.transform = Translated(x, 0.0f, 0.0f);
   scene.trusses[uuid] = truss;
+}
+
+// Writes a minimal GDTF ZIP archive for production resolver tests.
+void WriteGdtf(const std::filesystem::path &path, const std::string &xml) {
+  wxFFileOutputStream file(path.string());
+  wxZipOutputStream zip(file);
+  zip.PutNextEntry("description.xml");
+  zip.Write(xml.data(), xml.size());
+  zip.CloseEntry();
+  zip.Close();
+}
+
+// Returns a minimal GDTF description with an optional Magnet.
+std::string ArchiveXml(bool withMagnet, float xMeters = 0.0f) {
+  const std::string magnet =
+      withMagnet
+          ? "<Magnet Name='ArchiveMagnet' Position='{1,0,0," +
+                std::to_string(xMeters) + "}{0,1,0,0}{0,0,1,0}{0,0,0,1}'/>"
+          : "";
+  return "<GDTF><FixtureType><Geometries><Geometry Name='Root'>" + magnet +
+         "</Geometry></Geometries></FixtureType></GDTF>";
 }
 
 } // namespace
@@ -84,6 +112,150 @@ int main() {
              MatrixUtils::Identity())
              .candidates.empty());
 
+  const auto tempRoot = std::filesystem::temp_directory_path() /
+                        "perastage-truss-attachment-test";
+  std::filesystem::remove_all(tempRoot);
+  std::filesystem::create_directories(tempRoot / "resources");
+  const auto publicArchive = tempRoot / "resources" / "public.gdtf";
+  const auto auxiliaryArchive = tempRoot / "resources" / "auxiliary.gdtf";
+  WriteGdtf(publicArchive, ArchiveXml(true, 0.25f));
+  WriteGdtf(auxiliaryArchive, ArchiveXml(true, 0.5f));
+  MvrScene resourceScene;
+  resourceScene.basePath = tempRoot.string();
+  Truss resourceTruss;
+  resourceTruss.uuid = "resource-truss";
+  resourceTruss.lengthMm = 3000;
+  resourceTruss.widthMm = 400;
+  resourceTruss.heightMm = 400;
+  resourceTruss.gdtfSpec = "resources/public.gdtf";
+  truss_attachment::CandidateResolver resolver;
+  auto resolved =
+      truss_attachment::BuildCandidates(resourceScene, resourceTruss, resolver);
+  assert(resolved.candidates.size() == 1);
+  assert(resolved.candidates[0].kind == CandidateKind::ExplicitGdtfMagnet);
+  assert(resolved.candidates[0].localTransform.o[0] == 250.0f);
+  assert(resolver.ArchiveParseCount() == 1);
+  resourceTruss.transform.o[1] = 2000.0f;
+  resolved =
+      truss_attachment::BuildCandidates(resourceScene, resourceTruss, resolver);
+  assert(resolver.ArchiveParseCount() == 1);
+  assert(resolved.candidates[0].worldTransform.o[1] == 2000.0f);
+
+  resourceTruss.gdtfSpec = "resources/missing.gdtf";
+  resourceTruss.perastageAuxGdtfArchivePath = "resources/auxiliary.gdtf";
+  resolved =
+      truss_attachment::BuildCandidates(resourceScene, resourceTruss, resolver);
+  assert(resolved.candidates.size() == 1);
+  assert(resolved.candidates[0].localTransform.o[0] == 500.0f);
+  assert(!resolved.diagnostics.empty());
+  assert(resolver.ArchiveParseCount() == 2);
+
+  resourceTruss.gdtfSpec = publicArchive.string();
+  resourceTruss.perastageAuxGdtfArchivePath.clear();
+  resolved =
+      truss_attachment::BuildCandidates(resourceScene, resourceTruss, resolver);
+  assert(resolved.candidates.size() == 1);
+  assert(resolver.ArchiveParseCount() == 2);
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  WriteGdtf(publicArchive, ArchiveXml(true, 0.75f));
+  resolved =
+      truss_attachment::BuildCandidates(resourceScene, resourceTruss, resolver);
+  assert(resolver.ArchiveParseCount() == 3);
+  assert(resolved.candidates[0].localTransform.o[0] == 750.0f);
+
+  const auto malformedArchive = tempRoot / "resources" / "malformed.gdtf";
+  std::ofstream(malformedArchive) << "not a zip";
+  resourceTruss.gdtfSpec = malformedArchive.string();
+  resolved =
+      truss_attachment::BuildCandidates(resourceScene, resourceTruss, resolver);
+  assert(resolved.candidates.size() == 2);
+  assert(!resolved.diagnostics.empty());
+
+  const auto noMagnetArchive = tempRoot / "resources" / "no-magnet.gdtf";
+  WriteGdtf(noMagnetArchive, ArchiveXml(false));
+  resourceTruss.gdtfSpec = noMagnetArchive.string();
+  resolved =
+      truss_attachment::BuildCandidates(resourceScene, resourceTruss, resolver);
+  assert(resolved.candidates.size() == 2);
+
+  MvrScene cachedSnapScene;
+  cachedSnapScene.basePath = tempRoot.string();
+  AddTruss(cachedSnapScene, "cached-target", 0.0f);
+  AddTruss(cachedSnapScene, "cached-source", 200.0f);
+  cachedSnapScene.trusses["cached-target"].gdtfSpec =
+      "resources/auxiliary.gdtf";
+  cachedSnapScene.trusses["cached-source"].gdtfSpec =
+      "resources/auxiliary.gdtf";
+  truss_attachment::CandidateResolver interactiveResolver;
+  magnet_snap::SnapSettings cachedSettings;
+  cachedSettings.candidateResolver = &interactiveResolver;
+  assert(magnet_snap::FindSnap(
+      cachedSnapScene, {magnet_snap::ObjectType::Truss, "cached-source"},
+      cachedSettings));
+  assert(interactiveResolver.ArchiveParseCount() == 1);
+  cachedSnapScene.trusses["cached-source"].transform.o[1] = 10.0f;
+  assert(magnet_snap::FindSnap(
+      cachedSnapScene, {magnet_snap::ObjectType::Truss, "cached-source"},
+      cachedSettings));
+  assert(interactiveResolver.ArchiveParseCount() == 1);
+
+  Matrix rotated = MatrixUtils::EulerToMatrix(90.0f, 0.0f, 0.0f);
+  const auto rotatedCandidates = truss_attachment::BuildInferredCandidates(
+      {3000, 400, 400}, rotated, "rotated");
+  assert(rotatedCandidates.size() == 2);
+  assert(std::fabs(std::fabs(rotatedCandidates[1].worldTransform.o[1]) -
+                   3000.0f) < 0.001f);
+
+  MvrScene straightGroupScene;
+  GroupObject straightGroup;
+  straightGroup.uuid = "straight-group";
+  for (int index = 0; index < 3; ++index) {
+    const std::string uuid = "straight-" + std::to_string(index);
+    AddTruss(straightGroupScene, uuid, index * 3000.0f);
+    straightGroupScene.trusses[uuid].parentGroupUuid = straightGroup.uuid;
+    straightGroup.children.push_back({MvrNodeType::Truss, uuid});
+  }
+  straightGroupScene.groupObjects[straightGroup.uuid] = straightGroup;
+  const auto straightCandidates = magnet_snap::BuildTrussGroupCandidates(
+      straightGroupScene, straightGroup.uuid);
+  assert(straightCandidates.size() == 2);
+  assert(straightCandidates[0].worldTransform.o[0] == 0.0f);
+  assert(straightCandidates[1].worldTransform.o[0] == 9000.0f);
+
+  MvrScene rotatedGroupScene;
+  GroupObject rotatedGroup;
+  rotatedGroup.uuid = "rotated-group";
+  for (int index = 0; index < 2; ++index) {
+    const std::string uuid = "rotated-" + std::to_string(index);
+    AddTruss(rotatedGroupScene, uuid, 0.0f);
+    rotatedGroupScene.trusses[uuid].transform = rotated;
+    rotatedGroupScene.trusses[uuid].transform.o[1] = -index * 3000.0f;
+    rotatedGroupScene.trusses[uuid].parentGroupUuid = rotatedGroup.uuid;
+    rotatedGroup.children.push_back({MvrNodeType::Truss, uuid});
+  }
+  rotatedGroupScene.groupObjects[rotatedGroup.uuid] = rotatedGroup;
+  assert(magnet_snap::BuildTrussGroupCandidates(rotatedGroupScene,
+                                                rotatedGroup.uuid)
+             .size() == 2);
+
+  MvrScene bentGroupScene;
+  GroupObject bentGroup;
+  bentGroup.uuid = "bent-group";
+  AddTruss(bentGroupScene, "bent-x", 0.0f);
+  AddTruss(bentGroupScene, "bent-y", 3000.0f);
+  bentGroupScene.trusses["bent-y"].transform = rotated;
+  bentGroupScene.trusses["bent-y"].transform.o = {3000.0f, 0.0f, 0.0f};
+  for (const std::string uuid : {"bent-x", "bent-y"}) {
+    bentGroupScene.trusses[uuid].parentGroupUuid = bentGroup.uuid;
+    bentGroup.children.push_back({MvrNodeType::Truss, uuid});
+  }
+  bentGroupScene.groupObjects[bentGroup.uuid] = bentGroup;
+  const auto bentCandidates =
+      magnet_snap::BuildTrussGroupCandidates(bentGroupScene, bentGroup.uuid);
+  assert(bentCandidates.size() == 6);
+  for (const auto &candidate : bentCandidates)
+    assert(candidate.kind == CandidateKind::InferredFaceCenter);
+
   MvrScene scene;
   AddTruss(scene, "target", 0.0f);
   AddTruss(scene, "source", 3250.0f);
@@ -109,6 +281,71 @@ int main() {
       sideSurfaceScene, {magnet_snap::ObjectType::Truss, "source"},
       topSideSettings);
   assert(!sideSurfaceSnap);
+
+  MvrScene screenScene;
+  AddTruss(screenScene, "screen-target", 0.0f);
+  AddTruss(screenScene, "screen-source", 0.0f);
+  screenScene.trusses["screen-target"].transform.o[2] = 500.0f;
+  magnet_snap::SnapSettings screenSettings;
+  truss_attachment::CandidateResolver screenResolver;
+  screenSettings.candidateResolver = &screenResolver;
+  truss_screen_snap::ProjectionSnapshot screenProjection;
+  screenProjection.modelView = {1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1};
+  screenProjection.projection = screenProjection.modelView;
+  screenProjection.viewport = {0, 0, 1000, 1000};
+  screenProjection.contentScale = 1.0;
+  screenSettings.trussProjection = screenProjection;
+  auto screenSnap = magnet_snap::FindSnap(
+      screenScene, {magnet_snap::ObjectType::Truss, "screen-source"},
+      screenSettings);
+  assert(screenSnap);
+  assert(std::fabs(screenSnap->translationDeltaMm[2] - 500.0f) < 0.001f);
+  screenScene.trusses["screen-target"].transform.o[1] = 100.0f;
+  assert(!magnet_snap::FindSnap(
+      screenScene, {magnet_snap::ObjectType::Truss, "screen-source"},
+      screenSettings));
+  screenScene.trusses["screen-target"].transform.o[2] = 0.0f;
+  screenScene.trusses["screen-target"].transform.o[1] = 40.0f;
+  assert(!magnet_snap::FindSnap(
+      screenScene, {magnet_snap::ObjectType::Truss, "screen-source"},
+      screenSettings));
+
+  MvrScene depthRankScene;
+  AddTruss(depthRankScene, "source", 0.0f);
+  AddTruss(depthRankScene, "far-depth", 0.0f);
+  AddTruss(depthRankScene, "near-depth", 0.0f);
+  depthRankScene.trusses["far-depth"].transform.o[2] = 600.0f;
+  depthRankScene.trusses["near-depth"].transform.o[2] = 400.0f;
+  auto rankedSnap = magnet_snap::FindSnap(
+      depthRankScene, {magnet_snap::ObjectType::Truss, "source"},
+      screenSettings);
+  assert(rankedSnap && rankedSnap->targetUuid == "near-depth");
+
+  auto flattenedProjection = screenProjection;
+  flattenedProjection.projection[5] = 0.0;
+  screenSettings.trussProjection = flattenedProjection;
+  MvrScene worldRankScene;
+  AddTruss(worldRankScene, "source", 0.0f);
+  AddTruss(worldRankScene, "far-world", 0.0f);
+  AddTruss(worldRankScene, "near-world", 0.0f);
+  worldRankScene.trusses["far-world"].transform.o[1] = 200.0f;
+  worldRankScene.trusses["near-world"].transform.o[1] = 100.0f;
+  rankedSnap = magnet_snap::FindSnap(worldRankScene,
+                                     {magnet_snap::ObjectType::Truss, "source"},
+                                     screenSettings);
+  assert(rankedSnap && rankedSnap->targetUuid == "near-world");
+
+  MvrScene identityRankScene;
+  AddTruss(identityRankScene, "source", 0.0f);
+  AddTruss(identityRankScene, "z-target", 0.0f);
+  AddTruss(identityRankScene, "a-target", 0.0f);
+  rankedSnap = magnet_snap::FindSnap(identityRankScene,
+                                     {magnet_snap::ObjectType::Truss, "source"},
+                                     screenSettings);
+  assert(rankedSnap && rankedSnap->targetUuid == "a-target");
+  assert(!rankedSnap->sourceCandidateId.empty());
+  assert(!rankedSnap->targetCandidateId.empty());
+  screenSettings.trussProjection = screenProjection;
 
   scene.trusses["source"].transform.o[0] = 3250.0f;
   snap =
@@ -156,6 +393,22 @@ int main() {
   assert(topViewSnap);
   assert(std::fabs(topViewSnap->translationDeltaMm[2]) > 0.001f);
   scene.trusses.erase("top-view-source");
+
+  for (const auto &[hiddenAxis, sourceId] :
+       std::vector<std::pair<int, std::string>>{{2, "bottom-view-source"},
+                                                {1, "front-view-source"},
+                                                {0, "side-view-source"}}) {
+    magnet_snap::SnapSettings viewSettings;
+    viewSettings.axisWeights[hiddenAxis] = 0.0f;
+    AddTruss(scene, sourceId, hiddenAxis == 0 ? 20000.0f : 9250.0f);
+    if (hiddenAxis != 0)
+      scene.trusses[sourceId].transform.o[hiddenAxis] = 1000.0f;
+    auto viewSnap = magnet_snap::FindSnap(
+        scene, {magnet_snap::ObjectType::Truss, sourceId}, viewSettings);
+    assert(viewSnap);
+    assert(std::fabs(viewSnap->translationDeltaMm[hiddenAxis]) > 0.001f);
+    scene.trusses.erase(sourceId);
+  }
 
   MvrScene elevatedFixtureScene;
   AddTruss(elevatedFixtureScene, "elevated-truss", 0.0f);

--- a/tests/magnet_snap_test.cpp
+++ b/tests/magnet_snap_test.cpp
@@ -3,18 +3,22 @@
 #include "matrixutils.h"
 #include "scene_grouping.h"
 #include "truss_attachment_candidates.h"
+#include "wx_path_utils.h"
 
-#include <cassert>
 #include <chrono>
 #include <cmath>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <string_view>
 
+#include <wx/init.h>
 #include <wx/wfstream.h>
 #include <wx/zipstrm.h>
 
 namespace {
+
+std::string_view g_stage = "startup";
 
 // Builds a translated identity matrix.
 Matrix Translated(float x, float y, float z) {
@@ -39,16 +43,22 @@ void AddTruss(MvrScene &scene, const std::string &uuid, float x) {
 
 // Writes a minimal GDTF ZIP archive for production resolver tests.
 bool WriteGdtf(const std::filesystem::path &path, const std::string &xml) {
-  wxFFileOutputStream file(path.string());
-  if (!file.IsOk())
-    return false;
-  wxZipOutputStream zip(file);
-  if (!zip.PutNextEntry("description.xml"))
-    return false;
-  zip.Write(xml.data(), xml.size());
-  if (!zip.IsOk() || !zip.CloseEntry() || !zip.Close())
-    return false;
-  return file.IsOk();
+  bool success = false;
+  {
+    wxFFileOutputStream file(WxPathUtils::WxStringFromFilesystemPath(path));
+    if (!file.IsOk())
+      return false;
+    wxZipOutputStream zip(file);
+    if (!zip.PutNextEntry("description.xml"))
+      return false;
+    zip.Write(xml.data(), xml.size());
+    if (!zip.IsOk() || zip.LastWrite() != xml.size())
+      return false;
+    if (!zip.CloseEntry() || !zip.Close())
+      return false;
+    success = file.IsOk();
+  }
+  return success;
 }
 
 // Returns a minimal GDTF description with an optional Magnet.
@@ -67,8 +77,15 @@ std::string ArchiveXml(bool withMagnet, float xMeters = 0.0f,
 bool Check(bool condition, const char *expression, int line) {
   if (condition)
     return true;
-  std::cerr << "CHECK failed at line " << line << ": " << expression << '\n';
+  std::cerr << "CHECK failed in stage '" << g_stage << "' at line " << line
+            << ": " << expression << std::endl;
   return false;
+}
+
+// Records and flushes concise context for any subsequent test failure or hang.
+void SetStage(std::string_view stage) {
+  g_stage = stage;
+  std::cerr << "MagnetSnapCore stage: " << stage << std::endl;
 }
 
 #define CHECK_OR_RETURN(expression)                                            \
@@ -82,36 +99,45 @@ bool Check(bool condition, const char *expression, int line) {
 // Verifies Magnet snap candidates, metadata preservation, and committed
 // grouping.
 int main() {
+  wxInitializer initializer;
+  CHECK_OR_RETURN(initializer.IsOk());
   using truss_attachment::CandidateKind;
+  SetStage("inferred candidates");
   const auto longitudinal = truss_attachment::BuildInferredCandidates(
       {3000.0f, 400.0f, 400.0f}, Translated(100.0f, 200.0f, 300.0f), "long");
-  assert(longitudinal.size() == 2);
-  assert(longitudinal[0].kind == CandidateKind::InferredLongitudinalEnd);
-  assert(longitudinal[0].localTransform.o[0] == 0.0f);
-  assert(longitudinal[1].localTransform.o[0] == 3000.0f);
-  assert(longitudinal[0].worldTransform.o[0] == 100.0f);
-  assert(longitudinal[1].worldTransform.o[0] == 3100.0f);
-  assert(longitudinal[0].worldDirection &&
-         (*longitudinal[0].worldDirection)[0] == -1.0f);
-  assert(longitudinal[1].worldDirection &&
-         (*longitudinal[1].worldDirection)[0] == 1.0f);
-  assert(truss_attachment::ClassifyLongitudinalAxis({3000, 400, 400}) == 0);
-  assert(truss_attachment::ClassifyLongitudinalAxis({400, 3000, 400}) == 1);
-  assert(truss_attachment::ClassifyLongitudinalAxis({400, 400, 3000}) == 2);
-  assert(!truss_attachment::ClassifyLongitudinalAxis({800, 400, 400}));
-  assert(truss_attachment::ClassifyLongitudinalAxis({801, 400, 400}) == 0);
+  CHECK_OR_RETURN(longitudinal.size() == 2);
+  CHECK_OR_RETURN(longitudinal[0].kind ==
+                  CandidateKind::InferredLongitudinalEnd);
+  CHECK_OR_RETURN(longitudinal[0].localTransform.o[0] == 0.0f);
+  CHECK_OR_RETURN(longitudinal[1].localTransform.o[0] == 3000.0f);
+  CHECK_OR_RETURN(longitudinal[0].worldTransform.o[0] == 100.0f);
+  CHECK_OR_RETURN(longitudinal[1].worldTransform.o[0] == 3100.0f);
+  CHECK_OR_RETURN(longitudinal[0].worldDirection &&
+                  (*longitudinal[0].worldDirection)[0] == -1.0f);
+  CHECK_OR_RETURN(longitudinal[1].worldDirection &&
+                  (*longitudinal[1].worldDirection)[0] == 1.0f);
+  CHECK_OR_RETURN(
+      truss_attachment::ClassifyLongitudinalAxis({3000, 400, 400}) == 0);
+  CHECK_OR_RETURN(
+      truss_attachment::ClassifyLongitudinalAxis({400, 3000, 400}) == 1);
+  CHECK_OR_RETURN(
+      truss_attachment::ClassifyLongitudinalAxis({400, 400, 3000}) == 2);
+  CHECK_OR_RETURN(!truss_attachment::ClassifyLongitudinalAxis({800, 400, 400}));
+  CHECK_OR_RETURN(truss_attachment::ClassifyLongitudinalAxis({801, 400, 400}) ==
+                  0);
 
   const auto ambiguous = truss_attachment::BuildInferredCandidates(
       {400.0f, 400.0f, 400.0f}, MatrixUtils::Identity(), "cube");
-  assert(ambiguous.size() == 6);
-  assert(ambiguous.front().stableId == "face-axis-0-negative");
-  assert(ambiguous.back().stableId == "face-axis-2-positive");
+  CHECK_OR_RETURN(ambiguous.size() == 6);
+  CHECK_OR_RETURN(ambiguous.front().stableId == "face-axis-0-negative");
+  CHECK_OR_RETURN(ambiguous.back().stableId == "face-axis-2-positive");
   for (const auto &candidate : ambiguous)
-    assert(candidate.kind == CandidateKind::InferredFaceCenter);
-  assert(truss_attachment::BuildInferredCandidates({0.0f, 400.0f, 400.0f},
-                                                   MatrixUtils::Identity())
-             .size() == 6);
+    CHECK_OR_RETURN(candidate.kind == CandidateKind::InferredFaceCenter);
+  CHECK_OR_RETURN(truss_attachment::BuildInferredCandidates(
+                      {0.0f, 400.0f, 400.0f}, MatrixUtils::Identity())
+                      .size() == 6);
 
+  SetStage("explicit XML Magnet parsing");
   const std::string magnetXml =
       "<GDTF><FixtureType><Geometries>"
       "<Geometry Name='Root' Position='{1,0,0,1}{0,1,0,2}{0,0,1,3}{0,0,0,1}'>"
@@ -122,20 +148,21 @@ int main() {
       "</Geometries></FixtureType></GDTF>";
   const auto explicitMagnets = truss_attachment::ReadExplicitGdtfMagnets(
       magnetXml, Translated(100.0f, 0.0f, 0.0f));
-  assert(explicitMagnets.candidates.size() == 2);
-  assert(explicitMagnets.diagnostics.size() == 1);
-  assert(explicitMagnets.candidates[0].name == "A");
-  assert(explicitMagnets.candidates[0].model == "Connector");
-  assert(explicitMagnets.candidates[1].model.empty());
-  assert(explicitMagnets.candidates[0].localTransform.o[0] == 1500.0f);
-  assert(explicitMagnets.candidates[0].localTransform.o[1] == 2000.0f);
-  assert(explicitMagnets.candidates[0].worldTransform.o[0] == 1600.0f);
-  assert(!explicitMagnets.candidates[0].worldDirection);
-  assert(truss_attachment::ReadExplicitGdtfMagnets(
-             "<GDTF><FixtureType><Geometries/></FixtureType></GDTF>",
-             MatrixUtils::Identity())
-             .candidates.empty());
+  CHECK_OR_RETURN(explicitMagnets.candidates.size() == 2);
+  CHECK_OR_RETURN(explicitMagnets.diagnostics.size() == 1);
+  CHECK_OR_RETURN(explicitMagnets.candidates[0].name == "A");
+  CHECK_OR_RETURN(explicitMagnets.candidates[0].model == "Connector");
+  CHECK_OR_RETURN(explicitMagnets.candidates[1].model.empty());
+  CHECK_OR_RETURN(explicitMagnets.candidates[0].localTransform.o[0] == 1500.0f);
+  CHECK_OR_RETURN(explicitMagnets.candidates[0].localTransform.o[1] == 2000.0f);
+  CHECK_OR_RETURN(explicitMagnets.candidates[0].worldTransform.o[0] == 1600.0f);
+  CHECK_OR_RETURN(!explicitMagnets.candidates[0].worldDirection);
+  CHECK_OR_RETURN(truss_attachment::ReadExplicitGdtfMagnets(
+                      "<GDTF><FixtureType><Geometries/></FixtureType></GDTF>",
+                      MatrixUtils::Identity())
+                      .candidates.empty());
 
+  SetStage("temporary directory creation");
   const auto tempRoot =
       std::filesystem::temp_directory_path() /
       ("perastage-truss-attachment-test-" +
@@ -146,6 +173,7 @@ int main() {
   CHECK_OR_RETURN(!filesystemError);
   const auto publicArchive = tempRoot / "resources" / "public.gdtf";
   const auto auxiliaryArchive = tempRoot / "resources" / "auxiliary.gdtf";
+  SetStage("initial GDTF archive writes");
   CHECK_OR_RETURN(WriteGdtf(publicArchive, ArchiveXml(true, 0.25f)));
   CHECK_OR_RETURN(WriteGdtf(auxiliaryArchive, ArchiveXml(true, 0.5f)));
   MvrScene resourceScene;
@@ -157,33 +185,36 @@ int main() {
   resourceTruss.heightMm = 400;
   resourceTruss.gdtfSpec = "resources/public.gdtf";
   truss_attachment::CandidateResolver resolver;
+  SetStage("relative resource resolution");
   auto resolved =
       truss_attachment::BuildCandidates(resourceScene, resourceTruss, resolver);
-  assert(resolved.candidates.size() == 1);
-  assert(resolved.candidates[0].kind == CandidateKind::ExplicitGdtfMagnet);
-  assert(resolved.candidates[0].localTransform.o[0] == 250.0f);
-  assert(resolver.ArchiveParseCount() == 1);
+  CHECK_OR_RETURN(resolved.candidates.size() == 1);
+  CHECK_OR_RETURN(resolved.candidates[0].kind ==
+                  CandidateKind::ExplicitGdtfMagnet);
+  CHECK_OR_RETURN(resolved.candidates[0].localTransform.o[0] == 250.0f);
+  CHECK_OR_RETURN(resolver.ArchiveParseCount() == 1);
   resourceTruss.transform.o[1] = 2000.0f;
   resolved =
       truss_attachment::BuildCandidates(resourceScene, resourceTruss, resolver);
-  assert(resolver.ArchiveParseCount() == 1);
-  assert(resolved.candidates[0].worldTransform.o[1] == 2000.0f);
+  CHECK_OR_RETURN(resolver.ArchiveParseCount() == 1);
+  CHECK_OR_RETURN(resolved.candidates[0].worldTransform.o[1] == 2000.0f);
 
   resourceTruss.gdtfSpec = "resources/missing.gdtf";
   resourceTruss.perastageAuxGdtfArchivePath = "resources/auxiliary.gdtf";
+  SetStage("auxiliary resource fallback");
   resolved =
       truss_attachment::BuildCandidates(resourceScene, resourceTruss, resolver);
-  assert(resolved.candidates.size() == 1);
-  assert(resolved.candidates[0].localTransform.o[0] == 500.0f);
-  assert(!resolved.diagnostics.empty());
-  assert(resolver.ArchiveParseCount() == 2);
+  CHECK_OR_RETURN(resolved.candidates.size() == 1);
+  CHECK_OR_RETURN(resolved.candidates[0].localTransform.o[0] == 500.0f);
+  CHECK_OR_RETURN(!resolved.diagnostics.empty());
+  CHECK_OR_RETURN(resolver.ArchiveParseCount() == 2);
 
   resourceTruss.gdtfSpec = publicArchive.string();
   resourceTruss.perastageAuxGdtfArchivePath.clear();
   resolved =
       truss_attachment::BuildCandidates(resourceScene, resourceTruss, resolver);
-  assert(resolved.candidates.size() == 1);
-  assert(resolver.ArchiveParseCount() == 2);
+  CHECK_OR_RETURN(resolved.candidates.size() == 1);
+  CHECK_OR_RETURN(resolver.ArchiveParseCount() == 2);
   const auto previousWriteTime =
       std::filesystem::last_write_time(publicArchive, filesystemError);
   CHECK_OR_RETURN(!filesystemError);
@@ -191,6 +222,7 @@ int main() {
       std::filesystem::file_size(publicArchive, filesystemError);
   CHECK_OR_RETURN(!filesystemError);
   CHECK_OR_RETURN(WriteGdtf(publicArchive, ArchiveXml(true, 0.35f)));
+  SetStage("same-metadata cache behavior");
   CHECK_OR_RETURN(std::filesystem::file_size(publicArchive, filesystemError) ==
                   previousSize);
   std::filesystem::last_write_time(publicArchive, previousWriteTime,
@@ -200,12 +232,14 @@ int main() {
       truss_attachment::BuildCandidates(resourceScene, resourceTruss, resolver);
   CHECK_OR_RETURN(resolver.ArchiveParseCount() == 2);
   CHECK_OR_RETURN(resolved.candidates[0].localTransform.o[0] == 250.0f);
+  SetStage("explicit cache Clear");
   resolver.Clear();
   resolved =
       truss_attachment::BuildCandidates(resourceScene, resourceTruss, resolver);
   CHECK_OR_RETURN(resolver.ArchiveParseCount() == 3);
   CHECK_OR_RETURN(resolved.candidates[0].localTransform.o[0] == 350.0f);
 
+  SetStage("changed-version cache invalidation");
   CHECK_OR_RETURN(WriteGdtf(
       publicArchive, ArchiveXml(true, 0.75f, "<Geometry Name='Padding'/>")));
   std::filesystem::last_write_time(publicArchive,
@@ -214,9 +248,10 @@ int main() {
   CHECK_OR_RETURN(!filesystemError);
   resolved =
       truss_attachment::BuildCandidates(resourceScene, resourceTruss, resolver);
-  assert(resolver.ArchiveParseCount() == 4);
-  assert(resolved.candidates[0].localTransform.o[0] == 750.0f);
+  CHECK_OR_RETURN(resolver.ArchiveParseCount() == 4);
+  CHECK_OR_RETURN(resolved.candidates[0].localTransform.o[0] == 750.0f);
 
+  SetStage("malformed archive");
   const auto malformedArchive = tempRoot / "resources" / "malformed.gdtf";
   {
     std::ofstream malformedOutput(malformedArchive, std::ios::binary);
@@ -228,16 +263,18 @@ int main() {
   resourceTruss.gdtfSpec = malformedArchive.string();
   resolved =
       truss_attachment::BuildCandidates(resourceScene, resourceTruss, resolver);
-  assert(resolved.candidates.size() == 2);
-  assert(!resolved.diagnostics.empty());
+  CHECK_OR_RETURN(resolved.candidates.size() == 2);
+  CHECK_OR_RETURN(!resolved.diagnostics.empty());
 
+  SetStage("no-Magnet archive");
   const auto noMagnetArchive = tempRoot / "resources" / "no-magnet.gdtf";
   CHECK_OR_RETURN(WriteGdtf(noMagnetArchive, ArchiveXml(false)));
   resourceTruss.gdtfSpec = noMagnetArchive.string();
   resolved =
       truss_attachment::BuildCandidates(resourceScene, resourceTruss, resolver);
-  assert(resolved.candidates.size() == 2);
+  CHECK_OR_RETURN(resolved.candidates.size() == 2);
 
+  SetStage("interactive resolver reuse");
   MvrScene cachedSnapScene;
   cachedSnapScene.basePath = tempRoot.string();
   AddTruss(cachedSnapScene, "cached-target", 0.0f);
@@ -249,23 +286,26 @@ int main() {
   truss_attachment::CandidateResolver interactiveResolver;
   magnet_snap::SnapSettings cachedSettings;
   cachedSettings.candidateResolver = &interactiveResolver;
-  assert(magnet_snap::FindSnap(
+  CHECK_OR_RETURN(magnet_snap::FindSnap(
       cachedSnapScene, {magnet_snap::ObjectType::Truss, "cached-source"},
       cachedSettings));
-  assert(interactiveResolver.ArchiveParseCount() == 1);
+  CHECK_OR_RETURN(interactiveResolver.ArchiveParseCount() == 1);
   cachedSnapScene.trusses["cached-source"].transform.o[1] = 10.0f;
-  assert(magnet_snap::FindSnap(
+  CHECK_OR_RETURN(magnet_snap::FindSnap(
       cachedSnapScene, {magnet_snap::ObjectType::Truss, "cached-source"},
       cachedSettings));
-  assert(interactiveResolver.ArchiveParseCount() == 1);
+  CHECK_OR_RETURN(interactiveResolver.ArchiveParseCount() == 1);
 
+  SetStage("rotated candidates");
   Matrix rotated = MatrixUtils::EulerToMatrix(90.0f, 0.0f, 0.0f);
   const auto rotatedCandidates = truss_attachment::BuildInferredCandidates(
       {3000, 400, 400}, rotated, "rotated");
-  assert(rotatedCandidates.size() == 2);
-  assert(std::fabs(std::fabs(rotatedCandidates[1].worldTransform.o[1]) -
-                   3000.0f) < 0.001f);
+  CHECK_OR_RETURN(rotatedCandidates.size() == 2);
+  CHECK_OR_RETURN(
+      std::fabs(std::fabs(rotatedCandidates[1].worldTransform.o[1]) - 3000.0f) <
+      0.001f);
 
+  SetStage("straight group candidates");
   MvrScene straightGroupScene;
   GroupObject straightGroup;
   straightGroup.uuid = "straight-group";
@@ -278,11 +318,11 @@ int main() {
   straightGroupScene.groupObjects[straightGroup.uuid] = straightGroup;
   const auto straightCandidates = magnet_snap::BuildTrussGroupCandidates(
       straightGroupScene, straightGroup.uuid);
-  assert(straightCandidates.size() == 2);
-  assert(straightCandidates[0].worldTransform.o[0] == 0.0f);
-  assert(straightCandidates[1].worldTransform.o[0] == 9000.0f);
-  assert(straightCandidates[0].ownerTrussUuid == "straight-0");
-  assert(straightCandidates[1].ownerTrussUuid == "straight-2");
+  CHECK_OR_RETURN(straightCandidates.size() == 2);
+  CHECK_OR_RETURN(straightCandidates[0].worldTransform.o[0] == 0.0f);
+  CHECK_OR_RETURN(straightCandidates[1].worldTransform.o[0] == 9000.0f);
+  CHECK_OR_RETURN(straightCandidates[0].ownerTrussUuid == "straight-0");
+  CHECK_OR_RETURN(straightCandidates[1].ownerTrussUuid == "straight-2");
 
   MvrScene rotatedGroupScene;
   GroupObject rotatedGroup;
@@ -296,10 +336,11 @@ int main() {
     rotatedGroup.children.push_back({MvrNodeType::Truss, uuid});
   }
   rotatedGroupScene.groupObjects[rotatedGroup.uuid] = rotatedGroup;
-  assert(magnet_snap::BuildTrussGroupCandidates(rotatedGroupScene,
-                                                rotatedGroup.uuid)
-             .size() == 2);
+  CHECK_OR_RETURN(magnet_snap::BuildTrussGroupCandidates(rotatedGroupScene,
+                                                         rotatedGroup.uuid)
+                      .size() == 2);
 
+  SetStage("bent group member candidates");
   MvrScene bentGroupScene;
   GroupObject bentGroup;
   bentGroup.uuid = "bent-group";
@@ -314,21 +355,24 @@ int main() {
   bentGroupScene.groupObjects[bentGroup.uuid] = bentGroup;
   const auto bentCandidates =
       magnet_snap::BuildTrussGroupCandidates(bentGroupScene, bentGroup.uuid);
-  assert(bentCandidates.size() == 4);
+  CHECK_OR_RETURN(bentCandidates.size() == 4);
   for (const auto &candidate : bentCandidates) {
-    assert(candidate.kind == CandidateKind::InferredLongitudinalEnd);
-    assert(candidate.ownerTrussUuid == "bent-x" ||
-           candidate.ownerTrussUuid == "bent-y");
+    CHECK_OR_RETURN(candidate.kind == CandidateKind::InferredLongitudinalEnd);
+    CHECK_OR_RETURN(candidate.ownerTrussUuid == "bent-x" ||
+                    candidate.ownerTrussUuid == "bent-y");
   }
   AddTruss(bentGroupScene, "bent-moving", 250.0f);
   auto bentGroupSnap = magnet_snap::FindSnap(
       bentGroupScene, {magnet_snap::ObjectType::Truss, "bent-moving"});
-  assert(bentGroupSnap);
-  assert(bentGroupSnap->targetUuid == bentGroup.uuid);
-  assert(bentGroupSnap->targetMemberTrussUuid == "bent-x");
-  assert(bentGroupSnap->sourceCandidateId == "longitudinal-axis-0-positive");
-  assert(std::fabs(bentGroupSnap->translationDeltaMm[0] + 3250.0f) < 0.001f);
+  CHECK_OR_RETURN(bentGroupSnap);
+  CHECK_OR_RETURN(bentGroupSnap->targetUuid == bentGroup.uuid);
+  CHECK_OR_RETURN(bentGroupSnap->targetMemberTrussUuid == "bent-x");
+  CHECK_OR_RETURN(bentGroupSnap->sourceCandidateId ==
+                  "longitudinal-axis-0-positive");
+  CHECK_OR_RETURN(std::fabs(bentGroupSnap->translationDeltaMm[0] + 3250.0f) <
+                  0.001f);
 
+  SetStage("explicit group member Magnet");
   MvrScene explicitGroupScene;
   explicitGroupScene.basePath = tempRoot.string();
   GroupObject explicitGroup;
@@ -342,22 +386,26 @@ int main() {
   explicitGroupScene.groupObjects[explicitGroup.uuid] = explicitGroup;
   const auto explicitGroupCandidates = magnet_snap::BuildTrussGroupCandidates(
       explicitGroupScene, explicitGroup.uuid);
-  assert(explicitGroupCandidates.size() == 1);
-  assert(explicitGroupCandidates[0].kind == CandidateKind::ExplicitGdtfMagnet);
-  assert(explicitGroupCandidates[0].ownerTrussUuid == "explicit-member");
+  CHECK_OR_RETURN(explicitGroupCandidates.size() == 1);
+  CHECK_OR_RETURN(explicitGroupCandidates[0].kind ==
+                  CandidateKind::ExplicitGdtfMagnet);
+  CHECK_OR_RETURN(explicitGroupCandidates[0].ownerTrussUuid ==
+                  "explicit-member");
 
+  SetStage("basic truss snap");
   MvrScene scene;
   AddTruss(scene, "target", 0.0f);
   AddTruss(scene, "source", 3250.0f);
 
   auto snap =
       magnet_snap::FindSnap(scene, {magnet_snap::ObjectType::Truss, "source"});
-  assert(snap);
-  assert(snap->kind == magnet_snap::SnapKind::TrussToTruss);
-  assert(snap->needsGrouping);
-  assert(std::fabs(snap->translationDeltaMm[0] + 250.0f) < 0.001f);
-  assert(snap->sourceCandidateId == "longitudinal-axis-0-negative");
+  CHECK_OR_RETURN(snap);
+  CHECK_OR_RETURN(snap->kind == magnet_snap::SnapKind::TrussToTruss);
+  CHECK_OR_RETURN(snap->needsGrouping);
+  CHECK_OR_RETURN(std::fabs(snap->translationDeltaMm[0] + 250.0f) < 0.001f);
+  CHECK_OR_RETURN(snap->sourceCandidateId == "longitudinal-axis-0-negative");
 
+  SetStage("left extension");
   MvrScene leftExtensionScene;
   AddTruss(leftExtensionScene, "target", 0.0f);
   AddTruss(leftExtensionScene, "source", 250.0f);
@@ -365,17 +413,21 @@ int main() {
       leftExtensionScene.trusses["source"].transform;
   auto leftSnap = magnet_snap::FindSnap(
       leftExtensionScene, {magnet_snap::ObjectType::Truss, "source"});
-  assert(leftSnap);
-  assert(leftSnap->sourceCandidateId == "longitudinal-axis-0-positive");
-  assert(std::fabs(leftSnap->translationDeltaMm[0] + 3250.0f) < 0.001f);
-  assert(magnet_snap::ApplySnapTransform(leftExtensionScene, *leftSnap));
-  assert(leftExtensionScene.trusses["source"].transform.u ==
-         leftSourceBefore.u);
-  assert(leftExtensionScene.trusses["source"].transform.v ==
-         leftSourceBefore.v);
-  assert(leftExtensionScene.trusses["source"].transform.w ==
-         leftSourceBefore.w);
-  assert(leftExtensionScene.trusses["source"].transform.o[0] == -3000.0f);
+  CHECK_OR_RETURN(leftSnap);
+  CHECK_OR_RETURN(leftSnap->sourceCandidateId ==
+                  "longitudinal-axis-0-positive");
+  CHECK_OR_RETURN(std::fabs(leftSnap->translationDeltaMm[0] + 3250.0f) <
+                  0.001f);
+  CHECK_OR_RETURN(
+      magnet_snap::ApplySnapTransform(leftExtensionScene, *leftSnap));
+  CHECK_OR_RETURN(leftExtensionScene.trusses["source"].transform.u ==
+                  leftSourceBefore.u);
+  CHECK_OR_RETURN(leftExtensionScene.trusses["source"].transform.v ==
+                  leftSourceBefore.v);
+  CHECK_OR_RETURN(leftExtensionScene.trusses["source"].transform.w ==
+                  leftSourceBefore.w);
+  CHECK_OR_RETURN(leftExtensionScene.trusses["source"].transform.o[0] ==
+                  -3000.0f);
 
   MvrScene ambiguousSourceScene;
   AddTruss(ambiguousSourceScene, "target", 0.0f);
@@ -385,9 +437,11 @@ int main() {
   ambiguousSourceScene.trusses["source"].heightMm = 400.0f;
   auto ambiguousSourceSnap = magnet_snap::FindSnap(
       ambiguousSourceScene, {magnet_snap::ObjectType::Truss, "source"});
-  assert(ambiguousSourceSnap);
-  assert(ambiguousSourceSnap->sourceCandidateId.rfind("face-axis-", 0) == 0);
+  CHECK_OR_RETURN(ambiguousSourceSnap);
+  CHECK_OR_RETURN(
+      ambiguousSourceSnap->sourceCandidateId.rfind("face-axis-", 0) == 0);
 
+  SetStage("rotated extension");
   MvrScene rotatedExtensionScene;
   AddTruss(rotatedExtensionScene, "target", 0.0f);
   AddTruss(rotatedExtensionScene, "source", 0.0f);
@@ -398,12 +452,14 @@ int main() {
         rotated.u[component] * 250.0f;
   auto rotatedLeftSnap = magnet_snap::FindSnap(
       rotatedExtensionScene, {magnet_snap::ObjectType::Truss, "source"});
-  assert(rotatedLeftSnap);
-  assert(rotatedLeftSnap->sourceCandidateId == "longitudinal-axis-0-positive");
+  CHECK_OR_RETURN(rotatedLeftSnap);
+  CHECK_OR_RETURN(rotatedLeftSnap->sourceCandidateId ==
+                  "longitudinal-axis-0-positive");
   for (int component = 0; component < 3; ++component)
-    assert(std::fabs(rotatedLeftSnap->translationDeltaMm[component] +
-                     rotated.u[component] * 3250.0f) < 0.001f);
+    CHECK_OR_RETURN(std::fabs(rotatedLeftSnap->translationDeltaMm[component] +
+                              rotated.u[component] * 3250.0f) < 0.001f);
 
+  SetStage("group extension");
   MvrScene groupExtensionScene;
   GroupObject targetGroup;
   targetGroup.uuid = "target-group";
@@ -417,16 +473,19 @@ int main() {
   AddTruss(groupExtensionScene, "moving", 250.0f);
   auto groupLeftSnap = magnet_snap::FindSnap(
       groupExtensionScene, {magnet_snap::ObjectType::Truss, "moving"});
-  assert(groupLeftSnap);
-  assert(groupLeftSnap->targetUuid == targetGroup.uuid);
-  assert(groupLeftSnap->targetMemberTrussUuid == "target-member-0");
-  assert(groupLeftSnap->targetCandidateId == "longitudinal-axis-0-negative");
-  assert(groupLeftSnap->sourceCandidateId == "longitudinal-axis-0-positive");
-  assert(std::fabs(groupLeftSnap->translationDeltaMm[0] + 3250.0f) < 0.001f);
+  CHECK_OR_RETURN(groupLeftSnap);
+  CHECK_OR_RETURN(groupLeftSnap->targetUuid == targetGroup.uuid);
+  CHECK_OR_RETURN(groupLeftSnap->targetMemberTrussUuid == "target-member-0");
+  CHECK_OR_RETURN(groupLeftSnap->targetCandidateId ==
+                  "longitudinal-axis-0-negative");
+  CHECK_OR_RETURN(groupLeftSnap->sourceCandidateId ==
+                  "longitudinal-axis-0-positive");
+  CHECK_OR_RETURN(std::fabs(groupLeftSnap->translationDeltaMm[0] + 3250.0f) <
+                  0.001f);
 
   scene.trusses["source"].transform.o[0] = 4000.0f;
-  assert(!magnet_snap::FindSnap(scene,
-                                {magnet_snap::ObjectType::Truss, "source"}));
+  CHECK_OR_RETURN(!magnet_snap::FindSnap(
+      scene, {magnet_snap::ObjectType::Truss, "source"}));
 
   MvrScene sideSurfaceScene;
   AddTruss(sideSurfaceScene, "target", 0.0f);
@@ -437,8 +496,9 @@ int main() {
   auto sideSurfaceSnap = magnet_snap::FindSnap(
       sideSurfaceScene, {magnet_snap::ObjectType::Truss, "source"},
       topSideSettings);
-  assert(!sideSurfaceSnap);
+  CHECK_OR_RETURN(!sideSurfaceSnap);
 
+  SetStage("Viewer3D screen-space cases");
   MvrScene screenScene;
   AddTruss(screenScene, "screen-target", 0.0f);
   AddTruss(screenScene, "screen-source", 0.0f);
@@ -455,8 +515,9 @@ int main() {
   auto screenSnap = magnet_snap::FindSnap(
       screenScene, {magnet_snap::ObjectType::Truss, "screen-source"},
       screenSettings);
-  assert(screenSnap);
-  assert(std::fabs(screenSnap->translationDeltaMm[2] - 500.0f) < 0.001f);
+  CHECK_OR_RETURN(screenSnap);
+  CHECK_OR_RETURN(std::fabs(screenSnap->translationDeltaMm[2] - 500.0f) <
+                  0.001f);
 
   MvrScene screenLeftScene;
   AddTruss(screenLeftScene, "target", 0.0f);
@@ -466,16 +527,18 @@ int main() {
   auto screenLeftSnap = magnet_snap::FindSnap(
       screenLeftScene, {magnet_snap::ObjectType::Truss, "source"},
       screenLeftSettings);
-  assert(screenLeftSnap);
-  assert(screenLeftSnap->sourceCandidateId == "longitudinal-axis-0-positive");
-  assert(std::fabs(screenLeftSnap->translationDeltaMm[0] + 3250.0f) < 0.001f);
+  CHECK_OR_RETURN(screenLeftSnap);
+  CHECK_OR_RETURN(screenLeftSnap->sourceCandidateId ==
+                  "longitudinal-axis-0-positive");
+  CHECK_OR_RETURN(std::fabs(screenLeftSnap->translationDeltaMm[0] + 3250.0f) <
+                  0.001f);
   screenScene.trusses["screen-target"].transform.o[1] = 100.0f;
-  assert(!magnet_snap::FindSnap(
+  CHECK_OR_RETURN(!magnet_snap::FindSnap(
       screenScene, {magnet_snap::ObjectType::Truss, "screen-source"},
       screenSettings));
   screenScene.trusses["screen-target"].transform.o[2] = 0.0f;
   screenScene.trusses["screen-target"].transform.o[1] = 40.0f;
-  assert(!magnet_snap::FindSnap(
+  CHECK_OR_RETURN(!magnet_snap::FindSnap(
       screenScene, {magnet_snap::ObjectType::Truss, "screen-source"},
       screenSettings));
 
@@ -488,7 +551,7 @@ int main() {
   auto rankedSnap = magnet_snap::FindSnap(
       depthRankScene, {magnet_snap::ObjectType::Truss, "source"},
       screenSettings);
-  assert(rankedSnap && rankedSnap->targetUuid == "near-depth");
+  CHECK_OR_RETURN(rankedSnap && rankedSnap->targetUuid == "near-depth");
 
   auto flattenedProjection = screenProjection;
   flattenedProjection.projection[5] = 0.0;
@@ -502,7 +565,7 @@ int main() {
   rankedSnap = magnet_snap::FindSnap(worldRankScene,
                                      {magnet_snap::ObjectType::Truss, "source"},
                                      screenSettings);
-  assert(rankedSnap && rankedSnap->targetUuid == "near-world");
+  CHECK_OR_RETURN(rankedSnap && rankedSnap->targetUuid == "near-world");
 
   MvrScene identityRankScene;
   AddTruss(identityRankScene, "source", 0.0f);
@@ -511,49 +574,52 @@ int main() {
   rankedSnap = magnet_snap::FindSnap(identityRankScene,
                                      {magnet_snap::ObjectType::Truss, "source"},
                                      screenSettings);
-  assert(rankedSnap && rankedSnap->targetUuid == "a-target");
-  assert(!rankedSnap->sourceCandidateId.empty());
-  assert(!rankedSnap->targetCandidateId.empty());
+  CHECK_OR_RETURN(rankedSnap && rankedSnap->targetUuid == "a-target");
+  CHECK_OR_RETURN(!rankedSnap->sourceCandidateId.empty());
+  CHECK_OR_RETURN(!rankedSnap->targetCandidateId.empty());
   screenSettings.trussProjection = screenProjection;
 
+  SetStage("committed grouping");
   scene.trusses["source"].transform.o[0] = 3250.0f;
   snap =
       magnet_snap::FindSnap(scene, {magnet_snap::ObjectType::Truss, "source"});
-  assert(snap);
+  CHECK_OR_RETURN(snap);
   const std::string hang = scene.trusses["source"].positionName;
-  assert(magnet_snap::ApplySnapTransform(scene, *snap));
-  assert(scene.trusses["source"].positionName == hang);
-  assert(magnet_snap::ApplyCommittedSnapGrouping(scene, *snap));
-  assert(scene.groupObjects.size() == 1);
+  CHECK_OR_RETURN(magnet_snap::ApplySnapTransform(scene, *snap));
+  CHECK_OR_RETURN(scene.trusses["source"].positionName == hang);
+  CHECK_OR_RETURN(magnet_snap::ApplyCommittedSnapGrouping(scene, *snap));
+  CHECK_OR_RETURN(scene.groupObjects.size() == 1);
   const std::string groupUuid = scene.trusses["target"].parentGroupUuid;
-  assert(!groupUuid.empty());
+  CHECK_OR_RETURN(!groupUuid.empty());
 
   AddTruss(scene, "loose", 6250.0f);
   auto groupSnap = magnet_snap::FindSnap(
       scene, {magnet_snap::ObjectType::TrussGroup, groupUuid});
-  assert(groupSnap);
-  assert(groupSnap->kind == magnet_snap::SnapKind::TrussToTruss);
-  assert(groupSnap->sourceUuid == groupUuid);
-  assert(groupSnap->sourceMemberTrussUuid == "source");
-  assert(groupSnap->targetUuid == "loose");
-  assert(std::fabs(groupSnap->translationDeltaMm[0] - 250.0f) < 0.001f);
+  CHECK_OR_RETURN(groupSnap);
+  CHECK_OR_RETURN(groupSnap->kind == magnet_snap::SnapKind::TrussToTruss);
+  CHECK_OR_RETURN(groupSnap->sourceUuid == groupUuid);
+  CHECK_OR_RETURN(groupSnap->sourceMemberTrussUuid == "source");
+  CHECK_OR_RETURN(groupSnap->targetUuid == "loose");
+  CHECK_OR_RETURN(std::fabs(groupSnap->translationDeltaMm[0] - 250.0f) <
+                  0.001f);
   scene.trusses.erase("loose");
 
   AddTruss(scene, "source-2", 6250.0f);
   auto snap2 = magnet_snap::FindSnap(
       scene, {magnet_snap::ObjectType::Truss, "source-2"});
-  assert(snap2);
-  assert(snap2->targetUuid == groupUuid);
-  assert(magnet_snap::ApplySnapTransform(scene, *snap2));
-  assert(magnet_snap::ApplyCommittedSnapGrouping(scene, *snap2));
-  assert(scene.trusses["source-2"].parentGroupUuid == groupUuid);
-  assert(scene.groupObjects.size() == 1);
+  CHECK_OR_RETURN(snap2);
+  CHECK_OR_RETURN(snap2->targetUuid == groupUuid);
+  CHECK_OR_RETURN(magnet_snap::ApplySnapTransform(scene, *snap2));
+  CHECK_OR_RETURN(magnet_snap::ApplyCommittedSnapGrouping(scene, *snap2));
+  CHECK_OR_RETURN(scene.trusses["source-2"].parentGroupUuid == groupUuid);
+  CHECK_OR_RETURN(scene.groupObjects.size() == 1);
 
   AddTruss(scene, "interior-candidate", 3250.0f);
-  assert(!magnet_snap::FindSnap(
+  CHECK_OR_RETURN(!magnet_snap::FindSnap(
       scene, {magnet_snap::ObjectType::Truss, "interior-candidate"}));
   scene.trusses.erase("interior-candidate");
 
+  SetStage("hidden-axis cases");
   magnet_snap::SnapSettings topViewSettings;
   topViewSettings.axisWeights[2] = 0.0f;
   AddTruss(scene, "top-view-source", 9250.0f);
@@ -561,8 +627,8 @@ int main() {
   auto topViewSnap = magnet_snap::FindSnap(
       scene, {magnet_snap::ObjectType::Truss, "top-view-source"},
       topViewSettings);
-  assert(topViewSnap);
-  assert(std::fabs(topViewSnap->translationDeltaMm[2]) > 0.001f);
+  CHECK_OR_RETURN(topViewSnap);
+  CHECK_OR_RETURN(std::fabs(topViewSnap->translationDeltaMm[2]) > 0.001f);
   scene.trusses.erase("top-view-source");
 
   for (const auto &[hiddenAxis, sourceId] :
@@ -576,11 +642,13 @@ int main() {
       scene.trusses[sourceId].transform.o[hiddenAxis] = 1000.0f;
     auto viewSnap = magnet_snap::FindSnap(
         scene, {magnet_snap::ObjectType::Truss, sourceId}, viewSettings);
-    assert(viewSnap);
-    assert(std::fabs(viewSnap->translationDeltaMm[hiddenAxis]) > 0.001f);
+    CHECK_OR_RETURN(viewSnap);
+    CHECK_OR_RETURN(std::fabs(viewSnap->translationDeltaMm[hiddenAxis]) >
+                    0.001f);
     scene.trusses.erase(sourceId);
   }
 
+  SetStage("fixture regressions");
   MvrScene elevatedFixtureScene;
   AddTruss(elevatedFixtureScene, "elevated-truss", 0.0f);
   elevatedFixtureScene.trusses["elevated-truss"].transform.o[2] = 10000.0f;
@@ -592,15 +660,15 @@ int main() {
       elevatedFixtureScene,
       {magnet_snap::ObjectType::Fixture, elevatedFixture.uuid},
       topViewSettings);
-  assert(elevatedFixtureSnap);
-  assert(elevatedFixtureSnap->targetUuid == "elevated-truss");
-  assert(std::fabs(elevatedFixtureSnap->translationDeltaMm[1] + 10.0f) <
-         0.001f);
-  assert(std::fabs(elevatedFixtureSnap->translationDeltaMm[2] - 7000.0f) <
-         0.001f);
-  assert(magnet_snap::ApplySnapTransform(elevatedFixtureScene,
-                                         *elevatedFixtureSnap));
-  assert(
+  CHECK_OR_RETURN(elevatedFixtureSnap);
+  CHECK_OR_RETURN(elevatedFixtureSnap->targetUuid == "elevated-truss");
+  CHECK_OR_RETURN(
+      std::fabs(elevatedFixtureSnap->translationDeltaMm[1] + 10.0f) < 0.001f);
+  CHECK_OR_RETURN(
+      std::fabs(elevatedFixtureSnap->translationDeltaMm[2] - 7000.0f) < 0.001f);
+  CHECK_OR_RETURN(magnet_snap::ApplySnapTransform(elevatedFixtureScene,
+                                                  *elevatedFixtureSnap));
+  CHECK_OR_RETURN(
       std::fabs(
           elevatedFixtureScene.fixtures[elevatedFixture.uuid].transform.o[2] -
           10000.0f) < 0.001f);
@@ -612,11 +680,12 @@ int main() {
   scene.fixtures[fixture.uuid] = fixture;
   auto fixtureSnap = magnet_snap::FindSnap(
       scene, {magnet_snap::ObjectType::Fixture, fixture.uuid});
-  assert(fixtureSnap);
-  assert(fixtureSnap->kind == magnet_snap::SnapKind::FixtureToTruss);
-  assert(fixtureSnap->needsGrouping);
-  assert(std::fabs(fixtureSnap->translationDeltaMm[1] + 10.0f) < 0.001f);
-  assert(std::fabs(fixtureSnap->translationDeltaMm[2]) < 0.001f);
+  CHECK_OR_RETURN(fixtureSnap);
+  CHECK_OR_RETURN(fixtureSnap->kind == magnet_snap::SnapKind::FixtureToTruss);
+  CHECK_OR_RETURN(fixtureSnap->needsGrouping);
+  CHECK_OR_RETURN(std::fabs(fixtureSnap->translationDeltaMm[1] + 10.0f) <
+                  0.001f);
+  CHECK_OR_RETURN(std::fabs(fixtureSnap->translationDeltaMm[2]) < 0.001f);
 
   Fixture topEdgeFixture;
   topEdgeFixture.uuid = "top-edge-fixture";
@@ -624,16 +693,20 @@ int main() {
   scene.fixtures[topEdgeFixture.uuid] = topEdgeFixture;
   auto topEdgeFixtureSnap = magnet_snap::FindSnap(
       scene, {magnet_snap::ObjectType::Fixture, topEdgeFixture.uuid});
-  assert(topEdgeFixtureSnap);
-  assert(topEdgeFixtureSnap->kind == magnet_snap::SnapKind::FixtureToTruss);
-  assert(std::fabs(topEdgeFixtureSnap->translationDeltaMm[1] + 10.0f) < 0.001f);
-  assert(std::fabs(topEdgeFixtureSnap->translationDeltaMm[2]) < 0.001f);
+  CHECK_OR_RETURN(topEdgeFixtureSnap);
+  CHECK_OR_RETURN(topEdgeFixtureSnap->kind ==
+                  magnet_snap::SnapKind::FixtureToTruss);
+  CHECK_OR_RETURN(std::fabs(topEdgeFixtureSnap->translationDeltaMm[1] + 10.0f) <
+                  0.001f);
+  CHECK_OR_RETURN(std::fabs(topEdgeFixtureSnap->translationDeltaMm[2]) <
+                  0.001f);
 
-  assert(magnet_snap::ApplyCommittedSnapGrouping(scene, *fixtureSnap));
-  assert(scene.fixtures[fixture.uuid].parentGroupUuid == groupUuid);
-  assert(scene.fixtures[fixture.uuid].layer ==
-         scene.groupObjects[groupUuid].layer);
-  assert(scene.trusses["target"].layer == scene.groupObjects[groupUuid].layer);
+  CHECK_OR_RETURN(magnet_snap::ApplyCommittedSnapGrouping(scene, *fixtureSnap));
+  CHECK_OR_RETURN(scene.fixtures[fixture.uuid].parentGroupUuid == groupUuid);
+  CHECK_OR_RETURN(scene.fixtures[fixture.uuid].layer ==
+                  scene.groupObjects[groupUuid].layer);
+  CHECK_OR_RETURN(scene.trusses["target"].layer ==
+                  scene.groupObjects[groupUuid].layer);
 
   SceneObject object;
   object.uuid = "object";
@@ -641,8 +714,9 @@ int main() {
   scene.sceneObjects[object.uuid] = object;
   auto objectSnap = magnet_snap::FindSnap(
       scene, {magnet_snap::ObjectType::SceneObject, object.uuid});
-  assert(objectSnap);
-  assert(objectSnap->kind == magnet_snap::SnapKind::SceneObjectToObject);
+  CHECK_OR_RETURN(objectSnap);
+  CHECK_OR_RETURN(objectSnap->kind ==
+                  magnet_snap::SnapKind::SceneObjectToObject);
 
   magnet_snap::SnapResult groupedTrussMove;
   groupedTrussMove.snapped = true;
@@ -652,18 +726,20 @@ int main() {
   const float fixtureZBeforeGroupMove =
       scene.fixtures[fixture.uuid].transform.o[2];
   const float trussZBeforeGroupMove = scene.trusses["target"].transform.o[2];
-  assert(magnet_snap::ApplySnapTransform(scene, groupedTrussMove));
-  assert(std::fabs(scene.fixtures[fixture.uuid].transform.o[2] -
-                   fixtureZBeforeGroupMove - 100.0f) < 0.001f);
-  assert(std::fabs(scene.trusses["target"].transform.o[2] -
-                   trussZBeforeGroupMove - 100.0f) < 0.001f);
+  CHECK_OR_RETURN(magnet_snap::ApplySnapTransform(scene, groupedTrussMove));
+  CHECK_OR_RETURN(std::fabs(scene.fixtures[fixture.uuid].transform.o[2] -
+                            fixtureZBeforeGroupMove - 100.0f) < 0.001f);
+  CHECK_OR_RETURN(std::fabs(scene.trusses["target"].transform.o[2] -
+                            trussZBeforeGroupMove - 100.0f) < 0.001f);
 
-  assert(magnet_snap::DetachSnapSourceFromGroup(scene, *fixtureSnap));
-  assert(scene.fixtures[fixture.uuid].parentGroupUuid.empty());
-  assert(scene.trusses["target"].parentGroupUuid == groupUuid);
+  CHECK_OR_RETURN(magnet_snap::DetachSnapSourceFromGroup(scene, *fixtureSnap));
+  CHECK_OR_RETURN(scene.fixtures[fixture.uuid].parentGroupUuid.empty());
+  CHECK_OR_RETURN(scene.trusses["target"].parentGroupUuid == groupUuid);
 
+  SetStage("temporary cleanup");
   std::filesystem::remove_all(tempRoot, filesystemError);
   CHECK_OR_RETURN(!filesystemError);
 
+  SetStage("normal exit");
   return 0;
 }

--- a/tests/truss_screen_snap_test.cpp
+++ b/tests/truss_screen_snap_test.cpp
@@ -1,0 +1,44 @@
+#include "truss_screen_snap.h"
+
+#include <cassert>
+#include <cmath>
+
+namespace {
+
+// Returns an identity OpenGL matrix.
+std::array<double, 16> Identity() {
+  return {1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1};
+}
+
+// Builds an orthographic projection snapshot at a requested content scale.
+truss_screen_snap::ProjectionSnapshot Snapshot(double contentScale) {
+  truss_screen_snap::ProjectionSnapshot snapshot;
+  snapshot.modelView = Identity();
+  snapshot.projection = Identity();
+  snapshot.viewport = {0, 0, static_cast<int>(1000 * contentScale),
+                       static_cast<int>(1000 * contentScale)};
+  snapshot.contentScale = contentScale;
+  return snapshot;
+}
+
+} // namespace
+
+// Verifies pure projection, clipping, and logical-pixel DPI behavior.
+int main() {
+  for (double scale : {1.0, 1.5, 2.0}) {
+    const auto snapshot = Snapshot(scale);
+    const auto origin = truss_screen_snap::Project(snapshot, {0, 0, 0});
+    const auto near = truss_screen_snap::Project(snapshot, {30, 0, 0});
+    const auto far = truss_screen_snap::Project(snapshot, {34, 0, 0});
+    assert(origin && near && far);
+    assert(std::fabs(near->logicalX - origin->logicalX - 15.0) < 0.001);
+    assert(std::fabs(far->logicalX - origin->logicalX - 17.0) < 0.001);
+  }
+
+  auto perspective = Snapshot(1.0);
+  perspective.projection = {1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0};
+  assert(truss_screen_snap::Project(perspective, {100, 0, 500}));
+  assert(!truss_screen_snap::Project(perspective, {100, 0, -500}));
+  assert(!truss_screen_snap::Project(Snapshot(1.0), {2000, 0, 0}));
+  return 0;
+}

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -1852,6 +1852,7 @@ Viewer2DPanel::BuildActiveMagnetSource() const {
 // Builds view-aware Magnet settings for the active 2D projection.
 magnet_snap::SnapSettings Viewer2DPanel::BuildActiveMagnetSettings() const {
   magnet_snap::SnapSettings settings;
+  settings.candidateResolver = &m_trussCandidateResolver;
   switch (m_view) {
   case Viewer2DView::Top:
   case Viewer2DView::Bottom:

--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -187,6 +187,7 @@ public:
   }
 
 private:
+  mutable truss_attachment::CandidateResolver m_trussCandidateResolver;
   enum class DragMode { None, View, Selection, RectSelection };
   enum class DragAxis { None, Horizontal, Vertical };
   enum class DragTarget { None, Fixtures, Trusses, Supports, SceneObjects };

--- a/viewer3d/gdtf_geometry_types.h
+++ b/viewer3d/gdtf_geometry_types.h
@@ -32,7 +32,8 @@ struct GdtfObject {
 enum class GdtfNodeType {
     Geometry,
     Axis,
-    Emitter
+    Emitter,
+    Magnet
 };
 
 struct GdtfNode3D {

--- a/viewer3d/gdtfloader.cpp
+++ b/viewer3d/gdtfloader.cpp
@@ -1380,6 +1380,8 @@ static void ParseGeometry(tinyxml2::XMLElement* node,
                 return std::string("Axis_") + stableToken;
             case GdtfNodeType::Emitter:
                 return std::string("Emitter_") + stableToken;
+            case GdtfNodeType::Magnet:
+                return std::string("Magnet_") + stableToken;
             case GdtfNodeType::Geometry:
             default:
                 return std::string("Geometry_") + stableToken;
@@ -1414,6 +1416,8 @@ static void ParseGeometry(tinyxml2::XMLElement* node,
         parsedNodeType = GdtfNodeType::Axis;
     else if (nodeType == "Beam" || isLensGeometry)
         parsedNodeType = GdtfNodeType::Emitter;
+    else if (nodeType == "Magnet")
+        parsedNodeType = GdtfNodeType::Magnet;
 
     const int currentNodeIndex = static_cast<int>(outTree.nodes.size());
     GdtfNode3D node3d;

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -3508,12 +3508,11 @@ void Viewer3DPanel::OnMouseMove(wxMouseEvent &event) {
                         m_draggedSincePress = true;
                     }
                 } else {
-          const auto lastPoint =
-              ProjectMouseToSelectionDragViewPlane(
-                m_lastMousePos, renderSize, m_selectionDragAnchorMeters);
-          const auto currentPoint =
-              ProjectMouseToSelectionDragViewPlane(
-                        pos, renderSize, m_selectionDragAnchorMeters);
+                    const auto rawAnchor = CurrentRawSelectionDragAnchor();
+                    const auto lastPoint = ProjectMouseToSelectionDragViewPlane(
+                        m_lastMousePos, renderSize, rawAnchor);
+                    const auto currentPoint = ProjectMouseToSelectionDragViewPlane(
+                        pos, renderSize, rawAnchor);
                     if (lastPoint && currentPoint) {
                         const std::array<float, 3> worldDelta{
                             (*currentPoint)[0] - (*lastPoint)[0],

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -2929,6 +2929,7 @@ Viewer3DPanel::BuildActiveMagnetSource() const {
 magnet_snap::SnapSettings Viewer3DPanel::BuildActiveMagnetSettings(
     const magnet_snap::SnapSource &source) const {
     magnet_snap::SnapSettings settings;
+    settings.candidateResolver = &m_trussCandidateResolver;
     settings.thresholdMm = source.type == magnet_snap::ObjectType::Fixture
                                ? magnet_snap::kDefaultSnapDistanceMm * 2.0f
                                : magnet_snap::kDefaultSnapDistanceMm;
@@ -2945,6 +2946,25 @@ magnet_snap::SnapSettings Viewer3DPanel::BuildActiveMagnetSettings(
     for (int axis = 0; axis < 3; ++axis)
     settings.axisWeights[axis] =
         std::max(kMinimumViewAxisWeight, 1.0f - std::fabs(forward[axis]));
+    if (source.type == magnet_snap::ObjectType::Truss ||
+        source.type == magnet_snap::ObjectType::TrussGroup) {
+        truss_screen_snap::ProjectionSnapshot snapshot;
+        GLdouble modelView[16] = {};
+        GLdouble projection[16] = {};
+        GLint viewport[4] = {};
+        glGetDoublev(GL_MODELVIEW_MATRIX, modelView);
+        glGetDoublev(GL_PROJECTION_MATRIX, projection);
+        glGetIntegerv(GL_VIEWPORT, viewport);
+        std::copy(std::begin(modelView), std::end(modelView),
+                  snapshot.modelView.begin());
+        std::copy(std::begin(projection), std::end(projection),
+                  snapshot.projection.begin());
+        std::copy(std::begin(viewport), std::end(viewport),
+                  snapshot.viewport.begin());
+        snapshot.contentScale =
+            std::max(1.0, static_cast<double>(GetContentScaleFactor()));
+        settings.trussProjection = snapshot;
+    }
     return settings;
 }
 

--- a/viewer3d/viewer3dpanel.h
+++ b/viewer3d/viewer3dpanel.h
@@ -140,6 +140,7 @@ private:
     transform_space::TransformSpace m_transformSpace =
         transform_space::TransformSpace::World;
     std::optional<magnet_snap::SnapResult> m_pendingMagnetSnap;
+    mutable truss_attachment::CandidateResolver m_trussCandidateResolver;
     wxLongLong m_selectionDragPressTime = 0;
     HoverTargetTable m_selectionDragTarget = HoverTargetTable::None;
     std::vector<std::string> m_dragSelectionUuids;


### PR DESCRIPTION
### Motivation
- Replace unrestricted truss face-to-face snapping with prioritized, deterministic attachment points sourced from explicit GDTF Magnet nodes or conservative inferred fallbacks. 
- Provide a small GUI-independent core layer to represent candidates so snapping logic can pair points rather than faces while preserving existing fixture behavior and grouping semantics. 
- Fix a narrowly scoped Viewer3D drag asymmetry so unconstrained pointer projections share the same raw drag anchor.

### Description
- Added a focused candidate service `core/truss_attachment_candidates.{h,cpp}` that exposes explicit GDTF Magnet reads, deterministic candidate identities, candidate kinds (`ExplicitGdtfMagnet`, `InferredLongitudinalEnd`, `InferredFaceCenter`), local/world transforms, and structured diagnostics. 
- Implemented GDTF Magnet reading as a tolerant, read-only traversal that composes parent transforms, preserves `Name` and optional `Model`, converts GDTF Position into scene millimetres, and skips malformed Magnet nodes with diagnostics. 
- Replaced truss face-pair pairing in `core/magnet_snap.cpp` with source/target candidate-point pairing that keeps existing axis-weight scoring, threshold semantics, deterministic tie resolution, translation-only deltas, and existing grouping/self/descendant rejections. 
- Implemented longitudinal classification (dominance ratio constant = 2.0) and exact fallback generation: exactly two terminal points for clearly longitudinal trusses and six face-center points for ambiguous shapes. 
- Kept fixture-to-truss snapping path unchanged (insertion-point → nearest surface). 
- Differentiated `Magnet` node type in the reused viewer GDTF geometry tree by updating `viewer3d/gdtf_geometry_types.h` and `viewer3d/gdtfloader.cpp`. 
- Fixed unconstrained Viewer3D selection-drag asymmetry by using `CurrentRawSelectionDragAnchor()` for both unconstrained pointer projections in `viewer3d/viewer3dpanel.cpp`. 
- Added unit/regression checks and tests: extended `tests/magnet_snap_test.cpp` with explicit magnet and inference assertions and added `tests/check_viewer3d_raw_drag_anchor.sh` to assert the raw-anchor usage; updated `tests/CMakeLists.txt` and `core/CMakeLists.txt` to include the new module. 
- Added developer documentation `docs/developer/truss_attachment_candidates.md` and updated `docs/release-notes-draft.md` with the user-facing summary.

### Testing
- Ran the focused Magnet snap test executable by compiling and executing a MagnetSnapCore-equivalent binary, and the focused test passed (candidate inference, explicit Magnet reads, group behavior and fixture regressions validated). 
- Built and executed the `selection_drag_math` focused test and it passed. 
- Executed repository policy checks including `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh` and the new `tests/check_viewer3d_raw_drag_anchor.sh`, and all these checks passed. 
- Performed local compile-and-run verification by compiling core test binaries with system libraries (wxWidgets, tinyxml2) and running `magnet_snap`-equivalent tests; those focused runs succeeded. 
- Attempted full CMake configuration and CI-style build but the environment initially lacked several native dev packages (installed many dependencies during the run); a remaining environmental package (`mdns` CMake config) prevented a complete repository-wide CTest run in this session, so the full CI matrix (Linux/Windows/macOS) was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b4df529ec8324b996c076b5209f36)