### PR TITLE
Show symbol usage summary after layout PDF export

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -6,6 +6,10 @@ Changes since **v1.5.0**.
 
 ## New features and workflow improvements
 
+- Layout PDF completion messages now summarize how many elements used generated
+  Perastage symbols and how many used rendered fallbacks, making it easy to
+  verify symbol usage without comparing PDF file sizes.
+
 - Improved truss Magnet placement by preferring connector points declared in
   GDTF files, using terminal points for clearly straight trusses, and retaining
   conservative face-center snapping for ambiguous truss shapes and groups.

--- a/docs/user/features.md
+++ b/docs/user/features.md
@@ -164,7 +164,9 @@ Additional safeguards include:
 
 ## Printing and Export Outputs
 
-- Layout-to-PDF output for full documentation sets.
+- Layout-to-PDF output for full documentation sets. The completion message
+  reports how many elements used generated Perastage symbols and how many used
+  rendered fallbacks.
 - Print table workflows for fixtures/trusses/hoists/objects.
 - Debug-only 2D direct print dialog is gated in Release builds via feature flags.
 

--- a/gui/mainwindow_print.cpp
+++ b/gui/mainwindow_print.cpp
@@ -543,7 +543,12 @@ void MainWindow::OnPrintLayout(wxCommandEvent &WXUNUSED(event)) {
                 wxMessageBox(msg, _("Print Layout"), wxOK | wxICON_ERROR, this);
               } else {
                 SetPrintStatus(this, "");
-                wxString successMessage = wxString::Format(_("Layout saved to %s"), outputPathDisplay);
+                wxString successMessage =
+                    wxString::Format(_("Layout saved to %s"), outputPathDisplay);
+                successMessage += wxString::Format(
+                    _("\n\nSymbol summary:\nPerastage symbols: %zu\nRendered fallbacks: %zu"),
+                    res.perastageSymbolInstances,
+                    res.fallbackSymbolInstances);
                 wxMessageBox(successMessage, _("Print Layout"),
                              wxOK | wxICON_INFORMATION, this);
               }

--- a/viewer2d/pdf/layout_pdf_exporter.cpp
+++ b/viewer2d/pdf/layout_pdf_exporter.cpp
@@ -951,6 +951,32 @@ Viewer2DExportResult ExportLayoutToPdf(
     }
   }
 
+  for (const auto &group : layoutGroups) {
+    const SymbolDefinitionSnapshot *groupSymbols =
+        group.symbolSnapshot ? group.symbolSnapshot.get() : symbolSnapshot.get();
+    for (const auto &command : views[group.viewIndex].buffer.commands) {
+      if (std::holds_alternative<PlaceSymbolCommand>(command)) {
+        ++result.fallbackSymbolInstances;
+        continue;
+      }
+      const auto *instance = std::get_if<SymbolInstanceCommand>(&command);
+      if (!instance)
+        continue;
+      const SymbolDefinition *definition = nullptr;
+      if (groupSymbols) {
+        const auto definitionIt = groupSymbols->find(instance->symbolId);
+        if (definitionIt != groupSymbols->end())
+          definition = &definitionIt->second;
+      }
+      if (definition &&
+          definition->source == SymbolDefinition::Source::PerastageSvg) {
+        ++result.perastageSymbolInstances;
+      } else {
+        ++result.fallbackSymbolInstances;
+      }
+    }
+  }
+
   if (layoutGroups.empty() && legends.empty() && tables.empty() &&
       texts.empty() && images.empty()) {
     result.message = "Nothing to export";

--- a/viewer2d/symbolcache.h
+++ b/viewer2d/symbolcache.h
@@ -55,10 +55,13 @@ template <> struct hash<SymbolKey> {
 } // namespace std
 
 struct SymbolDefinition {
+  enum class Source { RenderedFallback, PerastageSvg };
+
   SymbolKey key{};
   uint32_t symbolId = 0;
   SymbolBounds bounds{};
   CommandBuffer localCommands{};
+  Source source = Source::RenderedFallback;
 };
 
 using SymbolDefinitionSnapshot =

--- a/viewer2d/viewer2dpdfexporter.h
+++ b/viewer2d/viewer2dpdfexporter.h
@@ -50,6 +50,8 @@ struct Viewer2DPrintOptions {
 struct Viewer2DExportResult {
   bool success = false;
   std::string message;
+  size_t perastageSymbolInstances = 0;
+  size_t fallbackSymbolInstances = 0;
 };
 
 struct LayoutViewExportData {

--- a/viewer3d/render/perastage_svg_symbol_builder.cpp
+++ b/viewer3d/render/perastage_svg_symbol_builder.cpp
@@ -128,6 +128,7 @@ bool TryBuildPerastageSvgSymbolDefinition(const std::string &gdtfPath,
 
   out = SymbolDefinition{};
   out.symbolId = symbolId;
+  out.source = SymbolDefinition::Source::PerastageSvg;
   out.localCommands.currentSourceKey = "svg";
 
   for (const auto &polygon : svg.fills)


### PR DESCRIPTION
### Motivation

- When exporting/printing layouts there was no easy way to tell whether exported elements used generated Perastage SVG symbols or rendered fallback geometry, forcing users to compare output sizes to infer symbol usage. 

### Description

- Add symbol provenance to symbol definitions by introducing `SymbolDefinition::Source` and a `source` field to record whether a definition is `PerastageSvg` or a `RenderedFallback`.
- Mark generated Perastage SVG symbol definitions as `PerastageSvg` when created by the symbol builder. 
- Extend `Viewer2DExportResult` with `perastageSymbolInstances` and `fallbackSymbolInstances` counters and count symbol placements during `ExportLayoutToPdf` by scanning layout view command buffers and classifying each `PlaceSymbolCommand` and `SymbolInstanceCommand` against available symbol snapshots.
- Surface the counts in the successful Print Layout dialog by appending a compact "Symbol summary" showing Perastage symbols vs rendered fallbacks, and document the behavior in `docs/user/features.md` and `docs/release-notes-draft.md`.

### Testing

- `git diff --check` ran and reported no issues. 
- `tests/check_perastage_tree_modules.sh` ran and passed. 
- `tests/check_no_configmanager_get_in_gui.sh` ran and passed. 
- Attempted a CMake configure/build with the `wsl-x64-debug` preset but configuration could not complete in this environment due to missing wxWidgets development libraries, so full build verification is blocked by the environment (warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a778e87449c832499b1b040f0bdae7b)