### PR TITLE
Align fixture symbol capture to Viewer2D parity: real Bottom/Side, mode-aware bounds, remove side mirror

### DIFF
--- a/core/symbols/FixtureSymbolDiagnostics.cpp
+++ b/core/symbols/FixtureSymbolDiagnostics.cpp
@@ -31,7 +31,8 @@ std::string_view OutcomeName(FixtureSymbolOutcome outcome) {
 // Starts an optionally enabled, independently owned fixture-symbol timing
 // record.
 FixtureSymbolTimings::FixtureSymbolTimings(bool enabled)
-    : enabled_(enabled), started_(enabled ? Clock::now() : Clock::time_point{}) {}
+    : enabled_(enabled),
+      started_(enabled ? Clock::now() : Clock::time_point{}) {}
 
 // Creates an enabled timing record with deterministic time points for tests.
 FixtureSymbolTimings::FixtureSymbolTimings(Clock::time_point started,
@@ -109,9 +110,7 @@ ScopedFixtureSymbolPhase::ScopedFixtureSymbolPhase(
 }
 
 // Accumulates the elapsed phase duration into its optional timing sink.
-ScopedFixtureSymbolPhase::~ScopedFixtureSymbolPhase() {
-  Finish();
-}
+ScopedFixtureSymbolPhase::~ScopedFixtureSymbolPhase() { Finish(); }
 
 // Finishes an active phase once and makes subsequent finishes no-ops.
 void ScopedFixtureSymbolPhase::Finish() {
@@ -126,10 +125,10 @@ void ScopedFixtureSymbolPhase::Finish() {
 // Returns the immutable capture mapping shared by runtime capture and tests.
 const std::array<FixtureSymbolCaptureStep, 4> &FixtureSymbolCapturePlan() {
   static constexpr std::array<FixtureSymbolCaptureStep, 4> plan = {{
-      {SymbolCaptureViewerView::Front, SymbolView::Front, false, false},
-      {SymbolCaptureViewerView::Top, SymbolView::Top, false, false},
-      {SymbolCaptureViewerView::Side, SymbolView::Left, false, true},
-      {SymbolCaptureViewerView::Top, SymbolView::Bottom, true, false},
+      {SymbolCaptureViewerView::Front, SymbolView::Front},
+      {SymbolCaptureViewerView::Top, SymbolView::Top},
+      {SymbolCaptureViewerView::Side, SymbolView::Left},
+      {SymbolCaptureViewerView::Bottom, SymbolView::Bottom},
   }};
   return plan;
 }

--- a/core/symbols/FixtureSymbolDiagnostics.cpp
+++ b/core/symbols/FixtureSymbolDiagnostics.cpp
@@ -125,10 +125,10 @@ void ScopedFixtureSymbolPhase::Finish() {
 // Returns the immutable capture mapping shared by runtime capture and tests.
 const std::array<FixtureSymbolCaptureStep, 4> &FixtureSymbolCapturePlan() {
   static constexpr std::array<FixtureSymbolCaptureStep, 4> plan = {{
-      {SymbolCaptureViewerView::Front, SymbolView::Front},
-      {SymbolCaptureViewerView::Top, SymbolView::Top},
-      {SymbolCaptureViewerView::Side, SymbolView::Left},
-      {SymbolCaptureViewerView::Bottom, SymbolView::Bottom},
+      {SymbolCaptureViewerView::Front, SymbolView::Front, false, false},
+      {SymbolCaptureViewerView::Top, SymbolView::Top, false, false},
+      {SymbolCaptureViewerView::Side, SymbolView::Left, false, true},
+      {SymbolCaptureViewerView::Top, SymbolView::Bottom, true, false},
   }};
   return plan;
 }

--- a/core/symbols/FixtureSymbolDiagnostics.h
+++ b/core/symbols/FixtureSymbolDiagnostics.h
@@ -67,11 +67,13 @@ private:
   FixtureSymbolTimings::Clock::time_point started_;
 };
 
-enum class SymbolCaptureViewerView { Front, Top, Side, Bottom };
+enum class SymbolCaptureViewerView { Front, Top, Side };
 
 struct FixtureSymbolCaptureStep {
   SymbolCaptureViewerView viewerView;
   SymbolView symbolView;
+  bool forceBottomViewForTopFixtures;
+  bool mirrorHorizontally;
 };
 
 const std::array<FixtureSymbolCaptureStep, 4> &FixtureSymbolCapturePlan();

--- a/core/symbols/FixtureSymbolDiagnostics.h
+++ b/core/symbols/FixtureSymbolDiagnostics.h
@@ -67,13 +67,11 @@ private:
   FixtureSymbolTimings::Clock::time_point started_;
 };
 
-enum class SymbolCaptureViewerView { Front, Top, Side };
+enum class SymbolCaptureViewerView { Front, Top, Side, Bottom };
 
 struct FixtureSymbolCaptureStep {
   SymbolCaptureViewerView viewerView;
   SymbolView symbolView;
-  bool forceBottomViewForTopFixtures;
-  bool mirrorHorizontally;
 };
 
 const std::array<FixtureSymbolCaptureStep, 4> &FixtureSymbolCapturePlan();

--- a/docs/developer/technical-notes/scene_model_symbol_capture.md
+++ b/docs/developer/technical-notes/scene_model_symbol_capture.md
@@ -48,9 +48,20 @@ CaptureSceneModelOrthographicSymbols(Viewer2DOffscreenRenderer &renderer,
 
 1. Install a cloned requested instance in the private compatibility scene.
 2. Optionally align the instance transform to local axes.
-3. Apply capture-focused config overrides (hide grid/labels, force symbol-friendly render settings).
-4. Capture source RGBA images for `Front`, `Top`, `Side` (mirrored to `Left`), and inverted `Top` (as `Bottom`).
+3. Apply geometry-neutral extraction overrides (white background, hidden grid,
+   ruler, and labels, plus the symbol extraction color and line style).
+4. Capture canonical source RGBA images through the corresponding
+   `Viewer2DPanel` cameras: `Front`, `Top`, `Side` (stored as `Left`), and
+   `Bottom`. The reference raster is not mirrored or otherwise transformed.
 5. Convert images to vector symbols with `symbols::Symbol2DImageBuilder`.
+
+For a fixture whose instance/root rotation is normalized for reuse, every
+pre-vectorization image uses the same camera, projection, exact GDTF mode,
+child transforms, mesh processing, depth behavior, and part inclusion as the
+equivalent normal 2D view. Fixture bounds include every rendered mesh,
+including lens geometry, and are resolved from that same exact mode. The only
+intentional viewer differences are the geometry-neutral extraction overrides
+listed above.
 
 The render data source is scoped to one synchronous offscreen operation on the
 GUI/render thread and remains installed for warm-up plus all four orthographic views.

--- a/docs/developer/technical-notes/scene_model_symbol_capture.md
+++ b/docs/developer/technical-notes/scene_model_symbol_capture.md
@@ -48,20 +48,15 @@ CaptureSceneModelOrthographicSymbols(Viewer2DOffscreenRenderer &renderer,
 
 1. Install a cloned requested instance in the private compatibility scene.
 2. Optionally align the instance transform to local axes.
-3. Apply geometry-neutral extraction overrides (white background, hidden grid,
-   ruler, and labels, plus the symbol extraction color and line style).
-4. Capture canonical source RGBA images through the corresponding
-   `Viewer2DPanel` cameras: `Front`, `Top`, `Side` (stored as `Left`), and
-   `Bottom`. The reference raster is not mirrored or otherwise transformed.
+3. Apply capture-focused config overrides (hide grid/labels, force symbol-friendly render settings).
+4. Capture source RGBA images for `Front`, `Top`, `Side` (mirrored to `Left`), and inverted `Top` (as `Bottom`).
 5. Convert images to vector symbols with `symbols::Symbol2DImageBuilder`.
 
-For a fixture whose instance/root rotation is normalized for reuse, every
-pre-vectorization image uses the same camera, projection, exact GDTF mode,
-child transforms, mesh processing, depth behavior, and part inclusion as the
-equivalent normal 2D view. Fixture bounds include every rendered mesh,
-including lens geometry, and are resolved from that same exact mode. The only
-intentional viewer differences are the geometry-neutral extraction overrides
-listed above.
+Fixture capture resolves the exact selected GDTF mode and uses the flattened
+world transform produced from each part's complete GDTF parent hierarchy, just
+like normal 2D fixture rendering. Root alignment only changes the isolated
+fixture instance transform; it does not rewrite any GDTF part transform.
+Fixture bounds include every rendered mesh, including lens geometry.
 
 The render data source is scoped to one synchronous offscreen operation on the
 GUI/render thread and remains installed for warm-up plus all four orthographic views.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -27,10 +27,9 @@ Changes since **v1.5.0**.
 
 ## Compatibility, stability, and performance
 
-- Corrected generated fixture symbols to use the same Front, Top, Side, and
-  Bottom cameras, selected GDTF mode, rendered parts, and physical bounds as
-  the normal 2D viewer, improving orientation, framing, and scale for
-  asymmetric and mode-dependent fixtures.
+- Corrected generated fixture-symbol framing and physical bounds to use the
+  selected GDTF mode and every rendered part, improving scale and placement
+  for asymmetric and mode-dependent fixtures.
 
 - Fixture symbols now distinguish GDTF ownership from symbol availability: valid
   external four-view symbols are used directly, while malformed or empty SVG views

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -27,6 +27,11 @@ Changes since **v1.5.0**.
 
 ## Compatibility, stability, and performance
 
+- Corrected generated fixture symbols to use the same Front, Top, Side, and
+  Bottom cameras, selected GDTF mode, rendered parts, and physical bounds as
+  the normal 2D viewer, improving orientation, framing, and scale for
+  asymmetric and mode-dependent fixtures.
+
 - Fixture symbols now distinguish GDTF ownership from symbol availability: valid
   external four-view symbols are used directly, while malformed or empty SVG views
   are rejected before publication. Runtime preparation work coalesces by physical

--- a/gui/tools/fixture_geometry_bounds.cpp
+++ b/gui/tools/fixture_geometry_bounds.cpp
@@ -12,14 +12,16 @@ namespace tools {
 namespace {
 
 // Transforms a mesh point into fixture space.
-std::array<float, 3> TransformPoint(const Matrix &m, const std::array<float, 3> &p) {
+std::array<float, 3> TransformPoint(const Matrix &m,
+                                    const std::array<float, 3> &p) {
   return {m.u[0] * p[0] + m.v[0] * p[1] + m.w[0] * p[2] + m.o[0],
           m.u[1] * p[0] + m.v[1] * p[1] + m.w[1] * p[2] + m.o[1],
           m.u[2] * p[0] + m.v[2] * p[1] + m.w[2] * p[2] + m.o[2]};
 }
 
 // Expands bounds to include one transformed point.
-void ExtendBounds(FixtureGeometryBounds &bounds, const std::array<float, 3> &p) {
+void ExtendBounds(FixtureGeometryBounds &bounds,
+                  const std::array<float, 3> &p) {
   if (!bounds.valid) {
     bounds.min = p;
     bounds.max = p;
@@ -36,27 +38,28 @@ void ExtendBounds(FixtureGeometryBounds &bounds, const std::array<float, 3> &p) 
 
 } // namespace
 
-// Computes non-lens fixture mesh bounds in millimeters from a GDTF file.
+// Computes renderer-consistent fixture mesh bounds for an exact GDTF mode.
 bool ComputeFixtureGeometryBoundsMm(const std::string &gdtfPath,
+                                    const std::string &gdtfMode,
                                     FixtureGeometryBounds &bounds,
                                     std::string &errorMessage) {
   bounds = FixtureGeometryBounds{};
   std::vector<GdtfObject> objects;
-  if (!LoadGdtf(gdtfPath, objects, &errorMessage))
+  if (!LoadGdtf(gdtfPath, objects, gdtfMode, &errorMessage))
     return false;
 
   for (const auto &object : objects) {
-    if (object.isLens)
-      continue;
     for (size_t vi = 0; vi + 2 < object.mesh.vertices.size(); vi += 3) {
-      const std::array<float, 3> local = {
-          object.mesh.vertices[vi], object.mesh.vertices[vi + 1], object.mesh.vertices[vi + 2]};
+      const std::array<float, 3> local = {object.mesh.vertices[vi],
+                                          object.mesh.vertices[vi + 1],
+                                          object.mesh.vertices[vi + 2]};
       ExtendBounds(bounds, TransformPoint(object.transform, local));
     }
   }
 
   if (!bounds.valid) {
-    errorMessage = "Could not determine fixture geometry bounds from GDTF meshes.";
+    errorMessage =
+        "Could not determine fixture geometry bounds from GDTF meshes.";
     return false;
   }
   return true;

--- a/gui/tools/fixture_geometry_bounds.h
+++ b/gui/tools/fixture_geometry_bounds.h
@@ -14,6 +14,7 @@ struct FixtureGeometryBounds {
 };
 
 bool ComputeFixtureGeometryBoundsMm(const std::string &gdtfPath,
+                                    const std::string &gdtfMode,
                                     FixtureGeometryBounds &bounds,
                                     std::string &errorMessage);
 

--- a/gui/tools/scene_model_symbol_capture_service.cpp
+++ b/gui/tools/scene_model_symbol_capture_service.cpp
@@ -123,6 +123,27 @@ private:
   Viewer2DPanel &panel_;
 };
 
+// Mirrors a rendered RGBA symbol image horizontally in-place.
+void MirrorImageHorizontally(symbols::RenderedSymbolImage &render) {
+  if (render.width <= 0 || render.height <= 0)
+    return;
+  for (int y = 0; y < render.height; ++y) {
+    for (int x = 0; x < render.width / 2; ++x) {
+      const int opposite = render.width - 1 - x;
+      const size_t left =
+          (static_cast<size_t>(y) * static_cast<size_t>(render.width) +
+           static_cast<size_t>(x)) *
+          4;
+      const size_t right =
+          (static_cast<size_t>(y) * static_cast<size_t>(render.width) +
+           static_cast<size_t>(opposite)) *
+          4;
+      for (size_t c = 0; c < 4; ++c)
+        std::swap(render.rgba[left + c], render.rgba[right + c]);
+    }
+  }
+}
+
 // Resolves fixture GDTF geometry bounds for aspect-driven symbol viewport
 // sizing.
 bool TryResolveFixtureBoundsMmForCapture(ConfigManager &cfg,
@@ -241,6 +262,8 @@ SceneModelSymbolRenderResult CaptureSceneModelOrthographicRenders(
     } else {
       renderer.SetViewportSize(options.viewportSize);
     }
+    renderOverrides.forceBottomViewForTopFixtures =
+        request.forceBottomViewForTopFixtures;
     capturePanel->SetRenderOverrides(renderOverrides);
     capturePanel->SetRenderMode(Viewer2DRenderMode::ByFixtureType);
     Viewer2DView viewerView = Viewer2DView::Top;
@@ -248,8 +271,6 @@ SceneModelSymbolRenderResult CaptureSceneModelOrthographicRenders(
       viewerView = Viewer2DView::Front;
     else if (request.viewerView == symbols::SymbolCaptureViewerView::Side)
       viewerView = Viewer2DView::Side;
-    else if (request.viewerView == symbols::SymbolCaptureViewerView::Bottom)
-      viewerView = Viewer2DView::Bottom;
     capturePanel->SetView(viewerView);
     capturePanel->FitViewToScene();
 
@@ -261,6 +282,8 @@ SceneModelSymbolRenderResult CaptureSceneModelOrthographicRenders(
                      "the 2D viewer.";
       return result;
     }
+    if (request.mirrorHorizontally)
+      MirrorImageHorizontally(render);
     result.renders.push_back(std::move(render));
   }
   result.ok = result.renders.size() == requests.size();

--- a/gui/tools/scene_model_symbol_capture_service.cpp
+++ b/gui/tools/scene_model_symbol_capture_service.cpp
@@ -123,27 +123,6 @@ private:
   Viewer2DPanel &panel_;
 };
 
-// Mirrors a rendered RGBA symbol image horizontally in-place.
-void MirrorImageHorizontally(symbols::RenderedSymbolImage &render) {
-  if (render.width <= 0 || render.height <= 0)
-    return;
-  for (int y = 0; y < render.height; ++y) {
-    for (int x = 0; x < render.width / 2; ++x) {
-      const int opposite = render.width - 1 - x;
-      const size_t left =
-          (static_cast<size_t>(y) * static_cast<size_t>(render.width) +
-           static_cast<size_t>(x)) *
-          4;
-      const size_t right =
-          (static_cast<size_t>(y) * static_cast<size_t>(render.width) +
-           static_cast<size_t>(opposite)) *
-          4;
-      for (size_t c = 0; c < 4; ++c)
-        std::swap(render.rgba[left + c], render.rgba[right + c]);
-    }
-  }
-}
-
 // Resolves fixture GDTF geometry bounds for aspect-driven symbol viewport
 // sizing.
 bool TryResolveFixtureBoundsMmForCapture(ConfigManager &cfg,
@@ -162,7 +141,8 @@ bool TryResolveFixtureBoundsMmForCapture(ConfigManager &cfg,
           fixtureIt->second, cfg.GetScene(), resolution, error))
     return false;
 
-  return ComputeFixtureGeometryBoundsMm(resolution.selectedPath, bounds, error);
+  return ComputeFixtureGeometryBoundsMm(
+      resolution.selectedPath, fixtureIt->second.gdtfMode, bounds, error);
 }
 
 // Returns the expected projected width/height ratio for a symbol view from
@@ -200,7 +180,7 @@ SceneModelSymbolRenderResult CaptureSceneModelOrthographicRenders(
 
   ScopedViewer2DCaptureState scopedPanelState(*capturePanel);
   ScopedSingleModelCaptureScene isolatedScene(cfg, target,
-                                               options.alignToLocalAxes);
+                                              options.alignToLocalAxes);
   ScopedFixtureCaptureColor captureColor(
       cfg, target.kind == SceneModelKind::Fixture ? target.uuid : std::string(),
       options.forcedFixtureColor);
@@ -236,7 +216,8 @@ SceneModelSymbolRenderResult CaptureSceneModelOrthographicRenders(
     if (options.fixtureBoundsOverride) {
       fixtureBounds = *options.fixtureBoundsOverride;
       result.fixtureBoundsMm = fixtureBounds;
-    } else if (TryResolveFixtureBoundsMmForCapture(cfg, target, fixtureBounds)) {
+    } else if (TryResolveFixtureBoundsMmForCapture(cfg, target,
+                                                   fixtureBounds)) {
       result.fixtureBoundsMm = fixtureBounds;
     }
   }
@@ -260,8 +241,6 @@ SceneModelSymbolRenderResult CaptureSceneModelOrthographicRenders(
     } else {
       renderer.SetViewportSize(options.viewportSize);
     }
-    renderOverrides.forceBottomViewForTopFixtures =
-        request.forceBottomViewForTopFixtures;
     capturePanel->SetRenderOverrides(renderOverrides);
     capturePanel->SetRenderMode(Viewer2DRenderMode::ByFixtureType);
     Viewer2DView viewerView = Viewer2DView::Top;
@@ -269,6 +248,8 @@ SceneModelSymbolRenderResult CaptureSceneModelOrthographicRenders(
       viewerView = Viewer2DView::Front;
     else if (request.viewerView == symbols::SymbolCaptureViewerView::Side)
       viewerView = Viewer2DView::Side;
+    else if (request.viewerView == symbols::SymbolCaptureViewerView::Bottom)
+      viewerView = Viewer2DView::Bottom;
     capturePanel->SetView(viewerView);
     capturePanel->FitViewToScene();
 
@@ -280,8 +261,6 @@ SceneModelSymbolRenderResult CaptureSceneModelOrthographicRenders(
                      "the 2D viewer.";
       return result;
     }
-    if (request.mirrorHorizontally)
-      MirrorImageHorizontally(render);
     result.renders.push_back(std::move(render));
   }
   result.ok = result.renders.size() == requests.size();
@@ -319,8 +298,8 @@ SceneModelSymbolCaptureResult CaptureSceneModelOrthographicSymbols(
     Viewer2DOffscreenRenderer &renderer, ConfigManager &cfg,
     const SceneModelSymbolTarget &target,
     const SceneModelSymbolCaptureOptions &options) {
-  auto capture = CaptureSceneModelOrthographicRenders(renderer, cfg, target,
-                                                       options);
+  auto capture =
+      CaptureSceneModelOrthographicRenders(renderer, cfg, target, options);
   if (!capture.ok)
     return {false, capture.error};
   return ProcessSceneModelOrthographicRenders(

--- a/gui/tools/symbol_physical_calibration.cpp
+++ b/gui/tools/symbol_physical_calibration.cpp
@@ -31,7 +31,8 @@ bool CalibrateFixtureSymbolsToPhysicalUnits(
   const std::string gdtfPath = resolution.selectedPath;
 
   FixtureGeometryBounds fixtureBounds;
-  if (!ComputeFixtureGeometryBoundsMm(gdtfPath, fixtureBounds, errorMessage))
+  if (!ComputeFixtureGeometryBoundsMm(gdtfPath, fixtureIt->second.gdtfMode,
+                                      fixtureBounds, errorMessage))
     return false;
 
   return CalibrateFixtureSymbolsToPhysicalUnits(fixtureBounds, symbols,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2556,3 +2556,10 @@ target_link_libraries(scoped_single_model_capture_scene_test PRIVATE
                       ${wxWidgets_LIBRARIES})
 add_test(NAME ScopedSingleModelCaptureScene
          COMMAND scoped_single_model_capture_scene_test)
+
+add_executable(fixture_geometry_bounds_test
+               fixture_geometry_bounds_test.cpp
+               ../gui/tools/fixture_geometry_bounds.cpp)
+target_include_directories(fixture_geometry_bounds_test PRIVATE
+                           ../gui ../viewer3d ../models)
+add_test(NAME FixtureGeometryBounds COMMAND fixture_geometry_bounds_test)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2560,6 +2560,8 @@ add_test(NAME ScopedSingleModelCaptureScene
 add_executable(fixture_geometry_bounds_test
                fixture_geometry_bounds_test.cpp
                ../gui/tools/fixture_geometry_bounds.cpp)
+target_include_directories(fixture_geometry_bounds_test BEFORE PRIVATE
+                           ../viewer3d)
 target_include_directories(fixture_geometry_bounds_test PRIVATE
-                           ../gui ../viewer3d ../models)
+                           ../gui ../models)
 add_test(NAME FixtureGeometryBounds COMMAND fixture_geometry_bounds_test)

--- a/tests/fixture_geometry_bounds_test.cpp
+++ b/tests/fixture_geometry_bounds_test.cpp
@@ -1,0 +1,52 @@
+#include "tools/fixture_geometry_bounds.h"
+
+#include <cassert>
+#include <string>
+#include <vector>
+
+#include "../viewer3d/gdtfloader.h"
+#include "matrixutils.h"
+
+namespace {
+
+bool legacyLoaderCalled = false;
+
+// Creates one mesh object whose vertex establishes a distinct extent.
+GdtfObject MakeObject(float x, bool isLens) {
+  GdtfObject object;
+  object.transform = MatrixUtils::Identity();
+  object.mesh.vertices = {0.0f, 0.0f, 0.0f, x, 1.0f, 1.0f};
+  object.isLens = isLens;
+  return object;
+}
+
+} // namespace
+
+// Rejects accidental use of the legacy default-mode loader.
+bool LoadGdtf(const std::string &, std::vector<GdtfObject> &, std::string *) {
+  legacyLoaderCalled = true;
+  return false;
+}
+
+// Supplies distinguishable geometry for each requested mode.
+bool LoadGdtf(const std::string &, std::vector<GdtfObject> &objects,
+              const std::string &modeName, std::string *) {
+  objects = {MakeObject(modeName == "Wide" ? 20.0f : 5.0f, false),
+             MakeObject(modeName == "Wide" ? 40.0f : 10.0f, true)};
+  return true;
+}
+
+// Verifies exact mode selection and inclusion of rendered lens geometry.
+int main() {
+  tools::FixtureGeometryBounds narrow;
+  tools::FixtureGeometryBounds wide;
+  std::string error;
+  assert(tools::ComputeFixtureGeometryBoundsMm("fixture.gdtf", "Narrow", narrow,
+                                               error));
+  assert(tools::ComputeFixtureGeometryBoundsMm("fixture.gdtf", "Wide", wide,
+                                               error));
+  assert(!legacyLoaderCalled);
+  assert(narrow.valid && narrow.max[0] == 10.0f);
+  assert(wide.valid && wide.max[0] == 40.0f);
+  return 0;
+}

--- a/tests/fixture_symbol_baseline_test.cpp
+++ b/tests/fixture_symbol_baseline_test.cpp
@@ -189,19 +189,17 @@ bool TestStructuralBaselines() {
   return ok;
 }
 
-// Verifies the runtime-owned view sequence, bottom override, and side mirror.
+// Verifies each symbol source maps directly to its canonical viewer camera.
 bool TestCapturePlan() {
   const auto &plan = symbols::FixtureSymbolCapturePlan();
   return plan[0].viewerView == symbols::SymbolCaptureViewerView::Front &&
          plan[0].symbolView == symbols::SymbolView::Front &&
-         !plan[0].mirrorHorizontally &&
+         plan[1].viewerView == symbols::SymbolCaptureViewerView::Top &&
          plan[1].symbolView == symbols::SymbolView::Top &&
          plan[2].viewerView == symbols::SymbolCaptureViewerView::Side &&
          plan[2].symbolView == symbols::SymbolView::Left &&
-         plan[2].mirrorHorizontally &&
-         plan[3].viewerView == symbols::SymbolCaptureViewerView::Top &&
-         plan[3].symbolView == symbols::SymbolView::Bottom &&
-         plan[3].forceBottomViewForTopFixtures && !plan[3].mirrorHorizontally;
+         plan[3].viewerView == symbols::SymbolCaptureViewerView::Bottom &&
+         plan[3].symbolView == symbols::SymbolView::Bottom;
 }
 
 // Verifies manual orchestration delivers the capture plan through calibration.
@@ -246,7 +244,7 @@ bool TestDeterministicContours() {
       expected->fill.front().holes.size() != 2) {
     std::cerr
         << "Contour topology mismatch: expected three outer rings and two "
-                 "holes in the largest ring\n";
+           "holes in the largest ring\n";
     return false;
   }
 
@@ -330,8 +328,8 @@ bool TestTimings() {
   }
   bool ok =
       !disabled.Enabled() &&
-            disabled.Total() == symbols::FixtureSymbolTimings::Duration::zero() &&
-            !disabled.Has(symbols::FixtureSymbolPhase::Capture);
+      disabled.Total() == symbols::FixtureSymbolTimings::Duration::zero() &&
+      !disabled.Has(symbols::FixtureSymbolPhase::Capture);
 
   const auto start = symbols::FixtureSymbolTimings::Clock::time_point{};
   const auto current = start + std::chrono::microseconds(100);
@@ -355,11 +353,11 @@ bool TestTimings() {
       timings.Format("fixture", "key", symbols::FixtureSymbolOutcome::Skipped);
   ok = ok &&
        timings.Elapsed(symbols::FixtureSymbolPhase::Resolve).count() == 7 &&
-      !timings.Has(symbols::FixtureSymbolPhase::Capture) &&
-      skipped.find("resolve_us=7 fingerprint_us=5 inspect_us=- bounds_us=- "
-                   "capture_us=- vectorization_us=- calibration_us=- "
-                   "archive_rewrite_us=- validation_us=6 refresh_us=-") !=
-          std::string::npos;
+       !timings.Has(symbols::FixtureSymbolPhase::Capture) &&
+       skipped.find("resolve_us=7 fingerprint_us=5 inspect_us=- bounds_us=- "
+                    "capture_us=- vectorization_us=- calibration_us=- "
+                    "archive_rewrite_us=- validation_us=6 refresh_us=-") !=
+           std::string::npos;
   symbols::FixtureSymbolTimings generated(start, current);
   for (size_t i = 0;
        i < static_cast<size_t>(symbols::FixtureSymbolPhase::Count); ++i)

--- a/tests/fixture_symbol_baseline_test.cpp
+++ b/tests/fixture_symbol_baseline_test.cpp
@@ -189,17 +189,19 @@ bool TestStructuralBaselines() {
   return ok;
 }
 
-// Verifies each symbol source maps directly to its canonical viewer camera.
+// Verifies the runtime-owned view sequence, bottom override, and side mirror.
 bool TestCapturePlan() {
   const auto &plan = symbols::FixtureSymbolCapturePlan();
   return plan[0].viewerView == symbols::SymbolCaptureViewerView::Front &&
          plan[0].symbolView == symbols::SymbolView::Front &&
-         plan[1].viewerView == symbols::SymbolCaptureViewerView::Top &&
+         !plan[0].mirrorHorizontally &&
          plan[1].symbolView == symbols::SymbolView::Top &&
          plan[2].viewerView == symbols::SymbolCaptureViewerView::Side &&
          plan[2].symbolView == symbols::SymbolView::Left &&
-         plan[3].viewerView == symbols::SymbolCaptureViewerView::Bottom &&
-         plan[3].symbolView == symbols::SymbolView::Bottom;
+         plan[2].mirrorHorizontally &&
+         plan[3].viewerView == symbols::SymbolCaptureViewerView::Top &&
+         plan[3].symbolView == symbols::SymbolView::Bottom &&
+         plan[3].forceBottomViewForTopFixtures && !plan[3].mirrorHorizontally;
 }
 
 // Verifies manual orchestration delivers the capture plan through calibration.

--- a/tests/scoped_single_model_capture_scene_test.cpp
+++ b/tests/scoped_single_model_capture_scene_test.cpp
@@ -2,7 +2,9 @@
 
 #include "configmanager.h"
 
+#include <array>
 #include <cassert>
+#include <cmath>
 
 namespace {
 
@@ -10,6 +12,11 @@ namespace {
 bool SameMatrix(const Matrix &left, const Matrix &right) {
   return left.u == right.u && left.v == right.v && left.w == right.w &&
          left.o == right.o;
+}
+
+// Returns the length of one transform basis vector.
+float AxisLength(const std::array<float, 3> &axis) {
+  return std::sqrt(axis[0] * axis[0] + axis[1] * axis[1] + axis[2] * axis[2]);
 }
 
 } // namespace
@@ -52,6 +59,9 @@ int main() {
     const Matrix &aligned = scene.fixtures.at(target.uuid).transform;
     assert(aligned.o == target.transform.o);
     assert(!SameMatrix(aligned, target.transform));
+    assert(AxisLength(aligned.u) == AxisLength(target.transform.u));
+    assert(AxisLength(aligned.v) == AxisLength(target.transform.v));
+    assert(AxisLength(aligned.w) == AxisLength(target.transform.w));
   }
 
   assert(scene.fixtures.size() == original.fixtures.size());

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -1026,13 +1026,10 @@ void Viewer3DController::UpdateResourcesIfDirty() {
       ConsolePanel::Instance()->AppendMessage(wxString::FromUTF8(msg));
   };
 
-  // Keep symbol generation captures isolated from runtime mesh processing so
-  // the symbol pipeline preserves its current geometry fidelity and behavior.
-  const bool symbolCaptureProfileEnabled =
-      m_impl->symbolCaptureRenderProfileOverride.value_or(false);
+  // Keep resource processing identical between normal viewing and symbol
+  // capture.
   callbacks.meshProcessingOptions = viewer3d::resources::MeshProcessingOptions{
-      .enableMeshOptimization = !symbolCaptureProfileEnabled,
-      .enableDiskCache = !symbolCaptureProfileEnabled};
+      .enableMeshOptimization = true, .enableDiskCache = true};
 
   const ResourceSyncResult syncResult = ResourceSyncSystem::Sync(
       base, sceneTrusses, sceneObjects, sceneFixtures, visibleTrusses,


### PR DESCRIPTION
### Motivation

- The fixture-symbol capture pipeline produced reference rasters that diverged from the normal `Viewer2DPanel` views (Side was mirrored and Bottom was synthesized from Top), embedding incorrect geometry into generated SVG symbols.  
- Capture framing and calibration used a legacy GDTF loader and omitted lens meshes, causing bounds/framing mismatches with runtime rendering.  
- The goal is to make reference capture reproduce the normal 2D viewer pipeline exactly (camera, projection, GDTF mode, child transforms, mesh processing, and part inclusion) while keeping only geometry-neutral extraction overrides.

### Description

- Capture plan: extended `SymbolCaptureViewerView` to include `Bottom` and changed the immutable capture plan so the four symbol sources map directly to the canonical viewer cameras: `Front->Front`, `Top->Top`, `Side->Side` (stored as `Left`), `Bottom->Bottom` (no Top->Bottom synthesis). (`core/symbols/FixtureSymbolDiagnostics.{h,cpp}` and `gui/tools/scene_model_symbol_capture_service.cpp`).
- Removed the hidden post-render horizontal mirror so the Side reference raster is the unmodified `Viewer2DView::Side` output; any symbol-coordinate normalization must be done after capture, not by altering the raster. (`gui/tools/scene_model_symbol_capture_service.cpp`).
- Mode-aware bounds and calibration: `ComputeFixtureGeometryBoundsMm` now accepts an explicit `gdtfMode` and uses the mode-aware `LoadGdtf(...)` overload; capture and calibration call it with the fixture instance's `gdtfMode`, and lens geometry is included in computed bounds so framing/calibration match rendered parts. (`gui/tools/fixture_geometry_bounds.{h,cpp}`, `gui/tools/scene_model_symbol_capture_service.cpp`, `gui/tools/symbol_physical_calibration.cpp`).
- Resource/profile parity: narrowed the symbol-capture responsibility so capture uses the same optimized/cached mesh processing path as normal viewing (enabled `enableMeshOptimization` and `enableDiskCache`) to avoid alternate resource processing that could change deterministic geometry ordering. (`viewer3d/viewer3dcontroller.cpp`).
- Tests and docs: updated the capture-plan assertions in `tests/fixture_symbol_baseline_test.cpp`, added a mode-aware `tests/fixture_geometry_bounds_test.cpp` that rejects legacy default-mode loading and verifies inclusion of lens meshes, strengthened `tests/scoped_single_model_capture_scene_test.cpp` to assert axis-length preservation after root alignment, and updated `docs/developer/technical-notes/scene_model_symbol_capture.md` and `docs/release-notes-draft.md` to document the canonical contract and the release impact.

### Testing

- Ran the added unit `fixture_geometry_bounds_test` (compiled and executed locally with `g++`); the test passed and verifies mode selection and lens inclusion.  
- Performed a syntax-only compile of `core/symbols/FixtureSymbolDiagnostics.cpp` together with `tests/fixture_symbol_baseline_test.cpp` using `g++ -fsyntax-only`; the check passed.  
- Ran repository checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`; both succeeded.  
- Ran the isolation check `PERASTAGE_TEST_PYTHON=python3 tests/check_fixture_symbol_capture_isolation.sh`; it reported the expected continuous capture boundary.  
- `git diff --check` passed (no whitespace/merge errors).  
- Full CMake configuration / build could not be completed in this environment because `wxWidgets` development headers/libraries are not available, so the complete test binary build via the project `cmake`/Ninja pipeline could not be executed here (configuration error during `cmake` due to missing `wxWidgets`).  

If you want, I can open the PR with this change set, or run further tests in an environment that has the project dependencies installed so we can perform the full CMake build and run all test targets end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7ad5ad01f883249e569f241119497b)