### PR TITLE
Fix empty labels in Viewer3D context menu

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -28,6 +28,10 @@ Changes since **v1.5.0**.
 
 ## Important fixes
 
+- Fixed the 3D viewport context menu failing to open in projects without
+  fixtures or trusses, on other Data View pages, or when viewport picking is
+  temporarily unavailable.
+
 - Improved Windows test reliability for truss Magnet archive and cache
   validation by initializing its native file services explicitly and reporting
   failures without modal dialogs.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2356,3 +2356,10 @@ add_executable(selection_drag_math_test
 target_include_directories(selection_drag_math_test PRIVATE
                            ../viewer3d/interaction)
 add_test(NAME SelectionDragMath COMMAND selection_drag_math_test)
+
+add_executable(viewer3d_context_menu_model_test
+               viewer3d_context_menu_model_test.cpp
+               ../viewer3d/interaction/context_menu_model.cpp)
+target_include_directories(viewer3d_context_menu_model_test PRIVATE
+                           ../viewer3d/interaction)
+add_test(NAME Viewer3DContextMenuModel COMMAND viewer3d_context_menu_model_test)

--- a/tests/viewer3d_context_menu_model_test.cpp
+++ b/tests/viewer3d_context_menu_model_test.cpp
@@ -1,0 +1,117 @@
+#include "context_menu_model.h"
+
+#include <cassert>
+#include <set>
+#include <string>
+
+namespace {
+
+using viewer3d::context_menu::Build;
+using viewer3d::context_menu::Input;
+using viewer3d::context_menu::Model;
+using viewer3d::context_menu::SelectableObject;
+using viewer3d::context_menu::SelectionPage;
+
+// Verifies the general menu actions and runtime labels in every model.
+void AssertValidModel(const Model &model) {
+  assert(model.renderStyleAvailable);
+  assert(model.exportImageAvailable);
+  if (model.selectionAvailable) {
+    assert(!model.selectAllLabel.empty());
+    assert(!model.typeSubmenuLabel.empty());
+  }
+  for (const std::string &label : model.typesOrModels)
+    assert(!label.empty());
+  for (const std::string &label : model.positions)
+    assert(!label.empty());
+}
+
+// Verifies states where fixture or truss selection actions are unavailable.
+void TestUnavailableSelectionStates() {
+  Input input;
+  input.pickingAvailable = true;
+  Model model = Build(input);
+  assert(!model.selectionAvailable);
+  AssertValidModel(model);
+
+  input.page = SelectionPage::Fixtures;
+  model = Build(input);
+  assert(!model.selectionAvailable);
+  AssertValidModel(model);
+
+  input.page = SelectionPage::Trusses;
+  model = Build(input);
+  assert(!model.selectionAvailable);
+  AssertValidModel(model);
+
+  input.objects = {{"Model", "Position"}};
+  input.selectionObjectHit = true;
+  model = Build(input);
+  assert(!model.selectionAvailable);
+  assert(model.typesOrModels.empty());
+  AssertValidModel(model);
+
+  input.selectionObjectHit = false;
+  input.pickingAvailable = false;
+  model = Build(input);
+  assert(!model.selectionAvailable);
+  AssertValidModel(model);
+}
+
+// Verifies fixture labels and deterministic type and position collection.
+void TestFixtureSelectionModel() {
+  Input input;
+  input.page = SelectionPage::Fixtures;
+  input.pickingAvailable = true;
+  input.objects = {{"Wash", "FOH"}, {"Spot", ""}, {"Wash", "FOH"}};
+  const Model model = Build(input);
+
+  assert(model.selectionAvailable);
+  assert(model.selectAllLabel == "All fixtures");
+  assert(model.typeSubmenuLabel == "Select by fixture type");
+  assert((model.typesOrModels == std::vector<std::string>{"Spot", "Wash"}));
+  assert((model.positions == std::vector<std::string>{"FOH"}));
+  assert(model.hasNoPosition);
+  AssertValidModel(model);
+}
+
+// Verifies truss labels and deterministic model and position collection.
+void TestTrussSelectionModel() {
+  Input input;
+  input.page = SelectionPage::Trusses;
+  input.pickingAvailable = true;
+  input.objects = {{"F34-3000", "Upstage"}, {"F34-2000", "Downstage"}};
+  const Model model = Build(input);
+
+  assert(model.selectionAvailable);
+  assert(model.selectAllLabel == "All trusses");
+  assert(model.typeSubmenuLabel == "Select by model");
+  assert((model.typesOrModels ==
+          std::vector<std::string>{"F34-2000", "F34-3000"}));
+  assert((model.positions == std::vector<std::string>{"Downstage", "Upstage"}));
+  assert(!model.hasNoPosition);
+  AssertValidModel(model);
+}
+
+// Verifies conversion remains independent from fixture and truss selection.
+void TestSceneObjectConversionModel() {
+  Input input;
+  input.pickingAvailable = true;
+  input.convertibleSceneObjectHit = true;
+  const Model model = Build(input);
+
+  assert(model.convertToTrussAvailable);
+  assert(!model.selectionAvailable);
+  AssertValidModel(model);
+}
+
+} // namespace
+
+// Runs the Viewer3D context-menu state regression scenarios.
+int main() {
+  TestUnavailableSelectionStates();
+  TestFixtureSelectionModel();
+  TestTrussSelectionModel();
+  TestSceneObjectConversionModel();
+  return 0;
+}

--- a/viewer3d/CMakeLists.txt
+++ b/viewer3d/CMakeLists.txt
@@ -4,6 +4,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/culling/visibilitysystem.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtfloader.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/interaction/selection_drag_math.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/interaction/context_menu_model.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/labels/label_render_system.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/loader3ds.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/loaderglb.cpp

--- a/viewer3d/interaction/context_menu_model.cpp
+++ b/viewer3d/interaction/context_menu_model.cpp
@@ -1,0 +1,43 @@
+#include "context_menu_model.h"
+
+#include <set>
+
+namespace viewer3d::context_menu {
+
+// Calculates the valid 3D context-menu actions without constructing GUI
+// objects.
+Model Build(const Input &input) {
+  Model model;
+  model.convertToTrussAvailable =
+      input.pickingAvailable && input.convertibleSceneObjectHit;
+
+  if (!input.pickingAvailable || input.selectionObjectHit ||
+      input.objects.empty() || input.page == SelectionPage::Other) {
+    return model;
+  }
+
+  model.selectionAvailable = true;
+  if (input.page == SelectionPage::Fixtures) {
+    model.selectAllLabel = "All fixtures";
+    model.typeSubmenuLabel = "Select by fixture type";
+  } else {
+    model.selectAllLabel = "All trusses";
+    model.typeSubmenuLabel = "Select by model";
+  }
+
+  std::set<std::string> typesOrModels;
+  std::set<std::string> positions;
+  for (const SelectableObject &object : input.objects) {
+    if (!object.typeOrModel.empty())
+      typesOrModels.insert(object.typeOrModel);
+    if (object.position.empty())
+      model.hasNoPosition = true;
+    else
+      positions.insert(object.position);
+  }
+  model.typesOrModels.assign(typesOrModels.begin(), typesOrModels.end());
+  model.positions.assign(positions.begin(), positions.end());
+  return model;
+}
+
+} // namespace viewer3d::context_menu

--- a/viewer3d/interaction/context_menu_model.h
+++ b/viewer3d/interaction/context_menu_model.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace viewer3d::context_menu {
+
+enum class SelectionPage { Other, Fixtures, Trusses };
+
+struct SelectableObject {
+  std::string typeOrModel;
+  std::string position;
+};
+
+struct Input {
+  SelectionPage page = SelectionPage::Other;
+  std::vector<SelectableObject> objects;
+  bool pickingAvailable = false;
+  bool selectionObjectHit = false;
+  bool convertibleSceneObjectHit = false;
+};
+
+struct Model {
+  bool selectionAvailable = false;
+  std::string selectAllLabel;
+  std::string typeSubmenuLabel;
+  std::vector<std::string> typesOrModels;
+  std::vector<std::string> positions;
+  bool hasNoPosition = false;
+  bool convertToTrussAvailable = false;
+  bool renderStyleAvailable = true;
+  bool exportImageAvailable = true;
+};
+
+// Calculates the valid 3D context-menu actions without constructing GUI
+// objects.
+Model Build(const Input &input);
+
+} // namespace viewer3d::context_menu

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -54,6 +54,7 @@
 #include "configmanager.h"
 #include "continuous_placement_scene.h"
 #include "selection_movement_settings.h"
+#include "interaction/context_menu_model.h"
 #include "../viewport_interaction_scope.h"
 #include "magnet_snap.h"
 #include "scene_grouping.h"
@@ -2182,67 +2183,45 @@ void Viewer3DPanel::OnRightUp(wxMouseEvent &event) {
     const bool trussPageActive =
         TrussTablePanel::Instance() && TrussTablePanel::Instance()->IsActivePage();
     const auto& scene = ConfigManager::Get().GetScene();
-    std::set<std::string> typeNames;
-    std::set<std::string> positionNames;
-    bool hasNoPosition = false;
-    bool showSelectionSubmenus = false;
-    wxString allSelectionLabel;
-    wxString typeSelectionLabel;
+    viewer3d::context_menu::Input menuInput;
+    if (fixturePageActive)
+        menuInput.page = viewer3d::context_menu::SelectionPage::Fixtures;
+    else if (trussPageActive)
+        menuInput.page = viewer3d::context_menu::SelectionPage::Trusses;
     std::string hitSceneObjectUuid;
-    if (TryBindGlContextForInteraction("OnRightUp")) {
+    menuInput.pickingAvailable = TryBindGlContextForInteraction("OnRightUp");
+    if (menuInput.pickingAvailable) {
         const wxPoint pickPos = ToFramebufferPoint(this, event.GetPosition());
         QueryHoverUuid(m_controller, HoverTargetTable::SceneObjects, pickPos.x,
                        pickPos.y, w, h, hitSceneObjectUuid);
-    }
-    if (fixturePageActive && !scene.fixtures.empty() &&
-        TryBindGlContextForInteraction("OnRightUp")) {
         std::string hitUuid;
-        const wxPoint pickPos = ToFramebufferPoint(this, event.GetPosition());
-        if (!QueryHoverUuid(m_controller, HoverTargetTable::Fixtures, pickPos.x,
-                            pickPos.y, w, h, hitUuid)) {
+        if (fixturePageActive && !scene.fixtures.empty()) {
+            menuInput.selectionObjectHit = QueryHoverUuid(
+                m_controller, HoverTargetTable::Fixtures, pickPos.x, pickPos.y,
+                w, h, hitUuid);
             for (const auto& [uuid, fixture] : scene.fixtures) {
-                if (!fixture.typeName.empty())
-                    typeNames.insert(fixture.typeName);
-                if (fixture.positionName.empty())
-                    hasNoPosition = true;
-                else
-                    positionNames.insert(fixture.positionName);
+                menuInput.objects.push_back(
+                    {fixture.typeName, fixture.positionName});
             }
-            allSelectionLabel = "All fixtures";
-            typeSelectionLabel = "Select by fixture type";
-            showSelectionSubmenus = true;
-        }
-    }
-    if (trussPageActive && !scene.trusses.empty() &&
-        TryBindGlContextForInteraction("OnRightUp")) {
-        std::string hitUuid;
-        const wxPoint pickPos = ToFramebufferPoint(this, event.GetPosition());
-        if (!QueryHoverUuid(m_controller, HoverTargetTable::Trusses, pickPos.x,
-                            pickPos.y, w, h, hitUuid)) {
+        } else if (trussPageActive && !scene.trusses.empty()) {
+            menuInput.selectionObjectHit = QueryHoverUuid(
+                m_controller, HoverTargetTable::Trusses, pickPos.x, pickPos.y,
+                w, h, hitUuid);
             for (const auto& [uuid, truss] : scene.trusses) {
-                const std::string modelKey = BuildTrussModelSelectionKey(truss);
-                if (!modelKey.empty())
-                    typeNames.insert(modelKey);
-                if (truss.positionName.empty())
-                    hasNoPosition = true;
-                else
-                    positionNames.insert(truss.positionName);
+                menuInput.objects.push_back(
+                    {BuildTrussModelSelectionKey(truss), truss.positionName});
             }
-            allSelectionLabel = "All trusses";
-            typeSelectionLabel = "Select by model";
-            showSelectionSubmenus = true;
         }
     }
+    menuInput.convertibleSceneObjectHit = !hitSceneObjectUuid.empty();
+    const viewer3d::context_menu::Model menuModel =
+        viewer3d::context_menu::Build(menuInput);
 
     wxMenu rootMenu;
-    auto typeSubmenu = std::make_unique<wxMenu>();
-    auto positionSubmenu = std::make_unique<wxMenu>();
     auto renderStyleSubmenu = std::make_unique<wxMenu>();
 
     constexpr int kSelectTypeAllId = wxID_HIGHEST + 900;
-    constexpr int kSelectTypeBaseId = wxID_HIGHEST + 901;
     constexpr int kSelectPositionNoneId = wxID_HIGHEST + 1100;
-    constexpr int kSelectPositionBaseId = wxID_HIGHEST + 1101;
     constexpr int kRenderStyleStandardId = wxID_HIGHEST + 1200;
     constexpr int kRenderStyleWhiteId = wxID_HIGHEST + 1201;
     constexpr int kRenderStyleSketchId = wxID_HIGHEST + 1202;
@@ -2254,23 +2233,10 @@ void Viewer3DPanel::OnRightUp(wxMouseEvent &event) {
     constexpr int kExportImagePngId = wxID_HIGHEST + 1208;
     constexpr int kConvertSceneObjectToTrussId = wxID_HIGHEST + 1209;
 
-    typeSubmenu->Append(kSelectTypeAllId, allSelectionLabel);
-    std::vector<std::string> orderedTypes;
-    orderedTypes.reserve(typeNames.size());
-    int nextTypeId = kSelectTypeBaseId;
-    for (const auto& typeName : typeNames) {
-        orderedTypes.push_back(typeName);
-        typeSubmenu->Append(nextTypeId++, wxString::FromUTF8(typeName));
-    }
-
-    positionSubmenu->Append(kSelectPositionNoneId, "No position");
-    std::vector<std::string> orderedPositions;
-    orderedPositions.reserve(positionNames.size());
-    int nextPositionId = kSelectPositionBaseId;
-    for (const auto& positionName : positionNames) {
-        orderedPositions.push_back(positionName);
-        positionSubmenu->Append(nextPositionId++, wxString::FromUTF8(positionName));
-    }
+    const auto& orderedTypes = menuModel.typesOrModels;
+    const auto& orderedPositions = menuModel.positions;
+    std::vector<int> orderedTypeIds;
+    std::vector<int> orderedPositionIds;
 
     renderStyleSubmenu->AppendRadioItem(kRenderStyleStandardId, "Standard");
     renderStyleSubmenu->AppendRadioItem(kRenderStyleSketchId, "Sketch mode");
@@ -2311,12 +2277,35 @@ void Viewer3DPanel::OnRightUp(wxMouseEvent &event) {
             break;
     }
 
-    if (!hitSceneObjectUuid.empty()) {
+    if (menuModel.convertToTrussAvailable) {
         rootMenu.Append(kConvertSceneObjectToTrussId, "Convert to Truss");
         rootMenu.AppendSeparator();
     }
-    if (showSelectionSubmenus) {
-        rootMenu.AppendSubMenu(typeSubmenu.release(), typeSelectionLabel);
+    if (menuModel.selectionAvailable) {
+        wxASSERT_MSG(!menuModel.selectAllLabel.empty() &&
+                         !menuModel.typeSubmenuLabel.empty(),
+                     "Selection menu labels must not be empty.");
+        auto typeSubmenu = std::make_unique<wxMenu>();
+        typeSubmenu->Append(kSelectTypeAllId,
+                            wxString::FromUTF8(menuModel.selectAllLabel));
+        for (const auto& typeName : orderedTypes) {
+            wxASSERT_MSG(!typeName.empty(), "Selection type label must not be empty.");
+            const int itemId = wxWindow::NewControlId();
+            orderedTypeIds.push_back(itemId);
+            typeSubmenu->Append(itemId, wxString::FromUTF8(typeName));
+        }
+        auto positionSubmenu = std::make_unique<wxMenu>();
+        positionSubmenu->Append(kSelectPositionNoneId, "No position");
+        for (const auto& positionName : orderedPositions) {
+            wxASSERT_MSG(!positionName.empty(),
+                         "Selection position label must not be empty.");
+            const int itemId = wxWindow::NewControlId();
+            orderedPositionIds.push_back(itemId);
+            positionSubmenu->Append(itemId,
+                                    wxString::FromUTF8(positionName));
+        }
+        rootMenu.AppendSubMenu(typeSubmenu.release(),
+                               wxString::FromUTF8(menuModel.typeSubmenuLabel));
         rootMenu.AppendSubMenu(positionSubmenu.release(), "Select by position");
         rootMenu.AppendSeparator();
     }
@@ -2391,9 +2380,11 @@ void Viewer3DPanel::OnRightUp(wxMouseEvent &event) {
         return;
     }
 
-    if (selectedId >= kSelectTypeBaseId &&
-        selectedId < kSelectTypeBaseId + static_cast<int>(orderedTypes.size())) {
-        const size_t idx = static_cast<size_t>(selectedId - kSelectTypeBaseId);
+    const auto selectedType =
+        std::find(orderedTypeIds.begin(), orderedTypeIds.end(), selectedId);
+    if (selectedType != orderedTypeIds.end()) {
+        const size_t idx =
+            static_cast<size_t>(selectedType - orderedTypeIds.begin());
         if (fixturePageActive)
       ApplyFixtureSelectionToUi(
           BuildFixtureSelectionByType(scene, orderedTypes[idx]), this,
@@ -2407,7 +2398,7 @@ void Viewer3DPanel::OnRightUp(wxMouseEvent &event) {
     }
 
     if (selectedId == kSelectPositionNoneId) {
-        if (!hasNoPosition) {
+        if (!menuModel.hasNoPosition) {
             if (fixturePageActive)
                 ApplyFixtureSelectionToUi({}, this, m_controller);
             else
@@ -2425,10 +2416,11 @@ void Viewer3DPanel::OnRightUp(wxMouseEvent &event) {
         return;
     }
 
-    if (selectedId >= kSelectPositionBaseId &&
-      selectedId <
-          kSelectPositionBaseId + static_cast<int>(orderedPositions.size())) {
-        const size_t idx = static_cast<size_t>(selectedId - kSelectPositionBaseId);
+    const auto selectedPosition = std::find(
+        orderedPositionIds.begin(), orderedPositionIds.end(), selectedId);
+    if (selectedPosition != orderedPositionIds.end()) {
+        const size_t idx =
+            static_cast<size_t>(selectedPosition - orderedPositionIds.begin());
         if (fixturePageActive)
             ApplyFixtureSelectionToUi(
           BuildFixtureSelectionByPosition(scene, orderedPositions[idx], false),


### PR DESCRIPTION
### Motivation
- Prevent a wxWidgets Debug assertion triggered by appending non-stock menu items with empty runtime labels from the 3D viewer right-click handler.
- Make the selection-submenu decision logic explicit and GUI-independent so the menu layer only constructs valid, labelled items when selection actions are actually available.
- Preserve existing behavior for render-style, export, and SceneObject-conversion actions while safely degrading when picking or selection data is unavailable.

### Description
- Add a small GUI-independent helper model `viewer3d::context_menu::Build` that computes whether selection submenus, labels, types, and positions should be presented (new files `viewer3d/interaction/context_menu_model.{h,cpp}`).
- Update `Viewer3DPanel::OnRightUp` to compute menu state from the helper and only create/append the type/position submenus when valid, keeping RAII ownership until `AppendSubMenu` and adding `wxASSERT_MSG` checks for runtime labels (modified `viewer3d/viewer3dpanel.cpp`).
- Replace fixed-range reserved IDs for dynamic selection entries with `wxWindow::NewControlId()` per-item allocation and track those IDs to dispatch actions without stale index arithmetic.
- Add a focused plain-C++ regression test exercising the state model (new `tests/viewer3d_context_menu_model_test.cpp`) and register it in the test CMake (`tests/CMakeLists.txt`), plus wire the new helper into the `viewer3d` target (`viewer3d/CMakeLists.txt`).
- Update `docs/release-notes-draft.md` with a stability fix entry for the 3D context menu.
- Intentionally do not change the deletion subsystem, cache cleanup, or any wxWidgets internals; the fix is local to menu-state calculation and menu construction.

### Testing
- Built and executed the unit regression locally with: `g++ -std=c++20 -Wall -Wextra -Werror -Iviewer3d/interaction tests/viewer3d_context_menu_model_test.cpp viewer3d/interaction/context_menu_model.cpp -o /tmp/viewer3d_context_menu_model_test && /tmp/viewer3d_context_menu_model_test`, which completed successfully.
- Ran repository policy checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both of which passed in this environment.
- Ran `git diff --check` and static checks included in the flow with no issues reported in the modified files.
- CMake/CTest full build was attempted with `cmake --preset wsl-x64-debug` but configuration failed because wxWidgets development libraries are not available in this Linux task environment, so the full CTest suite and a Debug GUI build (Windows) could not be executed here; the change is nevertheless registered with CMake/CTest so CI or a local developer environment with wxWidgets can run the full suite.
- Manual Windows Debug acceptance (open `minitest.pstg`, exercise empty/filled Fixtures/Trusses pages, right-click over empty space and over objects, verify no wxWidgets assertion and that `Convert to Truss`, render-style, and export actions remain available) remains recommended and was not executed here because `minitest.pstg` was not present and a runnable wxWidgets build was not available in the task environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6d96625f588324bde8b232ccd9e525)