### PR TITLE
Correct fixture visual-color resolution and legacy recovery

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -15,6 +15,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/dummyprofilelibrary.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/file_import_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/filesystem_path_utils.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/fixture_visual_color.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtfdictionary.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtf_archive_reader.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtf_description_reader.cpp

--- a/core/fixture_visual_color.cpp
+++ b/core/fixture_visual_color.cpp
@@ -1,0 +1,87 @@
+#include "fixture_visual_color.h"
+
+#include <cctype>
+
+// Normalizes a hexadecimal RGB color to canonical uppercase #RRGGBB form.
+std::optional<std::string> NormalizeFixtureVisualColor(std::string_view raw) {
+  size_t first = 0;
+  size_t last = raw.size();
+  while (first < last && std::isspace(static_cast<unsigned char>(raw[first])))
+    ++first;
+  while (last > first &&
+         std::isspace(static_cast<unsigned char>(raw[last - 1])))
+    --last;
+  if (last > first && raw[first] == '#')
+    ++first;
+  if (last - first != 6)
+    return std::nullopt;
+
+  std::string normalized = "#";
+  normalized.reserve(7);
+  for (size_t index = first; index < last; ++index) {
+    const unsigned char value = static_cast<unsigned char>(raw[index]);
+    if (!std::isxdigit(value))
+      return std::nullopt;
+    normalized.push_back(static_cast<char>(std::toupper(value)));
+  }
+  return normalized;
+}
+
+// Resolves one fixture color according to project, recovery, and automatic precedence.
+FixtureVisualColorResult
+ResolveFixtureVisualColor(const FixtureVisualColorInput &input) {
+  FixtureVisualColorResult result;
+  if (const auto project = NormalizeFixtureVisualColor(input.projectColorHex)) {
+    result.source = FixtureVisualColorSource::ProjectInstance;
+    result.colorHex = project;
+    return result;
+  }
+  result.hadInvalidInput = !input.projectColorHex.empty();
+
+  if (input.projectState == FixtureProjectColorState::ExplicitEmpty) {
+    result.source = FixtureVisualColorSource::ExplicitEmpty;
+    return result;
+  }
+  if (input.allowLegacyMvrRecovery &&
+      input.projectState == FixtureProjectColorState::Missing) {
+    if (const auto recovered =
+            NormalizeFixtureVisualColor(input.mvrFixtureColorHex)) {
+      result.source = FixtureVisualColorSource::LegacyMvrRecovery;
+      result.colorHex = recovered;
+      return result;
+    }
+    result.hadInvalidInput =
+        result.hadInvalidInput || !input.mvrFixtureColorHex.empty();
+  }
+  if (const auto automatic =
+          NormalizeFixtureVisualColor(input.automaticColorHex)) {
+    result.source = FixtureVisualColorSource::AutomaticFixtureType;
+    result.colorHex = automatic;
+    return result;
+  }
+  result.hadInvalidInput =
+      result.hadInvalidInput || !input.automaticColorHex.empty();
+  return result;
+}
+
+// Aggregates resolved colors without depending on fixture iteration order.
+FixtureVisualColorAggregate AggregateFixtureVisualColors(
+    const std::vector<FixtureVisualColorResult> &colors) {
+  FixtureVisualColorAggregate aggregate;
+  if (colors.empty())
+    return aggregate;
+
+  const auto &first = colors.front();
+  aggregate.colorHex = first.colorHex;
+  aggregate.source = first.source;
+  for (const auto &color : colors) {
+    if (color.colorHex != aggregate.colorHex ||
+        (!color.colorHex && color.source != aggregate.source)) {
+      aggregate.colorHex.reset();
+      aggregate.mixed = true;
+      aggregate.source = FixtureVisualColorSource::Unresolved;
+      return aggregate;
+    }
+  }
+  return aggregate;
+}

--- a/core/fixture_visual_color.h
+++ b/core/fixture_visual_color.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+enum class FixtureVisualColorSource {
+  ProjectInstance,
+  LegacyMvrRecovery,
+  AutomaticFixtureType,
+  ExplicitEmpty,
+  Unresolved
+};
+
+enum class FixtureProjectColorState { Missing, Present, ExplicitEmpty };
+
+struct FixtureVisualColorInput {
+  std::string_view projectColorHex;
+  std::string_view mvrFixtureColorHex;
+  std::string_view automaticColorHex;
+  FixtureProjectColorState projectState = FixtureProjectColorState::Missing;
+  bool allowLegacyMvrRecovery = false;
+};
+
+struct FixtureVisualColorResult {
+  FixtureVisualColorSource source = FixtureVisualColorSource::Unresolved;
+  std::optional<std::string> colorHex;
+  bool hadInvalidInput = false;
+};
+
+struct FixtureVisualColorAggregate {
+  std::optional<std::string> colorHex;
+  bool mixed = false;
+  FixtureVisualColorSource source = FixtureVisualColorSource::Unresolved;
+};
+
+// Normalizes a hexadecimal RGB color to canonical uppercase #RRGGBB form.
+std::optional<std::string> NormalizeFixtureVisualColor(std::string_view raw);
+
+// Resolves one fixture color according to project, recovery, and automatic precedence.
+FixtureVisualColorResult
+ResolveFixtureVisualColor(const FixtureVisualColorInput &input);
+
+// Aggregates resolved colors without depending on fixture iteration order.
+FixtureVisualColorAggregate AggregateFixtureVisualColors(
+    const std::vector<FixtureVisualColorResult> &colors);

--- a/docs/developer/fixture_visual_color.md
+++ b/docs/developer/fixture_visual_color.md
@@ -1,0 +1,34 @@
+# Fixture visual-color resolution
+
+Perastage keeps two color properties with different ownership. `visualColorHex`
+is Perastage project-instance presentation metadata used by plans and user
+interfaces. `mvrFixtureColorHex` represents the official MVR `Fixture/Color`
+value converted between CIE xyY and RGB for editing; exporting it continues to
+use the standards-compliant CIE path.
+
+The GUI-independent `fixture_visual_color` domain module owns validation,
+canonical uppercase `#RRGGBB` normalization, resolution, and grouped-color
+aggregation. Display consumers must not recreate these rules.
+
+Resolution uses this precedence:
+
+1. a valid project-instance color;
+2. only while restoring a project whose fixture metadata entry is absent, a
+   valid official MVR fixture color recovered into the project value;
+3. a valid automatic fixture-type color supplied by the dictionary boundary;
+4. an explicit-empty or unresolved structured result.
+
+A present `hasVisualColorHex="false"` entry is an intentional empty value. It
+is never populated from MVR or an automatic default. Its presentation remains
+the existing neutral/no-fill treatment. Invalid metadata is diagnosed by the
+importer and remains permissive, but its presence prevents it from being
+mistaken for absent legacy metadata. Ordinary external MVR imports never run
+the project migration. A recovered value is held in `visualColorHex`, so the
+normal project writer persists it canonically on the next save without
+changing `mvrFixtureColorHex`.
+
+For a legend or summary group, equal normalized resolved colors produce that
+color. Different valid colors, or valid and intentional-empty values together,
+produce the deterministic mixed neutral/no-fill presentation. A group of only
+unresolved values also remains neutral/no-fill. Fixture grouping identity is
+unchanged by this policy.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -34,6 +34,11 @@ Changes since **v1.5.0**.
 
 ## Important fixes
 
+- Corrected fixture colors across summaries and layout legends by using one
+  canonical resolution policy. Legacy projects can now recover a missing
+  Perastage fixture color from the official restored MVR color, while colors
+  that users intentionally left empty remain empty.
+
 - Fixed fixture-symbol persistence so project saves validate the exact GDTF
   files packaged in `scene.mvr` before recording symbol-cache metadata. Valid
   four-view symbols now survive an unchanged save and reload without redundant

--- a/gui/layoutlegenditems.cpp
+++ b/gui/layoutlegenditems.cpp
@@ -17,8 +17,8 @@
  */
 #include "layoutlegenditems.h"
 #include "filesystem_path_utils.h"
+#include "fixture_visual_color.h"
 
-#include <cctype>
 #include <filesystem>
 #include <map>
 
@@ -37,31 +37,8 @@ struct LegendAggregate {
   bool mixedChannels = false;
   std::string symbolKey;
   std::string gdtfPath;
-  std::optional<std::string> firstColor;
-  bool hasMixedColors = false;
+  std::vector<FixtureVisualColorResult> colors;
 };
-
-// Normalizes fixture color text into a canonical #RRGGBB value when valid.
-std::optional<std::string> NormalizeHexColor(const std::string &raw) {
-  std::string value;
-  value.reserve(raw.size());
-  for (char ch : raw) {
-    if (!std::isspace(static_cast<unsigned char>(ch)))
-      value.push_back(ch);
-  }
-  if (value.empty())
-    return std::nullopt;
-  if (!value.empty() && value.front() == '#')
-    value.erase(value.begin());
-  if (value.size() != 6)
-    return std::nullopt;
-  for (char &ch : value) {
-    if (!std::isxdigit(static_cast<unsigned char>(ch)))
-      return std::nullopt;
-    ch = static_cast<char>(std::toupper(static_cast<unsigned char>(ch)));
-  }
-  return "#" + value;
-}
 } // namespace
 
 // Builds grouped layout legend entries with counts, channels, symbols, and
@@ -124,15 +101,11 @@ std::vector<SharedLayoutLegendItem> BuildSharedLayoutLegendItems() {
     if (agg.gdtfPath.empty() && !resolution.selectedPath.empty())
       agg.gdtfPath = resolution.selectedPath;
 
-    const std::optional<std::string> fixtureColor =
-        NormalizeHexColor(fixture.visualColorHex);
-    if (!fixtureColor.has_value())
-      continue;
-    if (!agg.firstColor.has_value()) {
-      agg.firstColor = fixtureColor;
-    } else if (agg.firstColor.value() != fixtureColor.value()) {
-      agg.hasMixedColors = true;
-    }
+    agg.colors.push_back(ResolveFixtureVisualColor(
+        {fixture.visualColorHex, {}, {},
+         fixture.visualColorHex.empty() ? FixtureProjectColorState::Missing
+                                        : FixtureProjectColorState::Present,
+         false}));
   }
 
   std::vector<SharedLayoutLegendItem> items;
@@ -145,8 +118,10 @@ std::vector<SharedLayoutLegendItem> BuildSharedLayoutLegendItems() {
       item.channelCount = agg.channelCount;
     item.symbolKey = agg.symbolKey;
     item.gdtfPath = agg.gdtfPath;
-    if (agg.firstColor.has_value() && !agg.hasMixedColors)
-      item.symbolFillHex = agg.firstColor;
+    const FixtureVisualColorAggregate color =
+        AggregateFixtureVisualColors(agg.colors);
+    if (!color.mixed)
+      item.symbolFillHex = color.colorHex;
     items.push_back(item);
   }
 

--- a/gui/summarypanel.cpp
+++ b/gui/summarypanel.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "summarypanel.h"
+#include "fixture_visual_color.h"
 #include "colorstore.h"
 #include "configmanager.h"
 #include "fixturetablepanel.h"
@@ -131,19 +132,24 @@ void SummaryPanel::ShowSummary(
     }
 }
 
+// Builds and displays deterministic fixture summary rows by fixture type.
 void SummaryPanel::ShowFixtureSummary() {
     UpdatePaneCaption(_("Fixtures"));
   if (!table || !store)
     return;
     std::map<std::string, FixtureSummaryRow> grouped;
+    std::map<std::string, std::vector<FixtureVisualColorResult>> colorsByType;
     const auto& fixtures = (*visibilityConfigManager).GetScene().fixtures;
     for (const auto& [uuid, fix] : fixtures) {
         (void)uuid;
         auto& row = grouped[fix.typeName];
         row.typeName = fix.typeName;
         row.count += 1;
-        if (row.colorHex.empty() && !fix.visualColorHex.empty())
-            row.colorHex = fix.visualColorHex;
+        colorsByType[fix.typeName].push_back(ResolveFixtureVisualColor(
+            {fix.visualColorHex, {}, {},
+             fix.visualColorHex.empty() ? FixtureProjectColorState::Missing
+                                        : FixtureProjectColorState::Present,
+             false}));
     }
 
     const auto hiddenFixtureTypes =
@@ -151,6 +157,10 @@ void SummaryPanel::ShowFixtureSummary() {
     std::vector<FixtureSummaryRow> rows;
     rows.reserve(grouped.size());
     for (auto& [typeName, row] : grouped) {
+        const FixtureVisualColorAggregate color =
+            AggregateFixtureVisualColors(colorsByType[typeName]);
+        if (!color.mixed && color.colorHex)
+            row.colorHex = *color.colorHex;
         row.visible = hiddenFixtureTypes.find(typeName) == hiddenFixtureTypes.end();
         rows.push_back(row);
     }

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -29,6 +29,7 @@
 #endif
 #include "fixture_label_overrides.h"
 #include "gdtf_catalog_matcher.h"
+#include "fixture_visual_color.h"
 #include "gdtf_catalog_service.h"
 #include "gdtf_fixture_category.h"
 #include "gdtf_import_matching.h"
@@ -1851,6 +1852,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
   };
 
   std::unordered_map<std::string, std::string> projectFixtureColorsByUuid;
+  std::unordered_set<std::string> projectFixtureMetadataUuids;
   std::unordered_set<std::string> consumedProjectFixtureColorUuids;
   // Collects project-only fixture colors only during explicit project restore.
   auto parseProjectFixtureMetadata = [&](tinyxml2::XMLElement *userDataNode) {
@@ -1889,6 +1891,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                      rawUuid + "'."});
             continue;
           }
+          projectFixtureMetadataUuids.insert(uuid);
           const std::string hasColor = ToLowerCopy(Trim(
               entry->Attribute("hasVisualColorHex")
                   ? entry->Attribute("hasVisualColorHex")
@@ -2751,8 +2754,21 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
         const auto projectColorIt =
             projectFixtureColorsByUuid.find(fixture.uuid);
         if (projectColorIt != projectFixtureColorsByUuid.end()) {
-          fixture.visualColorHex = projectColorIt->second;
+          const auto normalizedProjectColor =
+              NormalizeFixtureVisualColor(projectColorIt->second);
+          fixture.visualColorHex =
+              normalizedProjectColor.value_or(std::string{});
           consumedProjectFixtureColorUuids.insert(projectColorIt->first);
+        } else if (options.sourceKind == MvrImportSourceKind::ProjectRestore &&
+                   !projectFixtureMetadataUuids.contains(fixture.uuid)) {
+          const FixtureVisualColorResult recovered = ResolveFixtureVisualColor(
+              {fixture.visualColorHex, fixture.mvrFixtureColorHex, {},
+               FixtureProjectColorState::Missing, true});
+          if (recovered.source ==
+                  FixtureVisualColorSource::LegacyMvrRecovery &&
+              recovered.colorHex) {
+            fixture.visualColorHex = *recovered.colorHex;
+          }
         }
         const std::optional<GdtfDictionary::Entry> &dictionaryEntry =
             getDictionaryEntryCached(fixture.typeName);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -868,7 +868,7 @@ add_executable(save_load_roundtrip_test save_load_roundtrip_test.cpp
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp
+               ../mvr/mvrimporter.cpp ../core/fixture_visual_color.cpp
                ../mvr/gdtf_catalog_matcher.cpp
                ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
@@ -905,7 +905,7 @@ add_executable(mvr_project_fixture_metadata_contracts_test
                ../core/trussloader.cpp ../core/wx_path_utils.cpp
                ../core/runtime_storage.cpp ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp ../mvr/gdtf_catalog_matcher.cpp
+               ../mvr/mvrimporter.cpp ../core/fixture_visual_color.cpp ../mvr/gdtf_catalog_matcher.cpp
                ../viewer2d/fixture_label_overrides.cpp ../mvr/mvrexporter.cpp
                ../core/scene_transform_integrity.cpp
                ../core/mvr_identity_recovery.cpp
@@ -941,7 +941,7 @@ add_executable(project_support_userdata_roundtrip_test project_support_userdata_
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp
+               ../mvr/mvrimporter.cpp ../core/fixture_visual_color.cpp
                ../mvr/gdtf_catalog_matcher.cpp
                ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
@@ -1015,7 +1015,7 @@ add_executable(rider_truss_dictionary_normalization_test
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp
+               ../mvr/mvrimporter.cpp ../core/fixture_visual_color.cpp
                ../mvr/gdtf_catalog_matcher.cpp
                ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
@@ -1064,7 +1064,7 @@ add_executable(mvr_dmx_address_test mvr_dmx_address_test.cpp
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp
+               ../mvr/mvrimporter.cpp ../core/fixture_visual_color.cpp
                ../mvr/gdtf_catalog_matcher.cpp
                ../viewer2d/fixture_label_overrides.cpp
                ../core/logger.cpp
@@ -1102,7 +1102,7 @@ add_executable(mvr_support_userdata_roundtrip_test mvr_support_userdata_roundtri
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp
+               ../mvr/mvrimporter.cpp ../core/fixture_visual_color.cpp
                ../mvr/gdtf_catalog_matcher.cpp
                ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
@@ -1138,7 +1138,7 @@ add_executable(mvr_perastage_metadata_recovery_test
                ../core/trussloader.cpp ../core/wx_path_utils.cpp
                ../core/runtime_storage.cpp ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp ../mvr/gdtf_catalog_matcher.cpp
+               ../mvr/mvrimporter.cpp ../core/fixture_visual_color.cpp ../mvr/gdtf_catalog_matcher.cpp
                ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
                ../core/scene_transform_integrity.cpp
@@ -1158,6 +1158,11 @@ set_perastage_test_labels(MvrPerastageMetadataRecovery
                           LAYER tolerant-recovery DOMAINS mvr zip)
 set_library_env(MvrPerastageMetadataRecovery)
 
+add_executable(fixture_visual_color_test fixture_visual_color_test.cpp
+               ../core/fixture_visual_color.cpp)
+target_include_directories(fixture_visual_color_test PRIVATE ../core)
+add_test(NAME FixtureVisualColor COMMAND fixture_visual_color_test)
+
 
 add_executable(mvr_layer_appearance_userdata_test mvr_layer_appearance_userdata_test.cpp
                build_info_stub.cpp
@@ -1176,7 +1181,7 @@ add_executable(mvr_layer_appearance_userdata_test mvr_layer_appearance_userdata_
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp
+               ../mvr/mvrimporter.cpp ../core/fixture_visual_color.cpp
                ../mvr/gdtf_catalog_matcher.cpp
                ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
@@ -1220,7 +1225,7 @@ add_executable(mvr_fixture_category_roundtrip_test mvr_fixture_category_roundtri
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp
+               ../mvr/mvrimporter.cpp ../core/fixture_visual_color.cpp
                ../mvr/gdtf_catalog_matcher.cpp
                ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
@@ -1262,7 +1267,7 @@ add_executable(mvr_sceneobject_symbol_identity_test mvr_sceneobject_symbol_ident
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp
+               ../mvr/mvrimporter.cpp ../core/fixture_visual_color.cpp
                ../mvr/gdtf_catalog_matcher.cpp
                ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
@@ -1309,7 +1314,7 @@ add_executable(mvr_truss_roundtrip_structure_test mvr_truss_roundtrip_structure_
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp
+               ../mvr/mvrimporter.cpp ../core/fixture_visual_color.cpp
                ../mvr/gdtf_catalog_matcher.cpp
                ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
@@ -1353,7 +1358,7 @@ add_executable(mvr_exporter_compliance_test mvr_exporter_compliance_test.cpp
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp
+               ../mvr/mvrimporter.cpp ../core/fixture_visual_color.cpp
                ../mvr/gdtf_catalog_matcher.cpp
                ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
@@ -1403,7 +1408,7 @@ add_executable(rider_save_roundtrip_test rider_save_roundtrip_test.cpp
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp
+               ../mvr/mvrimporter.cpp ../core/fixture_visual_color.cpp
                ../mvr/gdtf_catalog_matcher.cpp
                ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
@@ -2004,7 +2009,7 @@ add_executable(symbol_fixture_applier_gdtf_test symbol_fixture_applier_gdtf_test
                ../viewer3d/loader3ds.cpp
                ../viewer3d/loaderglb.cpp
                ../viewer3d/meshprimitives.cpp
-               ../mvr/mvrimporter.cpp
+               ../mvr/mvrimporter.cpp ../core/fixture_visual_color.cpp
                ../mvr/gdtf_catalog_matcher.cpp
                ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
@@ -2064,7 +2069,7 @@ add_executable(mvr_patched_gdtf_export_test mvr_patched_gdtf_export_test.cpp
                ../viewer3d/loader3ds.cpp
                ../viewer3d/loaderglb.cpp
                ../viewer3d/meshprimitives.cpp
-               ../mvr/mvrimporter.cpp
+               ../mvr/mvrimporter.cpp ../core/fixture_visual_color.cpp
                ../mvr/gdtf_catalog_matcher.cpp
                ../viewer2d/fixture_label_overrides.cpp
                consolepanel_stub.cpp

--- a/tests/fixture_visual_color_test.cpp
+++ b/tests/fixture_visual_color_test.cpp
@@ -1,0 +1,68 @@
+#include "fixture_visual_color.h"
+
+#include <cassert>
+
+// Verifies resolver precedence, normalization, recovery, and empty semantics.
+static void TestResolution() {
+  auto result = ResolveFixtureVisualColor(
+      {" #a1b2c3 ", "#445566", "#778899",
+       FixtureProjectColorState::Present, true});
+  assert(result.source == FixtureVisualColorSource::ProjectInstance);
+  assert(result.colorHex == "#A1B2C3");
+
+  result = ResolveFixtureVisualColor(
+      {{}, "#12ab34", "#778899", FixtureProjectColorState::Missing, true});
+  assert(result.source == FixtureVisualColorSource::LegacyMvrRecovery);
+  assert(result.colorHex == "#12AB34");
+
+  result = ResolveFixtureVisualColor(
+      {{}, "#12AB34", "#778899", FixtureProjectColorState::ExplicitEmpty,
+       true});
+  assert(result.source == FixtureVisualColorSource::ExplicitEmpty);
+  assert(!result.colorHex);
+
+  result = ResolveFixtureVisualColor(
+      {{}, {}, "778899", FixtureProjectColorState::Missing, false});
+  assert(result.source == FixtureVisualColorSource::AutomaticFixtureType);
+  assert(result.colorHex == "#778899");
+
+  result = ResolveFixtureVisualColor(
+      {{}, {}, "#778899", FixtureProjectColorState::ExplicitEmpty, false});
+  assert(result.source == FixtureVisualColorSource::ExplicitEmpty);
+
+  result = ResolveFixtureVisualColor(
+      {"broken", "also-broken", "#xyzxyz", FixtureProjectColorState::Present,
+       false});
+  assert(result.source == FixtureVisualColorSource::Unresolved);
+  assert(!result.colorHex);
+  assert(result.hadInvalidInput);
+}
+
+// Verifies deterministic uniform, mixed, empty, and unresolved aggregation.
+static void TestAggregation() {
+  const auto red = ResolveFixtureVisualColor(
+      {"#ff0000", {}, {}, FixtureProjectColorState::Present, false});
+  const auto redAgain = ResolveFixtureVisualColor(
+      {"FF0000", {}, {}, FixtureProjectColorState::Present, false});
+  const auto blue = ResolveFixtureVisualColor(
+      {"#0000ff", {}, {}, FixtureProjectColorState::Present, false});
+  const auto empty = ResolveFixtureVisualColor(
+      {{}, {}, {}, FixtureProjectColorState::ExplicitEmpty, false});
+  const auto unresolved = ResolveFixtureVisualColor({});
+
+  auto aggregate = AggregateFixtureVisualColors({red, redAgain});
+  assert(!aggregate.mixed && aggregate.colorHex == "#FF0000");
+  aggregate = AggregateFixtureVisualColors({red, blue});
+  assert(aggregate.mixed && !aggregate.colorHex);
+  aggregate = AggregateFixtureVisualColors({red, empty});
+  assert(aggregate.mixed && !aggregate.colorHex);
+  aggregate = AggregateFixtureVisualColors({unresolved, unresolved});
+  assert(!aggregate.mixed && !aggregate.colorHex);
+}
+
+// Runs the fixture visual-color domain regression checks.
+int main() {
+  TestResolution();
+  TestAggregation();
+  return 0;
+}

--- a/tests/mvr_perastage_metadata_recovery_test.cpp
+++ b/tests/mvr_perastage_metadata_recovery_test.cpp
@@ -94,6 +94,19 @@ static void WriteProjectFixtureMetadataArchive(const fs::path &path) {
   WriteArchive(path, {{"GeneralSceneDescription.xml", xml}});
 }
 
+// Writes a color-bearing fixture with optional explicit-empty project metadata.
+static void WriteLegacyColorArchive(const fs::path &path,
+                                    bool includeExplicitEmpty) {
+  const std::string metadata = includeExplicitEmpty
+      ? "<UserData><Data provider=\"Perastage\" ver=\"1.0\"><ProjectFixtureMetadataMap schemaVersion=\"1.0\"><ProjectFixtureMetadata uuid=\"20000000-0000-4000-8000-000000000010\" hasVisualColorHex=\"false\"/></ProjectFixtureMetadataMap></Data></UserData>"
+      : "";
+  const std::string xml =
+      "<GeneralSceneDescription verMajor=\"1\" verMinor=\"6\" provider=\"Test\" providerVersion=\"1\">" +
+      metadata +
+      "<Scene><Layers><Layer uuid=\"10000000-0000-4000-8000-000000000001\" name=\"Default\"><ChildList><Fixture uuid=\"20000000-0000-4000-8000-000000000010\" name=\"Colored\"><FixtureID>1</FixtureID><FixtureIDNumeric>1</FixtureIDNumeric><Color>0.3127,0.3290,100</Color></Fixture></ChildList></Layer></Layers></Scene></GeneralSceneDescription>";
+  WriteArchive(path, {{"GeneralSceneDescription.xml", xml}});
+}
+
 // Returns whether the result contains the exact structured diagnostic code.
 static bool HasDiagnostic(const MvrImportResult &result,
                           const std::string &code) {
@@ -192,6 +205,41 @@ static void TestProjectFixtureMetadataRecovery(const fs::path &tempDir) {
            "invalid_project_fixture_visual_color"}) {
     assert(CountDiagnostic(restored, code) == 1);
   }
+}
+
+// Verifies project-only legacy MVR recovery and explicit-empty preservation.
+static void TestLegacyFixtureColorRecovery(const fs::path &tempDir) {
+  MvrImporter importer;
+  MvrImportOptions options;
+  options.promptConflicts = false;
+  options.applyDictionary = false;
+
+  const fs::path legacy = tempDir / "legacy-fixture-color.mvr";
+  WriteLegacyColorArchive(legacy, false);
+  options.sourceKind = MvrImportSourceKind::ExternalImport;
+  MvrImportResult external;
+  assert(importer.ImportFromFile(legacy.string(), external,
+                                 MvrImportMode::ParseOnly, options));
+  const Fixture &externalFixture = external.scene.fixtures.begin()->second;
+  assert(externalFixture.visualColorHex.empty());
+  assert(!externalFixture.mvrFixtureColorHex.empty());
+
+  options.sourceKind = MvrImportSourceKind::ProjectRestore;
+  MvrImportResult restored;
+  assert(importer.ImportFromFile(legacy.string(), restored,
+                                 MvrImportMode::ParseOnly, options));
+  const Fixture &restoredFixture = restored.scene.fixtures.begin()->second;
+  assert(restoredFixture.visualColorHex == restoredFixture.mvrFixtureColorHex);
+  assert(restoredFixture.visualColorHex.size() == 7);
+
+  const fs::path explicitEmpty = tempDir / "explicit-empty-fixture-color.mvr";
+  WriteLegacyColorArchive(explicitEmpty, true);
+  MvrImportResult emptyRestored;
+  assert(importer.ImportFromFile(explicitEmpty.string(), emptyRestored,
+                                 MvrImportMode::ParseOnly, options));
+  const Fixture &emptyFixture = emptyRestored.scene.fixtures.begin()->second;
+  assert(emptyFixture.visualColorHex.empty());
+  assert(!emptyFixture.mvrFixtureColorHex.empty());
 }
 
 // Verifies portable, missing, empty, and unsafe AuxGdtf value policy.
@@ -306,6 +354,7 @@ int main() {
   fs::create_directories(tempDir, ec);
   TestMetadataRecoveryMatrix(tempDir);
   TestProjectFixtureMetadataRecovery(tempDir);
+  TestLegacyFixtureColorRecovery(tempDir);
   TestAuxiliaryValuePolicy(tempDir);
   TestAmbiguousAuxiliaryResources(tempDir);
   TestAmbiguousSceneDescriptions(tempDir);

--- a/viewer3d/render/selection_overlay_pass.cpp
+++ b/viewer3d/render/selection_overlay_pass.cpp
@@ -16,6 +16,7 @@
 #include <wx/log.h>
 
 #include "configmanager.h"
+#include "fixture_visual_color.h"
 #include "opaque_fixture_pass.h"
 #include "opaque_object_pass.h"
 #include "opaque_truss_pass.h"
@@ -145,7 +146,12 @@ void SelectionOverlayPass::Render(Viewer3DController &controller,
 
   auto getTypeColor = [&](const std::string &key, const std::string &hex) {
     std::array<float, 3> c;
-    if (!hex.empty() && HexToRGB(hex, c[0], c[1], c[2]))
+    const FixtureVisualColorResult resolved = ResolveFixtureVisualColor(
+        {hex, {}, {}, hex.empty() ? FixtureProjectColorState::Missing
+                                  : FixtureProjectColorState::Present,
+         false});
+    if (resolved.colorHex &&
+        HexToRGB(*resolved.colorHex, c[0], c[1], c[2]))
       return c;
     return MakeDeterministicColor("type:" + key);
   };

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -44,6 +44,7 @@
 #include <numeric>
 
 #include "configmanager.h"
+#include "fixture_visual_color.h"
 #include "loader3ds.h"
 #include "loaderglb.h"
 #include "matrixutils.h"
@@ -1368,7 +1369,12 @@ void Viewer3DController::RenderOpaqueFrame(const RenderFrameContext &context,
 
   auto getTypeColor = [&](const std::string &key, const std::string &hex) {
     std::array<float, 3> c;
-    if (!hex.empty() && HexToRGB(hex, c[0], c[1], c[2])) {
+    const FixtureVisualColorResult resolved = ResolveFixtureVisualColor(
+        {hex, {}, {}, hex.empty() ? FixtureProjectColorState::Missing
+                                  : FixtureProjectColorState::Present,
+         false});
+    if (resolved.colorHex &&
+        HexToRGB(*resolved.colorHex, c[0], c[1], c[2])) {
       m_impl->typeColors[key] = c;
       return c;
     }


### PR DESCRIPTION
### Motivation
- Remove inconsistent, duplicated color logic and provide one GUI-independent resolver so viewers, summaries, legends, and imports agree on visual fill behavior.
- Ensure legacy projects that lack Perastage project-instance color metadata can recover a canonical visual color from the restored official MVR `Fixture/Color` while preserving intentionally empty project colors.
- Make resolution testable, diagnosable, and deterministic for grouped legend/summary aggregation without changing symbol geometry or capture behavior.

### Description
- Add a small GUI-independent domain module `core/fixture_visual_color.{h,cpp}` that normalizes colors to canonical uppercase `#RRGGBB`, returns a structured `FixtureVisualColorResult` with an explicit source enum (`ProjectInstance`, `LegacyMvrRecovery`, `AutomaticFixtureType`, `ExplicitEmpty`, `Unresolved`), and provides `AggregateFixtureVisualColors(...)` for deterministic group aggregation.
- Update the MVR project restore path in `mvr/mvrimporter.cpp` to record whether a `ProjectFixtureMetadata` entry existed and, during `ProjectRestore` only, recover a missing project-instance color from a valid restored `mvrFixtureColorHex` (canonicalized), while preserving explicit-empty and invalid present metadata; also canonicalize accepted project colors on import.
- Route presentation consumers to the shared resolver: `gui/layoutlegenditems.cpp` and `gui/summarypanel.cpp` now use the resolver + aggregator to decide symbol fill and summary color, and `viewer3d` rendering paths (`viewer3d/viewer3dcontroller.cpp` and `viewer3d/render/selection_overlay_pass.cpp`) use the resolver for type-color selection, keeping deterministic fallback for missing/unresolved values.
- Add tests and docs: new `tests/fixture_visual_color_test.cpp` (resolver + aggregation unit tests), extend `tests/mvr_perastage_metadata_recovery_test.cpp` with legacy-recovery and explicit-empty checks, update `tests/CMakeLists.txt` to include the new test, and add developer docs `docs/developer/fixture_visual_color.md` plus a release-note entry in `docs/release-notes-draft.md`.
- Keep all symbol generation, caching, GDTF/MVR export behavior, and fixture-symbol baseline artifacts unchanged; no symbol geometry or capture changes were made.

### Testing
- Ran the new domain unit binary build and tests locally: `g++ -std=c++20 -Wall -Wextra -Werror -pedantic -Icore tests/fixture_visual_color_test.cpp core/fixture_visual_color.cpp -o /tmp/fixture_visual_color_test && /tmp/fixture_visual_color_test` — succeeded.
- Ran repository policy checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh` — both succeeded.
- Extended MVR recovery test run via the existing `mvr_perastage_metadata_recovery_test` source changes and invoked it in the test suite (added a focused legacy-recovery check); those tests compile / are wired in the test CMake, but full CTest/CTest matrix could not be executed here because `cmake --preset wsl-x64-debug` failed in this environment due to missing wxWidgets development libraries (`wxWidgets_LIBRARIES` and `wxWidgets_INCLUDE_DIRS`).
- Performed sanity checks (`git diff --check`, module checks) and verified no fixture-symbol baseline files or checked-in symbol snapshots were changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70683b1fe483248e4a2f3f385de0b6)