### PR TITLE
Manage fixture SVG cache invalidation and add portable Windows path normalization

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -78,6 +78,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/symbols/Symbol2DImageBuilder.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/symbols/FixtureSymbolDiagnostics.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/symbols/fixture_symbol_generation_identity.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/symbols/fixture_symbol_svg_cache.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/symbols/SymbolGeometrySimplifier.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/symbols/Symbol2DBuilder.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/symbols/PerastageSvgSymbol.cpp

--- a/core/symbols/fixture_symbol_generation_identity.cpp
+++ b/core/symbols/fixture_symbol_generation_identity.cpp
@@ -1,7 +1,10 @@
 #include "fixture_symbol_generation_identity.h"
 
+#include <algorithm>
 #include <cctype>
+#include <filesystem>
 #include <string_view>
+#include <vector>
 
 namespace symbol_cache {
 namespace {
@@ -13,7 +16,91 @@ void AppendField(std::string &output, std::string_view field) {
   output.append(field);
 }
 
+// Parses a Windows absolute path without relying on host filesystem semantics.
+bool ParseWindowsAbsolutePath(std::string value, char &drive,
+                              std::vector<std::string> &components) {
+  components.clear();
+  if (value.size() < 3 || !std::isalpha(static_cast<unsigned char>(value[0])) ||
+      value[1] != ':' || (value[2] != '/' && value[2] != '\\'))
+    return false;
+  drive = static_cast<char>(std::tolower(static_cast<unsigned char>(value[0])));
+  std::replace(value.begin(), value.end(), '\\', '/');
+  std::string component;
+  for (std::size_t i = 3; i <= value.size(); ++i) {
+    if (i == value.size() || value[i] == '/') {
+      if (component.empty() || component == ".") {
+        component.clear();
+        continue;
+      }
+      if (component == "..") {
+        if (components.empty())
+          return false;
+        components.pop_back();
+      } else {
+        components.push_back(component);
+      }
+      component.clear();
+    } else {
+      component.push_back(value[i]);
+    }
+  }
+  return true;
+}
+
+// Compares Windows path components using deterministic ASCII case folding.
+bool EqualWindowsComponent(std::string_view left, std::string_view right) {
+  if (left.size() != right.size())
+    return false;
+  for (std::size_t i = 0; i < left.size(); ++i) {
+    if (std::tolower(static_cast<unsigned char>(left[i])) !=
+        std::tolower(static_cast<unsigned char>(right[i])))
+      return false;
+  }
+  return true;
+}
+
 } // namespace
+
+// Converts an absolute project-owned path to a portable relative identity.
+std::string WindowsPathToPortable(const std::string &path,
+                                  const std::string &projectRoot) {
+  char pathDrive = 0;
+  char rootDrive = 0;
+  std::vector<std::string> pathComponents;
+  std::vector<std::string> rootComponents;
+  const bool pathIsWindows =
+      ParseWindowsAbsolutePath(path, pathDrive, pathComponents);
+  const bool rootIsWindows =
+      ParseWindowsAbsolutePath(projectRoot, rootDrive, rootComponents);
+  if (pathIsWindows || rootIsWindows) {
+    if (!pathIsWindows || !rootIsWindows || pathDrive != rootDrive ||
+        rootComponents.size() >= pathComponents.size())
+      return {};
+    for (std::size_t i = 0; i < rootComponents.size(); ++i) {
+      if (!EqualWindowsComponent(pathComponents[i], rootComponents[i]))
+        return {};
+    }
+    std::string relative;
+    for (std::size_t i = rootComponents.size(); i < pathComponents.size(); ++i) {
+      if (!relative.empty())
+        relative.push_back('/');
+      relative += pathComponents[i];
+    }
+    return relative;
+  }
+
+  const std::filesystem::path normalizedPath =
+      std::filesystem::path(path).lexically_normal();
+  const std::filesystem::path normalizedRoot =
+      std::filesystem::path(projectRoot).lexically_normal();
+  if (!normalizedPath.is_absolute() || !normalizedRoot.is_absolute())
+    return {};
+  const std::filesystem::path relative =
+      normalizedPath.lexically_relative(normalizedRoot);
+  if (relative.empty() || *relative.begin() == "..")
+    return {};
+  return relative.generic_string();
+}
 
 // Compares generation inputs while deliberately excluding presentation metadata.
 bool FixtureSymbolGenerationIdentity::operator==(

--- a/core/symbols/fixture_symbol_generation_identity.h
+++ b/core/symbols/fixture_symbol_generation_identity.h
@@ -29,4 +29,8 @@ bool NormalizePortableGdtfIdentity(const std::string &input,
                                    std::string &normalized,
                                    std::string &errorMessage);
 
+// Converts an absolute project-owned path to a portable relative identity.
+std::string WindowsPathToPortable(const std::string &path,
+                                  const std::string &projectRoot);
+
 } // namespace symbol_cache

--- a/core/symbols/fixture_symbol_svg_cache.cpp
+++ b/core/symbols/fixture_symbol_svg_cache.cpp
@@ -1,0 +1,142 @@
+#include "fixture_symbol_svg_cache.h"
+
+#include "filesystem_path_utils.h"
+#include "symbol_cache_manifest.h"
+
+#include <iterator>
+#include <utility>
+
+namespace symbol_cache {
+namespace {
+
+constexpr int kSvgParserFormatVersion = 1;
+
+// Builds the content-qualified lookup key without presentation labels.
+std::string BuildKey(const std::string &pathKey,
+                     const FixtureSymbolSvgRequest &request) {
+  return pathKey + "\n" + std::to_string(static_cast<int>(request.view)) +
+         "\n" + request.semanticFingerprint + "\n" +
+         request.generationIdentityKey + "\n" +
+         std::to_string(kSvgParserFormatVersion);
+}
+
+} // namespace
+
+// Creates a cache with the production loader unless a test loader is supplied.
+FixtureSymbolSvgCache::FixtureSymbolSvgCache(Loader loader)
+    : loader_(std::move(loader)) {
+  if (!loader_) {
+    loader_ = [](const std::string &path, SymbolViewKind view,
+                 PerastageSvgSymbolData &data, std::string *error) {
+      return LoadPerastageSvgSymbolFromGdtf(path, view, data, error);
+    };
+  }
+}
+
+// Returns an immutable cached symbol or loads it without retaining failures.
+FixtureSymbolSvgCache::SymbolHandle
+FixtureSymbolSvgCache::LookupOrLoad(const FixtureSymbolSvgRequest &request,
+                                    std::string *errorDetails) {
+  if (request.physicalGdtfPath.empty())
+    return {};
+  const std::string pathKey =
+      PathUtils::BuildFilesystemIdentityKey(request.physicalGdtfPath);
+  const std::string key = BuildKey(pathKey, request);
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    const auto found = entries_.find(key);
+    if (found != entries_.end()) {
+      ++stats_.positiveHits;
+      if (errorDetails)
+        errorDetails->clear();
+      return found->second.symbol;
+    }
+    ++stats_.loads;
+  }
+
+  PerastageSvgSymbolData loaded;
+  std::string localError;
+  if (!loader_(request.physicalGdtfPath, request.view, loaded, &localError)) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    ++stats_.loadFailures;
+    if (errorDetails)
+      *errorDetails = localError;
+    return {};
+  }
+  auto handle =
+      std::make_shared<const PerastageSvgSymbolData>(std::move(loaded));
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto [it, inserted] = entries_.emplace(
+        key, Entry{pathKey, request.generationIdentityKey, handle});
+    if (!inserted)
+      handle = it->second.symbol;
+    stats_.entries = entries_.size();
+  }
+  if (errorDetails)
+    errorDetails->clear();
+  return handle;
+}
+
+// Invalidates all parsed symbols addressing one canonical physical archive.
+void FixtureSymbolSvgCache::InvalidatePath(
+    const std::string &physicalGdtfPath) {
+  const std::string pathKey =
+      PathUtils::BuildFilesystemIdentityKey(physicalGdtfPath);
+  std::lock_guard<std::mutex> lock(mutex_);
+  for (auto it = entries_.begin(); it != entries_.end();) {
+    it = it->second.pathKey == pathKey ? entries_.erase(it) : std::next(it);
+  }
+  ++stats_.pathInvalidations;
+  stats_.entries = entries_.size();
+}
+
+// Invalidates parsed symbols for one canonical generation identity key.
+void FixtureSymbolSvgCache::InvalidateGenerationIdentity(
+    const std::string &identityKey) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  for (auto it = entries_.begin(); it != entries_.end();) {
+    it = !identityKey.empty() && it->second.generationIdentityKey == identityKey
+             ? entries_.erase(it)
+             : std::next(it);
+  }
+  ++stats_.identityInvalidations;
+  stats_.entries = entries_.size();
+}
+
+// Clears all project/session parsed symbols while preserving diagnostic
+// counters.
+void FixtureSymbolSvgCache::Clear() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  entries_.clear();
+  ++stats_.clears;
+  stats_.entries = 0;
+}
+
+// Returns a deterministic snapshot of cache statistics.
+FixtureSymbolSvgCacheStats FixtureSymbolSvgCache::GetStats() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return stats_;
+}
+
+// Returns the process service whose contents are bounded by project lifecycle
+// clears.
+FixtureSymbolSvgCache &GetFixtureSymbolSvgCache() {
+  static FixtureSymbolSvgCache cache;
+  return cache;
+}
+
+// Coordinates parsed-symbol and fingerprint invalidation after archive
+// replacement.
+void InvalidateFixtureSymbolCachesForPath(const std::string &physicalGdtfPath) {
+  GetFixtureSymbolSvgCache().InvalidatePath(physicalGdtfPath);
+  InvalidateGdtfSemanticFingerprintCache(physicalGdtfPath);
+}
+
+// Clears runtime symbol state at a committed project lifecycle transition.
+void ClearFixtureSymbolRuntimeCaches() {
+  GetFixtureSymbolSvgCache().Clear();
+  ClearGdtfSemanticFingerprintCache();
+}
+
+} // namespace symbol_cache

--- a/core/symbols/fixture_symbol_svg_cache.h
+++ b/core/symbols/fixture_symbol_svg_cache.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
+#include "PerastageSvgSymbol.h"
+
+namespace symbol_cache {
+
+struct FixtureSymbolSvgRequest {
+  std::string physicalGdtfPath;
+  SymbolViewKind view = SymbolViewKind::Top;
+  std::string semanticFingerprint;
+  std::string generationIdentityKey;
+};
+
+struct FixtureSymbolSvgCacheStats {
+  std::size_t positiveHits = 0;
+  std::size_t loads = 0;
+  std::size_t loadFailures = 0;
+  std::size_t pathInvalidations = 0;
+  std::size_t identityInvalidations = 0;
+  std::size_t clears = 0;
+  std::size_t entries = 0;
+};
+
+class FixtureSymbolSvgCache {
+public:
+  using SymbolHandle = std::shared_ptr<const PerastageSvgSymbolData>;
+  using Loader = std::function<bool(const std::string &, SymbolViewKind,
+                                    PerastageSvgSymbolData &, std::string *)>;
+
+  explicit FixtureSymbolSvgCache(Loader loader = {});
+  SymbolHandle LookupOrLoad(const FixtureSymbolSvgRequest &request,
+                            std::string *errorDetails = nullptr);
+  void InvalidatePath(const std::string &physicalGdtfPath);
+  void InvalidateGenerationIdentity(const std::string &identityKey);
+  void Clear();
+  FixtureSymbolSvgCacheStats GetStats() const;
+
+private:
+  struct Entry {
+    std::string pathKey;
+    std::string generationIdentityKey;
+    SymbolHandle symbol;
+  };
+  Loader loader_;
+  mutable std::mutex mutex_;
+  std::unordered_map<std::string, Entry> entries_;
+  FixtureSymbolSvgCacheStats stats_;
+};
+
+FixtureSymbolSvgCache &GetFixtureSymbolSvgCache();
+void InvalidateFixtureSymbolCachesForPath(const std::string &physicalGdtfPath);
+void ClearFixtureSymbolRuntimeCaches();
+
+} // namespace symbol_cache

--- a/docs/developer/fixture_symbol_generation_identity.md
+++ b/docs/developer/fixture_symbol_generation_identity.md
@@ -33,6 +33,14 @@ Portable archive references use `/`, must be relative, and may not contain empty
 absolute root. Temporary extraction paths are used only to read bytes and never enter
 the identity. Mode spelling is not case-folded.
 
+When an absolute project path must first be converted, Windows drive paths are parsed
+lexically on every host rather than through `std::filesystem`. Both supported
+separator spellings are accepted, drive letters and path components are compared
+case-insensitively, and the emitted relative reference preserves component spelling.
+Different drives, paths outside the root, traversal above a drive root, ambiguous
+relative roots, and UNC paths are rejected. POSIX absolute paths retain native lexical
+relative-path behavior.
+
 ## Planning, persistence, and failure policy
 
 Runtime work coalesces only after resolution and semantic fingerprinting produce the
@@ -48,6 +56,5 @@ requests. Unknown future formats are likewise non-authoritative. A successful sa
 rebuilds and writes only format 2 from the exact GDTFs packaged in `scene.mvr`, using
 the packaged reference, mode, bytes, and the same identity builder.
 
-Checkpoint 05 may consume this identity for explicit legend-cache invalidation. This
-checkpoint does not alter the process-static legend SVG cache, rendering, capture,
-scheduling, or thread ownership.
+Checkpoint 05 consumes this identity for precise parsed-SVG invalidation. It does not
+alter rendering, capture, scheduling, or thread ownership.

--- a/docs/developer/fixture_symbol_svg_cache.md
+++ b/docs/developer/fixture_symbol_svg_cache.md
@@ -1,0 +1,73 @@
+# Runtime fixture SVG cache
+
+Checkpoint 05 gives parsed fixture SVG symbols an explicit GUI-independent owner in
+`core/symbols/fixture_symbol_svg_cache.*`. The layout legend is the affected persistent
+consumer. Layout view preview and print use that shared legend path. The dedicated
+layout preview renderer, PDF exporter, fixture editor preview, and Viewer3D builders
+load or build transient data and cannot retain a legend miss across refreshes.
+Viewer2D's symbol cache stores scene symbol definitions rather than parsed GDTF SVG
+data and is unrelated.
+
+## Key and result contract
+
+Each positive entry is equal only when the canonical physical archive identity,
+`SymbolViewKind`, semantic fingerprint, optional canonical
+`FixtureSymbolGenerationIdentity::key`, and SVG parser format version are equal.
+Editable fixture and type names never participate. Runtime paths use
+`PathUtils::BuildFilesystemIdentityKey`; they are not persisted and extraction paths
+never become project identity.
+
+Lookups return `shared_ptr<const PerastageSvgSymbolData>`. Published geometry is
+immutable, and a handle remains valid after insertion, rehash, invalidation, or clear.
+Rendering colors, transforms, scaling, and fills remain outside the cache. A mutex
+protects map state and counters, but archive I/O and SVG parsing occur without that
+mutex. Concurrent duplicate loads converge on the first published immutable entry.
+
+Failures are not cached. Missing archives or views, malformed symbols, and loader
+failures are returned as ordinary misses with the loader diagnostic, so creation of a
+file or view can be observed on the next lookup even without a restart. Statistics
+distinguish positive hits, loads, failures, path and identity invalidations, clears,
+and live entries. Project lifecycle clearing bounds accumulation.
+
+## Invalidation and ordering
+
+The coordination API invalidates parsed SVG and semantic fingerprint state for a
+physical path. Atomic GDTF replacement invokes it immediately after the replacement
+commits and before post-write validation. Therefore a validation failure after
+replacement cannot expose old parsed geometry; a failure before replacement leaves
+the valid entry intact. Validation then recomputes and publishes the semantic
+fingerprint before any refresh can reload the symbol.
+
+A separately copied library derivative is invalidated independently before its
+validated project fingerprint is published. A scene/library pair resolving to the
+same physical path follows the scene mutation once. Optional library failure does not
+invalidate the valid project archive and remains non-fatal.
+
+Successful project load clears runtime parsed SVG and fingerprint state only after
+the load commits, so a failed load retains the active project's cache. New-project,
+reset, close, and switch paths pass through the reset boundary and clear both caches.
+Fingerprint changes also miss naturally because the fingerprint is part of the key.
+Path and generation-identity operations remain available for committed fixture
+replacement or reassignment boundaries without exposing the container.
+
+## Cache/load audit
+
+1. `GetCachedLegendSvgSymbol` and `CachedSvgSymbolEntry` were affected: their static
+   map retained positive and negative data and returned a raw pointer. They were
+   removed in favor of the managed service.
+2. `BuildSharedLayoutLegendItems` and `SharedLayoutLegendItem` are transient metadata
+   builders. Preview and print consume the shared legend renderer and managed result.
+3. The layout view renderer, PDF exporter, fixture editor preview, and Viewer3D SVG
+   builder perform direct transient loads. They reload from validated archives and do
+   not require another persistent cache.
+4. Viewer2D and Viewer3D geometry/resource caches are keyed or rebuilt by their scene
+   update lifecycle and do not store the legend's parsed SVG result.
+5. `ApplySymbolsToFixtureGdtfWithResult`, `RewriteGdtfWithProof`, library derivative
+   synchronization, semantic fingerprint publish/invalidate, project load, and reset
+   are mutation or lifecycle boundaries and now coordinate the affected runtime cache.
+6. The manifest and project snapshot remain versioned validity proof, not presentation
+   caches; their format-2 identity and zero-work reload behavior are unchanged.
+
+Checkpoint 06 and later still own readiness sequencing, scheduling, cancellation,
+capture ownership, renderer batching, visibility priority, and concurrency. None of
+those responsibilities are implemented here.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -23,6 +23,10 @@ Changes since **v1.5.0**.
 
 ## Compatibility, stability, and performance
 
+- Newly generated fixture symbols now appear immediately in layout legends, previews,
+  print output, and PDF workflows without restarting Perastage, while project and GDTF
+  changes can no longer reuse stale parsed symbol data.
+
 - Stabilized automatic fixture-symbol reuse around the project-owned GDTF archive,
   selected mode, symbol format, and semantic content, so fixture type renames no
   longer cause redundant work and identically named but distinct fixtures cannot

--- a/gui/layoutviewerpanel_legend.cpp
+++ b/gui/layoutviewerpanel_legend.cpp
@@ -22,7 +22,6 @@
 #include <cmath>
 #include <functional>
 #include <limits>
-#include <optional>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -50,6 +49,8 @@
 #include "guiconfigservices.h"
 #include "configmanager.h"
 #include "symbols/PerastageSvgSymbol.h"
+#include "symbols/fixture_symbol_svg_cache.h"
+#include "symbol_cache_manifest.h"
 #include "viewer2dcommandrenderer.h"
 #include <wx/dcgraph.h>
 #include <wx/graphics.h>
@@ -61,35 +62,6 @@ constexpr int kLegendSymbolSizePx =
 constexpr double kLegendFallbackSymbolScale = 2.0;
 constexpr double kLegendSvgSymbolScale = 0.4;
 constexpr double kLegendMaxSymbolSlotScale = 1.45;
-
-struct CachedSvgSymbolEntry {
-  std::optional<PerastageSvgSymbolData> symbol;
-};
-
-// Returns a process-wide cached SVG symbol entry to avoid repeated GDTF reads while resizing legends.
-const PerastageSvgSymbolData *GetCachedLegendSvgSymbol(const std::string &symbolKey,
-                                                       SymbolViewKind view) {
-  if (symbolKey.empty())
-    return nullptr;
-  using CacheKey = std::pair<std::string, SymbolViewKind>;
-  struct CacheKeyHash {
-    size_t operator()(const CacheKey &key) const {
-      return std::hash<std::string>{}(key.first) ^
-             (static_cast<size_t>(key.second) << 1);
-    }
-  };
-  static std::unordered_map<CacheKey, CachedSvgSymbolEntry, CacheKeyHash> cache;
-  const CacheKey key{symbolKey, view};
-  auto it = cache.find(key);
-  if (it == cache.end()) {
-    CachedSvgSymbolEntry entry;
-    PerastageSvgSymbolData data;
-    if (LoadPerastageSvgSymbolFromGdtf(symbolKey, view, data))
-      entry.symbol = std::move(data);
-    it = cache.emplace(key, std::move(entry)).first;
-  }
-  return it->second.symbol ? &it->second.symbol.value() : nullptr;
-}
 
 int SymbolViewRank(SymbolViewKind kind) {
   switch (kind) {
@@ -1114,11 +1086,22 @@ wxImage LayoutViewerPanel::BuildLegendImage(
     return symbolH * scale;
   };
 
-  // Resolves SVG symbols through a shared cache so legend resizes do not reload unchanged data.
+  std::vector<symbol_cache::FixtureSymbolSvgCache::SymbolHandle> svgHandles;
+  // Resolves immutable SVG symbols through the managed runtime cache.
   auto findSvgSymbol = [&](const std::string &symbolKey,
                            SymbolViewKind view)
       -> const PerastageSvgSymbolData * {
-    return GetCachedLegendSvgSymbol(symbolKey, view);
+    std::string fingerprintError;
+    symbol_cache::FixtureSymbolSvgRequest request;
+    request.physicalGdtfPath = symbolKey;
+    request.view = view;
+    request.semanticFingerprint = symbol_cache::ComputeGdtfSemanticFingerprint(
+        symbolKey, fingerprintError);
+    auto handle = symbol_cache::GetFixtureSymbolSvgCache().LookupOrLoad(request);
+    if (!handle)
+      return nullptr;
+    svgHandles.push_back(std::move(handle));
+    return svgHandles.back().get();
   };
   struct SvgGeometryMetrics {
     bool valid = false;

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -19,6 +19,7 @@
 #include "fixture_visual_color.h"
 #include "diagnostics/DiagnosticLogger.h"
 #include "filesystem_path_utils.h"
+#include "symbols/fixture_symbol_svg_cache.h"
 
 #include <algorithm>
 #include <cctype>
@@ -910,6 +911,7 @@ bool MainWindow::LoadProjectFromPath(const std::string &path,
   if (viewport2DPanel)
     viewport2DPanel->CompleteSceneReplacement();
   loadProfiler.EndPhase();
+  symbol_cache::ClearFixtureSymbolRuntimeCaches();
   if (layoutViewerPanel) {
     layoutViewerPanel->ResetPreviewCachesForProjectLoad();
     layoutViewerPanel->LoadPersistentViewCacheFromProject(path);
@@ -1072,6 +1074,7 @@ void MainWindow::LoadStartupProjectFromPath(const std::string &path) {
 // Resets project state, UI-bound data, and active layout context for a fresh
 // session.
 void MainWindow::ResetProject(bool applyLayoutDefaultsForNewProject) {
+  symbol_cache::ClearFixtureSymbolRuntimeCaches();
   activeLayoutName.clear();
   if (layoutViewerPanel)
     layoutViewerPanel->SetLayoutDefinition(layouts::LayoutDefinition{});

--- a/gui/windows/symbol_fixture_applier.cpp
+++ b/gui/windows/symbol_fixture_applier.cpp
@@ -30,6 +30,7 @@
 #include "gdtf_mutation_audit.h"
 #include "gdtf_canonicalizer.h"
 #include "symbol_cache_manifest.h"
+#include "symbols/fixture_symbol_svg_cache.h"
 #include "windows/symbol_preview_exporter.h"
 
 namespace fs = std::filesystem;
@@ -668,6 +669,7 @@ GdtfRewriteResult RewriteGdtfWithProof(
   }
 
   result.atomicReplacementCompleted = true;
+  symbol_cache::InvalidateFixtureSymbolCachesForPath(sourcePath.string());
   rewritePhase.Finish();
   symbols::ScopedFixtureSymbolPhase validationPhase(
       timings, symbols::FixtureSymbolPhase::Validation);
@@ -676,7 +678,6 @@ GdtfRewriteResult RewriteGdtfWithProof(
         "The replaced GDTF archive did not pass generated SVG post-validation.";
     return result;
   }
-  symbol_cache::InvalidateGdtfSemanticFingerprintCache(sourcePath.string());
   std::string validationError;
   const std::string validatedFingerprint =
       symbol_cache::ComputeGdtfSemanticFingerprint(sourcePath.string(),
@@ -870,6 +871,7 @@ ApplySymbolsResult ApplySymbolsToFixtureGdtfWithResult(
         result.libraryUpdated = result.sceneUpdated;
       } else if (result.sceneUpdated) {
         // The derivative was copied from the already validated project archive.
+        symbol_cache::InvalidateFixtureSymbolCachesForPath(derivative->path);
         symbol_cache::PublishGdtfSemanticFingerprintCache(
             derivative->path, result.finalSceneFingerprint);
         result.libraryUpdated = true;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -128,6 +128,7 @@ if(BASH_EXECUTABLE)
     add_bash_policy_test(Viewer2DFboCaptureDiagnostics ${CMAKE_CURRENT_SOURCE_DIR}/check_viewer2d_fbo_capture_diagnostics.sh)
     add_bash_policy_test(LayoutPreviewFailureDiagnostics ${CMAKE_CURRENT_SOURCE_DIR}/check_layout_preview_failure_diagnostics.sh)
     add_bash_policy_test(LayoutProjectLoadCacheReset ${CMAKE_CURRENT_SOURCE_DIR}/check_layout_project_load_cache_reset.sh)
+    add_bash_policy_test(FixtureSymbolSvgCacheBoundary ${CMAKE_CURRENT_SOURCE_DIR}/check_fixture_symbol_svg_cache_boundary.sh)
     add_bash_policy_test(LayoutViewerFitLifecycle ${CMAKE_CURRENT_SOURCE_DIR}/check_layout_viewer_fit_lifecycle.sh)
     add_bash_policy_test(LibraryUserDataPolicy ${CMAKE_CURRENT_SOURCE_DIR}/check_library_user_data_policy.sh)
     add_bash_policy_test(DictionaryPathsPolicy ${CMAKE_CURRENT_SOURCE_DIR}/check_dictionary_paths.sh)
@@ -2249,6 +2250,17 @@ target_include_directories(fixture_symbol_generation_identity_test PRIVATE
                            ${CMAKE_SOURCE_DIR}/core)
 add_test(NAME FixtureSymbolGenerationIdentity
          COMMAND fixture_symbol_generation_identity_test)
+
+add_executable(fixture_symbol_svg_cache_test
+               fixture_symbol_svg_cache_test.cpp
+               ../core/symbols/fixture_symbol_svg_cache.cpp
+               ../core/filesystem_path_utils.cpp)
+target_include_directories(fixture_symbol_svg_cache_test PRIVATE
+                           ${CMAKE_SOURCE_DIR}/core
+                           ${CMAKE_SOURCE_DIR}/third_party
+                           ${wxWidgets_INCLUDE_DIRS})
+target_link_libraries(fixture_symbol_svg_cache_test PRIVATE ${wxWidgets_LIBRARIES})
+add_test(NAME FixtureSymbolSvgCache COMMAND fixture_symbol_svg_cache_test)
 
 add_executable(project_symbol_cache_snapshot_test
                project_symbol_cache_snapshot_test.cpp

--- a/tests/check_fixture_symbol_svg_cache_boundary.sh
+++ b/tests/check_fixture_symbol_svg_cache_boundary.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+legend="$root/gui/layoutviewerpanel_legend.cpp"
+
+if rg -n 'static[[:space:]].*(unordered_map|FixtureSymbolSvg)' "$legend"; then
+  echo "layout legend must not own a function-static fixture SVG cache" >&2
+  exit 1
+fi
+if rg -n 'GetCachedLegendSvgSymbol|CachedSvgSymbolEntry' "$legend"; then
+  echo "layout legend must use the managed immutable fixture SVG cache" >&2
+  exit 1
+fi

--- a/tests/fixture_symbol_generation_identity_test.cpp
+++ b/tests/fixture_symbol_generation_identity_test.cpp
@@ -56,11 +56,40 @@ void TestPortableIdentityPolicy() {
   }
 }
 
+// Verifies Windows paths are portable even when tests run on non-Windows hosts.
+void TestHostIndependentWindowsPathConversion() {
+  using symbol_cache::WindowsPathToPortable;
+  assert(WindowsPathToPortable("C:\\work\\project\\gdtfs\\fixture.gdtf",
+                               "C:\\work\\project") == "gdtfs/fixture.gdtf");
+  assert(WindowsPathToPortable("c:/work/project/gdtfs\\fixture.gdtf",
+                               "C:\\WORK\\PROJECT\\") ==
+         "gdtfs/fixture.gdtf");
+  assert(WindowsPathToPortable("D:\\work\\project\\fixture.gdtf",
+                               "C:\\work\\project").empty());
+  assert(WindowsPathToPortable("C:\\work\\outside\\fixture.gdtf",
+                               "C:\\work\\project").empty());
+  assert(WindowsPathToPortable("C:\\..\\fixture.gdtf", "C:\\work").empty());
+  assert(WindowsPathToPortable("\\\\server\\share\\fixture.gdtf",
+                               "\\\\server\\share").empty());
+}
+
+// Verifies POSIX portable-path conversion retains its lexical behavior.
+void TestPosixPathConversion() {
+  using symbol_cache::WindowsPathToPortable;
+  assert(WindowsPathToPortable("/work/project/gdtfs/fixture.gdtf",
+                               "/work/project") == "gdtfs/fixture.gdtf");
+  assert(WindowsPathToPortable("/work/outside/fixture.gdtf",
+                               "/work/project").empty());
+  assert(WindowsPathToPortable("../fixture.gdtf", "/work/project").empty());
+}
+
 } // namespace
 
 // Runs fixture-symbol generation identity regression coverage.
 int main() {
   TestIdentityInputsAndCoalescing();
   TestPortableIdentityPolicy();
+  TestHostIndependentWindowsPathConversion();
+  TestPosixPathConversion();
   return 0;
 }

--- a/tests/fixture_symbol_svg_cache_test.cpp
+++ b/tests/fixture_symbol_svg_cache_test.cpp
@@ -1,0 +1,109 @@
+#include "symbols/fixture_symbol_svg_cache.h"
+
+#include <cassert>
+#include <filesystem>
+#include <string>
+#include <unordered_map>
+
+namespace {
+
+// Creates valid distinguishable symbol data for cache contract tests.
+PerastageSvgSymbolData MakeSymbol(double width, SymbolViewKind view) {
+  PerastageSvgSymbolData data;
+  data.viewKind = view;
+  data.viewBoxWidth = width;
+  data.viewBoxHeight = 10.0;
+  data.strokes.push_back({{{0.0, 0.0}, {width, 10.0}}});
+  return data;
+}
+
+// Verifies failures are retried and positive values are content-qualified.
+void TestMissMutationAndFingerprintCoherence() {
+  std::unordered_map<std::string, PerastageSvgSymbolData> available;
+  symbol_cache::FixtureSymbolSvgCache cache(
+      [&](const std::string &, SymbolViewKind view, PerastageSvgSymbolData &out,
+          std::string *) {
+        const auto it = available.find(std::to_string(static_cast<int>(view)));
+        if (it == available.end())
+          return false;
+        out = it->second;
+        return true;
+      });
+  symbol_cache::FixtureSymbolSvgRequest request{
+      "fixture.gdtf", SymbolViewKind::Top, "fp-a", "id-a"};
+  assert(!cache.LookupOrLoad(request));
+  available[std::to_string(static_cast<int>(SymbolViewKind::Top))] =
+      MakeSymbol(10.0, SymbolViewKind::Top);
+  cache.InvalidatePath("fixture.gdtf");
+  const auto first = cache.LookupOrLoad(request);
+  assert(first && first->viewBoxWidth == 10.0);
+
+  available[std::to_string(static_cast<int>(SymbolViewKind::Top))] =
+      MakeSymbol(20.0, SymbolViewKind::Top);
+  request.semanticFingerprint = "fp-b";
+  const auto second = cache.LookupOrLoad(request);
+  assert(second && second->viewBoxWidth == 20.0);
+  assert(first->viewBoxWidth == 10.0);
+}
+
+// Verifies views, identities, aliases, and lifecycle invalidation remain
+// separate.
+void TestStructuredKeysAndSafeHandles() {
+  int loads = 0;
+  symbol_cache::FixtureSymbolSvgCache cache(
+      [&](const std::string &, SymbolViewKind view, PerastageSvgSymbolData &out,
+          std::string *) {
+        ++loads;
+        out = MakeSymbol(view == SymbolViewKind::Top ? 10.0 : 30.0, view);
+        return true;
+      });
+  const auto temp =
+      std::filesystem::temp_directory_path() / "perastage_fixture_symbol_cache";
+  const auto path = temp / "fixture.gdtf";
+  symbol_cache::FixtureSymbolSvgRequest top{path.string(), SymbolViewKind::Top,
+                                            "fp", "identity-a"};
+  const auto first = cache.LookupOrLoad(top);
+  top.physicalGdtfPath = (temp / "." / "fixture.gdtf").string();
+  assert(cache.LookupOrLoad(top) == first);
+  assert(loads == 1);
+
+  auto front = top;
+  front.view = SymbolViewKind::Front;
+  assert(cache.LookupOrLoad(front)->viewBoxWidth == 30.0);
+  auto otherIdentity = top;
+  otherIdentity.generationIdentityKey = "identity-b";
+  assert(cache.LookupOrLoad(otherIdentity));
+  assert(loads == 3);
+
+  cache.InvalidateGenerationIdentity("identity-a");
+  assert(first->viewBoxWidth == 10.0);
+  assert(cache.LookupOrLoad(top));
+  cache.Clear();
+  assert(cache.GetStats().entries == 0);
+}
+
+} // namespace
+
+// Supplies the production loader symbol while focused tests inject their
+// loader.
+bool LoadPerastageSvgSymbolFromGdtf(const std::string &, SymbolViewKind,
+                                    PerastageSvgSymbolData &, std::string *) {
+  return false;
+}
+
+namespace symbol_cache {
+
+// Supplies the fingerprint invalidation symbol for the focused cache test.
+void InvalidateGdtfSemanticFingerprintCache(const std::string &) {}
+
+// Supplies the fingerprint clear symbol for the focused cache test.
+void ClearGdtfSemanticFingerprintCache() {}
+
+} // namespace symbol_cache
+
+// Runs managed fixture SVG cache regression coverage.
+int main() {
+  TestMissMutationAndFingerprintCoherence();
+  TestStructuredKeysAndSafeHandles();
+  return 0;
+}


### PR DESCRIPTION
### Motivation
- Prevent a process-static legend SVG cache from retaining stale positive or negative entries and returning unsafe raw pointers, and make parsed fixture SVG lifecycle explicitly owned and invalidatable.
- Ensure portable, deterministic handling of Windows-style absolute project paths on POSIX hosts so identity tests and CI are stable across platforms.
- Coordinate parsed-SVG cache invalidation with the existing semantic-fingerprint lifecycle so regenerated or replaced GDTFs become visible immediately without restarting the application.

### Description
- Added a GUI-independent managed parsed-SVG cache in `core/symbols/fixture_symbol_svg_cache.{h,cpp}` that keys lookups by canonical physical path, `SymbolViewKind`, semantic fingerprint, generation-identity key, and parser format, returns `shared_ptr<const PerastageSvgSymbolData>` handles, and exposes `LookupOrLoad`, `InvalidatePath`, `InvalidateGenerationIdentity`, and `Clear` operations.
- Replaced the function-local process-static legend map in `gui/layoutviewerpanel_legend.cpp` with calls into the managed cache and kept immutable handles for the render sequence so lifetime is safe after container mutations.
- Wired invalidation and lifecycle coordination so archive rewrite/publish flows call `InvalidateFixtureSymbolCachesForPath(...)` and project lifecycle transitions call `ClearFixtureSymbolRuntimeCaches()`, and ensured library-derivative updates invalidate independently before publishing fingerprints (`gui/windows/symbol_fixture_applier.cpp`, `gui/mainwindow.cpp`).
- Restored deterministic Windows-path conversion for identity tests by adding a host-independent `WindowsPathToPortable` helper and corresponding test coverage to avoid the Checkpoint 04 Linux CI regression (portable path parsing and normalization logic added to `core/symbols/fixture_symbol_generation_identity.*`).
- Added focused tests and repository checks: a unit test `tests/fixture_symbol_svg_cache_test.cpp` for the managed cache, a policy script `tests/check_fixture_symbol_svg_cache_boundary.sh` that forbids reintroducing a function-local static SVG cache in the legend, and hooked the boundary check into `tests/CMakeLists.txt` policy tests; also added developer docs at `docs/developer/fixture_symbol_svg_cache.md` and updated `docs/release-notes-draft.md` and the identity doc to document the behavior.
- Kept parsing/IO boundaries separate (the cache uses injectable loader semantics for testability) and avoided background scheduling or renderer/ capture changes as required by the checkpoint scope.

### Testing
- Ran focused identity tests with `g++ -std=c++20 -Icore tests/fixture_symbol_generation_identity_test.cpp core/symbols/fixture_symbol_generation_identity.cpp && /tmp/fixture_symbol_generation_identity_test`, which passed.
- Built and ran the cache unit test with `g++ -std=c++20 -pthread -Icore -Iviewer2d tests/fixture_symbol_svg_cache_test.cpp core/symbols/fixture_symbol_svg_cache.cpp core/filesystem_path_utils.cpp && /tmp/fixture_symbol_svg_cache_test`, which passed and validated miss→generation, fingerprint separation, view separation, safe handles, invalidation, and clear semantics.
- Executed repository policy checks `tests/check_fixture_symbol_svg_cache_boundary.sh`, `tests/check_perastage_tree_modules.sh`, and `tests/check_no_configmanager_get_in_gui.sh`, which all passed in this environment.
- Verified `git diff --check` and repository baseline checks for fixture symbol baselines where applicable; these showed no whitespace or baseline regressions in this run.
- Note: full CTest/CI could not be executed here because `cmake --preset wsl-x64-debug` failed to configure due to missing system `wxWidgets` development libraries in the execution environment, so the complete CTest suite and GUI/manual acceptance could not be run; CI platform runs are required to validate cross-platform Debug jobs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71697568a08324a10b8209f2152426)