### PR TITLE
docs: add initial code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Default repository owner
+#
+# Keep ownership intentionally simple while Perastage has a single maintainer.
+# More specific paths and additional reviewers can be added later when
+# contributors take responsibility for clearly defined areas.
+
+* @PeramatoG


### PR DESCRIPTION
## Summary

Adds an initial `.github/CODEOWNERS` file so GitHub can identify the current maintainer as the default owner for repository changes.

The ownership model is intentionally simple while Perastage has a single maintainer:

- All repository paths are owned by `@PeramatoG`.
- No external contributor receives write access or automatic ownership.
- More specific paths and additional reviewers can be added later when responsibility for an area is clearly established.

## Related issue or discussion

N/A — follows the contributor workflow improvements in PRs #2253 and #2254.

## Scope

- Add `.github/CODEOWNERS`.
- Set `@PeramatoG` as the default repository owner.

## Out of scope

- No branch protection, repository permissions, required-review settings, source code, CI, or release behavior is changed.
- No ownership is assigned to external contributors.

## User-facing impact

- [ ] New feature
- [ ] Improvement
- [ ] Bug fix
- [ ] Performance
- [ ] Stability / reliability
- [x] Documentation
- [ ] Internal only

User-facing release note:

Internal repository governance only.

## Architecture and implementation

N/A — repository metadata only.

## MVR / GDTF compatibility

N/A.

- [ ] Input remains permissive where safe and appropriate.
- [ ] Perastage-created or exported output remains strict and canonical.
- [ ] Original external GDTF files are not mutated merely because they were read.
- [x] Not applicable.

## Testing

Platforms tested:

- [ ] Windows
- [ ] macOS
- [ ] Linux
- [x] Not applicable

Validation performed:

- [ ] Built successfully
- [ ] Relevant automated tests passed
- [ ] Tested manually
- [ ] Regression test added or updated
- [ ] Architecture checks passed when applicable
- [x] Not applicable

Commands, configurations, sample files, and results:

Verified that the CODEOWNERS syntax uses the repository-wide `*` pattern and the valid GitHub owner `@PeramatoG`.

## Documentation and localization

- [ ] User documentation updated where required
- [x] Developer or technical policy documentation updated where required
- [ ] New user-facing text is marked for gettext translation
- [x] Documentation links remain valid
- [ ] No documentation or localization update is required

Documentation changed or reason not required:

The new `.github/CODEOWNERS` file is the complete repository metadata change. No application text is introduced.

## Visual evidence

N/A.

## Third-party code, assets, and data

N/A.

## Known limitations and follow-up work

CODEOWNERS identifies responsible reviewers but does not itself enforce required reviews or protect `main`. Repository rules must be reviewed and configured separately in GitHub settings.

## Contributor checklist

- [x] The pull request contains one coherent change.
- [x] Unrelated formatting or refactoring changes were avoided.
- [x] The code and comments are written in English.
- [x] Business logic and file-format logic remain outside the GUI where practical.
- [x] New responsibilities were placed in an appropriate module instead of growing a hotspot unnecessarily.
- [x] New dependencies, external material, and licensing have been documented.
- [x] I understand and take responsibility for all submitted code, including AI-assisted code.

## Release notes draft

- [ ] Updated `docs/release-notes-draft.md`
- [x] Not needed because this change is internal only
- [ ] Not needed for another documented reason above
