### PR TITLE
Fix Sketch mode multisample antialiasing

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -75,6 +75,10 @@ Changes since **v1.5.0**.
 
 ## Important fixes
 
+- Smoothed diagonal and curved geometry edges in the 3D Viewer Sketch style by
+  preserving the viewer's configured antialiasing through Sketch composition,
+  without changing the appearance of the other render styles.
+
 - Corrected inverted lighting in the 3D Sketch style by applying its three-tone
   treatment to the neutral output of the proven Standard renderer, preserving
   the same transforms and illumination while restoring smooth surfaces, the

--- a/tests/check_sketch_post_process_architecture.sh
+++ b/tests/check_sketch_post_process_architecture.sh
@@ -24,6 +24,9 @@ rg -q 'glColor4f\(0\.0f, 0\.0f, 0\.0f, 0\.0f\)' "$renderer"
 rg -q 'glPolygonOffset\(-1\.0f, -1\.0f\)' "$renderer"
 rg -q 'inkCoverage = 1\.0 - base\.a' "$post_process"
 rg -q 'GL_DRAW_FRAMEBUFFER_BINDING' "$post_process"
+rg -q 'glRenderbufferStorageMultisample' "$post_process"
+rg -q 'ResolveMultisampleTarget' "$post_process"
+rg -q 'GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT' "$post_process"
 if rg -q 'glBindFramebuffer\(GL_(DRAW_)?FRAMEBUFFER, 0\)' "$post_process"; then
   echo "Sketch post-processing must restore the captured destination framebuffer." >&2
   exit 1

--- a/tests/sketch_post_process_policy_test.cpp
+++ b/tests/sketch_post_process_policy_test.cpp
@@ -22,5 +22,10 @@ int main() {
   assert(SketchInkCoverage(0.0f) == 1.0f);
   assert(SketchInkCoverage(0.25f) == 0.75f);
   assert(SketchInkCoverage(1.0f) == 0.0f);
+  assert(SketchTargetConfigurationMatches(800, 600, 4, 800, 600, 4));
+  assert(!SketchTargetConfigurationMatches(800, 600, 4, 801, 600, 4));
+  assert(!SketchTargetConfigurationMatches(800, 600, 4, 800, 601, 4));
+  assert(!SketchTargetConfigurationMatches(800, 600, 4, 800, 600, 2));
+  assert(SketchTargetConfigurationMatches(800, 600, 0, 800, 600, 0));
   return 0;
 }

--- a/viewer3d/render/sketch_post_process_pass.cpp
+++ b/viewer3d/render/sketch_post_process_pass.cpp
@@ -90,14 +90,19 @@ GLuint CreateProgram() {
 } // namespace
 
 struct SketchPostProcessPass::Impl {
-  GLuint framebuffer = 0;
-  GLuint colorTexture = 0;
-  GLuint depthStencil = 0;
+  GLuint resolvedFramebuffer = 0;
+  GLuint resolvedColorTexture = 0;
+  GLuint resolvedDepthStencil = 0;
+  GLuint multisampleFramebuffer = 0;
+  GLuint multisampleColor = 0;
+  GLuint multisampleDepthStencil = 0;
   GLuint program = 0;
   GLint destinationFramebuffer = 0;
   GLint viewport[4] = {0, 0, 0, 0};
   int width = 0;
   int height = 0;
+  int samples = 0;
+  int configuredSamples = -1;
   bool active = false;
   bool targetComplete = false;
 
@@ -105,56 +110,128 @@ struct SketchPostProcessPass::Impl {
   void Release() {
     if (program != 0)
       glDeleteProgram(program);
-    if (depthStencil != 0)
-      glDeleteRenderbuffers(1, &depthStencil);
-    if (colorTexture != 0)
-      glDeleteTextures(1, &colorTexture);
-    if (framebuffer != 0)
-      glDeleteFramebuffers(1, &framebuffer);
+    if (multisampleDepthStencil != 0)
+      glDeleteRenderbuffers(1, &multisampleDepthStencil);
+    if (multisampleColor != 0)
+      glDeleteRenderbuffers(1, &multisampleColor);
+    if (multisampleFramebuffer != 0)
+      glDeleteFramebuffers(1, &multisampleFramebuffer);
+    if (resolvedDepthStencil != 0)
+      glDeleteRenderbuffers(1, &resolvedDepthStencil);
+    if (resolvedColorTexture != 0)
+      glDeleteTextures(1, &resolvedColorTexture);
+    if (resolvedFramebuffer != 0)
+      glDeleteFramebuffers(1, &resolvedFramebuffer);
     program = 0;
-    depthStencil = 0;
-    colorTexture = 0;
-    framebuffer = 0;
+    multisampleDepthStencil = 0;
+    multisampleColor = 0;
+    multisampleFramebuffer = 0;
+    resolvedDepthStencil = 0;
+    resolvedColorTexture = 0;
+    resolvedFramebuffer = 0;
     targetComplete = false;
   }
 
-  // Allocates or resizes the neutral-base framebuffer for the current viewport.
-  bool EnsureTarget(int requestedWidth, int requestedHeight) {
+  // Releases render targets while retaining the reusable shader program.
+  void ReleaseTargets() {
+    const GLuint retainedProgram = program;
+    program = 0;
+    Release();
+    program = retainedProgram;
+  }
+
+  // Reports whether multisample renderbuffers and framebuffer blits are available.
+  bool SupportsMultisampleTargets() const {
+    return GLEW_VERSION_3_0 || GLEW_ARB_framebuffer_object ||
+           (GLEW_EXT_framebuffer_multisample && GLEW_EXT_framebuffer_blit);
+  }
+
+  // Allocates or resizes resolved and optional multisample Sketch targets.
+  bool EnsureTarget(int requestedWidth, int requestedHeight,
+                    int requestedSamples) {
     if (requestedWidth <= 0 || requestedHeight <= 0)
       return false;
-    if (framebuffer != 0 && width == requestedWidth &&
-        height == requestedHeight)
+    if (!SupportsMultisampleTargets())
+      requestedSamples = 0;
+    if (resolvedFramebuffer != 0 &&
+        SketchTargetConfigurationMatches(width, height, configuredSamples,
+                                         requestedWidth, requestedHeight,
+                                         requestedSamples))
       return targetComplete;
 
-    if (depthStencil != 0)
-      glDeleteRenderbuffers(1, &depthStencil);
-    if (colorTexture != 0)
-      glDeleteTextures(1, &colorTexture);
-    if (framebuffer == 0)
-      glGenFramebuffers(1, &framebuffer);
+    ReleaseTargets();
     targetComplete = false;
 
-    glBindFramebuffer(GL_FRAMEBUFFER, framebuffer);
-    glGenTextures(1, &colorTexture);
-    glBindTexture(GL_TEXTURE_2D, colorTexture);
+    glGenFramebuffers(1, &resolvedFramebuffer);
+    glBindFramebuffer(GL_FRAMEBUFFER, resolvedFramebuffer);
+    glGenTextures(1, &resolvedColorTexture);
+    glBindTexture(GL_TEXTURE_2D, resolvedColorTexture);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, requestedWidth, requestedHeight, 0,
                  GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
     glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
-                           colorTexture, 0);
+                           resolvedColorTexture, 0);
 
-    glGenRenderbuffers(1, &depthStencil);
-    glBindRenderbuffer(GL_RENDERBUFFER, depthStencil);
+    glGenRenderbuffers(1, &resolvedDepthStencil);
+    glBindRenderbuffer(GL_RENDERBUFFER, resolvedDepthStencil);
     glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, requestedWidth,
                           requestedHeight);
     glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT,
-                              GL_RENDERBUFFER, depthStencil);
+                              GL_RENDERBUFFER, resolvedDepthStencil);
     width = requestedWidth;
     height = requestedHeight;
+    samples = requestedSamples;
+    configuredSamples = requestedSamples;
     targetComplete =
         glCheckFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE;
+    if (!targetComplete)
+      return false;
+
+    if (samples > 0) {
+      glGenFramebuffers(1, &multisampleFramebuffer);
+      glBindFramebuffer(GL_FRAMEBUFFER, multisampleFramebuffer);
+      glGenRenderbuffers(1, &multisampleColor);
+      glBindRenderbuffer(GL_RENDERBUFFER, multisampleColor);
+      glRenderbufferStorageMultisample(GL_RENDERBUFFER, samples, GL_RGBA8,
+                                       requestedWidth, requestedHeight);
+      glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+                                GL_RENDERBUFFER, multisampleColor);
+      glGenRenderbuffers(1, &multisampleDepthStencil);
+      glBindRenderbuffer(GL_RENDERBUFFER, multisampleDepthStencil);
+      glRenderbufferStorageMultisample(GL_RENDERBUFFER, samples,
+                                       GL_DEPTH24_STENCIL8, requestedWidth,
+                                       requestedHeight);
+      glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT,
+                                GL_RENDERBUFFER, multisampleDepthStencil);
+      if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+        glDeleteRenderbuffers(1, &multisampleDepthStencil);
+        glDeleteRenderbuffers(1, &multisampleColor);
+        glDeleteFramebuffers(1, &multisampleFramebuffer);
+        multisampleDepthStencil = 0;
+        multisampleColor = 0;
+        multisampleFramebuffer = 0;
+        samples = 0;
+      }
+    }
     return targetComplete;
+  }
+
+  // Returns the framebuffer into which Sketch scene geometry is rendered.
+  GLuint SceneFramebuffer() const {
+    return multisampleFramebuffer != 0 ? multisampleFramebuffer
+                                       : resolvedFramebuffer;
+  }
+
+  // Resolves multisampled color and depth for shader input and overlay depth.
+  void ResolveMultisampleTarget() const {
+    if (multisampleFramebuffer == 0)
+      return;
+    glBindFramebuffer(GL_READ_FRAMEBUFFER, multisampleFramebuffer);
+    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, resolvedFramebuffer);
+    glBlitFramebuffer(0, 0, width, height, 0, 0, width, height,
+                      GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT,
+                      GL_NEAREST);
   }
 };
 
@@ -169,11 +246,14 @@ bool SketchPostProcessPass::Begin() {
   m_impl->active = false;
   glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &m_impl->destinationFramebuffer);
   glGetIntegerv(GL_VIEWPORT, m_impl->viewport);
+  GLint effectiveSamples = 0;
+  glGetIntegerv(GL_SAMPLES, &effectiveSamples);
   GLint previousTexture = 0;
   GLint previousRenderbuffer = 0;
   glGetIntegerv(GL_TEXTURE_BINDING_2D, &previousTexture);
   glGetIntegerv(GL_RENDERBUFFER_BINDING, &previousRenderbuffer);
-  if (!m_impl->EnsureTarget(m_impl->viewport[2], m_impl->viewport[3])) {
+  if (!m_impl->EnsureTarget(m_impl->viewport[2], m_impl->viewport[3],
+                            effectiveSamples > 1 ? effectiveSamples : 0)) {
     glBindFramebuffer(GL_FRAMEBUFFER,
                       static_cast<GLuint>(m_impl->destinationFramebuffer));
     glBindTexture(GL_TEXTURE_2D, static_cast<GLuint>(previousTexture));
@@ -184,7 +264,7 @@ bool SketchPostProcessPass::Begin() {
 
   GLfloat clearColor[4];
   glGetFloatv(GL_COLOR_CLEAR_VALUE, clearColor);
-  glBindFramebuffer(GL_FRAMEBUFFER, m_impl->framebuffer);
+  glBindFramebuffer(GL_FRAMEBUFFER, m_impl->SceneFramebuffer());
   glBindTexture(GL_TEXTURE_2D, static_cast<GLuint>(previousTexture));
   glBindRenderbuffer(GL_RENDERBUFFER,
                      static_cast<GLuint>(previousRenderbuffer));
@@ -200,10 +280,11 @@ void SketchPostProcessPass::Composite() {
   if (!m_impl->active)
     return;
   m_impl->active = false;
+  m_impl->ResolveMultisampleTarget();
   if (m_impl->program == 0)
     m_impl->program = CreateProgram();
   if (m_impl->program == 0) {
-    glBindFramebuffer(GL_READ_FRAMEBUFFER, m_impl->framebuffer);
+    glBindFramebuffer(GL_READ_FRAMEBUFFER, m_impl->resolvedFramebuffer);
     glBindFramebuffer(GL_DRAW_FRAMEBUFFER,
                       static_cast<GLuint>(m_impl->destinationFramebuffer));
     glBlitFramebuffer(0, 0, m_impl->width, m_impl->height,
@@ -220,7 +301,7 @@ void SketchPostProcessPass::Composite() {
 
   {
     viewer3d::render::OpenGLStateGuard stateGuard;
-    glBindFramebuffer(GL_READ_FRAMEBUFFER, m_impl->framebuffer);
+    glBindFramebuffer(GL_READ_FRAMEBUFFER, m_impl->resolvedFramebuffer);
     glBindFramebuffer(GL_DRAW_FRAMEBUFFER,
                       static_cast<GLuint>(m_impl->destinationFramebuffer));
     glBlitFramebuffer(0, 0, m_impl->width, m_impl->height,
@@ -237,7 +318,7 @@ void SketchPostProcessPass::Composite() {
     glDisable(GL_BLEND);
     glUseProgram(m_impl->program);
     glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_2D, m_impl->colorTexture);
+    glBindTexture(GL_TEXTURE_2D, m_impl->resolvedColorTexture);
     glUniform1i(glGetUniformLocation(m_impl->program, "uNeutralBase"), 0);
     glUniform1f(
         glGetUniformLocation(m_impl->program, "uDarkLuminanceThreshold"),

--- a/viewer3d/render/sketch_post_process_pass.h
+++ b/viewer3d/render/sketch_post_process_pass.h
@@ -31,6 +31,15 @@ inline float SketchInkCoverage(float alpha) {
   return 1.0f - alpha;
 }
 
+// Returns whether existing Sketch targets match the next frame requirements.
+inline bool SketchTargetConfigurationMatches(int width, int height, int samples,
+                                             int requestedWidth,
+                                             int requestedHeight,
+                                             int requestedSamples) {
+  return width == requestedWidth && height == requestedHeight &&
+         samples == requestedSamples;
+}
+
 class SketchPostProcessPass {
 public:
   SketchPostProcessPass();


### PR DESCRIPTION
### Motivation
- Investigation confirmed the Sketch render path rasterized scene geometry into a single-sample intermediate target while the main viewer used MSAA, causing Sketch-only stair-step aliasing on diagonal/curved edges.
- The intent is to preserve the viewer-configured AA for Sketch mode without changing other render styles or overall visual appearance.

### Description
- Render the Sketch neutral/base scene into an MSAA framebuffer when available and resolve into the existing single-sample post-process texture, implemented in `viewer3d/render/sketch_post_process_pass.cpp` and the helper in `viewer3d/render/sketch_post_process_pass.h`.
- Use the destination context `GL_SAMPLES` to select the effective sample count and gracefully fall back to single-sample when multisample targets or extensions are unavailable.
- Resolve multisampled color and depth via `glBlitFramebuffer` into the single-sample resolved target, then feed the resolved texture to the existing single-sample post-process shader and preserve depth by blitting to the original destination framebuffer for overlays.
- Add robust resource lifecycle and configuration checks that recreate targets only when viewport size or sample count changes, and release all GL resources on teardown; update architecture/policy tests and `docs/release-notes-draft.md` to reflect the fix.

### Testing
- Ran `tests/check_sketch_post_process_architecture.sh` and it passed, confirming the new multisample/resolve path is present and the pass restores destination framebuffer state.
- Ran `tests/check_perastage_tree_modules.sh`, `tests/check_no_configmanager_get_in_gui.sh`, and `tests/check_opengl_lifecycle_centralized.sh`, and they all passed.
- Built and ran the small policy test via `g++ ... tests/sketch_post_process_policy_test.cpp` and it executed successfully, confirming the new configuration-matching helper behavior.
- Attempted a full `cmake` configure/build for the project but the environment lacked the system `wxWidgets` development libraries so a full build could not be completed; a standalone syntax check also failed due to missing GLEW headers in this container, so GPU-run visual verification is still recommended on developer machines with OpenGL/wxWidgets available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7ae5cb5884832498496ac8ab03c3a3)