### PR TITLE
Make GDTF consolidation notice non-blocking (log to console and persistent log)

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -38,6 +38,10 @@ Changes since **v1.5.0**.
 
 ## Important fixes
 
+- Replaced the blocking project GDTF consolidation information dialog with a
+  non-blocking message in the program console while retaining the diagnostic
+  in the persistent application log.
+
 - Fixed MVR fixture replacement so multiple imported source aliases explicitly mapped
   to the same GDTF Share revision and mode share one finalized project fixture. Canonical
   `@Perastage.gdtf` derivatives now require all four stored symbol views before library

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -179,8 +179,12 @@ bool ConsolidateLoadedProjectGdtfs(ConfigManager &cfg) {
   size_t reboundCount = 0;
   for (const project_gdtf::ConsolidationGroup &group : plan.groups)
     reboundCount += group.rebindings.size();
-  for (const std::string &diagnostic : plan.diagnostics)
-    wxLogMessage("%s", diagnostic.c_str());
+  for (const std::string &diagnostic : plan.diagnostics) {
+    Logger::Instance().Log(Logger::Level::Info, diagnostic);
+    if (ConsolePanel::Instance())
+      ConsolePanel::Instance()->AppendMessage(
+          "[INFO] " + wxString::FromUTF8(diagnostic));
+  }
   if (plan.complete) {
     cfg.SetValue(kGdtfDerivativeContractVersionKey,
                  std::to_string(kCurrentGdtfDerivativeContractVersion));


### PR DESCRIPTION
### Motivation
- Avoid showing a blocking informational dialog during project GDTF consolidation and instead surface diagnostics non-blockingly in the program console while retaining the persistent log entry.

### Description
- Replaced the `wxLogMessage` diagnostic emission in `ConsolidateLoadedProjectGdtfs` with `Logger::Instance().Log(...)` and, when available, `ConsolePanel::Instance()->AppendMessage(...)` so messages are written to the persistent log and the in-app console without blocking the UI.
- Added a short release-note entry in `docs/release-notes-draft.md` documenting the user-visible change.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it reported OK.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it reported OK.
- Ran `git diff --check` and no style/diff issues were reported.
- Attempted `cmake --preset wsl-x64-release` which failed to configure in this environment due to missing `wxWidgets` development libraries (environmental dependency), not related to the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a775b3008c88324a489ea81d2f809e1)