### PR TITLE
Guarantee fixture-symbol persistence across project roundtrips

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -64,6 +64,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/print/PageSetup.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/print/Viewer2DPrintSettings.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/projectutils.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/project_symbol_cache_snapshot.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/rigging_extra_weight_settings.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/riderimporter.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/scene_grouping.cpp

--- a/core/configmanager.cpp
+++ b/core/configmanager.cpp
@@ -661,11 +661,12 @@ const std::string &ConfigManager::GetLastProjectSaveError() const {
 // Loads a project package and restores optional symbol cache metadata.
 bool ConfigManager::LoadProject(const std::string &path,
                                 LoadProjectProgressCallback progressCallback) {
+  symbol_cache::SymbolCacheManifest restoredSymbolManifest;
   std::string manifestError;
-  if (!symbolCacheManifest.LoadFromProjectArchive(path, manifestError)) {
+  if (!restoredSymbolManifest.LoadFromProjectArchive(path, manifestError)) {
     Logger::Instance().Log(Logger::Level::Warn,
                            "Ignoring symbol cache manifest: " + manifestError);
-    symbolCacheManifest.Clear();
+    restoredSymbolManifest.Clear();
   }
 
   const bool hasUserView2dDarkMode = HasKey("view2d_dark_mode");
@@ -716,6 +717,7 @@ bool ConfigManager::LoadProject(const std::string &path,
       });
 
   if (ok) {
+    symbolCacheManifest = std::move(restoredSymbolManifest);
     const auto normalization =
         project_identity::NormalizeFixtureLabelOverrides(
             GetValue(project_identity::kFixtureLabelOverridesConfigKey),

--- a/core/configmanager.cpp
+++ b/core/configmanager.cpp
@@ -24,6 +24,7 @@
 #include "mvrexporter.h"
 #include "mvrimporter.h"
 #include "project_fixture_identity.h"
+#include "project_symbol_cache_snapshot.h"
 #include "selection_movement_settings.h"
 #include "uuidutils.h"
 #include <filesystem>
@@ -529,6 +530,10 @@ bool ConfigManager::SaveProject(const std::string &path) {
            SerializeHiddenLayerChecks(layerVisibilityState.GetHiddenLayers()));
   SetValue(kHiddenFixtureTypesConfigKey,
            SerializeStringSet(GetHiddenFixtureTypes()));
+  const auto fixtureSymbolIdentities =
+      symbol_cache::CollectProjectFixtureSymbolIdentities(GetScene());
+  std::optional<symbol_cache::SymbolCacheManifest> pendingSymbolManifest;
+  std::string pendingSymbolManifestError;
   bool ok = projectSession.SaveProject(
       path, [this](std::vector<uint8_t> &configBytes) {
         UserPreferencesStore serializationSnapshot = preferencesStore;
@@ -581,8 +586,25 @@ bool ConfigManager::SaveProject(const std::string &path) {
         }
         return exported;
       },
-      [this]() {
-        std::vector<ProjectSession::ArchiveResource> resources;
+      [this, &fixtureSymbolIdentities, &pendingSymbolManifest,
+       &pendingSymbolManifestError](
+          const std::vector<std::uint8_t> &sceneBytes,
+          std::vector<ProjectSession::ArchiveResource> &resources,
+          std::string &errorMessage) {
+        const auto snapshot = symbol_cache::BuildProjectSymbolCacheSnapshot(
+            sceneBytes, fixtureSymbolIdentities, &symbolCacheManifest);
+        if (!snapshot.sceneValid) {
+          errorMessage = snapshot.errorMessage.empty()
+                             ? "Could not validate packaged fixture GDTFs."
+                             : snapshot.errorMessage;
+          return false;
+        }
+        for (const std::string &warning : snapshot.warnings) {
+          Logger::Instance().Log(
+              Logger::Level::Warn,
+              "Project symbol cache snapshot omitted fixture: " + warning);
+        }
+        pendingSymbolManifest = snapshot.manifest;
         for (const auto &entry :
              layouts::LayoutImageResourceRegistry::Get().UsedResources()) {
           resources.push_back({entry.archivePath, entry.bytes});
@@ -590,27 +612,44 @@ bool ConfigManager::SaveProject(const std::string &path) {
 
         std::string manifestError;
         if (auto manifestResource =
-                symbolCacheManifest.ToArchiveResource(manifestError)) {
-          resources.push_back(
-              {manifestResource->entryName, std::move(manifestResource->bytes)});
+                pendingSymbolManifest->ToArchiveResource(manifestError)) {
+          resources.push_back({manifestResource->entryName,
+                               std::move(manifestResource->bytes), true});
         } else if (!manifestError.empty()) {
-          Logger::Instance().Log(Logger::Level::Warn,
-                                 "Could not serialize symbol cache manifest: " +
-                                     manifestError);
+          pendingSymbolManifestError = manifestError;
+          errorMessage = "Could not serialize validated symbol cache manifest: " +
+                         manifestError;
+          return false;
         }
         if (projectArchiveResourceProvider) {
-          auto providedResources = projectArchiveResourceProvider();
-          resources.insert(resources.end(),
-                           std::make_move_iterator(providedResources.begin()),
-                           std::make_move_iterator(providedResources.end()));
+          try {
+            auto providedResources = projectArchiveResourceProvider();
+            resources.insert(resources.end(),
+                             std::make_move_iterator(providedResources.begin()),
+                             std::make_move_iterator(providedResources.end()));
+          } catch (const std::exception &exception) {
+            Logger::Instance().Log(
+                Logger::Level::Warn,
+                std::string("Optional project resources skipped: ") +
+                    exception.what());
+          } catch (...) {
+            Logger::Instance().Log(
+                Logger::Level::Warn,
+                "Optional project resources skipped: unknown error");
+          }
         }
-        return resources;
+        return true;
       });
-  if (ok)
+  if (ok) {
+    if (pendingSymbolManifest)
+      symbolCacheManifest = std::move(*pendingSymbolManifest);
     projectSession.MarkSaved();
-  else
+  } else {
     lastProjectSaveError =
-        "Project archive could not be written. See the diagnostic log for the failing save stage.";
+        pendingSymbolManifestError.empty()
+            ? "Project archive could not be written. See the diagnostic log for the failing save stage."
+            : pendingSymbolManifestError;
+  }
   return ok;
 }
 

--- a/core/configservices.cpp
+++ b/core/configservices.cpp
@@ -17,6 +17,7 @@
 #include <memory>
 #include <sstream>
 #include <string_view>
+#include <unordered_set>
 #include <iterator>
 
 #include <wx/stdpaths.h>
@@ -765,7 +766,8 @@ const MvrScene &ProjectSession::GetScene() const { return scene; }
 bool ProjectSession::SaveProject(
     const std::string &path, const SaveConfigToBufferFn &saveConfigToBuffer,
     const SaveSceneToBufferFn &saveSceneToBuffer) const {
-  return SaveProject(path, saveConfigToBuffer, saveSceneToBuffer, {});
+  return SaveProject(path, saveConfigToBuffer, saveSceneToBuffer,
+                     CollectArchiveResourcesFromSceneFn{});
 }
 
 // Saves a project package with additional resource entries supplied by the caller.
@@ -773,6 +775,34 @@ bool ProjectSession::SaveProject(
     const std::string &path, const SaveConfigToBufferFn &saveConfigToBuffer,
     const SaveSceneToBufferFn &saveSceneToBuffer,
     const CollectArchiveResourcesFn &collectResources) const {
+  CollectArchiveResourcesFromSceneFn adapter;
+  if (collectResources) {
+    adapter = [collectResources](const std::vector<std::uint8_t> &,
+                                 std::vector<ArchiveResource> &resources,
+                                 std::string &) {
+      try {
+        resources = collectResources();
+      } catch (const std::exception &error) {
+        Logger::Instance().Log(Logger::Level::Warn,
+                               std::string("Optional project resources skipped: ") +
+                                   error.what());
+        resources.clear();
+      } catch (...) {
+        Logger::Instance().Log(Logger::Level::Warn,
+                               "Optional project resources skipped: unknown error");
+        resources.clear();
+      }
+      return true;
+    };
+  }
+  return SaveProject(path, saveConfigToBuffer, saveSceneToBuffer, adapter);
+}
+
+// Saves a project package with resources transactionally derived from scene.mvr bytes.
+bool ProjectSession::SaveProject(
+    const std::string &path, const SaveConfigToBufferFn &saveConfigToBuffer,
+    const SaveSceneToBufferFn &saveSceneToBuffer,
+    const CollectArchiveResourcesFromSceneFn &collectResources) const {
   if (!saveConfigToBuffer || !saveSceneToBuffer)
     return LogProjectSaveFailure("ValidateCallbacks",
                                  "missing config or scene serializer");
@@ -851,21 +881,41 @@ bool ProjectSession::SaveProject(
   const auto resourcesStart = std::chrono::steady_clock::now();
   std::vector<ArchiveResource> resourceEntries;
   if (collectResources) {
+    std::string resourceError;
     try {
-      resourceEntries = collectResources();
+      if (!collectResources(sceneBytes, resourceEntries, resourceError)) {
+        return LogProjectSaveFailure(
+            "CollectRequiredResources",
+            resourceError.empty() ? "transactional resource collection failed"
+                                  : resourceError);
+      }
     } catch (const std::exception &e) {
-      Logger::Instance().Log(Logger::Level::Warn,
-                             std::string("Optional project resources skipped: ") +
-                                 e.what());
-      resourceEntries.clear();
+      return LogProjectSaveFailure("CollectRequiredResources", e.what());
     } catch (...) {
-      Logger::Instance().Log(Logger::Level::Warn,
-                             "Optional project resources skipped: unknown error");
-      resourceEntries.clear();
+      return LogProjectSaveFailure("CollectRequiredResources", "unknown error");
     }
   }
+  std::unordered_set<std::string> writtenResourceNames = {
+      "config.json", "scene.mvr"};
   for (const auto &resource : resourceEntries) {
+    const std::string resourceIdentity = ToLowerCopy(resource.entryName);
+    if (!writtenResourceNames.insert(resourceIdentity).second) {
+      if (resource.required) {
+        return LogProjectSaveFailure("WriteRequiredResource",
+                                     "transactional resource path is duplicated",
+                                     resource.entryName);
+      }
+      Logger::Instance().Log(Logger::Level::Warn,
+                             "Skipping duplicate optional project resource '" +
+                                 resource.entryName + "'.");
+      continue;
+    }
     if (!WriteZipBytes(zip, resource.entryName, resource.bytes)) {
+      if (resource.required) {
+        return LogProjectSaveFailure("WriteRequiredResource",
+                                     "could not write transactional resource",
+                                     resource.entryName);
+      }
       Logger::Instance().Log(Logger::Level::Warn,
                              "Skipping optional project resource '" +
                                  resource.entryName + "' because it could not be written.");

--- a/core/configservices.h
+++ b/core/configservices.h
@@ -151,11 +151,16 @@ public:
   struct ArchiveResource {
     std::string entryName;
     std::vector<std::uint8_t> bytes;
+    bool required = false;
   };
 
   using LoadProgressFn =
       std::function<void(const std::string &stage, int completed, int total)>;
   using CollectArchiveResourcesFn = std::function<std::vector<ArchiveResource>()>;
+  using CollectArchiveResourcesFromSceneFn =
+      std::function<bool(const std::vector<std::uint8_t> &sceneBytes,
+                         std::vector<ArchiveResource> &resources,
+                         std::string &errorMessage)>;
 
   MvrScene &GetScene();
   const MvrScene &GetScene() const;
@@ -169,6 +174,11 @@ public:
                    const SaveConfigToBufferFn &saveConfigToBuffer,
                    const SaveSceneToBufferFn &saveSceneToBuffer,
                    const CollectArchiveResourcesFn &collectResources) const;
+  bool SaveProject(
+      const std::string &path,
+      const SaveConfigToBufferFn &saveConfigToBuffer,
+      const SaveSceneToBufferFn &saveSceneToBuffer,
+      const CollectArchiveResourcesFromSceneFn &collectResources) const;
   bool LoadProject(const std::string &path, const LoadConfigFn &loadConfig,
                    const LoadSceneFn &loadScene,
                    const LoadProgressFn &progress = {});

--- a/core/project_symbol_cache_snapshot.cpp
+++ b/core/project_symbol_cache_snapshot.cpp
@@ -59,6 +59,127 @@ std::string FoldAscii(std::string value) {
   return value;
 }
 
+// Converts a wx archive name to UTF-8 without consulting the process locale.
+std::string ArchiveNameToUtf8(const wxArchiveEntry &entry) {
+  const wxString name = entry.GetName(wxPATH_UNIX);
+  const wxScopedCharBuffer utf8 = name.utf8_str();
+  return utf8.data() ? std::string(utf8.data()) : std::string{};
+}
+
+// Reads a little-endian 16-bit value from ZIP metadata.
+std::uint16_t ReadLe16(const std::uint8_t *bytes) {
+  return static_cast<std::uint16_t>(bytes[0]) |
+         (static_cast<std::uint16_t>(bytes[1]) << 8);
+}
+
+// Reads a little-endian 32-bit value from ZIP metadata.
+std::uint32_t ReadLe32(const std::uint8_t *bytes) {
+  return static_cast<std::uint32_t>(bytes[0]) |
+         (static_cast<std::uint32_t>(bytes[1]) << 8) |
+         (static_cast<std::uint32_t>(bytes[2]) << 16) |
+         (static_cast<std::uint32_t>(bytes[3]) << 24);
+}
+
+// Preflights raw central-directory names before wxWidgets presents normalized paths.
+bool ValidateRawArchiveNames(const std::vector<std::uint8_t> &bytes,
+                             std::string &errorMessage) {
+  constexpr std::uint32_t kEndSignature = 0x06054b50;
+  constexpr std::uint32_t kCentralSignature = 0x02014b50;
+  if (bytes.size() < 22) {
+    errorMessage = "Archive central directory is malformed.";
+    return false;
+  }
+  const std::size_t searchStart =
+      bytes.size() > 65557 ? bytes.size() - 65557 : 0;
+  std::size_t endOffset = bytes.size() - 22;
+  bool foundEnd = false;
+  while (true) {
+    if (ReadLe32(bytes.data() + endOffset) == kEndSignature &&
+        endOffset + 22ULL + ReadLe16(bytes.data() + endOffset + 20) ==
+            bytes.size()) {
+      foundEnd = true;
+      break;
+    }
+    if (endOffset == searchStart)
+      break;
+    --endOffset;
+  }
+  if (!foundEnd) {
+    errorMessage = "Archive central directory is malformed.";
+    return false;
+  }
+  const std::uint16_t entryCount = ReadLe16(bytes.data() + endOffset + 10);
+  const std::uint32_t centralSize = ReadLe32(bytes.data() + endOffset + 12);
+  const std::uint32_t centralOffset = ReadLe32(bytes.data() + endOffset + 16);
+  if (centralOffset > endOffset || centralSize > endOffset - centralOffset) {
+    errorMessage = "Archive central directory is malformed.";
+    return false;
+  }
+  std::size_t cursor = centralOffset;
+  std::unordered_set<std::string> identities;
+  for (std::uint16_t index = 0; index < entryCount; ++index) {
+    if (cursor > endOffset || endOffset - cursor < 46 ||
+        ReadLe32(bytes.data() + cursor) != kCentralSignature) {
+      errorMessage = "Archive central directory is malformed.";
+      return false;
+    }
+    const std::uint16_t nameLength = ReadLe16(bytes.data() + cursor + 28);
+    const std::uint16_t extraLength = ReadLe16(bytes.data() + cursor + 30);
+    const std::uint16_t commentLength = ReadLe16(bytes.data() + cursor + 32);
+    const std::uint32_t localOffset = ReadLe32(bytes.data() + cursor + 42);
+    const std::size_t recordSize =
+        46ULL + nameLength + extraLength + commentLength;
+    if (nameLength == 0 || recordSize > endOffset - cursor) {
+      errorMessage = "Archive central directory is malformed.";
+      return false;
+    }
+    std::string rawName(reinterpret_cast<const char *>(bytes.data() + cursor + 46),
+                        nameLength);
+    if (localOffset >= centralOffset || centralOffset - localOffset < 30 ||
+        ReadLe32(bytes.data() + localOffset) != 0x04034b50) {
+      errorMessage = "Archive local entry header is malformed.";
+      return false;
+    }
+    const std::uint16_t localNameLength = ReadLe16(bytes.data() + localOffset + 26);
+    const std::uint16_t localExtraLength = ReadLe16(bytes.data() + localOffset + 28);
+    if (30ULL + localNameLength + localExtraLength > centralOffset - localOffset) {
+      errorMessage = "Archive local entry header is malformed.";
+      return false;
+    }
+    const std::string localName(
+        reinterpret_cast<const char *>(bytes.data() + localOffset + 30),
+        localNameLength);
+    if (localName != rawName) {
+      errorMessage = "Archive local and central entry names do not match.";
+      return false;
+    }
+    const wxString decoded = wxString::FromUTF8(rawName.data(), rawName.size());
+    const wxScopedCharBuffer encoded = decoded.utf8_str();
+    if (encoded.data() == nullptr || std::string(encoded.data()) != rawName) {
+      errorMessage = "Archive contains a malformed UTF-8 entry name.";
+      return false;
+    }
+    const bool directory = rawName.back() == '/';
+    if (directory)
+      rawName.pop_back();
+    std::string normalized;
+    if (!NormalizeSafeArchivePath(rawName, normalized)) {
+      errorMessage = "Archive contains an unsafe or malformed entry path.";
+      return false;
+    }
+    if (!identities.insert(FoldAscii(normalized)).second) {
+      errorMessage = "Archive contains duplicate or ambiguous entry paths.";
+      return false;
+    }
+    cursor += recordSize;
+  }
+  if (cursor != static_cast<std::size_t>(centralOffset) + centralSize) {
+    errorMessage = "Archive central directory is malformed.";
+    return false;
+  }
+  return true;
+}
+
 // Reads the current ZIP entry into an immutable byte buffer.
 std::vector<std::uint8_t> ReadCurrentEntry(wxZipInputStream &zip) {
   std::vector<std::uint8_t> bytes;
@@ -83,6 +204,8 @@ bool ReadArchive(const std::vector<std::uint8_t> &bytes,
     errorMessage = "Archive payload is empty.";
     return false;
   }
+  if (!ValidateRawArchiveNames(bytes, errorMessage))
+    return false;
   wxMemoryInputStream memory(bytes.data(), bytes.size());
   wxZipInputStream zip(memory);
   std::unordered_set<std::string> identities;
@@ -93,7 +216,7 @@ bool ReadArchive(const std::vector<std::uint8_t> &bytes,
     if (entry->IsDir())
       continue;
     std::string path;
-    if (!NormalizeSafeArchivePath(entry->GetName().ToStdString(), path)) {
+    if (!NormalizeSafeArchivePath(ArchiveNameToUtf8(*entry), path)) {
       errorMessage = "Archive contains an unsafe or malformed entry path.";
       return false;
     }

--- a/core/project_symbol_cache_snapshot.cpp
+++ b/core/project_symbol_cache_snapshot.cpp
@@ -1,0 +1,374 @@
+#include "project_symbol_cache_snapshot.h"
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <filesystem>
+#include <map>
+#include <memory>
+#include <set>
+#include <unordered_map>
+#include <unordered_set>
+
+#include <tinyxml2.h>
+#include <wx/mstream.h>
+#include <wx/zipstrm.h>
+
+
+namespace symbol_cache {
+namespace {
+
+struct FixtureReference {
+  std::string uuid;
+  std::string gdtfSpec;
+};
+
+// Normalizes a portable archive entry and rejects unsafe or ambiguous spellings.
+bool NormalizeSafeArchivePath(const std::string &input, std::string &normalized) {
+  normalized.clear();
+  if (input.empty() || input.find('\\') != std::string::npos ||
+      input.front() == '/' || (input.size() >= 2 && input[1] == ':'))
+    return false;
+  bool priorSlash = false;
+  std::string component;
+  for (unsigned char ch : input) {
+    if (ch < 32 || ch == 127)
+      return false;
+    if (ch == '/') {
+      if (component.empty() || component == "." || component == ".." || priorSlash)
+        return false;
+      normalized += component + '/';
+      component.clear();
+      priorSlash = true;
+    } else {
+      component.push_back(static_cast<char>(ch));
+      priorSlash = false;
+    }
+  }
+  if (component.empty() || component == "." || component == "..")
+    return false;
+  normalized += component;
+  return true;
+}
+
+// Folds an archive identity for deterministic duplicate detection on every platform.
+std::string FoldAscii(std::string value) {
+  std::transform(value.begin(), value.end(), value.begin(), [](unsigned char ch) {
+    return static_cast<char>(std::tolower(ch));
+  });
+  return value;
+}
+
+// Reads the current ZIP entry into an immutable byte buffer.
+std::vector<std::uint8_t> ReadCurrentEntry(wxZipInputStream &zip) {
+  std::vector<std::uint8_t> bytes;
+  std::array<char, 8192> buffer{};
+  while (true) {
+    zip.Read(buffer.data(), buffer.size());
+    const std::size_t count = zip.LastRead();
+    if (count == 0)
+      break;
+    const auto *first = reinterpret_cast<const std::uint8_t *>(buffer.data());
+    bytes.insert(bytes.end(), first, first + count);
+  }
+  return bytes;
+}
+
+// Reads a ZIP payload while rejecting unsafe, duplicate, and case-colliding entries.
+bool ReadArchive(const std::vector<std::uint8_t> &bytes,
+                 std::map<std::string, std::vector<std::uint8_t>> &entries,
+                 std::string &errorMessage) {
+  entries.clear();
+  if (bytes.empty()) {
+    errorMessage = "Archive payload is empty.";
+    return false;
+  }
+  wxMemoryInputStream memory(bytes.data(), bytes.size());
+  wxZipInputStream zip(memory);
+  std::unordered_set<std::string> identities;
+  while (true) {
+    std::unique_ptr<wxZipEntry> entry(zip.GetNextEntry());
+    if (!entry)
+      break;
+    if (entry->IsDir())
+      continue;
+    std::string path;
+    if (!NormalizeSafeArchivePath(entry->GetName().ToStdString(), path)) {
+      errorMessage = "Archive contains an unsafe or malformed entry path.";
+      return false;
+    }
+    if (!identities.insert(FoldAscii(path)).second) {
+      errorMessage = "Archive contains duplicate or ambiguous entry paths.";
+      return false;
+    }
+    entries.emplace(path, ReadCurrentEntry(zip));
+  }
+  if (!zip.IsOk() && !zip.Eof()) {
+    errorMessage = "Archive payload could not be read completely.";
+    return false;
+  }
+  return true;
+}
+
+// Normalizes an MVR UUID for matching scene identities to exported XML nodes.
+std::string NormalizeUuid(std::string value) {
+  value.erase(std::remove_if(value.begin(), value.end(), [](unsigned char ch) {
+                return ch == '{' || ch == '}' || ch == '-' || std::isspace(ch);
+              }),
+              value.end());
+  return FoldAscii(std::move(value));
+}
+
+// Recursively collects fixture UUID and GDTFSpec pairs from MVR scene XML.
+void CollectFixtureReferences(tinyxml2::XMLElement *element,
+                              std::vector<FixtureReference> &references) {
+  for (tinyxml2::XMLElement *current = element; current;
+       current = current->NextSiblingElement()) {
+    tinyxml2::XMLElement *gdtf = current->FirstChildElement("GDTFSpec");
+    const char *uuid = current->Attribute("uuid");
+    if (uuid && gdtf && gdtf->GetText())
+      references.push_back({NormalizeUuid(uuid), gdtf->GetText()});
+    CollectFixtureReferences(current->FirstChildElement(), references);
+  }
+}
+
+// Resolves the preferred GDTF model used by the existing symbol inspection contract.
+const tinyxml2::XMLElement *ResolvePreferredModel(
+    const tinyxml2::XMLElement *fixtureType) {
+  const tinyxml2::XMLElement *models =
+      fixtureType ? fixtureType->FirstChildElement("Models") : nullptr;
+  const tinyxml2::XMLElement *fallback = nullptr;
+  for (const tinyxml2::XMLElement *model =
+           models ? models->FirstChildElement("Model") : nullptr;
+       model; model = model->NextSiblingElement("Model")) {
+    if (!fallback)
+      fallback = model;
+    const char *name = model->Attribute("Name");
+    if (name && std::string(name) == "Main")
+      return model;
+  }
+  return fallback;
+}
+
+// Reports whether legacy audit metadata identifies a Perastage mutation.
+bool HasPerastageAudit(const tinyxml2::XMLElement *fixtureType) {
+  const char *editor = fixtureType ? fixtureType->Attribute("Editor") : nullptr;
+  if (editor && (std::string(editor) == "Perastage" ||
+                 std::string(editor).rfind("Perastage ", 0) == 0))
+    return true;
+  const tinyxml2::XMLElement *revisions =
+      fixtureType ? fixtureType->FirstChildElement("Revisions") : nullptr;
+  for (const tinyxml2::XMLElement *revision =
+           revisions ? revisions->FirstChildElement("Revision") : nullptr;
+       revision; revision = revision->NextSiblingElement("Revision")) {
+    const char *modifiedBy = revision->Attribute("ModifiedBy");
+    if (modifiedBy &&
+        (std::string(modifiedBy) == "Perastage" ||
+         std::string(modifiedBy).rfind("Perastage ", 0) == 0))
+      return true;
+  }
+  return false;
+}
+
+// Validates the complete Perastage symbol set and computes its exact semantic hash.
+bool ValidatePackagedGdtf(const std::vector<std::uint8_t> &bytes,
+                          std::string &fingerprint,
+                          std::string &diagnostic) {
+  std::map<std::string, std::vector<std::uint8_t>> entries;
+  if (!ReadArchive(bytes, entries, diagnostic))
+    return false;
+  auto descriptionIt = std::find_if(entries.begin(), entries.end(), [](const auto &item) {
+    return FoldAscii(item.first) == "description.xml";
+  });
+  if (descriptionIt == entries.end()) {
+    diagnostic = "Packaged GDTF does not contain description.xml.";
+    return false;
+  }
+  tinyxml2::XMLDocument document;
+  if (document.Parse(reinterpret_cast<const char *>(descriptionIt->second.data()),
+                     descriptionIt->second.size()) != tinyxml2::XML_SUCCESS) {
+    diagnostic = "Packaged GDTF description.xml is malformed.";
+    return false;
+  }
+  const tinyxml2::XMLElement *fixtureType = document.FirstChildElement("GDTF");
+  fixtureType = fixtureType ? fixtureType->FirstChildElement("FixtureType")
+                            : document.FirstChildElement("FixtureType");
+  const tinyxml2::XMLElement *audit =
+      fixtureType ? fixtureType->FirstChildElement("PerastageMutationAudit") : nullptr;
+  int auditVersion = -1;
+  const bool hasKnownAudit =
+      audit && audit->QueryIntAttribute("SchemaVersion", &auditVersion) ==
+                   tinyxml2::XML_SUCCESS &&
+      auditVersion == 1;
+  const bool hasUnknownAudit = audit && !hasKnownAudit;
+  const bool perastageOwned =
+      hasKnownAudit || (!audit && HasPerastageAudit(fixtureType));
+  const tinyxml2::XMLElement *model = ResolvePreferredModel(fixtureType);
+  const char *file = model ? model->Attribute("File") : nullptr;
+  const char *name = model ? model->Attribute("Name") : nullptr;
+  const std::string base = file && *file ? file : (name && *name ? name : "main");
+  const std::set<std::string> required = {
+      FoldAscii("models/svg/" + base + ".svg"),
+      FoldAscii("models/svg/" + base + "_bottom.svg"),
+      FoldAscii("models/svg_front/" + base + ".svg"),
+      FoldAscii("models/svg_side/" + base + ".svg")};
+  std::set<std::string> present;
+  std::vector<GdtfSemanticFingerprintEntry> fingerprintEntries;
+  for (const auto &[path, payload] : entries) {
+    present.insert(FoldAscii(path));
+    fingerprintEntries.push_back({path, payload});
+  }
+  if (!perastageOwned ||
+      !std::includes(present.begin(), present.end(), required.begin(), required.end())) {
+    diagnostic = hasUnknownAudit
+                     ? "Packaged GDTF uses an unsupported Perastage mutation audit version."
+                     : "Packaged GDTF does not contain a proven complete Perastage symbol set.";
+    return false;
+  }
+  fingerprint = ComputeGdtfSemanticFingerprintFromEntries(fingerprintEntries, diagnostic);
+  return !fingerprint.empty();
+}
+
+// Finds a prior timestamp without accepting prior metadata as validation proof.
+std::string ProvenanceTimestamp(const SymbolCacheManifest *manifest,
+                                const std::string &fixtureKey) {
+  if (manifest) {
+    for (const auto &entry : manifest->Entries()) {
+      if (entry.fixtureKey == fixtureKey)
+        return entry.lastGenerationTimestampUtc;
+    }
+  }
+  return {};
+}
+
+} // namespace
+
+// Builds the stable fixture-type key shared by persistence and auto-update planning.
+std::string BuildFixtureSymbolCacheKey(const Fixture &fixture) {
+  if (!fixture.typeName.empty())
+    return fixture.typeName;
+  if (!fixture.gdtfSpec.empty()) {
+    std::string key = std::filesystem::path(fixture.gdtfSpec)
+                          .lexically_normal()
+                          .generic_string();
+    return key;
+  }
+  return {};
+}
+
+// Collects immutable fixture identities for exact packaged-scene validation.
+std::vector<ProjectFixtureSymbolIdentity>
+CollectProjectFixtureSymbolIdentities(const MvrScene &scene) {
+  std::vector<ProjectFixtureSymbolIdentity> identities;
+  identities.reserve(scene.fixtures.size());
+  for (const auto &[uuid, fixture] : scene.fixtures) {
+    const std::string key = BuildFixtureSymbolCacheKey(fixture);
+    if (!uuid.empty() && !key.empty())
+      identities.push_back({uuid, key, fixture.typeName});
+  }
+  return identities;
+}
+
+// Builds a manifest snapshot exclusively from GDTFs packaged in the supplied MVR bytes.
+ProjectSymbolCacheSnapshotResult BuildProjectSymbolCacheSnapshot(
+    const std::vector<std::uint8_t> &sceneMvrBytes,
+    const std::vector<ProjectFixtureSymbolIdentity> &fixtureIdentities,
+    const SymbolCacheManifest *provenanceManifest,
+    const std::string &newEntryTimestampUtc) {
+  ProjectSymbolCacheSnapshotResult result;
+  std::map<std::string, std::vector<std::uint8_t>> mvrEntries;
+  if (!ReadArchive(sceneMvrBytes, mvrEntries, result.errorMessage))
+    return result;
+  auto sceneIt = std::find_if(mvrEntries.begin(), mvrEntries.end(), [](const auto &item) {
+    return FoldAscii(item.first) == "generalscenedescription.xml";
+  });
+  if (sceneIt == mvrEntries.end()) {
+    result.errorMessage = "scene.mvr does not contain GeneralSceneDescription.xml.";
+    return result;
+  }
+  tinyxml2::XMLDocument sceneDocument;
+  if (sceneDocument.Parse(reinterpret_cast<const char *>(sceneIt->second.data()),
+                          sceneIt->second.size()) != tinyxml2::XML_SUCCESS) {
+    result.errorMessage = "scene.mvr GeneralSceneDescription.xml is malformed.";
+    return result;
+  }
+  std::vector<FixtureReference> references;
+  CollectFixtureReferences(sceneDocument.RootElement(), references);
+  std::unordered_map<std::string, std::string> gdtfByUuid;
+  for (const auto &reference : references)
+    gdtfByUuid.emplace(reference.uuid, reference.gdtfSpec);
+
+  std::set<std::string> processedKeys;
+  for (const auto &identity : fixtureIdentities) {
+    if (!processedKeys.insert(identity.fixtureKey).second)
+      continue;
+    ProjectSymbolSnapshotOutcome outcome;
+    outcome.fixtureKey = identity.fixtureKey;
+    const auto referenceIt = gdtfByUuid.find(NormalizeUuid(identity.fixtureUuid));
+    if (referenceIt == gdtfByUuid.end()) {
+      outcome.status = ProjectSymbolSnapshotStatus::MissingReference;
+      outcome.diagnostic = "Exported fixture has no identifiable packaged GDTF reference.";
+      ++result.missingCount;
+      ++result.omittedCount;
+      result.warnings.push_back(identity.fixtureKey + ": " + outcome.diagnostic);
+      result.outcomes.push_back(std::move(outcome));
+      continue;
+    }
+    std::string archivePath;
+    if (!NormalizeSafeArchivePath(referenceIt->second, archivePath)) {
+      result.errorMessage = "scene.mvr contains an unsafe fixture GDTF reference.";
+      return result;
+    }
+    const auto archiveIt = mvrEntries.find(archivePath);
+    if (archiveIt == mvrEntries.end()) {
+      outcome.status = ProjectSymbolSnapshotStatus::MissingArchive;
+      outcome.diagnostic = "Referenced GDTF is missing from scene.mvr.";
+      ++result.missingCount;
+      ++result.omittedCount;
+      result.warnings.push_back(identity.fixtureKey + ": " + outcome.diagnostic);
+      result.outcomes.push_back(std::move(outcome));
+      continue;
+    }
+    std::string fingerprint;
+    if (!ValidatePackagedGdtf(archiveIt->second, fingerprint, outcome.diagnostic)) {
+      outcome.status = ProjectSymbolSnapshotStatus::InvalidSymbols;
+      ++result.omittedCount;
+      result.warnings.push_back(identity.fixtureKey + ": " + outcome.diagnostic);
+      result.outcomes.push_back(std::move(outcome));
+      continue;
+    }
+    ValidationRequest request;
+    request.fixtureKey = identity.fixtureKey;
+    request.fixtureTypeName = identity.fixtureTypeName;
+#ifdef _WIN32
+    request.gdtfSpec = FoldAscii(archivePath);
+#else
+    request.gdtfSpec = archivePath;
+#endif
+    request.gdtfContentHash = fingerprint;
+    request.requiredViews = RequiredPerastageSymbolViews();
+    std::string timestamp = ProvenanceTimestamp(provenanceManifest, identity.fixtureKey);
+    if (timestamp.empty())
+      timestamp = newEntryTimestampUtc.empty() ? CurrentUtcTimestamp() : newEntryTimestampUtc;
+    result.manifest.MarkFixtureSymbolsValid(request, std::move(timestamp));
+    outcome.status = ProjectSymbolSnapshotStatus::Validated;
+    ++result.validatedCount;
+    result.outcomes.push_back(std::move(outcome));
+  }
+  result.sceneValid = true;
+  return result;
+}
+
+// Returns the validation requests that still require automatic inspection or generation.
+std::vector<std::size_t> PlanFixtureSymbolCacheMisses(
+    const SymbolCacheManifest &manifest,
+    const std::vector<ValidationRequest> &requests) {
+  std::vector<std::size_t> misses;
+  for (std::size_t index = 0; index < requests.size(); ++index) {
+    if (!manifest.ValidateFixture(requests[index]).valid)
+      misses.push_back(index);
+  }
+  return misses;
+}
+
+} // namespace symbol_cache

--- a/core/project_symbol_cache_snapshot.cpp
+++ b/core/project_symbol_cache_snapshot.cpp
@@ -173,6 +173,7 @@ bool HasPerastageAudit(const tinyxml2::XMLElement *fixtureType) {
 // Validates the complete Perastage symbol set and computes its exact semantic hash.
 bool ValidatePackagedGdtf(const std::vector<std::uint8_t> &bytes,
                           std::string &fingerprint,
+                          std::string &fixtureTypeName,
                           std::string &diagnostic) {
   std::map<std::string, std::vector<std::uint8_t>> entries;
   if (!ReadArchive(bytes, entries, diagnostic))
@@ -203,6 +204,8 @@ bool ValidatePackagedGdtf(const std::vector<std::uint8_t> &bytes,
   const bool hasUnknownAudit = audit && !hasKnownAudit;
   const bool perastageOwned =
       hasKnownAudit || (!audit && HasPerastageAudit(fixtureType));
+  const char *fixtureName = fixtureType ? fixtureType->Attribute("Name") : nullptr;
+  fixtureTypeName = fixtureName ? fixtureName : "";
   const tinyxml2::XMLElement *model = ResolvePreferredModel(fixtureType);
   const char *file = model ? model->Attribute("File") : nullptr;
   const char *name = model ? model->Attribute("Name") : nullptr;
@@ -298,9 +301,10 @@ ProjectSymbolCacheSnapshotResult BuildProjectSymbolCacheSnapshot(
   for (const auto &reference : references)
     gdtfByUuid.emplace(reference.uuid, reference.gdtfSpec);
 
-  std::set<std::string> processedKeys;
+  std::set<std::string> processedSourceKeys;
+  std::set<std::string> validatedKeys;
   for (const auto &identity : fixtureIdentities) {
-    if (!processedKeys.insert(identity.fixtureKey).second)
+    if (!processedSourceKeys.insert(identity.fixtureKey).second)
       continue;
     ProjectSymbolSnapshotOutcome outcome;
     outcome.fixtureKey = identity.fixtureKey;
@@ -330,21 +334,26 @@ ProjectSymbolCacheSnapshotResult BuildProjectSymbolCacheSnapshot(
       continue;
     }
     std::string fingerprint;
-    if (!ValidatePackagedGdtf(archiveIt->second, fingerprint, outcome.diagnostic)) {
+    std::string packagedFixtureTypeName;
+    if (!ValidatePackagedGdtf(archiveIt->second, fingerprint,
+                              packagedFixtureTypeName, outcome.diagnostic)) {
       outcome.status = ProjectSymbolSnapshotStatus::InvalidSymbols;
       ++result.omittedCount;
       result.warnings.push_back(identity.fixtureKey + ": " + outcome.diagnostic);
       result.outcomes.push_back(std::move(outcome));
       continue;
     }
+    const std::string manifestKey = packagedFixtureTypeName.empty()
+                                        ? identity.fixtureKey
+                                        : packagedFixtureTypeName;
+    if (!validatedKeys.insert(manifestKey).second)
+      continue;
     ValidationRequest request;
-    request.fixtureKey = identity.fixtureKey;
-    request.fixtureTypeName = identity.fixtureTypeName;
-#ifdef _WIN32
-    request.gdtfSpec = FoldAscii(archivePath);
-#else
+    request.fixtureKey = manifestKey;
+    request.fixtureTypeName = packagedFixtureTypeName.empty()
+                                  ? identity.fixtureTypeName
+                                  : packagedFixtureTypeName;
     request.gdtfSpec = archivePath;
-#endif
     request.gdtfContentHash = fingerprint;
     request.requiredViews = RequiredPerastageSymbolViews();
     std::string timestamp = ProvenanceTimestamp(provenanceManifest, identity.fixtureKey);

--- a/core/project_symbol_cache_snapshot.h
+++ b/core/project_symbol_cache_snapshot.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "fixture.h"
+#include "mvrscene.h"
+#include "symbol_cache_manifest.h"
+
+namespace symbol_cache {
+
+struct ProjectFixtureSymbolIdentity {
+  std::string fixtureUuid;
+  std::string fixtureKey;
+  std::string fixtureTypeName;
+};
+
+enum class ProjectSymbolSnapshotStatus {
+  Validated,
+  MissingReference,
+  MissingArchive,
+  InvalidSymbols,
+  Failed,
+};
+
+struct ProjectSymbolSnapshotOutcome {
+  std::string fixtureKey;
+  ProjectSymbolSnapshotStatus status = ProjectSymbolSnapshotStatus::Failed;
+  std::string diagnostic;
+};
+
+struct ProjectSymbolCacheSnapshotResult {
+  bool sceneValid = false;
+  SymbolCacheManifest manifest;
+  std::vector<ProjectSymbolSnapshotOutcome> outcomes;
+  std::vector<std::string> warnings;
+  std::size_t validatedCount = 0;
+  std::size_t omittedCount = 0;
+  std::size_t missingCount = 0;
+  std::size_t failedCount = 0;
+  std::string errorMessage;
+};
+
+// Builds the stable fixture-type key shared by persistence and auto-update planning.
+std::string BuildFixtureSymbolCacheKey(const Fixture &fixture);
+
+// Collects immutable fixture identities for exact packaged-scene validation.
+std::vector<ProjectFixtureSymbolIdentity>
+CollectProjectFixtureSymbolIdentities(const MvrScene &scene);
+
+// Builds a manifest snapshot exclusively from GDTFs packaged in the supplied MVR bytes.
+ProjectSymbolCacheSnapshotResult BuildProjectSymbolCacheSnapshot(
+    const std::vector<std::uint8_t> &sceneMvrBytes,
+    const std::vector<ProjectFixtureSymbolIdentity> &fixtureIdentities,
+    const SymbolCacheManifest *provenanceManifest = nullptr,
+    const std::string &newEntryTimestampUtc = {});
+
+// Returns the validation requests that still require automatic inspection or generation.
+std::vector<std::size_t> PlanFixtureSymbolCacheMisses(
+    const SymbolCacheManifest &manifest,
+    const std::vector<ValidationRequest> &requests);
+
+} // namespace symbol_cache

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -32,7 +32,8 @@ Changes since **v1.5.0**.
   files packaged in `scene.mvr` before recording symbol-cache metadata. Valid
   four-view symbols now survive an unchanged save and reload without redundant
   regeneration across platforms, including mixed-case and Unicode resource
-  paths, while stale or incomplete cache metadata is discarded safely.
+  paths and canonical nested ZIP entries, while stale or incomplete cache
+  metadata is discarded safely.
 
 - Fixed project persistence for automatically generated fixture symbols when
   both project and fixture-library copies are updated, preventing a library

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -32,8 +32,8 @@ Changes since **v1.5.0**.
   files packaged in `scene.mvr` before recording symbol-cache metadata. Valid
   four-view symbols now survive an unchanged save and reload without redundant
   regeneration across platforms, including mixed-case and Unicode resource
-  paths and canonical nested ZIP entries, while stale or incomplete cache
-  metadata is discarded safely.
+  paths and consistently decoded canonical nested ZIP entries, while stale or
+  incomplete cache metadata is discarded safely.
 
 - Fixed project persistence for automatically generated fixture symbols when
   both project and fixture-library copies are updated, preventing a library

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -28,6 +28,11 @@ Changes since **v1.5.0**.
 
 ## Important fixes
 
+- Fixed fixture-symbol persistence so project saves validate the exact GDTF
+  files packaged in `scene.mvr` before recording symbol-cache metadata. Valid
+  four-view symbols now survive an unchanged save and reload without redundant
+  regeneration, while stale or incomplete cache metadata is discarded safely.
+
 - Fixed project persistence for automatically generated fixture symbols when
   both project and fixture-library copies are updated, preventing a library
   synchronization issue from causing symbols to be regenerated after reload.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -31,7 +31,8 @@ Changes since **v1.5.0**.
 - Fixed fixture-symbol persistence so project saves validate the exact GDTF
   files packaged in `scene.mvr` before recording symbol-cache metadata. Valid
   four-view symbols now survive an unchanged save and reload without redundant
-  regeneration, while stale or incomplete cache metadata is discarded safely.
+  regeneration across platforms, including mixed-case and Unicode resource
+  paths, while stale or incomplete cache metadata is discarded safely.
 
 - Fixed project persistence for automatically generated fixture symbols when
   both project and fixture-library copies are updated, preventing a library

--- a/gui/mainwindow_fixture_symbol_autoupdate.cpp
+++ b/gui/mainwindow_fixture_symbol_autoupdate.cpp
@@ -13,6 +13,7 @@
 #include "filesystem_path_utils.h"
 #include "guiconfigservices.h"
 #include "opaque_pass_utils.h"
+#include "project_symbol_cache_snapshot.h"
 #include "splashscreen.h"
 #include "symbol_cache_manifest.h"
 #include "tools/scene_model_symbol_capture_service.h"
@@ -29,11 +30,7 @@ std::unordered_map<MainWindow *, wxEvtHandler *> g_statusTimerHandlers;
 
 // Builds a stable deduplication key for fixture symbol auto-update work items.
 std::string BuildFixtureAutoUpdateKey(const Fixture &fixture) {
-  if (!fixture.typeName.empty())
-    return fixture.typeName;
-  if (!fixture.gdtfSpec.empty())
-    return NormalizeModelKey(fixture.gdtfSpec);
-  return {};
+  return symbol_cache::BuildFixtureSymbolCacheKey(fixture);
 }
 
 // Builds a human-readable fixture label for progress and error reporting.

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -181,9 +181,6 @@ static std::string NormalizeArchivePathValue(const std::string &archivePath) {
     if (trimPos != gdtfPos)
       normalized.erase(trimPos, gdtfPos - trimPos);
   }
-#ifdef _WIN32
-  normalized = ToLowerAscii(normalized);
-#endif
   return normalized;
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -82,6 +82,15 @@ add_library(perastage_test_path_utils STATIC
             ../core/filesystem_path_utils.cpp)
 target_include_directories(perastage_test_path_utils PRIVATE ../core)
 
+add_library(perastage_test_project_symbol_cache_snapshot STATIC
+            ../core/project_symbol_cache_snapshot.cpp)
+target_include_directories(perastage_test_project_symbol_cache_snapshot PUBLIC
+                           ../core
+                           ../models)
+target_link_libraries(perastage_test_project_symbol_cache_snapshot PUBLIC
+                      ${wxWidgets_LIBRARIES}
+                      tinyxml2::tinyxml2)
+
 add_executable(runtime_storage_test
                runtime_storage_test.cpp
                ../core/runtime_storage.cpp
@@ -2200,7 +2209,6 @@ add_test(NAME SymbolCacheManifestValidation COMMAND symbol_cache_manifest_test)
 
 add_executable(project_symbol_cache_snapshot_test
                project_symbol_cache_snapshot_test.cpp
-               ../core/project_symbol_cache_snapshot.cpp
                ../core/symbol_cache_manifest.cpp
                ../core/filesystem_path_utils.cpp)
 target_include_directories(project_symbol_cache_snapshot_test PRIVATE
@@ -2209,18 +2217,55 @@ target_include_directories(project_symbol_cache_snapshot_test PRIVATE
     ${CMAKE_SOURCE_DIR}/third_party
     ${wxWidgets_INCLUDE_DIRS})
 target_link_libraries(project_symbol_cache_snapshot_test PRIVATE
-                      ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
+                      perastage_test_project_symbol_cache_snapshot)
 add_test(NAME ProjectSymbolCacheSnapshot COMMAND project_symbol_cache_snapshot_test)
+
+set(PERASTAGE_CONFIGMANAGER_TEST_TARGETS
+    fixture_label_overrides_reconcile_test
+    gdtf_dictionary_color_roundtrip_test
+    gdtf_dictionary_color_mode_propagation_test
+    dictionary_seed_merge_backup_test
+    active_dictionary_workflow_test
+    save_load_roundtrip_test
+    mvr_project_fixture_metadata_contracts_test
+    project_support_userdata_roundtrip_test
+    rider_truss_dictionary_normalization_test
+    mvr_dmx_address_test
+    mvr_support_userdata_roundtrip_test
+    mvr_perastage_metadata_recovery_test
+    mvr_layer_appearance_userdata_test
+    mvr_fixture_category_roundtrip_test
+    mvr_sceneobject_symbol_identity_test
+    mvr_truss_roundtrip_structure_test
+    mvr_exporter_compliance_test
+    rider_save_roundtrip_test
+    riderimporter_fixtureid_test
+    rider_import_order_test
+    rider_import_linear_order_test
+    rider_import_preserve_existing_test
+    rider_import_category_test
+    rider_autopatch_test
+    rider_layer_mode_test
+    rider_filter_preview_test
+    rider_comments_test
+    rider_floor_default_hang_test
+    rider_led_screen_object_test
+    rider_hoist_import_test
+    rider_lx_sides_import_test
+    rider_pipe_import_test
+    rider_rigging_target_normalization_contracts_test
+    rider_import_benchmark
+    symbol_fixture_applier_gdtf_test
+    mvr_patched_gdtf_export_test
+    layout_image_resource_registry_test)
+foreach(PERASTAGE_CONFIGMANAGER_TEST_TARGET IN LISTS PERASTAGE_CONFIGMANAGER_TEST_TARGETS)
+    target_link_libraries(${PERASTAGE_CONFIGMANAGER_TEST_TARGET} PRIVATE
+                          perastage_test_project_symbol_cache_snapshot)
+endforeach()
+
 get_property(PERASTAGE_TEST_TARGETS DIRECTORY PROPERTY BUILDSYSTEM_TARGETS)
 foreach(PERASTAGE_TEST_TARGET IN LISTS PERASTAGE_TEST_TARGETS)
     get_target_property(PERASTAGE_TEST_SOURCES ${PERASTAGE_TEST_TARGET} SOURCES)
-    if(PERASTAGE_TEST_SOURCES AND
-       "../core/configmanager.cpp" IN_LIST PERASTAGE_TEST_SOURCES AND
-       NOT "../core/project_symbol_cache_snapshot.cpp" IN_LIST PERASTAGE_TEST_SOURCES)
-        target_sources(${PERASTAGE_TEST_TARGET} PRIVATE
-                       ../core/project_symbol_cache_snapshot.cpp)
-        target_link_libraries(${PERASTAGE_TEST_TARGET} PRIVATE tinyxml2::tinyxml2)
-    endif()
     if(NOT PERASTAGE_TEST_TARGET STREQUAL "perastage_test_diagnostics" AND
        PERASTAGE_TEST_SOURCES AND
        ("../core/logger.cpp" IN_LIST PERASTAGE_TEST_SOURCES OR
@@ -2316,7 +2361,9 @@ add_executable(dictionary_reset_transaction_test
 target_include_directories(dictionary_reset_transaction_test PRIVATE
                            . ../core ../models ../third_party)
 target_link_libraries(dictionary_reset_transaction_test PRIVATE
-                      ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
+                      ${wxWidgets_LIBRARIES}
+                      tinyxml2::tinyxml2
+                      perastage_test_project_symbol_cache_snapshot)
 add_test(NAME DictionaryResetTransaction COMMAND dictionary_reset_transaction_test)
 
 add_executable(dictionary_duplicate_test

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2197,9 +2197,30 @@ target_include_directories(symbol_cache_manifest_test PRIVATE
     ${wxWidgets_INCLUDE_DIRS})
 target_link_libraries(symbol_cache_manifest_test PRIVATE ${wxWidgets_LIBRARIES})
 add_test(NAME SymbolCacheManifestValidation COMMAND symbol_cache_manifest_test)
+
+add_executable(project_symbol_cache_snapshot_test
+               project_symbol_cache_snapshot_test.cpp
+               ../core/project_symbol_cache_snapshot.cpp
+               ../core/symbol_cache_manifest.cpp
+               ../core/filesystem_path_utils.cpp)
+target_include_directories(project_symbol_cache_snapshot_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/core
+    ${CMAKE_SOURCE_DIR}/models
+    ${CMAKE_SOURCE_DIR}/third_party
+    ${wxWidgets_INCLUDE_DIRS})
+target_link_libraries(project_symbol_cache_snapshot_test PRIVATE
+                      ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
+add_test(NAME ProjectSymbolCacheSnapshot COMMAND project_symbol_cache_snapshot_test)
 get_property(PERASTAGE_TEST_TARGETS DIRECTORY PROPERTY BUILDSYSTEM_TARGETS)
 foreach(PERASTAGE_TEST_TARGET IN LISTS PERASTAGE_TEST_TARGETS)
     get_target_property(PERASTAGE_TEST_SOURCES ${PERASTAGE_TEST_TARGET} SOURCES)
+    if(PERASTAGE_TEST_SOURCES AND
+       "../core/configmanager.cpp" IN_LIST PERASTAGE_TEST_SOURCES AND
+       NOT "../core/project_symbol_cache_snapshot.cpp" IN_LIST PERASTAGE_TEST_SOURCES)
+        target_sources(${PERASTAGE_TEST_TARGET} PRIVATE
+                       ../core/project_symbol_cache_snapshot.cpp)
+        target_link_libraries(${PERASTAGE_TEST_TARGET} PRIVATE tinyxml2::tinyxml2)
+    endif()
     if(NOT PERASTAGE_TEST_TARGET STREQUAL "perastage_test_diagnostics" AND
        PERASTAGE_TEST_SOURCES AND
        ("../core/logger.cpp" IN_LIST PERASTAGE_TEST_SOURCES OR

--- a/tests/mvr_io_stubs.cpp
+++ b/tests/mvr_io_stubs.cpp
@@ -166,6 +166,21 @@ const std::vector<FixtureSymbolCacheEntry> &SymbolCacheManifest::Entries() const
   return entries;
 }
 
+// Returns a deterministic fingerprint for project-persistence stub targets.
+std::string ComputeGdtfSemanticFingerprintFromEntries(
+    const std::vector<GdtfSemanticFingerprintEntry> &, std::string &errorMessage) {
+  errorMessage.clear();
+  return "stub-gdtf-fingerprint";
+}
+
+// Returns the complete symbol view set for project-persistence stub targets.
+std::set<std::string> RequiredPerastageSymbolViews() {
+  return {"top", "bottom", "front", "side"};
+}
+
+// Returns a deterministic timestamp for project-persistence stub targets.
+std::string CurrentUtcTimestamp() { return "2000-01-01T00:00:00Z"; }
+
 } // namespace symbol_cache
 
 // Returns false because legacy truss conversion is intentionally disabled in this stub.

--- a/tests/project_session_io_test.cpp
+++ b/tests/project_session_io_test.cpp
@@ -78,6 +78,25 @@ int main() {
   assert(!zeroSceneSaveOk);
   assert(!fs::exists(zeroSceneProjectPath));
 
+  const fs::path requiredResourceFailurePath =
+      tempDir / "required_resource_failure.pera";
+  const bool requiredResourceFailure = zeroSceneSession.SaveProject(
+      requiredResourceFailurePath.string(),
+      [](std::vector<std::uint8_t> &out) {
+        out = {'{', '}'};
+        return true;
+      },
+      [](std::vector<std::uint8_t> &out) {
+        out = {'P', 'K'};
+        return true;
+      },
+      ProjectSession::CollectArchiveResourcesFn([] {
+        return std::vector<ProjectSession::ArchiveResource>{
+            {"../unsafe-manifest.json", {'{', '}'}, true}};
+      }));
+  assert(!requiredResourceFailure);
+  assert(!fs::exists(requiredResourceFailurePath));
+
   const fs::path jsonPath = tempDir / "config_only.json";
   {
     std::ofstream out(jsonPath, std::ios::binary);

--- a/tests/project_symbol_cache_snapshot_test.cpp
+++ b/tests/project_symbol_cache_snapshot_test.cpp
@@ -57,12 +57,12 @@ std::vector<std::uint8_t> BuildGdtf(bool includeSide = true) {
 std::vector<std::uint8_t> BuildMvr(const std::vector<std::uint8_t> &gdtf) {
   const std::string xml =
       "<GeneralSceneDescription><Scene><Layers><Layer><ChildList>"
-      "<Fixture uuid=\"fixture-0001\"><GDTFSpec>Roundtrip.gdtf</GDTFSpec>"
+      "<Fixture uuid=\"fixture-0001\"><GDTFSpec>RoundTrip.gdtf</GDTFSpec>"
       "</Fixture><Fixture uuid=\"fixture-0002\">"
-      "<GDTFSpec>Roundtrip.gdtf</GDTFSpec></Fixture>"
+      "<GDTFSpec>RoundTrip.gdtf</GDTFSpec></Fixture>"
       "</ChildList></Layer></Layers></Scene></GeneralSceneDescription>";
   return BuildZip({{"GeneralSceneDescription.xml", Bytes(xml)},
-                   {"Roundtrip.gdtf", gdtf}});
+                   {"RoundTrip.gdtf", gdtf}});
 }
 
 // Verifies exact packaged proof, stale replacement, deduplication, and planning.
@@ -87,7 +87,7 @@ void TestValidatedSnapshotAndPlanner() {
   assert(snapshot.validatedCount == 1);
   assert(snapshot.manifest.Entries().size() == 1);
   const auto &entry = snapshot.manifest.Entries().front();
-  assert(entry.gdtfSpec == "Roundtrip.gdtf");
+  assert(entry.gdtfSpec == "RoundTrip.gdtf");
   assert(entry.gdtfContentHash != "stale");
 
   symbol_cache::ValidationRequest reloadRequest;

--- a/tests/project_symbol_cache_snapshot_test.cpp
+++ b/tests/project_symbol_cache_snapshot_test.cpp
@@ -1,5 +1,6 @@
 #include "project_symbol_cache_snapshot.h"
 
+#include <algorithm>
 #include <cassert>
 #include <cstdint>
 #include <map>
@@ -19,7 +20,9 @@ BuildZip(const std::map<std::string, std::vector<std::uint8_t>> &entries) {
   {
     wxZipOutputStream zip(memory);
     for (const auto &[name, bytes] : entries) {
-      assert(zip.PutNextEntry(name));
+      auto *entry = new wxZipEntry();
+      entry->SetName(wxString::FromUTF8(name), wxPATH_UNIX);
+      assert(zip.PutNextEntry(entry));
       if (!bytes.empty())
         zip.Write(bytes.data(), bytes.size());
       assert(zip.CloseEntry());
@@ -36,6 +39,20 @@ std::vector<std::uint8_t> Bytes(const std::string &text) {
   return {text.begin(), text.end()};
 }
 
+// Replaces every fixed-width ZIP name occurrence without changing record offsets.
+void ReplaceArchiveName(std::vector<std::uint8_t> &archive,
+                        const std::string &from, const std::string &to) {
+  assert(from.size() == to.size());
+  const std::vector<std::uint8_t> source(from.begin(), from.end());
+  for (auto position = std::search(archive.begin(), archive.end(), source.begin(),
+                                   source.end());
+       position != archive.end();
+       position = std::search(position + to.size(), archive.end(), source.begin(),
+                              source.end())) {
+    std::copy(to.begin(), to.end(), position);
+  }
+}
+
 // Builds a canonical minimal GDTF with an optional missing side symbol.
 std::vector<std::uint8_t> BuildGdtf(bool includeSide = true) {
   const std::string description =
@@ -47,7 +64,8 @@ std::vector<std::uint8_t> BuildGdtf(bool includeSide = true) {
       {"description.xml", Bytes(description)},
       {"models/svg/main.svg", Bytes("top")},
       {"models/svg/main_bottom.svg", Bytes("bottom")},
-      {"models/svg_front/main.svg", Bytes("front")}};
+      {"models/svg_front/main.svg", Bytes("front")},
+      {"resources/Información.txt", Bytes("unicode")}};
   if (includeSide)
     entries["models/svg_side/main.svg"] = Bytes("side");
   return BuildZip(entries);
@@ -123,6 +141,38 @@ void TestMalformedSceneFails() {
   assert(!snapshot.errorMessage.empty());
 }
 
+// Verifies raw unsafe and ambiguous ZIP names remain rejected before normalization.
+void TestUnsafeRawArchiveNamesFail() {
+  const std::string sceneXml = "<GeneralSceneDescription/>";
+  for (const auto &[safeName, unsafeName] :
+       std::vector<std::pair<std::string, std::string>>{
+           {"aa/unsafe.txt", "../unsafe.txt"},
+           {"xunsafe.txt", "/unsafe.txt"},
+           {"xx/unsafe.txt", "C:/unsafe.txt"}}) {
+    auto archive = BuildZip({{"GeneralSceneDescription.xml", Bytes(sceneXml)},
+                             {safeName, Bytes("unsafe")}});
+    ReplaceArchiveName(archive, safeName, unsafeName);
+    const auto snapshot = symbol_cache::BuildProjectSymbolCacheSnapshot(
+        archive, {});
+    assert(!snapshot.sceneValid);
+  }
+
+  const auto collision = BuildZip(
+      {{"GeneralSceneDescription.xml", Bytes(sceneXml)},
+       {"Resources/Fixture.gdtf", Bytes("first")},
+       {"resources/fixture.gdtf", Bytes("second")}});
+  assert(!symbol_cache::BuildProjectSymbolCacheSnapshot(collision, {}).sceneValid);
+
+  auto gdtf = BuildGdtf();
+  ReplaceArchiveName(gdtf, "models/svg/main.svg", "models\\svg\\main.svg");
+  const auto snapshot = symbol_cache::BuildProjectSymbolCacheSnapshot(
+      BuildMvr(gdtf),
+      {{"fixture-0001", "Roundtrip Type", "Roundtrip Type"}});
+  assert(snapshot.sceneValid);
+  assert(snapshot.validatedCount == 0);
+  assert(snapshot.omittedCount == 1);
+}
+
 } // namespace
 
 // Runs project symbol-cache snapshot regression coverage.
@@ -132,5 +182,6 @@ int main() {
   TestValidatedSnapshotAndPlanner();
   TestIncompleteSymbolsAreOmitted();
   TestMalformedSceneFails();
+  TestUnsafeRawArchiveNamesFail();
   return 0;
 }

--- a/tests/project_symbol_cache_snapshot_test.cpp
+++ b/tests/project_symbol_cache_snapshot_test.cpp
@@ -1,0 +1,136 @@
+#include "project_symbol_cache_snapshot.h"
+
+#include <cassert>
+#include <cstdint>
+#include <map>
+#include <string>
+#include <vector>
+
+#include <wx/init.h>
+#include <wx/mstream.h>
+#include <wx/zipstrm.h>
+
+namespace {
+
+// Creates an in-memory ZIP archive from deterministic entry payloads.
+std::vector<std::uint8_t>
+BuildZip(const std::map<std::string, std::vector<std::uint8_t>> &entries) {
+  wxMemoryOutputStream memory;
+  {
+    wxZipOutputStream zip(memory);
+    for (const auto &[name, bytes] : entries) {
+      assert(zip.PutNextEntry(name));
+      if (!bytes.empty())
+        zip.Write(bytes.data(), bytes.size());
+      assert(zip.CloseEntry());
+    }
+    assert(zip.Close());
+  }
+  std::vector<std::uint8_t> bytes(memory.GetSize());
+  memory.CopyTo(bytes.data(), bytes.size());
+  return bytes;
+}
+
+// Converts text into an archive byte payload.
+std::vector<std::uint8_t> Bytes(const std::string &text) {
+  return {text.begin(), text.end()};
+}
+
+// Builds a canonical minimal GDTF with an optional missing side symbol.
+std::vector<std::uint8_t> BuildGdtf(bool includeSide = true) {
+  const std::string description =
+      "<GDTF><FixtureType Name=\"Roundtrip Type\">"
+      "<PerastageMutationAudit SchemaVersion=\"1\"/>"
+      "<Models><Model Name=\"Main\" File=\"main\"/></Models>"
+      "</FixtureType></GDTF>";
+  std::map<std::string, std::vector<std::uint8_t>> entries = {
+      {"description.xml", Bytes(description)},
+      {"models/svg/main.svg", Bytes("top")},
+      {"models/svg/main_bottom.svg", Bytes("bottom")},
+      {"models/svg_front/main.svg", Bytes("front")}};
+  if (includeSide)
+    entries["models/svg_side/main.svg"] = Bytes("side");
+  return BuildZip(entries);
+}
+
+// Builds an MVR that references the supplied exact packaged GDTF bytes.
+std::vector<std::uint8_t> BuildMvr(const std::vector<std::uint8_t> &gdtf) {
+  const std::string xml =
+      "<GeneralSceneDescription><Scene><Layers><Layer><ChildList>"
+      "<Fixture uuid=\"fixture-0001\"><GDTFSpec>Roundtrip.gdtf</GDTFSpec>"
+      "</Fixture><Fixture uuid=\"fixture-0002\">"
+      "<GDTFSpec>Roundtrip.gdtf</GDTFSpec></Fixture>"
+      "</ChildList></Layer></Layers></Scene></GeneralSceneDescription>";
+  return BuildZip({{"GeneralSceneDescription.xml", Bytes(xml)},
+                   {"Roundtrip.gdtf", gdtf}});
+}
+
+// Verifies exact packaged proof, stale replacement, deduplication, and planning.
+void TestValidatedSnapshotAndPlanner() {
+  const auto mvr = BuildMvr(BuildGdtf());
+  const std::vector<symbol_cache::ProjectFixtureSymbolIdentity> identities = {
+      {"fixture-0001", "Roundtrip Type", "Roundtrip Type"},
+      {"fixture-0002", "Roundtrip Type", "Roundtrip Type"}};
+
+  symbol_cache::SymbolCacheManifest stale;
+  symbol_cache::ValidationRequest staleRequest;
+  staleRequest.fixtureKey = "Roundtrip Type";
+  staleRequest.fixtureTypeName = "Roundtrip Type";
+  staleRequest.gdtfSpec = "old.gdtf";
+  staleRequest.gdtfContentHash = "stale";
+  staleRequest.requiredViews = symbol_cache::RequiredPerastageSymbolViews();
+  stale.MarkFixtureSymbolsValid(staleRequest, "2026-01-01T00:00:00Z");
+
+  const auto snapshot = symbol_cache::BuildProjectSymbolCacheSnapshot(
+      mvr, identities, &stale, "2026-02-01T00:00:00Z");
+  assert(snapshot.sceneValid);
+  assert(snapshot.validatedCount == 1);
+  assert(snapshot.manifest.Entries().size() == 1);
+  const auto &entry = snapshot.manifest.Entries().front();
+  assert(entry.gdtfSpec == "Roundtrip.gdtf");
+  assert(entry.gdtfContentHash != "stale");
+
+  symbol_cache::ValidationRequest reloadRequest;
+  reloadRequest.fixtureKey = entry.fixtureKey;
+  reloadRequest.fixtureTypeName = entry.fixtureTypeName;
+  reloadRequest.gdtfSpec = entry.gdtfSpec;
+  reloadRequest.gdtfContentHash = entry.gdtfContentHash;
+  reloadRequest.requiredViews = symbol_cache::RequiredPerastageSymbolViews();
+  assert(snapshot.manifest.ValidateFixture(reloadRequest).valid);
+  assert(symbol_cache::PlanFixtureSymbolCacheMisses(snapshot.manifest,
+                                                     {reloadRequest})
+             .empty());
+}
+
+// Verifies incomplete packaged symbols are omitted rather than guessed valid.
+void TestIncompleteSymbolsAreOmitted() {
+  const auto snapshot = symbol_cache::BuildProjectSymbolCacheSnapshot(
+      BuildMvr(BuildGdtf(false)),
+      {{"fixture-0001", "Roundtrip Type", "Roundtrip Type"}}, nullptr,
+      "2026-02-01T00:00:00Z");
+  assert(snapshot.sceneValid);
+  assert(snapshot.validatedCount == 0);
+  assert(snapshot.omittedCount == 1);
+  assert(snapshot.manifest.Entries().empty());
+}
+
+// Verifies malformed scene payloads fail the correctness stage.
+void TestMalformedSceneFails() {
+  const auto snapshot = symbol_cache::BuildProjectSymbolCacheSnapshot(
+      Bytes("not a zip"),
+      {{"fixture-0001", "Roundtrip Type", "Roundtrip Type"}});
+  assert(!snapshot.sceneValid);
+  assert(!snapshot.errorMessage.empty());
+}
+
+} // namespace
+
+// Runs project symbol-cache snapshot regression coverage.
+int main() {
+  wxInitializer initializer;
+  assert(initializer.IsOk());
+  TestValidatedSnapshotAndPlanner();
+  TestIncompleteSymbolsAreOmitted();
+  TestMalformedSceneFails();
+  return 0;
+}

--- a/tests/save_load_roundtrip_test.cpp
+++ b/tests/save_load_roundtrip_test.cpp
@@ -47,6 +47,7 @@
 #include "project_symbol_cache_snapshot.h"
 #include "sceneobject.h"
 #include "scene_node_operations.h"
+#include "support/zip_test_utils.h"
 #include "support.h"
 #include "truss.h"
 #include "uuidutils.h"
@@ -77,7 +78,7 @@ static std::map<std::string, std::vector<std::uint8_t>> ReadZipEntries(
     if (entry->IsDir())
       continue;
     const std::string bytes = ReadCurrentZipEntry(zip);
-    entries.emplace(entry->GetName().ToStdString(),
+    entries.emplace(tests::zip::ToUtf8(entry->GetName(wxPATH_UNIX)),
                     std::vector<std::uint8_t>(bytes.begin(), bytes.end()));
   }
   return entries;
@@ -95,7 +96,7 @@ static std::map<std::string, std::vector<std::uint8_t>> ReadProjectEntries(
     if (entry->IsDir())
       continue;
     const std::string bytes = ReadCurrentZipEntry(zip);
-    entries.emplace(entry->GetName().ToStdString(),
+    entries.emplace(tests::zip::ToUtf8(entry->GetName(wxPATH_UNIX)),
                     std::vector<std::uint8_t>(bytes.begin(), bytes.end()));
   }
   return entries;

--- a/tests/save_load_roundtrip_test.cpp
+++ b/tests/save_load_roundtrip_test.cpp
@@ -20,7 +20,10 @@
 #include <cmath>
 #include <filesystem>
 #include <fstream>
+#include <iostream>
 #include <memory>
+#include <map>
+#include <optional>
 #include <set>
 #include <string>
 #include <utility>
@@ -34,17 +37,20 @@
 #include "configmanager.h"
 #include "fixture.h"
 #include "fixture_label_overrides.h"
+#include "filesystem_path_utils.h"
 #include "gdtf_test_fixture_builder.h"
 #include "gdtfdictionary.h"
 #include "layer.h"
 #include "matrixutils.h"
 #include "projectutils.h"
 #include "project_fixture_identity.h"
+#include "project_symbol_cache_snapshot.h"
 #include "sceneobject.h"
 #include "scene_node_operations.h"
 #include "support.h"
 #include "truss.h"
 #include "uuidutils.h"
+#include "wx_path_utils.h"
 
 // Reads all bytes from the current ZIP entry.
 static std::string ReadCurrentZipEntry(wxZipInputStream &zip) {
@@ -58,6 +64,93 @@ static std::string ReadCurrentZipEntry(wxZipInputStream &zip) {
     bytes.append(buffer, count);
   }
   return bytes;
+}
+
+// Reads every file entry from an immutable in-memory ZIP payload.
+static std::map<std::string, std::vector<std::uint8_t>> ReadZipEntries(
+    const std::string &archiveBytes) {
+  wxMemoryInputStream input(archiveBytes.data(), archiveBytes.size());
+  wxZipInputStream zip(input);
+  std::map<std::string, std::vector<std::uint8_t>> entries;
+  std::unique_ptr<wxZipEntry> entry;
+  while ((entry.reset(zip.GetNextEntry())), entry) {
+    if (entry->IsDir())
+      continue;
+    const std::string bytes = ReadCurrentZipEntry(zip);
+    entries.emplace(entry->GetName().ToStdString(),
+                    std::vector<std::uint8_t>(bytes.begin(), bytes.end()));
+  }
+  return entries;
+}
+
+// Reads every file entry from a project archive through the native wx path boundary.
+static std::map<std::string, std::vector<std::uint8_t>> ReadProjectEntries(
+    const std::filesystem::path &projectPath) {
+  wxFileInputStream input(WxPathUtils::WxStringFromFilesystemPath(projectPath));
+  assert(input.IsOk());
+  wxZipInputStream zip(input);
+  std::map<std::string, std::vector<std::uint8_t>> entries;
+  std::unique_ptr<wxZipEntry> entry;
+  while ((entry.reset(zip.GetNextEntry())), entry) {
+    if (entry->IsDir())
+      continue;
+    const std::string bytes = ReadCurrentZipEntry(zip);
+    entries.emplace(entry->GetName().ToStdString(),
+                    std::vector<std::uint8_t>(bytes.begin(), bytes.end()));
+  }
+  return entries;
+}
+
+// Rewrites a project with a missing or replacement symbol-cache manifest.
+static void WriteProjectManifestVariant(
+    const std::filesystem::path &sourcePath,
+    const std::filesystem::path &destinationPath,
+    const std::optional<std::string> &manifestText) {
+  auto entries = ReadProjectEntries(sourcePath);
+  entries.erase(symbol_cache::kProjectArchiveEntryName);
+  if (manifestText) {
+    entries.emplace(symbol_cache::kProjectArchiveEntryName,
+                    std::vector<std::uint8_t>(manifestText->begin(),
+                                              manifestText->end()));
+  }
+  wxFileOutputStream output(
+      WxPathUtils::WxStringFromFilesystemPath(destinationPath));
+  assert(output.IsOk());
+  wxZipOutputStream zip(output);
+  for (const auto &[name, bytes] : entries) {
+    assert(zip.PutNextEntry(name));
+    if (!bytes.empty())
+      zip.Write(bytes.data(), bytes.size());
+    assert(zip.CloseEntry());
+  }
+  assert(zip.Close());
+}
+
+// Reads the fixture type name that the production GDTF loader restores.
+static std::string ReadFixtureTypeName(
+    const std::filesystem::path &gdtfPath) {
+  wxFileInputStream input(WxPathUtils::WxStringFromFilesystemPath(gdtfPath));
+  assert(input.IsOk());
+  wxZipInputStream zip(input);
+  std::unique_ptr<wxZipEntry> entry;
+  while ((entry.reset(zip.GetNextEntry())), entry) {
+    if (entry->GetName().CmpNoCase("description.xml") != 0)
+      continue;
+    const std::string xml = ReadCurrentZipEntry(zip);
+    tinyxml2::XMLDocument document;
+    assert(document.Parse(xml.c_str(), xml.size()) == tinyxml2::XML_SUCCESS);
+    const tinyxml2::XMLElement *fixtureType =
+        document.FirstChildElement("GDTF");
+    fixtureType = fixtureType
+                      ? fixtureType->FirstChildElement("FixtureType")
+                      : document.FirstChildElement("FixtureType");
+    assert(fixtureType != nullptr);
+    const char *name = fixtureType->Attribute("Name");
+    assert(name != nullptr);
+    return name;
+  }
+  assert(false);
+  return {};
 }
 
 struct ProjectIdentityPayload {
@@ -82,7 +175,8 @@ static bool MatrixEqual(const Matrix &lhs, const Matrix &rhs) {
 // Reads the two project payloads that must agree on fixture identity.
 static ProjectIdentityPayload ReadProjectIdentityPayload(
     const std::filesystem::path &projectPath) {
-  wxFileInputStream projectInput(projectPath.string());
+  wxFileInputStream projectInput(
+      WxPathUtils::WxStringFromFilesystemPath(projectPath));
   assert(projectInput.IsOk());
   wxZipInputStream projectZip(projectInput);
   ProjectIdentityPayload payload;
@@ -114,10 +208,11 @@ static void WriteProjectWithConfig(
     const std::filesystem::path &sourcePath,
     const std::filesystem::path &destinationPath,
     const std::string &configJson) {
-  wxFileInputStream input(sourcePath.string());
+  wxFileInputStream input(WxPathUtils::WxStringFromFilesystemPath(sourcePath));
   assert(input.IsOk());
   wxZipInputStream sourceZip(input);
-  wxFileOutputStream output(destinationPath.string());
+  wxFileOutputStream output(
+      WxPathUtils::WxStringFromFilesystemPath(destinationPath));
   assert(output.IsOk());
   wxZipOutputStream destinationZip(output);
   std::unique_ptr<wxZipEntry> entry;
@@ -136,7 +231,8 @@ static void WriteProjectWithConfig(
 // Extracts the deterministic project fixture metadata signature.
 static std::vector<std::pair<std::string, std::string>>
 ReadProjectFixtureMetadata(const std::filesystem::path &projectPath) {
-  wxFileInputStream projectInput(projectPath.string());
+  wxFileInputStream projectInput(
+      WxPathUtils::WxStringFromFilesystemPath(projectPath));
   assert(projectInput.IsOk());
   wxZipInputStream projectZip(projectInput);
   std::string sceneBytes;
@@ -216,6 +312,7 @@ int main() {
     tests::gdtf::BuildMinimalValidFixture()
         .WithFixtureIdentity("Original", "Perastage",
                              "11111111-1111-4111-8111-111111111111")
+        .WithPerastageGeneratedSymbols()
         .WriteArchive(tempDir / "orig.gdtf");
     tests::gdtf::BuildMinimalValidFixture()
         .WithFixtureIdentity("Dictionary", "Perastage",
@@ -425,9 +522,62 @@ int main() {
   sInherited.hoistDataSource = "Inherited";
   scene.supports[sInherited.uuid] = sInherited;
 
-  std::filesystem::path temp =
-      std::filesystem::temp_directory_path() / "roundtrip_test.pera";
-    assert(cfg.SaveProject(temp.string()));
+  std::filesystem::path temp = std::filesystem::temp_directory_path() /
+                               std::filesystem::path(u8"símbolos_roundtrip.pstg");
+    assert(cfg.SaveProject(PathUtils::PathToUtf8(temp)));
+
+    const auto projectEntries = ReadProjectEntries(temp);
+    assert(projectEntries.contains("config.json"));
+    assert(projectEntries.contains("scene.mvr"));
+    assert(projectEntries.contains(symbol_cache::kProjectArchiveEntryName));
+    const std::string sceneArchiveBytes(projectEntries.at("scene.mvr").begin(),
+                                        projectEntries.at("scene.mvr").end());
+    const auto sceneEntries = ReadZipEntries(sceneArchiveBytes);
+    assert(sceneEntries.contains("GeneralSceneDescription.xml"));
+    const std::string sceneDescription(
+        sceneEntries.at("GeneralSceneDescription.xml").begin(),
+        sceneEntries.at("GeneralSceneDescription.xml").end());
+    tinyxml2::XMLDocument savedSceneDocument;
+    assert(savedSceneDocument.Parse(sceneDescription.c_str(),
+                                    sceneDescription.size()) ==
+           tinyxml2::XML_SUCCESS);
+    tinyxml2::XMLElement *savedFixture =
+        savedSceneDocument.RootElement()
+            ->FirstChildElement("Scene")
+            ->FirstChildElement("Layers")
+            ->FirstChildElement("Layer")
+            ->FirstChildElement("ChildList")
+            ->FirstChildElement("Fixture");
+    assert(savedFixture != nullptr);
+    const char *savedGdtfText =
+        savedFixture->FirstChildElement("GDTFSpec")->GetText();
+    assert(savedGdtfText != nullptr);
+    const std::string savedGdtfSpec = savedGdtfText;
+    assert(sceneEntries.contains(savedGdtfSpec));
+    const std::string packagedGdtfBytes(sceneEntries.at(savedGdtfSpec).begin(),
+                                        sceneEntries.at(savedGdtfSpec).end());
+    const auto packagedGdtfEntries = ReadZipEntries(packagedGdtfBytes);
+    assert(packagedGdtfEntries.contains("models/svg/main.svg"));
+    assert(packagedGdtfEntries.contains("models/svg/main_bottom.svg"));
+    assert(packagedGdtfEntries.contains("models/svg_front/main.svg"));
+    assert(packagedGdtfEntries.contains("models/svg_side/main.svg"));
+    std::vector<symbol_cache::GdtfSemanticFingerprintEntry> fingerprintEntries;
+    for (const auto &[path, bytes] : packagedGdtfEntries)
+      fingerprintEntries.push_back({path, bytes});
+    std::string fingerprintError;
+    const std::string packagedFingerprint =
+        symbol_cache::ComputeGdtfSemanticFingerprintFromEntries(
+            fingerprintEntries, fingerprintError);
+    assert(!packagedFingerprint.empty());
+    symbol_cache::SymbolCacheManifest savedManifest;
+    std::string manifestError;
+    assert(savedManifest.LoadFromJsonText(
+        std::string(projectEntries.at(symbol_cache::kProjectArchiveEntryName).begin(),
+                    projectEntries.at(symbol_cache::kProjectArchiveEntryName).end()),
+        manifestError));
+    assert(savedManifest.Entries().size() == 1);
+    assert(savedManifest.Entries().front().gdtfSpec == savedGdtfSpec);
+    assert(savedManifest.Entries().front().gdtfContentHash == packagedFingerprint);
 
     const std::string canonicalFixtureUuid =
         CanonicalizeUuid(nonCanonicalFixtureUuid);
@@ -492,7 +642,7 @@ int main() {
 
     cfg.Reset();
 
-    assert(cfg.LoadProject(temp.string()));
+    assert(cfg.LoadProject(PathUtils::PathToUtf8(temp)));
 
     const auto &scene2 = cfg.GetScene();
     const auto &loadedGroupedTruss = scene2.trusses.at(t.uuid);
@@ -564,6 +714,54 @@ int main() {
     const auto &loaded = scene2.fixtures.at("20000000-0000-4000-8000-000000000001");
     assert(std::filesystem::path(loaded.gdtfSpec).filename() ==
            "Perastage@Original@Perastage.gdtf");
+    assert(loaded.gdtfSpec == savedGdtfSpec);
+    std::string reloadFingerprintError;
+    const std::filesystem::path reloadedGdtfPath =
+        PathUtils::PathFromUtf8(scene2.basePath) /
+        PathUtils::PathFromUtf8(loaded.gdtfSpec);
+    symbol_cache::ValidationRequest reloadRequest;
+    Fixture productionReloadIdentity = loaded;
+    productionReloadIdentity.typeName = ReadFixtureTypeName(reloadedGdtfPath);
+    reloadRequest.fixtureKey = symbol_cache::BuildFixtureSymbolCacheKey(
+        productionReloadIdentity);
+    reloadRequest.fixtureTypeName = productionReloadIdentity.typeName;
+    reloadRequest.gdtfSpec = loaded.gdtfSpec;
+    reloadRequest.gdtfContentHash = symbol_cache::ComputeFileContentHash(
+        PathUtils::PathToUtf8(reloadedGdtfPath), reloadFingerprintError);
+    reloadRequest.requiredViews = symbol_cache::RequiredPerastageSymbolViews();
+    assert(!reloadRequest.gdtfContentHash.empty());
+    const auto reloadValidation =
+        cfg.GetSymbolCacheManifest().ValidateFixture(reloadRequest);
+    if (!reloadValidation.valid) {
+      std::cerr << "Reload cache validation failed: "
+                << symbol_cache::ValidationStatusName(reloadValidation.status)
+                << " key=" << reloadRequest.fixtureKey
+                << " spec=" << reloadRequest.gdtfSpec
+                << " hash=" << reloadRequest.gdtfContentHash << '\n';
+    }
+    assert(reloadValidation.valid);
+    assert(symbol_cache::PlanFixtureSymbolCacheMisses(
+               cfg.GetSymbolCacheManifest(), {reloadRequest})
+               .empty());
+
+    const auto manifestBeforeFailedSave =
+        cfg.GetSymbolCacheManifest().Entries();
+    const auto dirtyStateBeforeFailedSave = cfg.CaptureDirtyState();
+    std::error_code failedSaveCleanupError;
+    std::filesystem::remove_all(tempDir / "missing-parent",
+                                failedSaveCleanupError);
+    const std::filesystem::path invalidSavePath =
+        tempDir / "missing-parent" / "failed.pstg";
+    assert(!cfg.SaveProject(PathUtils::PathToUtf8(invalidSavePath)));
+    assert(cfg.GetSymbolCacheManifest().Entries().size() ==
+           manifestBeforeFailedSave.size());
+    assert(cfg.GetSymbolCacheManifest().Entries().front().gdtfContentHash ==
+           manifestBeforeFailedSave.front().gdtfContentHash);
+    const auto dirtyStateAfterFailedSave = cfg.CaptureDirtyState();
+    assert(dirtyStateAfterFailedSave.revision ==
+           dirtyStateBeforeFailedSave.revision);
+    assert(dirtyStateAfterFailedSave.savedRevision ==
+           dirtyStateBeforeFailedSave.savedRevision);
     assert(std::filesystem::path(loaded.originalMvrGdtfSpec).filename() ==
            "Perastage@Original@Perastage.gdtf");
 
@@ -622,9 +820,25 @@ int main() {
       assert(fixtureNumericIds.insert(fixture.fixtureIdNumeric).second);
     }
 
+    const std::filesystem::path missingManifestProject =
+        tempDir / std::filesystem::path(u8"sin_manifiesto.pstg");
+    const std::filesystem::path malformedManifestProject =
+        tempDir / std::filesystem::path(u8"manifiesto_inválido.pstg");
+    WriteProjectManifestVariant(temp, missingManifestProject, std::nullopt);
+    WriteProjectManifestVariant(temp, malformedManifestProject,
+                                std::string("{invalid"));
+    cfg.Reset();
+    assert(cfg.LoadProject(PathUtils::PathToUtf8(missingManifestProject)));
+    assert(!cfg.GetSymbolCacheManifest().HasLoadedManifest());
+    cfg.Reset();
+    assert(cfg.LoadProject(PathUtils::PathToUtf8(malformedManifestProject)));
+    assert(!cfg.GetSymbolCacheManifest().HasLoadedManifest());
+
     std::filesystem::remove(temp);
     std::filesystem::remove(legacyProject);
     std::filesystem::remove(secondProject);
+    std::filesystem::remove(missingManifestProject);
+    std::filesystem::remove(malformedManifestProject);
   std::filesystem::remove(ProjectUtils::GetDefaultLibraryPath("fixtures") +
                           "/dict.gdtf");
     GdtfDictionary::Save({});

--- a/tests/support/gdtf_test_fixture_builder.cpp
+++ b/tests/support/gdtf_test_fixture_builder.cpp
@@ -62,7 +62,8 @@ void ValidateArchivePath(const std::string &path) {
 
 // Creates fixed ZIP metadata for deterministic test archives.
 wxZipEntry *CreateDeterministicEntry(const std::string &path) {
-  auto *entry = new wxZipEntry(wxString::FromUTF8(path));
+  auto *entry = new wxZipEntry();
+  entry->SetName(wxString::FromUTF8(path), wxPATH_UNIX);
   wxDateTime timestamp(1, wxDateTime::Jan, 2026, 0, 0, 0);
   entry->SetDateTime(timestamp);
   entry->SetMode(0644);

--- a/tests/support/gdtf_test_fixture_builder.cpp
+++ b/tests/support/gdtf_test_fixture_builder.cpp
@@ -157,6 +157,17 @@ FixtureBuilder &FixtureBuilder::WithFixtureCategorySignals() {
   return *this;
 }
 
+// Adds the complete audited Perastage fixture-symbol resource set.
+FixtureBuilder &FixtureBuilder::WithPerastageGeneratedSymbols() {
+  perastageGeneratedSymbols = true;
+  modelFileBase = "main";
+  archiveEntries.emplace_back("models/svg/main.svg", "<svg/>");
+  archiveEntries.emplace_back("models/svg/main_bottom.svg", "<svg/>");
+  archiveEntries.emplace_back("models/svg_front/main.svg", "<svg/>");
+  archiveEntries.emplace_back("models/svg_side/main.svg", "<svg/>");
+  return *this;
+}
+
 // Adds an extra portable archive entry that must be preserved by rewrite tests.
 FixtureBuilder &FixtureBuilder::WithArchiveEntry(std::string path, std::string bytes) {
   archiveEntries.emplace_back(std::move(path), std::move(bytes));
@@ -176,6 +187,9 @@ std::string FixtureBuilder::BuildDescriptionXml() const {
          "\" Description=\"Minimal canonical GDTF 1.2 fixture for tests\" FixtureTypeID=\"" +
          fixtureTypeId + category +
          "\">\n"
+         + (perastageGeneratedSymbols
+                ? "    <PerastageMutationAudit SchemaVersion=\"1\"/>\n"
+                : "") +
          "    <AttributeDefinitions><ActivationGroups/><FeatureGroups><FeatureGroup Name=\"Dimmer\" Pretty=\"Dimmer\"><Feature Name=\"Dimmer\"/></FeatureGroup></FeatureGroups><Attributes><Attribute Name=\"Dimmer\" Pretty=\"Dimmer\" Feature=\"Dimmer.Dimmer\" PhysicalUnit=\"LuminousIntensity\"/></Attributes></AttributeDefinitions>\n"
          "    <Wheels/>\n"
          "    <PhysicalDescriptions><Emitters/><Filters/><ColorSpace Mode=\"sRGB\"/><DMXProfiles/><CRIs/><Connectors/></PhysicalDescriptions>\n"

--- a/tests/support/gdtf_test_fixture_builder.h
+++ b/tests/support/gdtf_test_fixture_builder.h
@@ -18,6 +18,7 @@ public:
   FixtureBuilder &WithModelResource(std::string fileBase);
   FixtureBuilder &WithModelDimensionsMeters(float length, float width, float height);
   FixtureBuilder &WithFixtureCategorySignals();
+  FixtureBuilder &WithPerastageGeneratedSymbols();
   FixtureBuilder &WithArchiveEntry(std::string path, std::string bytes);
   std::string BuildDescriptionXml() const;
   void WriteArchive(const std::filesystem::path &archivePath) const;
@@ -32,6 +33,7 @@ private:
   float modelWidthMeters = 0.1f;
   float modelHeightMeters = 0.1f;
   bool categorySignals = false;
+  bool perastageGeneratedSymbols = false;
   std::vector<std::pair<std::string, std::string>> archiveEntries;
 };
 FixtureBuilder BuildMinimalValidFixture();


### PR DESCRIPTION
### Motivation

- Ensure the project symbol-cache manifest is derived from the exact immutable GDTF archives actually packaged into the saved `scene.mvr`, eliminating mismatches caused by using mutable in-memory metadata during save.
- Make project save a single transactional operation so manifest metadata is only serialized after packaged-GDTF post-validation succeeds and is not committed on save failure.
- Preserve reload permissiveness while enabling reload-side validation to produce zero regeneration work for unchanged validated fixture types.

### Description

- Added a focused, GUI-independent project snapshot service in `core/project_symbol_cache_snapshot.{h,cpp}` that: reads the exported `scene.mvr` bytes, safely parses ZIP entries rejecting unsafe/duplicate/ambiguous paths, extracts packaged GDTFs in-memory, verifies Perastage mutation-audit ownership and presence of required views (top/bottom/front/side), computes the semantic fingerprint from exact symbol-relevant entries, and returns a structured `ProjectSymbolCacheSnapshotResult` with per-fixture outcomes and a `SymbolCacheManifest` snapshot.
- Refactored project save transaction to derive the manifest from the exact exported scene buffer by extending `ProjectSession::SaveProject` with a scene-derived resource-collection seam and by updating `ConfigManager::SaveProject` to: build scene bytes first, build a pending manifest snapshot from those bytes, serialize the pending manifest only after validation succeeds, pass required transactional resources to `ProjectSession::SaveProject`, and commit the pending snapshot to the active in-memory manifest only after the outer archive finalizes successfully.
- Treated the validated manifest resource as a required transactional archive entry (marked `required`) so failures to serialize or write the validated manifest abort finalization, while preserving existing optional layout-image behavior and GUI-provided resources as non-fatal.
- Implemented archive safety, deduplication, and deterministic path folding logic used by validation and transactional resource writing, and preserved prior manifest only as provenance for timestamps (never as proof of a packaged GDTF fingerprint).
- Added a small planning seam `PlanFixtureSymbolCacheMisses` and reused the same fixture-type key for auto-update planning by exposing `BuildFixtureSymbolCacheKey` and switching the auto-update key implementation to it.
- Added regression coverage: `tests/project_symbol_cache_snapshot_test.cpp` (end-to-end in-memory MVR/GDTF roundtrip checks for valid packaged symbols, missing views, malformed scene payloads), extended `tests/project_session_io_test.cpp` to check required-resource failure behavior, and added minimal test stubs for deterministic behavior in the test environment.
- Updated `docs/release-notes-draft.md` with the stability/fix summary; no visual/symbol-generation behavior was changed.

### Testing

- Ran the new focused snapshot unit test by compiling and executing the focused binary: `c++ -std=c++20 -Icore -Imodels -Ithird_party $(wx-config --cxxflags) tests/project_symbol_cache_snapshot_test.cpp core/project_symbol_cache_snapshot.cpp core/symbol_cache_manifest.cpp core/filesystem_path_utils.cpp -o /tmp/perastage-manual/project_symbol_cache_snapshot_test $(wx-config --libs std,core) -ltinyxml2 && /tmp/perastage-manual/project_symbol_cache_snapshot_test`, and the test passed locally (validated snapshot, omission on incomplete symbols, and malformed-scene failure cases).
- Compiled key translation units to verify integration boundaries: `c++ -std=c++20 -Icore -Imodels -Ithird_party $(wx-config --cxxflags) -c core/configservices.cpp` and `c++ -std=c++20 -Icore -Icore/layouts -Icore/print -Imodels -Imvr -Igui -Iviewer3d/render -Ithird_party $(wx-config --cxxflags) -c core/configmanager.cpp`, which succeeded to validate the API changes and include boundaries.
- Ran required repository checks: `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both returned OK.
- Ran `git diff --check` to verify no whitespace issues; it passed.
- Note: an attempt to run a full CMake/CTest build in this container was blocked by missing system packages (`mdnsConfig.cmake` / related dev package not present in the ephemeral environment), so the complete CTest CI was not executed locally; GitHub Actions for `windows-debug`, `linux-debug`, and `macos-debug` remain pending and should validate platform-wide integration.

If you want, I can: (a) split the new snapshot code into smaller helper files/units, (b) run any additional deterministic unit tests you prefer, or (c) prepare the exact GitHub Actions matrix changes to run the new test on CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6dde48893483249fd86e5c7a78da96)