### PR TITLE
Fix fixture symbol project and library persistence ownership

### DIFF
--- a/core/filesystem_path_utils.cpp
+++ b/core/filesystem_path_utils.cpp
@@ -120,4 +120,24 @@ std::string BuildFilesystemIdentityKey(const std::filesystem::path &path,
   return BuildFilesystemIdentityKey(path);
 }
 
+// Determines whether two paths identify the same physical or canonical location.
+bool AreFilesystemPathsEquivalent(const std::filesystem::path &left,
+                                  const std::filesystem::path &right,
+                                  std::error_code &error) {
+  error.clear();
+  if (left.empty() || right.empty())
+    return false;
+  const bool equivalent = std::filesystem::equivalent(left, right, error);
+  if (!error)
+    return equivalent;
+  error.clear();
+  const std::filesystem::path canonicalLeft =
+      std::filesystem::weakly_canonical(left, error);
+  if (error)
+    return false;
+  const std::filesystem::path canonicalRight =
+      std::filesystem::weakly_canonical(right, error);
+  return !error && canonicalLeft == canonicalRight;
+}
+
 } // namespace PathUtils

--- a/core/filesystem_path_utils.h
+++ b/core/filesystem_path_utils.h
@@ -2,6 +2,7 @@
 
 #include <filesystem>
 #include <string>
+#include <system_error>
 
 namespace PathUtils {
 
@@ -11,5 +12,8 @@ std::string BuildFilesystemIdentityKey(const std::filesystem::path &path);
 std::string BuildFilesystemIdentityKey(const std::string &utf8Path);
 std::string BuildFilesystemIdentityKey(const std::filesystem::path &path,
                                        const std::filesystem::path &basePath);
+bool AreFilesystemPathsEquivalent(const std::filesystem::path &left,
+                                  const std::filesystem::path &right,
+                                  std::error_code &error);
 
 } // namespace PathUtils

--- a/docs/developer/technical-notes/gdtf_mutation_audit.md
+++ b/docs/developer/technical-notes/gdtf_mutation_audit.md
@@ -35,3 +35,13 @@ In short:
 
 This keeps Perastage application versioning separate from GDTF format
 compatibility versioning.
+
+## Fixture symbol persistence ownership
+
+Generated fixture symbols are committed to the project-owned GDTF before an
+optional library derivative is synchronized. The fixture `gdtfSpec` continues
+to identify the project archive so the next project save packages the same
+archive that passed SVG-path and semantic-fingerprint validation. A library
+synchronization failure is reported separately and does not invalidate a
+successfully committed project copy. Library-only operations remain available,
+but do not report project ownership.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -28,6 +28,10 @@ Changes since **v1.5.0**.
 
 ## Important fixes
 
+- Fixed project persistence for automatically generated fixture symbols when
+  both project and fixture-library copies are updated, preventing a library
+  synchronization issue from causing symbols to be regenerated after reload.
+
 - Fixed the 3D viewport context menu failing to open in projects without
   fixtures or trusses, on other Data View pages, or when viewport picking is
   temporarily unavailable.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -103,6 +103,10 @@ Changes since **v1.5.0**.
 
 ## Technical and packaging changes
 
+- Strengthened cross-platform fixture-symbol persistence verification by
+  releasing archive readers before atomic replacement and restoring temporary
+  fixture-library configuration deterministically.
+
 - Stabilized the internal GDTF Share security verification by making temporary
   credential fixtures uniquely owned and reliably cleaned up across platforms.
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -31,6 +31,8 @@ Changes since **v1.5.0**.
 - Fixed project persistence for automatically generated fixture symbols when
   both project and fixture-library copies are updated, preventing a library
   synchronization issue from causing symbols to be regenerated after reload.
+  Manual symbol application now also distinguishes a successful project update
+  from a fixture-library synchronization warning.
 
 - Fixed the 3D viewport context menu failing to open in projects without
   fixtures or trusses, on other Data View pages, or when viewport picking is

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -23,6 +23,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/tools/scene_model_symbol_capture_service.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tools/symbol_physical_calibration.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/windows/SymbolPreviewWindow.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/windows/symbol_fixture_apply_presentation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/windows/symbol_fixture_applier.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/windows/symbol_preview_exporter.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dialogs/GenerateFixtureSymbolsDialog.cpp

--- a/gui/mainwindow_fixture_symbol_autoupdate.cpp
+++ b/gui/mainwindow_fixture_symbol_autoupdate.cpp
@@ -10,6 +10,7 @@
 #include "consolepanel.h"
 #include "fixture.h"
 #include "fixtures/fixture_gdtf_resolution.h"
+#include "filesystem_path_utils.h"
 #include "guiconfigservices.h"
 #include "opaque_pass_utils.h"
 #include "splashscreen.h"
@@ -445,9 +446,29 @@ void MainWindow::ProcessNextFixtureSymbolAutoUpdate() {
         ResolveFixtureSymbolCacheRequest(
             updatedFixtureIt->second, cfg.GetScene(), key, updatedCacheRequest,
             updatedCacheResolution, updatedCacheError);
-    if (resolvedFinalScene && !applyResult.finalSceneFingerprint.empty())
+    std::error_code scenePathError;
+    const bool finalSceneOwnershipConfirmed =
+        resolvedFinalScene && !updatedCacheResolution.scenePath.empty() &&
+        PathUtils::AreFilesystemPathsEquivalent(
+            std::filesystem::path(updatedCacheResolution.scenePath),
+            std::filesystem::path(applyResult.finalScenePath), scenePathError);
+    if (resolvedFinalScene && !finalSceneOwnershipConfirmed) {
+      std::ostringstream pathDiagnostic;
+      pathDiagnostic
+          << "resolved project archive '"
+          << std::filesystem::path(updatedCacheResolution.scenePath).filename().string()
+          << "' does not identify the validated archive '"
+          << std::filesystem::path(applyResult.finalScenePath).filename().string()
+          << "'";
+      if (scenePathError)
+        pathDiagnostic << " (filesystem check: " << scenePathError.message() << ")";
+      updatedCacheError = pathDiagnostic.str();
+    }
+    if (finalSceneOwnershipConfirmed &&
+        !applyResult.finalSceneFingerprint.empty())
       updatedCacheRequest.gdtfContentHash = applyResult.finalSceneFingerprint;
-    if (resolvedFinalScene && !applyResult.finalSceneFingerprint.empty() &&
+    if (finalSceneOwnershipConfirmed &&
+        !applyResult.finalSceneFingerprint.empty() &&
         symbol_preview::InspectFixtureSymbolState(updatedFixtureIt->second,
                                                   cfg.GetScene(),
                                                   updatedInspection,

--- a/gui/mainwindow_fixture_symbol_autoupdate.cpp
+++ b/gui/mainwindow_fixture_symbol_autoupdate.cpp
@@ -413,17 +413,15 @@ void MainWindow::ProcessNextFixtureSymbolAutoUpdate() {
     return;
   }
 
-  std::string applyError;
   symbol_preview::ApplySymbolsOptions applyOptions;
   applyOptions.updateSceneCopy = true;
   applyOptions.updateLibraryCopy = true;
-  if (symbol_preview::ApplySymbolsToFixtureGdtf(capture.symbols, fixtureUuid,
-                                                applyError, applyOptions)) {
-    std::string locationMessage = "scene";
-    if (!inspection.scenePath.empty() && !inspection.libraryPath.empty())
-      locationMessage = "scene and library";
-    else if (!inspection.libraryPath.empty())
-      locationMessage = "library";
+  const symbol_preview::ApplySymbolsResult applyResult =
+      symbol_preview::ApplySymbolsToFixtureGdtfWithResult(
+          capture.symbols, fixtureUuid, applyOptions);
+  if (applyResult.success && applyResult.sceneUpdated) {
+    const std::string locationMessage =
+        applyResult.libraryUpdated ? "scene and library" : "scene";
 
     ReportFixtureAutoUpdate(*this, consolePanel,
                             "Fixture symbol auto-update: symbols generated for '" +
@@ -431,16 +429,25 @@ void MainWindow::ProcessNextFixtureSymbolAutoUpdate() {
                                 " GDTF updated.",
                             false);
     cfg.MarkDirty();
+    for (const std::string &warning : applyResult.warnings) {
+      ReportFixtureAutoUpdate(
+          *this, consolePanel,
+          "Fixture symbol auto-update: library synchronization warning for '" +
+              fixtureLabel + "' (" + warning + ").");
+    }
     symbol_cache::ValidationRequest updatedCacheRequest;
     gui::fixtures::FixtureGdtfResolution updatedCacheResolution;
     std::string updatedCacheError;
     symbol_preview::FixtureSymbolInspectionResult updatedInspection;
     const auto updatedFixtureIt = cfg.GetScene().fixtures.find(fixtureUuid);
-    if (updatedFixtureIt != cfg.GetScene().fixtures.end() &&
-        ResolveFixtureSymbolCacheRequest(updatedFixtureIt->second, cfg.GetScene(),
-                                         key, updatedCacheRequest,
-                                         updatedCacheResolution,
-                                         updatedCacheError) &&
+    const bool resolvedFinalScene =
+        updatedFixtureIt != cfg.GetScene().fixtures.end() &&
+        ResolveFixtureSymbolCacheRequest(
+            updatedFixtureIt->second, cfg.GetScene(), key, updatedCacheRequest,
+            updatedCacheResolution, updatedCacheError);
+    if (resolvedFinalScene && !applyResult.finalSceneFingerprint.empty())
+      updatedCacheRequest.gdtfContentHash = applyResult.finalSceneFingerprint;
+    if (resolvedFinalScene && !applyResult.finalSceneFingerprint.empty() &&
         symbol_preview::InspectFixtureSymbolState(updatedFixtureIt->second,
                                                   cfg.GetScene(),
                                                   updatedInspection,
@@ -466,8 +473,9 @@ void MainWindow::ProcessNextFixtureSymbolAutoUpdate() {
     ReportFixtureAutoUpdate(
         *this, consolePanel,
         "Fixture symbol auto-update: failed to apply symbols for '" + fixtureLabel +
-            "' (" + (applyError.empty() ? std::string("unknown apply error")
-                                         : applyError) +
+            "' (" + (applyResult.diagnostic.empty()
+                           ? std::string("project-owned GDTF was not updated")
+                           : applyResult.diagnostic) +
             ").",
         false);
     fixtureSymbolAutoUpdateErrors.push_back("Apply failed for '" + fixtureLabel +

--- a/gui/windows/SymbolPreviewWindow.cpp
+++ b/gui/windows/SymbolPreviewWindow.cpp
@@ -13,6 +13,7 @@
 
 #include "mainwindow.h"
 #include "windows/symbol_fixture_applier.h"
+#include "windows/symbol_fixture_apply_presentation.h"
 #include "windows/symbol_preview_exporter.h"
 
 namespace {
@@ -188,18 +189,23 @@ void SymbolPreviewWindow::OnExportSelectedView(wxCommandEvent &WXUNUSED(event)) 
 
 
 void SymbolPreviewWindow::OnApplySymbolToFixture(wxCommandEvent &WXUNUSED(event)) {
-  std::string errorMessage;
-  if (!symbol_preview::ApplySymbolsToFixtureGdtf(symbols_, fixtureUuid_, errorMessage)) {
-    wxMessageBox(errorMessage, "Apply Views to Fixture", wxOK | wxICON_ERROR,
-                 this);
+  const symbol_preview::ApplySymbolsResult result =
+      symbol_preview::ApplySymbolsToFixtureGdtfWithResult(symbols_, fixtureUuid_);
+  const symbol_preview::ApplySymbolsPresentation presentation =
+      symbol_preview::BuildApplySymbolsPresentation(result);
+  if (presentation.kind == symbol_preview::ApplySymbolsMessageKind::Error) {
+    wxMessageBox(presentation.message, "Apply Views to Fixture",
+                 wxOK | wxICON_ERROR, this);
     return;
   }
 
   if (MainWindow *mainWindow = MainWindow::Instance())
     mainWindow->RefreshAfterFixtureSymbolUpdate();
 
-  wxMessageBox("Symbol views applied to fixture GDTF successfully.\nCheck the file in your fixtures library.",
-               "Apply Views to Fixture", wxOK | wxICON_INFORMATION, this);
+  const long icon = presentation.kind == symbol_preview::ApplySymbolsMessageKind::Warning
+                        ? wxICON_WARNING
+                        : wxICON_INFORMATION;
+  wxMessageBox(presentation.message, "Apply Views to Fixture", wxOK | icon, this);
 }
 
 void SymbolPreviewWindow::OnPaint(wxPaintEvent &WXUNUSED(event)) {

--- a/gui/windows/symbol_fixture_applier.cpp
+++ b/gui/windows/symbol_fixture_applier.cpp
@@ -664,6 +664,23 @@ GdtfRewriteResult RewriteGdtfWithProof(
   }
 
   result.atomicReplacementCompleted = true;
+  if (!VerifyArchiveEntries(sourcePath, payloads)) {
+    result.diagnostic =
+        "The replaced GDTF archive did not pass generated SVG post-validation.";
+    return result;
+  }
+  symbol_cache::InvalidateGdtfSemanticFingerprintCache(sourcePath.string());
+  std::string validationError;
+  const std::string validatedFingerprint =
+      symbol_cache::ComputeGdtfSemanticFingerprint(sourcePath.string(),
+                                                   validationError);
+  if (validatedFingerprint.empty() ||
+      validatedFingerprint != result.finalSemanticFingerprint) {
+    result.diagnostic = validationError.empty()
+                            ? "The replaced GDTF archive fingerprint did not match the validated mutation."
+                            : validationError;
+    return result;
+  }
   std::error_code metadataError;
   result.finalFileSize = fs::file_size(sourcePath, metadataError);
   metadataError.clear();
@@ -689,16 +706,39 @@ bool RewriteGdtf(const fs::path &sourcePath,
   return result.success;
 }
 
+// Determines whether two resolved paths identify the same physical archive.
+bool PathsReferToSameFile(const fs::path &left, const fs::path &right) {
+  if (left.empty() || right.empty())
+    return false;
+  std::error_code ec;
+  const bool equivalent = fs::equivalent(left, right, ec);
+  if (!ec)
+    return equivalent;
+  ec.clear();
+  const fs::path canonicalLeft = fs::weakly_canonical(left, ec);
+  if (ec)
+    return false;
+  ec.clear();
+  const fs::path canonicalRight = fs::weakly_canonical(right, ec);
+  return !ec && canonicalLeft == canonicalRight;
+}
+
 } // namespace
 
-// Applies generated SVG symbol views to the selected fixture GDTF.
-bool ApplySymbolsToFixtureGdtf(const std::vector<symbols::Symbol2D> &symbols,
-                               const std::string &fixtureUuid,
-                               std::string &errorMessage,
-                               const ApplySymbolsOptions &options) {
+// Applies generated SVG symbol views and reports scene and library ownership separately.
+ApplySymbolsResult ApplySymbolsToFixtureGdtfWithResult(
+    const std::vector<symbols::Symbol2D> &symbols,
+    const std::string &fixtureUuid,
+    const ApplySymbolsOptions &options) {
+  ApplySymbolsResult result;
+  std::string errorMessage;
+  if (!options.updateSceneCopy && !options.updateLibraryCopy) {
+    result.diagnostic = "No fixture GDTF persistence target was requested.";
+    return result;
+  }
   if (fixtureUuid.empty()) {
-    errorMessage = "No fixture was selected for this symbol preview.";
-    return false;
+    result.diagnostic = "No fixture was selected for this symbol preview.";
+    return result;
   }
 
   ConfigManager &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
@@ -707,22 +747,26 @@ bool ApplySymbolsToFixtureGdtf(const std::vector<symbols::Symbol2D> &symbols,
   auto fixtureIt = fixtures.find(fixtureUuid);
   if (fixtureIt == fixtures.end()) {
     errorMessage = "Could not resolve the selected fixture in the scene.";
-    return false;
+    result.diagnostic = "Could not resolve the selected fixture in the scene.";
+    return result;
   }
 
   gui::fixtures::FixtureGdtfResolution resolution;
   if (!gui::fixtures::ResolveFixtureGdtfDeterministic(fixtureIt->second, scene,
                                                       resolution, errorMessage,
                                                       "apply")) {
-    return false;
+    result.diagnostic = errorMessage;
+    return result;
   }
   const std::string scenePath = resolution.scenePath;
   const std::string libraryPath = resolution.libraryPath;
 
   const std::string inspectPath = resolution.selectedPath;
   std::string modelSvgBase = ResolveModelSvgBasename(inspectPath, errorMessage);
-  if (modelSvgBase.empty())
-    return false;
+  if (modelSvgBase.empty()) {
+    result.diagnostic = errorMessage;
+    return result;
+  }
 
   const std::string topSvgPath = "models/svg/" + modelSvgBase + ".svg";
   const std::string sideSvgPath = "models/svg_side/" + modelSvgBase + ".svg";
@@ -757,7 +801,8 @@ bool ApplySymbolsToFixtureGdtf(const std::vector<symbols::Symbol2D> &symbols,
   if (payloads.empty()) {
     errorMessage =
         "No valid symbol views were available to apply to the fixture.";
-    return false;
+    result.diagnostic = errorMessage;
+    return result;
   }
 
   std::string writableScenePath = scenePath;
@@ -768,37 +813,21 @@ bool ApplySymbolsToFixtureGdtf(const std::vector<symbols::Symbol2D> &symbols,
     if (!EnsureSceneLocalGdtfCopy(fs::path(writableScenePath), fs::path(scene.basePath),
                                   fixtureIt->second, writableScenePath,
                                   errorMessage)) {
-      return false;
+      result.diagnostic = errorMessage;
+      return result;
     }
   }
 
-  if (options.updateSceneCopy && writableScenePath.empty() && !scene.basePath.empty() &&
-      (libraryPath.empty() || !options.updateLibraryCopy)) {
+  if (options.updateSceneCopy && writableScenePath.empty() && !scene.basePath.empty()) {
     const std::string copySourcePath = !inspectPath.empty() ? inspectPath : libraryPath;
     if (!copySourcePath.empty()) {
       if (!EnsureSceneLocalGdtfCopy(fs::path(copySourcePath), fs::path(scene.basePath),
                                     fixtureIt->second, writableScenePath,
                                     errorMessage)) {
-        return false;
+        result.diagnostic = errorMessage;
+        return result;
       }
     }
-  }
-
-  if (options.updateLibraryCopy && !libraryPath.empty() &&
-      !fixtureIt->second.typeName.empty()) {
-    auto derivative = GdtfDictionary::CreateOrUpdatePerastageLibraryDerivative(
-        fixtureIt->second.typeName, libraryPath, fixtureIt->second.gdtfMode,
-        fixtureIt->second.category);
-    if (!derivative || derivative->path.empty()) {
-      errorMessage = "Could not create the Perastage library fixture derivative.";
-      return false;
-    }
-    if (!RewriteGdtf(derivative->path, payloads, topSvgPath, sideSvgPath,
-                     frontSvgPath, bottomSvgPath, errorMessage)) {
-      return false;
-    }
-    fixtureIt->second.gdtfSpec = fs::path(derivative->path).filename().string();
-    return true;
   }
 
   if (options.updateSceneCopy && !writableScenePath.empty()) {
@@ -807,22 +836,74 @@ bool ApplySymbolsToFixtureGdtf(const std::vector<symbols::Symbol2D> &symbols,
       if (!EnsureSceneLocalGdtfCopy(fs::path(writableScenePath), fs::path(scene.basePath),
                                     fixtureIt->second, writableScenePath,
                                     errorMessage)) {
-        return false;
+        result.diagnostic = errorMessage;
+        return result;
       }
     }
-    if (!RewriteGdtf(writableScenePath, payloads, topSvgPath, sideSvgPath, frontSvgPath,
-                     bottomSvgPath, errorMessage)) {
-      return false;
+    const GdtfRewriteResult rewrite = RewriteGdtfWithProof(
+        writableScenePath, payloads, topSvgPath, sideSvgPath, frontSvgPath,
+        bottomSvgPath);
+    if (!rewrite.success) {
+      result.diagnostic = rewrite.diagnostic;
+      return result;
     }
     sceneUpdated = true;
+    result.sceneUpdated = true;
+    result.finalScenePath = rewrite.finalArchivePath.string();
+    result.finalSceneFingerprint = rewrite.finalSemanticFingerprint;
   }
 
-  if (!sceneUpdated) {
+  if (options.updateSceneCopy && !sceneUpdated) {
     errorMessage = "Could not resolve a project-owned fixture GDTF copy to update.";
-    return false;
+    result.diagnostic = "Could not resolve a project-owned fixture GDTF copy to update.";
+    return result;
   }
 
-  return true;
+  if (options.updateLibraryCopy) {
+    const std::string librarySource = result.sceneUpdated ? result.finalScenePath : inspectPath;
+    auto derivative = GdtfDictionary::CreateOrUpdatePerastageLibraryDerivative(
+        fixtureIt->second.typeName, librarySource, fixtureIt->second.gdtfMode,
+        fixtureIt->second.category);
+    if (!derivative || derivative->path.empty()) {
+      const std::string warning =
+          "Could not synchronize the Perastage library fixture derivative.";
+      if (options.updateSceneCopy)
+        result.warnings.push_back(warning);
+      else
+        result.diagnostic = warning;
+    } else {
+      result.finalLibraryPath = derivative->path;
+      if (PathsReferToSameFile(result.finalScenePath, derivative->path)) {
+        result.libraryUpdated = result.sceneUpdated;
+      } else if (result.sceneUpdated) {
+        // The derivative was copied from the already validated project archive.
+        symbol_cache::PublishGdtfSemanticFingerprintCache(
+            derivative->path, result.finalSceneFingerprint);
+        result.libraryUpdated = true;
+      } else if (RewriteGdtf(derivative->path, payloads, topSvgPath, sideSvgPath,
+                             frontSvgPath, bottomSvgPath, errorMessage)) {
+        result.libraryUpdated = true;
+      } else {
+        result.diagnostic = errorMessage;
+      }
+    }
+  }
+
+  result.success = options.updateSceneCopy ? result.sceneUpdated : result.libraryUpdated;
+  if (!result.success && result.diagnostic.empty())
+    result.diagnostic = "The requested fixture GDTF persistence operation failed.";
+  return result;
+}
+
+// Applies generated SVG symbol views through the compatibility boolean contract.
+bool ApplySymbolsToFixtureGdtf(const std::vector<symbols::Symbol2D> &symbols,
+                               const std::string &fixtureUuid,
+                               std::string &errorMessage,
+                               const ApplySymbolsOptions &options) {
+  const ApplySymbolsResult result =
+      ApplySymbolsToFixtureGdtfWithResult(symbols, fixtureUuid, options);
+  errorMessage = result.diagnostic;
+  return result.success;
 }
 
 

--- a/gui/windows/symbol_fixture_applier.cpp
+++ b/gui/windows/symbol_fixture_applier.cpp
@@ -24,6 +24,7 @@
 
 #include "configmanager.h"
 #include "fixtures/fixture_gdtf_resolution.h"
+#include "filesystem_path_utils.h"
 #include "guiconfigservices.h"
 #include "gdtfdictionary.h"
 #include "gdtf_mutation_audit.h"
@@ -706,23 +707,6 @@ bool RewriteGdtf(const fs::path &sourcePath,
   return result.success;
 }
 
-// Determines whether two resolved paths identify the same physical archive.
-bool PathsReferToSameFile(const fs::path &left, const fs::path &right) {
-  if (left.empty() || right.empty())
-    return false;
-  std::error_code ec;
-  const bool equivalent = fs::equivalent(left, right, ec);
-  if (!ec)
-    return equivalent;
-  ec.clear();
-  const fs::path canonicalLeft = fs::weakly_canonical(left, ec);
-  if (ec)
-    return false;
-  ec.clear();
-  const fs::path canonicalRight = fs::weakly_canonical(right, ec);
-  return !ec && canonicalLeft == canonicalRight;
-}
-
 } // namespace
 
 // Applies generated SVG symbol views and reports scene and library ownership separately.
@@ -873,7 +857,10 @@ ApplySymbolsResult ApplySymbolsToFixtureGdtfWithResult(
         result.diagnostic = warning;
     } else {
       result.finalLibraryPath = derivative->path;
-      if (PathsReferToSameFile(result.finalScenePath, derivative->path)) {
+      std::error_code pathError;
+      if (PathUtils::AreFilesystemPathsEquivalent(
+              fs::path(result.finalScenePath), fs::path(derivative->path),
+              pathError)) {
         result.libraryUpdated = result.sceneUpdated;
       } else if (result.sceneUpdated) {
         // The derivative was copied from the already validated project archive.

--- a/gui/windows/symbol_fixture_applier.h
+++ b/gui/windows/symbol_fixture_applier.h
@@ -40,7 +40,7 @@ bool InspectFixtureSymbolState(const Fixture &fixture,
                                FixtureSymbolInspectionResult &result,
                                std::string &errorMessage);
 
-// Applies generated SVG symbol views into fixture GDTF archives.
+// Applies generated SVG views through a boolean contract that cannot report warnings.
 // This mutation path must comply with docs/developer/gdtf_mutation_policy.md
 // (Perastage audit metadata, revision stamping, and compatibility fallback).
 bool ApplySymbolsToFixtureGdtf(const std::vector<symbols::Symbol2D> &symbols,

--- a/gui/windows/symbol_fixture_applier.h
+++ b/gui/windows/symbol_fixture_applier.h
@@ -14,6 +14,17 @@ struct ApplySymbolsOptions {
   bool updateLibraryCopy = true;
 };
 
+struct ApplySymbolsResult {
+  bool success = false;
+  bool sceneUpdated = false;
+  bool libraryUpdated = false;
+  std::string finalScenePath;
+  std::string finalLibraryPath;
+  std::string finalSceneFingerprint;
+  std::vector<std::string> warnings;
+  std::string diagnostic;
+};
+
 struct FixtureSymbolInspectionResult {
   bool hasResolvableGdtf = false;
   bool editorIsPerastage = false;
@@ -36,6 +47,12 @@ bool ApplySymbolsToFixtureGdtf(const std::vector<symbols::Symbol2D> &symbols,
                                const std::string &fixtureUuid,
                                std::string &errorMessage,
                                const ApplySymbolsOptions &options = {});
+
+// Applies generated SVG views and reports each requested persistence outcome.
+ApplySymbolsResult ApplySymbolsToFixtureGdtfWithResult(
+    const std::vector<symbols::Symbol2D> &symbols,
+    const std::string &fixtureUuid,
+    const ApplySymbolsOptions &options = {});
 
 bool SyncFixtureGdtfToLibrary(const Fixture &fixture,
                               const MvrScene &scene,

--- a/gui/windows/symbol_fixture_apply_presentation.cpp
+++ b/gui/windows/symbol_fixture_apply_presentation.cpp
@@ -1,0 +1,40 @@
+#include "windows/symbol_fixture_apply_presentation.h"
+
+namespace symbol_preview {
+
+// Formats fixture-symbol persistence outcomes without overstating archive ownership.
+ApplySymbolsPresentation BuildApplySymbolsPresentation(
+    const ApplySymbolsResult &result) {
+  ApplySymbolsPresentation presentation;
+  if (!result.success || !result.sceneUpdated) {
+    presentation.kind = ApplySymbolsMessageKind::Error;
+    presentation.message = result.diagnostic.empty()
+                               ? "The project fixture GDTF was not updated."
+                               : result.diagnostic;
+    if (result.libraryUpdated)
+      presentation.message += " The library-only update was not project persistence.";
+    return presentation;
+  }
+
+  if (result.libraryUpdated) {
+    presentation.kind = ApplySymbolsMessageKind::Success;
+    presentation.message =
+        "Symbol views were applied to the project fixture GDTF and the fixture library derivative.";
+    return presentation;
+  }
+
+  presentation.kind = result.warnings.empty() ? ApplySymbolsMessageKind::Success
+                                               : ApplySymbolsMessageKind::Warning;
+  presentation.message = "Symbol views were applied to the project fixture GDTF.";
+  if (!result.warnings.empty()) {
+    presentation.message += " Fixture library synchronization failed: ";
+    for (std::size_t i = 0; i < result.warnings.size(); ++i) {
+      if (i > 0)
+        presentation.message += " | ";
+      presentation.message += result.warnings[i];
+    }
+  }
+  return presentation;
+}
+
+} // namespace symbol_preview

--- a/gui/windows/symbol_fixture_apply_presentation.h
+++ b/gui/windows/symbol_fixture_apply_presentation.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <string>
+
+#include "windows/symbol_fixture_applier.h"
+
+namespace symbol_preview {
+
+enum class ApplySymbolsMessageKind { Success, Warning, Error };
+
+struct ApplySymbolsPresentation {
+  ApplySymbolsMessageKind kind = ApplySymbolsMessageKind::Error;
+  std::string message;
+};
+
+// Formats fixture-symbol persistence outcomes without depending on GUI controls.
+ApplySymbolsPresentation BuildApplySymbolsPresentation(
+    const ApplySymbolsResult &result);
+
+} // namespace symbol_preview

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1963,6 +1963,7 @@ add_executable(symbol_fixture_applier_gdtf_test symbol_fixture_applier_gdtf_test
                ../gui/windows/symbol_preview_exporter.cpp
                ../core/configmanager.cpp
                ../core/configservices.cpp
+               ../core/filesystem_path_utils.cpp
                ../core/guiconfigservices.cpp
                ../core/gdtfdictionary.cpp
                ../core/gdtf_fixture_category.cpp
@@ -2003,6 +2004,14 @@ target_include_directories(symbol_fixture_applier_gdtf_test PRIVATE
 target_link_libraries(symbol_fixture_applier_gdtf_test PRIVATE ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2 perastage_test_gdtf_archive_reader)
 add_test(NAME SymbolFixtureApplierGdtfMutation COMMAND symbol_fixture_applier_gdtf_test)
 set_library_env(SymbolFixtureApplierGdtfMutation)
+
+add_executable(symbol_fixture_apply_presentation_test
+               symbol_fixture_apply_presentation_test.cpp
+               ../gui/windows/symbol_fixture_apply_presentation.cpp)
+target_include_directories(symbol_fixture_apply_presentation_test PRIVATE
+                           ../core ../models ../gui)
+add_test(NAME SymbolFixtureApplyPresentation
+         COMMAND symbol_fixture_apply_presentation_test)
 
 add_executable(mvr_patched_gdtf_export_test mvr_patched_gdtf_export_test.cpp
                support/gdtf_test_fixture_builder.cpp

--- a/tests/symbol_fixture_applier_gdtf_test.cpp
+++ b/tests/symbol_fixture_applier_gdtf_test.cpp
@@ -23,6 +23,7 @@
 #include "../core/configmanager.h"
 #include "../core/gdtfdictionary.h"
 #include "../core/gdtf_mutation_audit.h"
+#include "../core/symbol_cache_manifest.h"
 #include "../core/symbols/Symbol2D.h"
 #include "../gui/windows/symbol_fixture_applier.h"
 #include "../models/fixture.h"
@@ -44,6 +45,39 @@ std::string ReadCurrentZipEntry(wxZipInputStream &zip) {
     content.append(buffer, bytes);
   }
   return content;
+}
+
+// Counts standard revisions created by fixture-symbol application in an archive.
+std::size_t CountSymbolMutationRevisions(const fs::path &archivePath) {
+  wxFileInputStream input(archivePath.string());
+  assert(input.IsOk());
+  wxZipInputStream zip(input);
+  std::unique_ptr<wxZipEntry> entry;
+  std::string descriptionXml;
+  while ((entry.reset(zip.GetNextEntry())), entry) {
+    if (!entry->IsDir() && entry->GetName() == "description.xml") {
+      descriptionXml = ReadCurrentZipEntry(zip);
+      break;
+    }
+  }
+  tinyxml2::XMLDocument document;
+  assert(document.Parse(descriptionXml.c_str(), descriptionXml.size()) ==
+         tinyxml2::XML_SUCCESS);
+  const tinyxml2::XMLElement *fixtureType =
+      document.FirstChildElement("GDTF")->FirstChildElement("FixtureType");
+  const tinyxml2::XMLElement *revisions = fixtureType->FirstChildElement("Revisions");
+  std::size_t count = 0;
+  if (!revisions)
+    return count;
+  for (const tinyxml2::XMLElement *revision =
+           revisions->FirstChildElement("Revision");
+       revision; revision = revision->NextSiblingElement("Revision")) {
+    const char *text = revision->Attribute("Text");
+    if (text && std::string(text) ==
+                    "Applied fixture SVG symbol views (top, side, front, bottom)")
+      ++count;
+  }
+  return count;
 }
 
 // Writes a canonical minimal GDTF 1.2 archive for symbol mutation tests.
@@ -327,6 +361,43 @@ int main() {
   assert(!libraryOnlyResult.sceneUpdated);
   assert(libraryOnlyResult.libraryUpdated);
   assert(libraryOnlyResult.finalScenePath.empty());
+
+  const fs::path dictionaryAssets =
+      project.path / "fixture-symbol-dictionary_assets";
+  fs::create_directories(dictionaryAssets);
+  const fs::path sameFileArchive =
+      dictionaryAssets /
+      GdtfDictionary::BuildPerastageCanonicalGdtfFileName(gdtfPath);
+  fs::copy_file(gdtfPath, sameFileArchive,
+                fs::copy_options::overwrite_existing);
+  Fixture sameFileFixture;
+  sameFileFixture.uuid = "fixture-symbol-same-file";
+  sameFileFixture.typeName = "SameFileSymbolFixture";
+  sameFileFixture.gdtfSpec =
+      fs::relative(sameFileArchive, project.path).generic_string();
+  scene.fixtures[sameFileFixture.uuid] = sameFileFixture;
+  const std::size_t revisionsBefore =
+      CountSymbolMutationRevisions(sameFileArchive);
+  symbol_cache::ClearGdtfSemanticFingerprintCache();
+  const symbol_preview::ApplySymbolsResult sameFileResult =
+      symbol_preview::ApplySymbolsToFixtureGdtfWithResult(
+          symbols, sameFileFixture.uuid, dualOptions);
+  assert(sameFileResult.success);
+  assert(sameFileResult.sceneUpdated);
+  assert(sameFileResult.libraryUpdated);
+  std::error_code equivalenceError;
+  assert(fs::equivalent(sameFileResult.finalScenePath,
+                        sameFileResult.finalLibraryPath, equivalenceError));
+  assert(!equivalenceError);
+  assert(CountSymbolMutationRevisions(sameFileArchive) == revisionsBefore + 1);
+  assert(!InspectFixturePath("fixture-same-file-inspection",
+                             sameFileArchive.string())
+              .requiresSymbolGeneration);
+  std::string fingerprintError;
+  assert(symbol_cache::ComputeGdtfSemanticFingerprint(
+             sameFileArchive.string(), fingerprintError) ==
+         sameFileResult.finalSceneFingerprint);
+  assert(fingerprintError.empty());
 
   assert(GdtfDictionary::SetActiveDictionaryFilePath(previousDictionaryPath,
                                                      &errorMessage));

--- a/tests/symbol_fixture_applier_gdtf_test.cpp
+++ b/tests/symbol_fixture_applier_gdtf_test.cpp
@@ -21,6 +21,7 @@
 #include "support/gdtf_test_fixture_builder.h"
 
 #include "../core/configmanager.h"
+#include "../core/gdtfdictionary.h"
 #include "../core/gdtf_mutation_audit.h"
 #include "../core/symbols/Symbol2D.h"
 #include "../gui/windows/symbol_fixture_applier.h"
@@ -172,12 +173,20 @@ int main() {
   symbol_preview::ApplySymbolsOptions options;
   options.updateSceneCopy = true;
   options.updateLibraryCopy = false;
-  if (!symbol_preview::ApplySymbolsToFixtureGdtf(symbols, fixture.uuid, errorMessage,
-                                                 options)) {
-    std::cerr << "ApplySymbolsToFixtureGdtf failed: " << errorMessage << std::endl;
+  const symbol_preview::ApplySymbolsResult sceneResult =
+      symbol_preview::ApplySymbolsToFixtureGdtfWithResult(symbols, fixture.uuid,
+                                                          options);
+  if (!sceneResult.success) {
+    std::cerr << "ApplySymbolsToFixtureGdtf failed: " << sceneResult.diagnostic
+              << std::endl;
     assert(false);
   }
-  assert(errorMessage.empty());
+  assert(sceneResult.sceneUpdated);
+  assert(!sceneResult.libraryUpdated);
+  assert(!sceneResult.finalScenePath.empty());
+  assert(!sceneResult.finalSceneFingerprint.empty());
+  assert(sceneResult.warnings.empty());
+  assert(scene.fixtures.at(fixture.uuid).gdtfSpec.find("fixtures/") == 0);
 
   const std::string mutatedPath =
       (project.path / scene.fixtures.at(fixture.uuid).gdtfSpec).string();
@@ -260,6 +269,67 @@ int main() {
   assert(after.editorIsPerastage);
   assert(after.hasValidSvgSymbolSet);
   assert(!after.requiresSymbolGeneration);
+
+  symbol_preview::ApplySymbolsOptions invalidOptions;
+  invalidOptions.updateSceneCopy = false;
+  invalidOptions.updateLibraryCopy = false;
+  const symbol_preview::ApplySymbolsResult invalidResult =
+      symbol_preview::ApplySymbolsToFixtureGdtfWithResult(
+          symbols, fixture.uuid, invalidOptions);
+  assert(!invalidResult.success);
+  assert(!invalidResult.sceneUpdated);
+  assert(!invalidResult.libraryUpdated);
+  assert(invalidResult.diagnostic ==
+         "No fixture GDTF persistence target was requested.");
+
+  scene.fixtures.at(fixture.uuid).typeName.clear();
+  symbol_preview::ApplySymbolsOptions dualOptions;
+  dualOptions.updateSceneCopy = true;
+  dualOptions.updateLibraryCopy = true;
+  const symbol_preview::ApplySymbolsResult libraryFailureResult =
+      symbol_preview::ApplySymbolsToFixtureGdtfWithResult(
+          symbols, fixture.uuid, dualOptions);
+  assert(libraryFailureResult.success);
+  assert(libraryFailureResult.sceneUpdated);
+  assert(!libraryFailureResult.libraryUpdated);
+  assert(!libraryFailureResult.finalSceneFingerprint.empty());
+  assert(libraryFailureResult.warnings.size() == 1);
+  scene.fixtures.at(fixture.uuid).typeName = fixture.typeName;
+
+  const std::string previousDictionaryPath =
+      GdtfDictionary::GetActiveDictionaryFilePath();
+  const fs::path dictionaryPath = project.path / "fixture-symbol-dictionary.json";
+  assert(GdtfDictionary::CreateEmptyDictionaryFile(dictionaryPath.string(),
+                                                   &errorMessage));
+  assert(GdtfDictionary::SetActiveDictionaryFilePath(dictionaryPath.string(),
+                                                     &errorMessage));
+
+  const symbol_preview::ApplySymbolsResult dualResult =
+      symbol_preview::ApplySymbolsToFixtureGdtfWithResult(
+          symbols, fixture.uuid, dualOptions);
+  assert(dualResult.success);
+  assert(dualResult.sceneUpdated);
+  assert(dualResult.libraryUpdated);
+  assert(!dualResult.finalScenePath.empty());
+  assert(!dualResult.finalLibraryPath.empty());
+  assert(scene.fixtures.at(fixture.uuid).gdtfSpec.find("fixtures/") == 0);
+  assert(!InspectFixturePath("fixture-library-inspection",
+                             dualResult.finalLibraryPath)
+              .requiresSymbolGeneration);
+
+  symbol_preview::ApplySymbolsOptions libraryOnlyOptions;
+  libraryOnlyOptions.updateSceneCopy = false;
+  libraryOnlyOptions.updateLibraryCopy = true;
+  const symbol_preview::ApplySymbolsResult libraryOnlyResult =
+      symbol_preview::ApplySymbolsToFixtureGdtfWithResult(
+          symbols, fixture.uuid, libraryOnlyOptions);
+  assert(libraryOnlyResult.success);
+  assert(!libraryOnlyResult.sceneUpdated);
+  assert(libraryOnlyResult.libraryUpdated);
+  assert(libraryOnlyResult.finalScenePath.empty());
+
+  assert(GdtfDictionary::SetActiveDictionaryFilePath(previousDictionaryPath,
+                                                     &errorMessage));
 
   const std::string currentVersionPath = MakeFixtureGdtfFromFixtureTypeXml(
       "<FixtureType Name=\"Current\" Manufacturer=\"Acme\" Editor=\"Vendor\">"

--- a/tests/symbol_fixture_applier_gdtf_test.cpp
+++ b/tests/symbol_fixture_applier_gdtf_test.cpp
@@ -25,6 +25,7 @@
 #include "../core/gdtf_mutation_audit.h"
 #include "../core/symbol_cache_manifest.h"
 #include "../core/symbols/Symbol2D.h"
+#include "../core/wx_path_utils.h"
 #include "../gui/windows/symbol_fixture_applier.h"
 #include "../models/fixture.h"
 #include "../viewer3d/gdtfloader.h"
@@ -47,21 +48,38 @@ std::string ReadCurrentZipEntry(wxZipInputStream &zip) {
   return content;
 }
 
-// Counts standard revisions created by fixture-symbol application in an archive.
-std::size_t CountSymbolMutationRevisions(const fs::path &archivePath) {
-  wxFileInputStream input(archivePath.string());
+struct ArchiveSnapshot {
+  std::unordered_set<std::string> entries;
+  std::string descriptionXml;
+};
+
+// Reads archive data while keeping all wxWidgets stream lifetimes inside the helper.
+ArchiveSnapshot ReadArchiveSnapshot(const fs::path &archivePath) {
+  ArchiveSnapshot snapshot;
+  wxFileInputStream input(
+      WxPathUtils::WxStringFromFilesystemPath(archivePath));
   assert(input.IsOk());
   wxZipInputStream zip(input);
   std::unique_ptr<wxZipEntry> entry;
-  std::string descriptionXml;
   while ((entry.reset(zip.GetNextEntry())), entry) {
-    if (!entry->IsDir() && entry->GetName() == "description.xml") {
-      descriptionXml = ReadCurrentZipEntry(zip);
-      break;
-    }
+    if (entry->IsDir())
+      continue;
+    const auto logicalName = tests::archive::NormalizePresentedArchivePath(
+        entry->GetName().ToStdString());
+    assert(logicalName.ok);
+    snapshot.entries.insert(logicalName.path);
+    if (logicalName.path == "description.xml")
+      snapshot.descriptionXml = ReadCurrentZipEntry(zip);
   }
+  return snapshot;
+}
+
+// Counts standard revisions created by fixture-symbol application in an archive.
+std::size_t CountSymbolMutationRevisions(const fs::path &archivePath) {
+  const ArchiveSnapshot snapshot = ReadArchiveSnapshot(archivePath);
   tinyxml2::XMLDocument document;
-  assert(document.Parse(descriptionXml.c_str(), descriptionXml.size()) ==
+  assert(document.Parse(snapshot.descriptionXml.c_str(),
+                        snapshot.descriptionXml.size()) ==
          tinyxml2::XML_SUCCESS);
   const tinyxml2::XMLElement *fixtureType =
       document.FirstChildElement("GDTF")->FirstChildElement("FixtureType");
@@ -173,6 +191,50 @@ public:
   fs::path path;
 };
 
+// Restores the active fixture dictionary when the scenario scope exits.
+class ScopedFixtureDictionary {
+public:
+  // Captures the dictionary path that must be restored after the test.
+  ScopedFixtureDictionary()
+      : previousPath_(GdtfDictionary::GetActiveDictionaryFilePath()) {}
+
+  // Restores the captured dictionary path before temporary files are removed.
+  ~ScopedFixtureDictionary() {
+    if (!changed_)
+      return;
+    std::string errorMessage;
+    if (!GdtfDictionary::SetActiveDictionaryFilePath(previousPath_, &errorMessage))
+      std::cerr << "Could not restore fixture dictionary: " << errorMessage << '\n';
+  }
+
+  // Activates a temporary fixture dictionary for the scoped scenarios.
+  bool Activate(const fs::path &dictionaryPath, std::string &errorMessage) {
+    changed_ = GdtfDictionary::SetActiveDictionaryFilePath(
+        dictionaryPath.string(), &errorMessage);
+    return changed_;
+  }
+
+private:
+  std::string previousPath_;
+  bool changed_ = false;
+};
+
+// Reports a structured application result when an expected condition fails.
+void ReportUnexpectedApplyResult(
+    const symbol_preview::ApplySymbolsResult &result, bool expected) {
+  if (expected)
+    return;
+  std::cerr << "Apply result: success=" << result.success
+            << " sceneUpdated=" << result.sceneUpdated
+            << " libraryUpdated=" << result.libraryUpdated
+            << " diagnostic='" << result.diagnostic << "'"
+            << " scene='" << result.finalScenePath << "'"
+            << " library='" << result.finalLibraryPath << "'";
+  for (const std::string &warning : result.warnings)
+    std::cerr << " warning='" << warning << "'";
+  std::cerr << '\n';
+}
+
 } // namespace
 
 // Runs the symbol-to-GDTF mutation ownership and compatibility regression test.
@@ -184,6 +246,7 @@ int main() {
   cfg.Reset();
   MvrScene &scene = cfg.GetScene();
   ScopedTempProject project;
+  ScopedFixtureDictionary dictionaryGuard;
   scene.basePath = project.path.string();
 
   const std::string gdtfSpec = MakeFixtureGdtf(project.path);
@@ -210,11 +273,13 @@ int main() {
   const symbol_preview::ApplySymbolsResult sceneResult =
       symbol_preview::ApplySymbolsToFixtureGdtfWithResult(symbols, fixture.uuid,
                                                           options);
-  if (!sceneResult.success) {
-    std::cerr << "ApplySymbolsToFixtureGdtf failed: " << sceneResult.diagnostic
-              << std::endl;
-    assert(false);
-  }
+  ReportUnexpectedApplyResult(
+      sceneResult, sceneResult.success && sceneResult.sceneUpdated &&
+                       !sceneResult.libraryUpdated &&
+                       !sceneResult.finalScenePath.empty() &&
+                       !sceneResult.finalSceneFingerprint.empty() &&
+                       sceneResult.warnings.empty());
+  assert(sceneResult.success);
   assert(sceneResult.sceneUpdated);
   assert(!sceneResult.libraryUpdated);
   assert(!sceneResult.finalScenePath.empty());
@@ -225,28 +290,17 @@ int main() {
   const std::string mutatedPath =
       (project.path / scene.fixtures.at(fixture.uuid).gdtfSpec).string();
 
-  wxFileInputStream input(mutatedPath);
-  assert(input.IsOk());
-  wxZipInputStream zipInput(input);
+  const ArchiveSnapshot mutatedSnapshot =
+      ReadArchiveSnapshot(fs::path(mutatedPath));
 
-  std::unordered_set<std::string> entries;
-  std::string descriptionXml;
-  std::unique_ptr<wxZipEntry> entry;
-  while ((entry.reset(zipInput.GetNextEntry())), entry) {
-    if (entry->IsDir())
-      continue;
-    const auto logicalName =
-        tests::archive::NormalizePresentedArchivePath(entry->GetName().ToStdString());
-    assert(logicalName.ok);
-    entries.insert(logicalName.path);
-    if (logicalName.path == "description.xml")
-      descriptionXml = ReadCurrentZipEntry(zipInput);
-  }
-
-  assert(entries.find("models/svg/Body.svg") != entries.end());
-  assert(entries.find("models/svg/Body_bottom.svg") != entries.end());
-  assert(entries.find("models/svg_side/Body.svg") != entries.end());
-  assert(entries.find("models/svg_front/Body.svg") != entries.end());
+  assert(mutatedSnapshot.entries.find("models/svg/Body.svg") !=
+         mutatedSnapshot.entries.end());
+  assert(mutatedSnapshot.entries.find("models/svg/Body_bottom.svg") !=
+         mutatedSnapshot.entries.end());
+  assert(mutatedSnapshot.entries.find("models/svg_side/Body.svg") !=
+         mutatedSnapshot.entries.end());
+  assert(mutatedSnapshot.entries.find("models/svg_front/Body.svg") !=
+         mutatedSnapshot.entries.end());
 
   std::string rawNameError;
   const std::vector<std::string> rawNames =
@@ -264,7 +318,8 @@ int main() {
   }
 
   tinyxml2::XMLDocument doc;
-  assert(doc.Parse(descriptionXml.c_str(), descriptionXml.size()) ==
+  assert(doc.Parse(mutatedSnapshot.descriptionXml.c_str(),
+                   mutatedSnapshot.descriptionXml.size()) ==
          tinyxml2::XML_SUCCESS);
 
   tinyxml2::XMLElement *fixtureType = doc.FirstChildElement("GDTF");
@@ -310,6 +365,11 @@ int main() {
   const symbol_preview::ApplySymbolsResult invalidResult =
       symbol_preview::ApplySymbolsToFixtureGdtfWithResult(
           symbols, fixture.uuid, invalidOptions);
+  ReportUnexpectedApplyResult(
+      invalidResult, !invalidResult.success && !invalidResult.sceneUpdated &&
+                         !invalidResult.libraryUpdated &&
+                         invalidResult.diagnostic ==
+                             "No fixture GDTF persistence target was requested.");
   assert(!invalidResult.success);
   assert(!invalidResult.sceneUpdated);
   assert(!invalidResult.libraryUpdated);
@@ -323,6 +383,12 @@ int main() {
   const symbol_preview::ApplySymbolsResult libraryFailureResult =
       symbol_preview::ApplySymbolsToFixtureGdtfWithResult(
           symbols, fixture.uuid, dualOptions);
+  ReportUnexpectedApplyResult(libraryFailureResult,
+                              libraryFailureResult.success &&
+                                  libraryFailureResult.sceneUpdated &&
+                                  !libraryFailureResult.libraryUpdated &&
+                                  !libraryFailureResult.finalSceneFingerprint.empty() &&
+                                  libraryFailureResult.warnings.size() == 1);
   assert(libraryFailureResult.success);
   assert(libraryFailureResult.sceneUpdated);
   assert(!libraryFailureResult.libraryUpdated);
@@ -330,17 +396,19 @@ int main() {
   assert(libraryFailureResult.warnings.size() == 1);
   scene.fixtures.at(fixture.uuid).typeName = fixture.typeName;
 
-  const std::string previousDictionaryPath =
-      GdtfDictionary::GetActiveDictionaryFilePath();
   const fs::path dictionaryPath = project.path / "fixture-symbol-dictionary.json";
   assert(GdtfDictionary::CreateEmptyDictionaryFile(dictionaryPath.string(),
                                                    &errorMessage));
-  assert(GdtfDictionary::SetActiveDictionaryFilePath(dictionaryPath.string(),
-                                                     &errorMessage));
+  assert(dictionaryGuard.Activate(dictionaryPath, errorMessage));
 
   const symbol_preview::ApplySymbolsResult dualResult =
       symbol_preview::ApplySymbolsToFixtureGdtfWithResult(
           symbols, fixture.uuid, dualOptions);
+  ReportUnexpectedApplyResult(
+      dualResult, dualResult.success && dualResult.sceneUpdated &&
+                      dualResult.libraryUpdated &&
+                      !dualResult.finalScenePath.empty() &&
+                      !dualResult.finalLibraryPath.empty());
   assert(dualResult.success);
   assert(dualResult.sceneUpdated);
   assert(dualResult.libraryUpdated);
@@ -357,6 +425,11 @@ int main() {
   const symbol_preview::ApplySymbolsResult libraryOnlyResult =
       symbol_preview::ApplySymbolsToFixtureGdtfWithResult(
           symbols, fixture.uuid, libraryOnlyOptions);
+  ReportUnexpectedApplyResult(
+      libraryOnlyResult,
+      libraryOnlyResult.success && !libraryOnlyResult.sceneUpdated &&
+          libraryOnlyResult.libraryUpdated &&
+          libraryOnlyResult.finalScenePath.empty());
   assert(libraryOnlyResult.success);
   assert(!libraryOnlyResult.sceneUpdated);
   assert(libraryOnlyResult.libraryUpdated);
@@ -382,6 +455,9 @@ int main() {
   const symbol_preview::ApplySymbolsResult sameFileResult =
       symbol_preview::ApplySymbolsToFixtureGdtfWithResult(
           symbols, sameFileFixture.uuid, dualOptions);
+  ReportUnexpectedApplyResult(
+      sameFileResult, sameFileResult.success && sameFileResult.sceneUpdated &&
+                          sameFileResult.libraryUpdated);
   assert(sameFileResult.success);
   assert(sameFileResult.sceneUpdated);
   assert(sameFileResult.libraryUpdated);
@@ -398,9 +474,6 @@ int main() {
              sameFileArchive.string(), fingerprintError) ==
          sameFileResult.finalSceneFingerprint);
   assert(fingerprintError.empty());
-
-  assert(GdtfDictionary::SetActiveDictionaryFilePath(previousDictionaryPath,
-                                                     &errorMessage));
 
   const std::string currentVersionPath = MakeFixtureGdtfFromFixtureTypeXml(
       "<FixtureType Name=\"Current\" Manufacturer=\"Acme\" Editor=\"Vendor\">"

--- a/tests/symbol_fixture_apply_presentation_test.cpp
+++ b/tests/symbol_fixture_apply_presentation_test.cpp
@@ -1,0 +1,50 @@
+#include <cassert>
+#include <string>
+
+#include "../gui/windows/symbol_fixture_apply_presentation.h"
+
+// Verifies that apply-result messages preserve project and library ownership semantics.
+int main() {
+  symbol_preview::ApplySymbolsResult complete;
+  complete.success = true;
+  complete.sceneUpdated = true;
+  complete.libraryUpdated = true;
+  const auto completeMessage =
+      symbol_preview::BuildApplySymbolsPresentation(complete);
+  assert(completeMessage.kind == symbol_preview::ApplySymbolsMessageKind::Success);
+  assert(completeMessage.message.find("project fixture GDTF") != std::string::npos);
+  assert(completeMessage.message.find("library derivative") != std::string::npos);
+
+  symbol_preview::ApplySymbolsResult warning = complete;
+  warning.libraryUpdated = false;
+  warning.warnings = {"dictionary storage is unavailable"};
+  const auto warningMessage =
+      symbol_preview::BuildApplySymbolsPresentation(warning);
+  assert(warningMessage.kind == symbol_preview::ApplySymbolsMessageKind::Warning);
+  assert(warningMessage.message.find("project fixture GDTF") != std::string::npos);
+  assert(warningMessage.message.find("synchronization failed") != std::string::npos);
+  assert(warningMessage.message.find("and the fixture library derivative") ==
+         std::string::npos);
+
+  symbol_preview::ApplySymbolsResult failure;
+  failure.diagnostic = "scene replacement failed";
+  const auto failureMessage =
+      symbol_preview::BuildApplySymbolsPresentation(failure);
+  assert(failureMessage.kind == symbol_preview::ApplySymbolsMessageKind::Error);
+  assert(failureMessage.message == failure.diagnostic);
+
+  symbol_preview::ApplySymbolsResult libraryOnly;
+  libraryOnly.success = true;
+  libraryOnly.libraryUpdated = true;
+  const auto libraryOnlyMessage =
+      symbol_preview::BuildApplySymbolsPresentation(libraryOnly);
+  assert(libraryOnlyMessage.kind == symbol_preview::ApplySymbolsMessageKind::Error);
+  assert(libraryOnlyMessage.message.find("not project persistence") !=
+         std::string::npos);
+
+  const auto fallbackMessage =
+      symbol_preview::BuildApplySymbolsPresentation({});
+  assert(fallbackMessage.kind == symbol_preview::ApplySymbolsMessageKind::Error);
+  assert(!fallbackMessage.message.empty());
+  return 0;
+}


### PR DESCRIPTION
### Motivation

- Fix a correctness bug where a library-only early return could bypass writing and validating the project-owned GDTF, causing generated fixture symbols to be lost or repeatedly regenerated on reload.
- Make scene vs library persistence outcomes explicit so the project archive is authoritative and library synchronization cannot silently invalidate project persistence.

### Description

- Introduce a structured `ApplySymbolsResult` and `ApplySymbolsToFixtureGdtfWithResult(...)` so callers receive explicit `sceneUpdated`, `libraryUpdated`, `finalScenePath`, `finalLibraryPath`, `finalSceneFingerprint`, `warnings`, and `diagnostic` outcomes while keeping the boolean compatibility wrapper `ApplySymbolsToFixtureGdtf(...)`. (files: `gui/windows/symbol_fixture_applier.h`, `gui/windows/symbol_fixture_applier.cpp`)
- Enforce ownership rules by committing and post-validating the project-owned GDTF first (atomic replacement, archive-entry verification, semantic-fingerprint validation and cache publication), then performing optional library synchronization from the validated scene result, and reporting library failures as warnings without invalidating the scene commit. (file: `gui/windows/symbol_fixture_applier.cpp`)
- Avoid duplicate writes when scene and library resolve to the same canonical file, invalidate/publish semantic-fingerprint cache correctly for replaced archives, and add a canonical path-equivalence helper. (file: `gui/windows/symbol_fixture_applier.cpp`)
- Update GUI auto-update flow to consume the structured result, mark the project symbol cache only from the validated scene copy (using the final scene fingerprint), re-resolve the fixture after application, and surface library sync warnings separately. (file: `gui/mainwindow_fixture_symbol_autoupdate.cpp`)
- Add regression tests covering scene-only, library-only, dual-target, same-file resolution, invalid options, and non-fatal library-failure scenarios, plus small test helpers to inspect final archive entries and fingerprints. (file: `tests/symbol_fixture_applier_gdtf_test.cpp`)
- Add a short developer note about fixture symbol persistence ownership and a release-note entry clarifying the fix without claiming any visual changes. (files: `docs/developer/technical-notes/gdtf_mutation_audit.md`, `docs/release-notes-draft.md`)

### Testing

- `tests/check_perastage_tree_modules.sh` ran and passed successfully.
- `tests/check_no_configmanager_get_in_gui.sh` ran and passed successfully.
- `git diff --check` ran and reported no issues.
- Attempting full CMake configuration with `cmake --preset wsl-x64-release` failed in this environment due to missing `wxWidgets` (environment limitation), so the C++ test build and runtime tests could not be executed here.  
- Attempting to build the test target (e.g. `symbol_fixture_applier_gdtf_test`) could not run because the project could not be configured in this environment (missing GUI libraries).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6dbf62e8c88324ad014250ebf1d4f8)