### PR TITLE
Fix intermittent project load finalization stall

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -91,6 +91,10 @@ Changes since **v1.5.0**.
 
 ## Important fixes
 
+- Project opening now completes its progress dialog explicitly before closing
+  it, preventing an intermittent stall at "Finalizing project load..." during
+  application startup.
+
 - Smoothed diagonal and curved geometry edges in the 3D Viewer Sketch style by
   preserving the viewer's configured antialiasing through Sketch composition,
   without changing the appearance of the other render styles.

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1052,7 +1052,11 @@ bool MainWindow::LoadProjectFromPath(const std::string &path,
   reportProjectLoadProgress(_("Updating window title..."), true);
   UpdateTitle();
   projectLoadProgressStep = kProjectLoadProgressSteps;
-  reportProjectLoadProgress(_("Finalizing project load..."));
+  // Complete the modal progress dialog before destroying it so wxWidgets does
+  // not leave its modal event loop waiting for an unfinished range.
+  reportProjectLoadProgress(_("Finalizing project load..."), false,
+                            projectLoadProgressStep,
+                            kProjectLoadProgressSteps);
   projectLoadProgressDialog.reset();
   if (showBlockingLoadUi)
     ClearBlockingProjectLoadUi();


### PR DESCRIPTION
### Motivation

- Users reported an intermittent startup hang where the UI stalls at "Finalizing project load...", likely caused by the modal progress dialog being destroyed without the progress range being completed.

### Description

- Ensure the progress UI is explicitly advanced to the final range before destroying the modal dialog by calling `reportProjectLoadProgress(..., completed, total)` with the final values in `MainWindow::LoadProjectFromPath` in `gui/mainwindow.cpp`.
- Preserve all existing load pipeline behavior, viewport/panel updates, and last-project persistence while preventing the modal dialog from leaving wxWidgets in an intermediate state.
- Update `docs/release-notes-draft.md` with a short entry describing the stability fix.

### Testing

- Ran `git diff --check` which reported no issues.
- Ran `tests/check_perastage_tree_modules.sh` which passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7c400073f88324b8d174e7554e158d)