### PR TITLE
Complete Checkpoint 03 fixture color resolution contracts

### DIFF
--- a/core/fixture_visual_color.cpp
+++ b/core/fixture_visual_color.cpp
@@ -64,6 +64,27 @@ ResolveFixtureVisualColor(const FixtureVisualColorInput &input) {
   return result;
 }
 
+// Resolves presentation color from the durable state stored by one fixture.
+FixtureVisualColorResult ResolveFixturePresentationColor(const Fixture &fixture) {
+  FixtureProjectColorState state = fixture.visualColorState;
+  if (!fixture.visualColorHex.empty())
+    state = FixtureProjectColorState::Present;
+  return ResolveFixtureVisualColor({fixture.visualColorHex, {},
+                                    fixture.automaticVisualColorHex, state, false});
+}
+
+// Persists an automatic fallback only when project metadata is genuinely missing.
+void PersistAutomaticFixtureVisualColor(Fixture &fixture, std::string_view colorHex) {
+  if (fixture.visualColorState != FixtureProjectColorState::Missing ||
+      !fixture.visualColorHex.empty())
+    return;
+  const auto normalized = NormalizeFixtureVisualColor(colorHex);
+  if (!normalized)
+    return;
+  fixture.visualColorHex = *normalized;
+  fixture.visualColorState = FixtureProjectColorState::Present;
+}
+
 // Aggregates resolved colors without depending on fixture iteration order.
 FixtureVisualColorAggregate AggregateFixtureVisualColors(
     const std::vector<FixtureVisualColorResult> &colors) {

--- a/core/fixture_visual_color.h
+++ b/core/fixture_visual_color.h
@@ -5,6 +5,8 @@
 #include <string_view>
 #include <vector>
 
+#include "../models/fixture.h"
+
 enum class FixtureVisualColorSource {
   ProjectInstance,
   LegacyMvrRecovery,
@@ -12,8 +14,6 @@ enum class FixtureVisualColorSource {
   ExplicitEmpty,
   Unresolved
 };
-
-enum class FixtureProjectColorState { Missing, Present, ExplicitEmpty };
 
 struct FixtureVisualColorInput {
   std::string_view projectColorHex;
@@ -41,6 +41,12 @@ std::optional<std::string> NormalizeFixtureVisualColor(std::string_view raw);
 // Resolves one fixture color according to project, recovery, and automatic precedence.
 FixtureVisualColorResult
 ResolveFixtureVisualColor(const FixtureVisualColorInput &input);
+
+// Resolves presentation color from the durable state stored by one fixture.
+FixtureVisualColorResult ResolveFixturePresentationColor(const Fixture &fixture);
+
+// Persists an automatic fallback only when project metadata is genuinely missing.
+void PersistAutomaticFixtureVisualColor(Fixture &fixture, std::string_view colorHex);
 
 // Aggregates resolved colors without depending on fixture iteration order.
 FixtureVisualColorAggregate AggregateFixtureVisualColors(

--- a/docs/developer/fixture_visual_color.md
+++ b/docs/developer/fixture_visual_color.md
@@ -6,6 +6,11 @@ interfaces. `mvrFixtureColorHex` represents the official MVR `Fixture/Color`
 value converted between CIE xyY and RGB for editing; exporting it continues to
 use the standards-compliant CIE path.
 
+`Fixture::visualColorState` durably distinguishes missing project metadata,
+present metadata, and an intentional `ExplicitEmpty`. The separate
+`automaticVisualColorHex` candidate holds type metadata, so automatic values
+are never mistaken for project-instance input.
+
 The GUI-independent `fixture_visual_color` domain module owns validation,
 canonical uppercase `#RRGGBB` normalization, resolution, and grouped-color
 aggregation. Display consumers must not recreate these rules.
@@ -15,7 +20,7 @@ Resolution uses this precedence:
 1. a valid project-instance color;
 2. only while restoring a project whose fixture metadata entry is absent, a
    valid official MVR fixture color recovered into the project value;
-3. a valid automatic fixture-type color supplied by the dictionary boundary;
+3. a valid root, dictionary, or deterministic automatic fixture-type color;
 4. an explicit-empty or unresolved structured result.
 
 A present `hasVisualColorHex="false"` entry is an intentional empty value. It
@@ -26,6 +31,13 @@ mistaken for absent legacy metadata. Ordinary external MVR imports never run
 the project migration. A recovered value is held in `visualColorHex`, so the
 normal project writer persists it canonically on the next save without
 changing `mvrFixtureColorHex`.
+
+`ResolveFixturePresentationColor` is the fixture-level boundary used by the 3D
+opaque and selection paths, fixture summaries, and shared layout legends.
+Layout preview, print, and PDF legends consume the shared legend result.
+Automatic persistence only changes `Missing` fixtures, so refresh and scene
+synchronization preserve `ExplicitEmpty`; save and reload retain both the state
+and any canonical recovered project value.
 
 For a legend or summary group, equal normalized resolved colors produce that
 color. Different valid colors, or valid and intentional-empty values together,

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -37,7 +37,8 @@ Changes since **v1.5.0**.
 - Corrected fixture colors across summaries and layout legends by using one
   canonical resolution policy. Legacy projects can now recover a missing
   Perastage fixture color from the official restored MVR color, while colors
-  that users intentionally left empty remain empty.
+  that users intentionally left empty remain empty through refresh, save, and
+  reload. Automatic type colors no longer outrank legacy project recovery.
 
 - Fixed fixture-symbol persistence so project saves validate the exact GDTF
   files packaged in `scene.mvr` before recording symbol-cache metadata. Valid

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -38,7 +38,8 @@ Changes since **v1.5.0**.
   canonical resolution policy. Legacy projects can now recover a missing
   Perastage fixture color from the official restored MVR color, while colors
   that users intentionally left empty remain empty through refresh, save, and
-  reload. Automatic type colors no longer outrank legacy project recovery.
+  reload. Automatic type colors no longer outrank legacy project recovery and
+  remain portable in standalone MVR exports.
 
 - Fixed fixture-symbol persistence so project saves validate the exact GDTF
   files packaged in `scene.mvr` before recording symbol-cache metadata. Valid

--- a/gui/layoutlegenditems.cpp
+++ b/gui/layoutlegenditems.cpp
@@ -101,11 +101,7 @@ std::vector<SharedLayoutLegendItem> BuildSharedLayoutLegendItems() {
     if (agg.gdtfPath.empty() && !resolution.selectedPath.empty())
       agg.gdtfPath = resolution.selectedPath;
 
-    agg.colors.push_back(ResolveFixtureVisualColor(
-        {fixture.visualColorHex, {}, {},
-         fixture.visualColorHex.empty() ? FixtureProjectColorState::Missing
-                                        : FixtureProjectColorState::Present,
-         false}));
+    agg.colors.push_back(ResolveFixturePresentationColor(fixture));
   }
 
   std::vector<SharedLayoutLegendItem> items;

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "mainwindow.h"
+#include "fixture_visual_color.h"
 #include "diagnostics/DiagnosticLogger.h"
 #include "filesystem_path_utils.h"
 
@@ -214,11 +215,12 @@ void PersistFixtureTypeAutoColors(ConfigManager &configManager) {
   auto &scene = configManager.GetScene();
   for (auto &[uuid, fixture] : scene.fixtures) {
     (void)uuid;
-    if (!fixture.visualColorHex.empty())
+    if (!fixture.visualColorHex.empty() ||
+        fixture.visualColorState == FixtureProjectColorState::ExplicitEmpty)
       continue;
 
-    fixture.visualColorHex =
-        Viewer3DController::BuildFixtureTypeAutoColorHex(fixture.gdtfSpec);
+    PersistAutomaticFixtureVisualColor(
+        fixture, Viewer3DController::BuildFixtureTypeAutoColorHex(fixture.gdtfSpec));
   }
 }
 

--- a/gui/summarypanel.cpp
+++ b/gui/summarypanel.cpp
@@ -145,11 +145,7 @@ void SummaryPanel::ShowFixtureSummary() {
         auto& row = grouped[fix.typeName];
         row.typeName = fix.typeName;
         row.count += 1;
-        colorsByType[fix.typeName].push_back(ResolveFixtureVisualColor(
-            {fix.visualColorHex, {}, {},
-             fix.visualColorHex.empty() ? FixtureProjectColorState::Missing
-                                        : FixtureProjectColorState::Present,
-             false}));
+        colorsByType[fix.typeName].push_back(ResolveFixturePresentationColor(fix));
     }
 
     const auto hiddenFixtureTypes =

--- a/models/fixture.h
+++ b/models/fixture.h
@@ -28,6 +28,9 @@ enum class FixturePhysicalPropertiesSource {
     Manual
 };
 
+// Distinguishes absent project color metadata from a stored value or clear.
+enum class FixtureProjectColorState { Missing, Present, ExplicitEmpty };
+
 // Represents a lighting fixture object parsed from MVR
 struct Fixture {
     std::string uuid;             // Unique identifier from the MVR file
@@ -55,6 +58,10 @@ struct Fixture {
 
     // Perastage-only visual color used in plans, summaries, legends, and viewers.
     std::string visualColorHex;
+    // Tracks durable project-instance color ownership.
+    FixtureProjectColorState visualColorState = FixtureProjectColorState::Missing;
+    // Automatic fixture-type color is separate from project metadata.
+    std::string automaticVisualColorHex;
     // Official MVR Fixture/Color represented as UI hex and converted to/from CIE xyY.
     std::string mvrFixtureColorHex;
 

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -717,7 +717,9 @@ static void MergeFixtureTypeInfoExport(
     std::map<std::string, FixtureTypeInfoExport> &metadataByType,
     const Fixture &fixture, const std::string &gdtfArchivePath) {
   const std::string category = TrimAscii(fixture.category);
-  const std::string visualColorHex = TrimAscii(fixture.automaticVisualColorHex);
+  const std::string visualColorHex = TrimAscii(
+      fixture.automaticVisualColorHex.empty() ? fixture.visualColorHex
+                                              : fixture.automaticVisualColorHex);
   if (category.empty() && visualColorHex.empty())
     return;
 

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -717,7 +717,7 @@ static void MergeFixtureTypeInfoExport(
     std::map<std::string, FixtureTypeInfoExport> &metadataByType,
     const Fixture &fixture, const std::string &gdtfArchivePath) {
   const std::string category = TrimAscii(fixture.category);
-  const std::string visualColorHex = TrimAscii(fixture.visualColorHex);
+  const std::string visualColorHex = TrimAscii(fixture.automaticVisualColorHex);
   if (category.empty() && visualColorHex.empty())
     return;
 
@@ -805,6 +805,9 @@ static void AppendProjectFixtureMetadata(tinyxml2::XMLDocument &doc,
     (void)key;
     const std::string uuid = CanonicalizeUuid(fixture.uuid);
     const std::string color = TrimAscii(fixture.visualColorHex);
+    if (fixture.visualColorState == FixtureProjectColorState::Missing &&
+        color.empty())
+      continue;
     if (!uuid.empty() &&
         (color.empty() ||
          (color.size() == 7 && color.front() == '#' &&

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -2749,7 +2749,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
             fixture.categorySource = rootTypeInfoIt->second.categorySource;
             fixture.categorySourceReason.clear();
           }
-          fixture.visualColorHex = rootTypeInfoIt->second.visualColorHex;
+          fixture.automaticVisualColorHex = rootTypeInfoIt->second.visualColorHex;
         }
         const auto projectColorIt =
             projectFixtureColorsByUuid.find(fixture.uuid);
@@ -2758,16 +2758,22 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
               NormalizeFixtureVisualColor(projectColorIt->second);
           fixture.visualColorHex =
               normalizedProjectColor.value_or(std::string{});
+          fixture.visualColorState = fixture.visualColorHex.empty()
+                                         ? FixtureProjectColorState::ExplicitEmpty
+                                         : FixtureProjectColorState::Present;
           consumedProjectFixtureColorUuids.insert(projectColorIt->first);
+        } else if (projectFixtureMetadataUuids.contains(fixture.uuid)) {
+          fixture.visualColorState = FixtureProjectColorState::Present;
         } else if (options.sourceKind == MvrImportSourceKind::ProjectRestore &&
                    !projectFixtureMetadataUuids.contains(fixture.uuid)) {
           const FixtureVisualColorResult recovered = ResolveFixtureVisualColor(
-              {fixture.visualColorHex, fixture.mvrFixtureColorHex, {},
+              {{}, fixture.mvrFixtureColorHex, fixture.automaticVisualColorHex,
                FixtureProjectColorState::Missing, true});
           if (recovered.source ==
                   FixtureVisualColorSource::LegacyMvrRecovery &&
               recovered.colorHex) {
             fixture.visualColorHex = *recovered.colorHex;
+            fixture.visualColorState = FixtureProjectColorState::Present;
           }
         }
         const std::optional<GdtfDictionary::Entry> &dictionaryEntry =

--- a/tests/fixture_visual_color_test.cpp
+++ b/tests/fixture_visual_color_test.cpp
@@ -36,6 +36,24 @@ static void TestResolution() {
   assert(result.source == FixtureVisualColorSource::Unresolved);
   assert(!result.colorHex);
   assert(result.hadInvalidInput);
+
+  result = ResolveFixtureVisualColor(
+      {"broken", "#123456", "#ABCDEF", FixtureProjectColorState::Present,
+       true});
+  assert(result.source == FixtureVisualColorSource::AutomaticFixtureType);
+
+  Fixture explicitEmpty;
+  explicitEmpty.visualColorState = FixtureProjectColorState::ExplicitEmpty;
+  explicitEmpty.mvrFixtureColorHex = "#123456";
+  explicitEmpty.automaticVisualColorHex = "#ABCDEF";
+  assert(ResolveFixturePresentationColor(explicitEmpty).source ==
+         FixtureVisualColorSource::ExplicitEmpty);
+  PersistAutomaticFixtureVisualColor(explicitEmpty, "#654321");
+  assert(explicitEmpty.visualColorHex.empty());
+
+  Fixture missing;
+  PersistAutomaticFixtureVisualColor(missing, "#abcdef");
+  assert(missing.visualColorHex == "#ABCDEF");
 }
 
 // Verifies deterministic uniform, mixed, empty, and unresolved aggregation.

--- a/tests/mvr_fixture_category_roundtrip_test.cpp
+++ b/tests/mvr_fixture_category_roundtrip_test.cpp
@@ -21,6 +21,7 @@
 #include "fixture.h"
 #include "gdtf_test_fixture_builder.h"
 #include "gdtfdictionary.h"
+#include "fixture_visual_color.h"
 #include "layer.h"
 #include "mvrexporter.h"
 #include "mvrimporter.h"
@@ -282,7 +283,9 @@ int main() {
       const Fixture &loaded = imported.fixtures.at(uuid);
       assert(loaded.category == "Spot");
       assert(loaded.categorySource == "Manual");
-      assert(loaded.visualColorHex == "#336699");
+      assert(loaded.visualColorHex.empty());
+      assert(loaded.automaticVisualColorHex == "#336699");
+      assert(ResolveFixturePresentationColor(loaded).colorHex == "#336699");
       assert(!loaded.gdtfSpec.empty());
       assert(loaded.gdtfMode == "ModeA");
     }

--- a/tests/mvr_perastage_metadata_recovery_test.cpp
+++ b/tests/mvr_perastage_metadata_recovery_test.cpp
@@ -15,6 +15,7 @@
 #include <wx/zipstrm.h>
 
 #include "mvrimporter.h"
+#include "fixture_visual_color.h"
 
 namespace fs = std::filesystem;
 
@@ -98,12 +99,15 @@ static void WriteProjectFixtureMetadataArchive(const fs::path &path) {
 static void WriteLegacyColorArchive(const fs::path &path,
                                     bool includeExplicitEmpty) {
   const std::string metadata = includeExplicitEmpty
-      ? "<UserData><Data provider=\"Perastage\" ver=\"1.0\"><ProjectFixtureMetadataMap schemaVersion=\"1.0\"><ProjectFixtureMetadata uuid=\"20000000-0000-4000-8000-000000000010\" hasVisualColorHex=\"false\"/></ProjectFixtureMetadataMap></Data></UserData>"
+      ? "<ProjectFixtureMetadataMap schemaVersion=\"1.0\"><ProjectFixtureMetadata uuid=\"20000000-0000-4000-8000-000000000010\" hasVisualColorHex=\"false\"/></ProjectFixtureMetadataMap>"
       : "";
+  const std::string userData =
+      "<UserData><Data provider=\"Perastage\" ver=\"1.0\"><FixtureTypeInfoMap><FixtureTypeInfo key=\"Legacy.gdtf|Mode\" gdtfSpec=\"Legacy.gdtf\" gdtfMode=\"Mode\"><VisualColor>#AABBCC</VisualColor></FixtureTypeInfo></FixtureTypeInfoMap>" +
+      metadata + "</Data></UserData>";
   const std::string xml =
       "<GeneralSceneDescription verMajor=\"1\" verMinor=\"6\" provider=\"Test\" providerVersion=\"1\">" +
-      metadata +
-      "<Scene><Layers><Layer uuid=\"10000000-0000-4000-8000-000000000001\" name=\"Default\"><ChildList><Fixture uuid=\"20000000-0000-4000-8000-000000000010\" name=\"Colored\"><FixtureID>1</FixtureID><FixtureIDNumeric>1</FixtureIDNumeric><Color>0.3127,0.3290,100</Color></Fixture></ChildList></Layer></Layers></Scene></GeneralSceneDescription>";
+      userData +
+      "<Scene><Layers><Layer uuid=\"10000000-0000-4000-8000-000000000001\" name=\"Default\"><ChildList><Fixture uuid=\"20000000-0000-4000-8000-000000000010\" name=\"Colored\"><GDTFSpec>Legacy.gdtf</GDTFSpec><GDTFMode>Mode</GDTFMode><FixtureID>1</FixtureID><FixtureIDNumeric>1</FixtureIDNumeric><Color>0.3127,0.3290,100</Color></Fixture></ChildList></Layer></Layers></Scene></GeneralSceneDescription>";
   WriteArchive(path, {{"GeneralSceneDescription.xml", xml}});
 }
 
@@ -223,6 +227,8 @@ static void TestLegacyFixtureColorRecovery(const fs::path &tempDir) {
   const Fixture &externalFixture = external.scene.fixtures.begin()->second;
   assert(externalFixture.visualColorHex.empty());
   assert(!externalFixture.mvrFixtureColorHex.empty());
+  assert(externalFixture.automaticVisualColorHex == "#AABBCC");
+  assert(ResolveFixturePresentationColor(externalFixture).colorHex == "#AABBCC");
 
   options.sourceKind = MvrImportSourceKind::ProjectRestore;
   MvrImportResult restored;
@@ -230,6 +236,7 @@ static void TestLegacyFixtureColorRecovery(const fs::path &tempDir) {
                                  MvrImportMode::ParseOnly, options));
   const Fixture &restoredFixture = restored.scene.fixtures.begin()->second;
   assert(restoredFixture.visualColorHex == restoredFixture.mvrFixtureColorHex);
+  assert(restoredFixture.visualColorHex != restoredFixture.automaticVisualColorHex);
   assert(restoredFixture.visualColorHex.size() == 7);
 
   const fs::path explicitEmpty = tempDir / "explicit-empty-fixture-color.mvr";
@@ -240,6 +247,7 @@ static void TestLegacyFixtureColorRecovery(const fs::path &tempDir) {
   const Fixture &emptyFixture = emptyRestored.scene.fixtures.begin()->second;
   assert(emptyFixture.visualColorHex.empty());
   assert(!emptyFixture.mvrFixtureColorHex.empty());
+  assert(emptyFixture.visualColorState == FixtureProjectColorState::ExplicitEmpty);
 }
 
 // Verifies portable, missing, empty, and unsafe AuxGdtf value policy.

--- a/tests/mvr_project_fixture_metadata_contracts_test.cpp
+++ b/tests/mvr_project_fixture_metadata_contracts_test.cpp
@@ -237,6 +237,9 @@ static void AddFixture(MvrScene &scene, const std::string &uuid,
   fixture.fixtureIdNumeric = numericId;
   fixture.fixtureIdText = textId;
   fixture.visualColorHex = color;
+  fixture.visualColorState = color.empty()
+                                 ? FixtureProjectColorState::ExplicitEmpty
+                                 : FixtureProjectColorState::Present;
   fixture.address = std::to_string(scene.fixtures.size() + 1) + ".1";
   scene.fixtures.emplace(uuid, std::move(fixture));
 }

--- a/tests/save_load_roundtrip_test.cpp
+++ b/tests/save_load_roundtrip_test.cpp
@@ -385,6 +385,7 @@ int main() {
   f.typeName = "FixtureType";
   f.gdtfSpec = "orig.gdtf";
   f.visualColorHex = "#445566";
+  f.visualColorState = FixtureProjectColorState::Present;
   f.fixtureIdText = "S101A";
   f.fixtureIdNumeric = 101;
   f.fixtureId = 101;
@@ -395,6 +396,7 @@ int main() {
   f2.layer = layer.name;
   f2.typeName = "FixtureType";
   f2.gdtfSpec = "orig.gdtf";
+  f2.visualColorState = FixtureProjectColorState::ExplicitEmpty;
   f2.fixtureIdText = "S101B";
   f2.fixtureIdNumeric = 101;
   f2.fixtureId = 101;
@@ -418,6 +420,7 @@ int main() {
   f4.typeName = "FixtureType";
   f4.gdtfSpec = "orig.gdtf";
   f4.visualColorHex = "#778899";
+  f4.visualColorState = FixtureProjectColorState::Present;
   f4.fixtureIdText = "Imported ID";
   f4.fixtureIdNumeric = 44;
   f4.fixtureId = 707;

--- a/viewer3d/picking/id_pick_pass.cpp
+++ b/viewer3d/picking/id_pick_pass.cpp
@@ -173,7 +173,7 @@ void IdPickPass::RebuildIfNeeded(
   auto getLayerColor = [](const std::string &) {
     return std::array<float, 3>{1.0f, 1.0f, 1.0f};
   };
-  auto getTypeColor = [](const std::string &, const std::string &) {
+  auto getTypeColor = [](const Fixture &) {
     return std::array<float, 3>{1.0f, 1.0f, 1.0f};
   };
   auto resolveSymbolView = [](Viewer2DView) { return SymbolViewKind::Top; };

--- a/viewer3d/render/opaque_fixture_pass.cpp
+++ b/viewer3d/render/opaque_fixture_pass.cpp
@@ -665,8 +665,7 @@ void AddFixtureInstancedDraw(FixtureInstancedBatches &batches, const Mesh &mesh,
 void OpaqueFixturePass::Render(
     Viewer3DController &controller, const RenderFrameContext &context,
     const Viewer3DVisibleSet &visibleSet,
-    const std::function<std::array<float, 3>(
-        const std::string &, const std::string &)> &getTypeColor,
+    const std::function<std::array<float, 3>(const Fixture &)> &getTypeColor,
     const std::function<std::array<float, 3>(const std::string &)>
         &getLayerColor,
     const std::function<SymbolViewKind(Viewer2DView)> &resolveSymbolView,
@@ -854,7 +853,7 @@ void OpaqueFixturePass::Render(
       g = c[1];
       b = c[2];
     } else if (mode == Viewer2DRenderMode::ByFixtureType) {
-      auto c = getTypeColor(f.gdtfSpec, f.visualColorHex);
+      auto c = getTypeColor(f);
       r = c[0];
       g = c[1];
       b = c[2];

--- a/viewer3d/render/opaque_fixture_pass.h
+++ b/viewer3d/render/opaque_fixture_pass.h
@@ -5,6 +5,7 @@
 
 #include "viewer3d_types.h"
 #include "symbolcache.h"
+#include "../../models/fixture.h"
 
 class Viewer3DController;
 
@@ -13,7 +14,7 @@ public:
   static void Render(
       Viewer3DController &controller, const RenderFrameContext &context,
       const Viewer3DVisibleSet &visibleSet,
-      const std::function<std::array<float, 3>(const std::string &, const std::string &)> &getTypeColor,
+      const std::function<std::array<float, 3>(const Fixture &)> &getTypeColor,
       const std::function<std::array<float, 3>(const std::string &)> &getLayerColor,
       const std::function<SymbolViewKind(Viewer2DView)> &resolveSymbolView,
       const std::function<std::array<float, 3>(const std::string &)> &getPickColor);

--- a/viewer3d/render/selection_overlay_pass.cpp
+++ b/viewer3d/render/selection_overlay_pass.cpp
@@ -144,16 +144,13 @@ void SelectionOverlayPass::Render(Viewer3DController &controller,
   if (overlaySet.Empty())
     return;
 
-  auto getTypeColor = [&](const std::string &key, const std::string &hex) {
+  auto getTypeColor = [&](const Fixture &fixture) {
     std::array<float, 3> c;
-    const FixtureVisualColorResult resolved = ResolveFixtureVisualColor(
-        {hex, {}, {}, hex.empty() ? FixtureProjectColorState::Missing
-                                  : FixtureProjectColorState::Present,
-         false});
+    const FixtureVisualColorResult resolved = ResolveFixturePresentationColor(fixture);
     if (resolved.colorHex &&
         HexToRGB(*resolved.colorHex, c[0], c[1], c[2]))
       return c;
-    return MakeDeterministicColor("type:" + key);
+    return MakeDeterministicColor("type:" + fixture.gdtfSpec);
   };
   auto getLayerColor = [&](const std::string &key) {
     std::array<float, 3> c;

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -1367,19 +1367,16 @@ void Viewer3DController::RenderOpaqueFrame(const RenderFrameContext &context,
     DrawGrid(context.gridStyle, context.gridR, context.gridG, context.gridB,
              view);
 
-  auto getTypeColor = [&](const std::string &key, const std::string &hex) {
+  auto getTypeColor = [&](const Fixture &fixture) {
     std::array<float, 3> c;
-    const FixtureVisualColorResult resolved = ResolveFixtureVisualColor(
-        {hex, {}, {}, hex.empty() ? FixtureProjectColorState::Missing
-                                  : FixtureProjectColorState::Present,
-         false});
+    const FixtureVisualColorResult resolved = ResolveFixturePresentationColor(fixture);
     if (resolved.colorHex &&
         HexToRGB(*resolved.colorHex, c[0], c[1], c[2])) {
-      m_impl->typeColors[key] = c;
+      m_impl->typeColors[fixture.gdtfSpec] = c;
       return c;
     }
-    c = MakeDeterministicColor("type:" + key);
-    m_impl->typeColors[key] = c;
+    c = MakeDeterministicColor("type:" + fixture.gdtfSpec);
+    m_impl->typeColors[fixture.gdtfSpec] = c;
     return c;
   };
   auto getLayerColor = [&](const std::string &key) {


### PR DESCRIPTION
### Motivation
- Finish Checkpoint 03 by centralizing fixture visual-color resolution and making presentation consistent across viewers, summaries, legends, print, and PDF.
- Preserve intentional project-instance explicit-empty values and ensure legacy MVR recovery runs only when project-instance metadata is genuinely missing during ProjectRestore.
- Prevent automatic type colors from being preloaded into project-instance fields and from overwriting explicit-empty state during normal refresh/save flows.
- Provide a single GUI-independent fixture-level boundary so all consumers receive the same resolved result and add regression coverage for the priority/round-trip behaviors.

### Description
- Added durable project color state and separate automatic candidate: introduced `FixtureProjectColorState { Missing, Present, ExplicitEmpty }`, `Fixture::visualColorState`, and `Fixture::automaticVisualColorHex` to the domain model (`models/fixture.h`).
- Exposed a single fixture-level resolver and automatic-persistence helpers in the core domain: `ResolveFixturePresentationColor(const Fixture&)` and `PersistAutomaticFixtureVisualColor(...)` (and header/API updates) in `core/fixture_visual_color.{h,cpp}`; canonical normalization remains via `NormalizeFixtureVisualColor`.
- Fixed MVR importer precedence: `mvr/mvrimporter.cpp` no longer preloads automatic type color into `visualColorHex`; root/type color is stored in `automaticVisualColorHex`, project metadata sets `visualColorState`, and ProjectRestore-only legacy MVR recovery runs when state is genuinely missing (and then marks recovered value `Present`).
- Export and persistence adjustments: `mvr/mvrexporter.cpp` omits genuinely-missing instance colors from the written ProjectFixtureMetadata map while continuing to emit explicit-empty and valid present metadata; type metadata export now reads from `automaticVisualColorHex`.
- Centralized presentation consumers: layout legend builder (`gui/layoutlegenditems.cpp`), summary panel (`gui/summarypanel.cpp`), Viewer3D opaque and selection rendering (`viewer3d/*`), and related pick/opaque passes now use the fixture-level `ResolveFixturePresentationColor` boundary (function-call/site migrations and small call-signature changes for color providers). `PersistFixtureTypeAutoColors` was adjusted to use `PersistAutomaticFixtureVisualColor` so automatic fallback only persists when the fixture state is `Missing`.
- Tests and docs: extended and adjusted `tests/fixture_visual_color_test.cpp` and `tests/mvr_perastage_metadata_recovery_test.cpp` to cover precedence, explicit-empty persistence, and ProjectRestore recovery; updated developer docs (`docs/developer/fixture_visual_color.md`) and release notes (`docs/release-notes-draft.md`) to describe durable state, precedence, boundaries, and save/reload behavior.
- Small API/consumer changes to route a Fixture object to color providers in viewer code (keeps deterministic fallback color generation intact); added short one-line comments for new functions in C++ where applicable.

### Testing
- Ran the focused domain unit binary build and tests: `g++ -std=c++20 -Icore -Imodels tests/fixture_visual_color_test.cpp core/fixture_visual_color.cpp && /tmp/fixture_color_test` — passed.
- Ran repository policy checks: `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh` — both passed.
- Ran `git diff --check` — passed.
- Verified that fixture-symbol structural baseline files were not changed via repository diff checks — confirmed unchanged.
- Note: full CMake/CTest and platform Debug CI could not be completed locally because wxWidgets is not available in this environment (CMake configuration failed for GUI tests); Linux/Windows/macOS CI should validate the full CTest matrix and platform builds in CI.
- Commit created: `fix: complete fixture color resolution contracts` (contains the described changes) and PR metadata prepared for review.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a708a6716dc83249353268a4abcd244)