### PR TITLE
Fix 3D highlight rendering in Sketch and Wireframe modes

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -97,9 +97,9 @@ Changes since **v1.5.0**.
 
 - Restored clear hover, group, and selection highlighting in the 3D Viewer
   Sketch and Wireframe styles. Sketch highlights now retain the same vivid
-  colors and black edge definition as the other filled styles instead of being
-  dimmed by its neutral material treatment, while Wireframe feedback remains
-  visible over its lines.
+  colors, light-and-shadow shading, and black edge definition as the other
+  filled styles instead of inheriting the muted Sketch base lighting, while
+  Wireframe feedback remains visible over its lines.
 
 - Project opening now completes its progress dialog explicitly before closing
   it, preventing an intermittent stall at "Finalizing project load..." during

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -95,6 +95,10 @@ Changes since **v1.5.0**.
 
 ## Important fixes
 
+- Restored clear hover, group, and selection highlighting in the 3D Viewer
+  Sketch and Wireframe styles, with colored feedback that remains visible over
+  each style's characteristic line treatment.
+
 - Project opening now completes its progress dialog explicitly before closing
   it, preventing an intermittent stall at "Finalizing project load..." during
   application startup.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -98,8 +98,8 @@ Changes since **v1.5.0**.
 - Restored clear hover, group, and selection highlighting in the 3D Viewer
   Sketch and Wireframe styles. Sketch highlights now retain the same vivid
   colors, light-and-shadow shading, and black edge definition as the other
-  filled styles instead of being posterized into the muted Sketch base image,
-  while Wireframe feedback remains visible over its lines.
+  filled styles by using the Standard highlight material after Sketch
+  composition, while Wireframe feedback remains visible over its lines.
 
 - Project opening now completes its progress dialog explicitly before closing
   it, preventing an intermittent stall at "Finalizing project load..." during

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -98,8 +98,8 @@ Changes since **v1.5.0**.
 - Restored clear hover, group, and selection highlighting in the 3D Viewer
   Sketch and Wireframe styles. Sketch highlights now retain the same vivid
   colors, light-and-shadow shading, and black edge definition as the other
-  filled styles instead of inheriting the muted Sketch base lighting, while
-  Wireframe feedback remains visible over its lines.
+  filled styles instead of being posterized into the muted Sketch base image,
+  while Wireframe feedback remains visible over its lines.
 
 - Project opening now completes its progress dialog explicitly before closing
   it, preventing an intermittent stall at "Finalizing project load..." during

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -97,8 +97,9 @@ Changes since **v1.5.0**.
 
 - Restored clear hover, group, and selection highlighting in the 3D Viewer
   Sketch and Wireframe styles. Sketch highlights now retain the same vivid
-  colors as the other filled styles instead of being dimmed by its neutral
-  material treatment, while Wireframe feedback remains visible over its lines.
+  colors and black edge definition as the other filled styles instead of being
+  dimmed by its neutral material treatment, while Wireframe feedback remains
+  visible over its lines.
 
 - Project opening now completes its progress dialog explicitly before closing
   it, preventing an intermittent stall at "Finalizing project load..." during

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -96,8 +96,9 @@ Changes since **v1.5.0**.
 ## Important fixes
 
 - Restored clear hover, group, and selection highlighting in the 3D Viewer
-  Sketch and Wireframe styles, with colored feedback that remains visible over
-  each style's characteristic line treatment.
+  Sketch and Wireframe styles. Sketch highlights now retain the same vivid
+  colors as the other filled styles instead of being dimmed by its neutral
+  material treatment, while Wireframe feedback remains visible over its lines.
 
 - Project opening now completes its progress dialog explicitly before closing
   it, preventing an intermittent stall at "Finalizing project load..." during

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -99,7 +99,8 @@ Changes since **v1.5.0**.
   Sketch and Wireframe styles. Sketch highlights now retain the same vivid
   colors, light-and-shadow shading, and black edge definition as the other
   filled styles by using the Standard highlight material after Sketch
-  composition, while Wireframe feedback remains visible over its lines.
+  composition with a depth-safe overlay, while Wireframe feedback remains
+  visible over its lines.
 
 - Project opening now completes its progress dialog explicitly before closing
   it, preventing an intermittent stall at "Finalizing project load..." during

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1902,7 +1902,9 @@ add_test(NAME MeshPrimitivesCubeNormals COMMAND meshprimitives_cube_normals_test
 
 add_executable(sketch_post_process_policy_test
                sketch_post_process_policy_test.cpp)
-target_include_directories(sketch_post_process_policy_test PRIVATE ../viewer3d)
+target_include_directories(sketch_post_process_policy_test PRIVATE
+                           ../viewer3d ../viewer3d/render ../viewer3d/interfaces
+                           ../viewer2d)
 add_test(NAME SketchPostProcessPolicy COMMAND sketch_post_process_policy_test)
 add_bash_policy_test(SketchPostProcessArchitecture
                      ${CMAKE_SOURCE_DIR}/tests/check_sketch_post_process_architecture.sh)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1902,9 +1902,7 @@ add_test(NAME MeshPrimitivesCubeNormals COMMAND meshprimitives_cube_normals_test
 
 add_executable(sketch_post_process_policy_test
                sketch_post_process_policy_test.cpp)
-target_include_directories(sketch_post_process_policy_test PRIVATE
-                           ../viewer3d ../viewer3d/render ../viewer3d/interfaces
-                           ../viewer2d)
+target_include_directories(sketch_post_process_policy_test PRIVATE ../viewer3d)
 add_test(NAME SketchPostProcessPolicy COMMAND sketch_post_process_policy_test)
 add_bash_policy_test(SketchPostProcessArchitecture
                      ${CMAKE_SOURCE_DIR}/tests/check_sketch_post_process_architecture.sh)

--- a/tests/sketch_post_process_policy_test.cpp
+++ b/tests/sketch_post_process_policy_test.cpp
@@ -1,5 +1,6 @@
 #include "render/sketch_post_process_pass.h"
 #include "render/selection_overlay_pass.h"
+#include "render/scenerenderer.h"
 
 #include <cassert>
 
@@ -13,6 +14,9 @@ int main() {
   assert(ShouldRenderSelectionOverlay(false, true, false));
   assert(!ShouldRenderSelectionOverlay(false, false, false));
   assert(!ShouldRenderSelectionOverlay(true, true, true));
+  assert(ShouldUseWhiteModelMeshPath(true, false));
+  assert(!ShouldUseWhiteModelMeshPath(true, true));
+  assert(!ShouldUseWhiteModelMeshPath(false, true));
 
   assert(QuantizeSketchLuminance(0.0f) == SketchTone::Dark);
   assert(QuantizeSketchLuminance(kSketchDarkLuminanceThreshold) ==

--- a/tests/sketch_post_process_policy_test.cpp
+++ b/tests/sketch_post_process_policy_test.cpp
@@ -9,6 +9,8 @@ int main() {
   assert(!ShouldApplySketchPostProcess(false, false, false));
   assert(!ShouldApplySketchPostProcess(true, true, false));
   assert(!ShouldApplySketchPostProcess(true, false, true));
+  assert(ShouldSuppressSketchBaseSelection(true));
+  assert(!ShouldSuppressSketchBaseSelection(false));
   assert(ShouldRenderSelectionOverlay(true, false, false));
   assert(ShouldRenderSelectionOverlay(false, true, false));
   assert(!ShouldRenderSelectionOverlay(false, false, false));

--- a/tests/sketch_post_process_policy_test.cpp
+++ b/tests/sketch_post_process_policy_test.cpp
@@ -14,9 +14,8 @@ int main() {
   assert(ShouldRenderSelectionOverlay(false, true, false));
   assert(!ShouldRenderSelectionOverlay(false, false, false));
   assert(!ShouldRenderSelectionOverlay(true, true, true));
-  assert(ShouldUseWhiteModelMeshPath(true, false));
-  assert(!ShouldUseWhiteModelMeshPath(true, true));
-  assert(!ShouldUseWhiteModelMeshPath(false, true));
+  assert(ShouldLightSelectionFill(false));
+  assert(!ShouldLightSelectionFill(true));
 
   assert(QuantizeSketchLuminance(0.0f) == SketchTone::Dark);
   assert(QuantizeSketchLuminance(kSketchDarkLuminanceThreshold) ==

--- a/tests/sketch_post_process_policy_test.cpp
+++ b/tests/sketch_post_process_policy_test.cpp
@@ -20,6 +20,9 @@ int main() {
   assert(!ShouldUseStandardSelectionLighting(false));
   assert(ShouldUseWhiteModelStyle(true, false));
   assert(!ShouldUseWhiteModelStyle(true, true));
+  assert(ShouldBiasStandardSelectionFill(true, true));
+  assert(!ShouldBiasStandardSelectionFill(true, false));
+  assert(!ShouldBiasStandardSelectionFill(false, true));
   assert(QuantizeSketchLuminance(0.0f) == SketchTone::Dark);
   assert(QuantizeSketchLuminance(kSketchDarkLuminanceThreshold) ==
          SketchTone::Dark);

--- a/tests/sketch_post_process_policy_test.cpp
+++ b/tests/sketch_post_process_policy_test.cpp
@@ -1,5 +1,6 @@
 #include "render/sketch_post_process_pass.h"
 #include "render/selection_overlay_pass.h"
+#include "render/scenerenderer.h"
 
 #include <cassert>
 
@@ -17,6 +18,8 @@ int main() {
   assert(!ShouldRenderSelectionOverlay(true, true, true));
   assert(ShouldUseStandardSelectionLighting(true));
   assert(!ShouldUseStandardSelectionLighting(false));
+  assert(ShouldUseWhiteModelStyle(true, false));
+  assert(!ShouldUseWhiteModelStyle(true, true));
   assert(QuantizeSketchLuminance(0.0f) == SketchTone::Dark);
   assert(QuantizeSketchLuminance(kSketchDarkLuminanceThreshold) ==
          SketchTone::Dark);

--- a/tests/sketch_post_process_policy_test.cpp
+++ b/tests/sketch_post_process_policy_test.cpp
@@ -1,6 +1,5 @@
 #include "render/sketch_post_process_pass.h"
 #include "render/selection_overlay_pass.h"
-#include "render/scenerenderer.h"
 
 #include <cassert>
 
@@ -14,9 +13,8 @@ int main() {
   assert(ShouldRenderSelectionOverlay(false, true, false));
   assert(!ShouldRenderSelectionOverlay(false, false, false));
   assert(!ShouldRenderSelectionOverlay(true, true, true));
-  assert(ShouldLightSelectionFill(false));
-  assert(!ShouldLightSelectionFill(true));
-
+  assert(ShouldUseStandardSelectionLighting(true));
+  assert(!ShouldUseStandardSelectionLighting(false));
   assert(QuantizeSketchLuminance(0.0f) == SketchTone::Dark);
   assert(QuantizeSketchLuminance(kSketchDarkLuminanceThreshold) ==
          SketchTone::Dark);

--- a/tests/sketch_post_process_policy_test.cpp
+++ b/tests/sketch_post_process_policy_test.cpp
@@ -1,4 +1,5 @@
 #include "render/sketch_post_process_pass.h"
+#include "render/selection_overlay_pass.h"
 
 #include <cassert>
 
@@ -8,6 +9,10 @@ int main() {
   assert(!ShouldApplySketchPostProcess(false, false, false));
   assert(!ShouldApplySketchPostProcess(true, true, false));
   assert(!ShouldApplySketchPostProcess(true, false, true));
+  assert(ShouldRenderSelectionOverlay(true, false, false));
+  assert(ShouldRenderSelectionOverlay(false, true, false));
+  assert(!ShouldRenderSelectionOverlay(false, false, false));
+  assert(!ShouldRenderSelectionOverlay(true, true, true));
 
   assert(QuantizeSketchLuminance(0.0f) == SketchTone::Dark);
   assert(QuantizeSketchLuminance(kSketchDarkLuminanceThreshold) ==

--- a/viewer3d/render/opaque_fixture_pass.cpp
+++ b/viewer3d/render/opaque_fixture_pass.cpp
@@ -777,7 +777,7 @@ void OpaqueFixturePass::Render(
                 *key.mesh, r, g, b, key.scale, false, false, false, draw.cx,
                 draw.cy, draw.cz, key.wireframe, key.mode,
                 [](const std::array<float, 3> &p) { return p; }, key.unlit,
-                draw.worldMatrix.data());
+                draw.worldMatrix.data(), false, context.selectionOverlayPass);
             glPopMatrix();
             ++drawCalls;
           }
@@ -1086,7 +1086,8 @@ void OpaqueFixturePass::Render(
           controller.DrawMeshWithOutline(
               obj.mesh, partR, partG, partB, RENDER_SCALE, highlight,
               groupHighlight, selected, cx, cy, cz, wireframe, mode,
-              applyCapture, drawUnlit, partMatrix);
+              applyCapture, drawUnlit, partMatrix, false,
+              context.selectionOverlayPass);
           ++drawCalls;
           glPopMatrix();
         }
@@ -1098,7 +1099,7 @@ void OpaqueFixturePass::Render(
         controller.DrawMeshWithOutline(
             FallbackFixtureCubeMesh(), r, g, b, 0.2f, highlight, groupHighlight,
             selected, cx, cy, cz, fallbackWireframe, mode, applyFixtureCapture,
-            fallbackUnlit, matrix);
+            fallbackUnlit, matrix, false, context.selectionOverlayPass);
         ++drawCalls;
       }
       return drawCalls;

--- a/viewer3d/render/opaque_fixture_pass.cpp
+++ b/viewer3d/render/opaque_fixture_pass.cpp
@@ -777,7 +777,7 @@ void OpaqueFixturePass::Render(
                 *key.mesh, r, g, b, key.scale, false, false, false, draw.cx,
                 draw.cy, draw.cz, key.wireframe, key.mode,
                 [](const std::array<float, 3> &p) { return p; }, key.unlit,
-                draw.worldMatrix.data(), false, context.selectionOverlayPass);
+                draw.worldMatrix.data());
             glPopMatrix();
             ++drawCalls;
           }
@@ -1086,8 +1086,7 @@ void OpaqueFixturePass::Render(
           controller.DrawMeshWithOutline(
               obj.mesh, partR, partG, partB, RENDER_SCALE, highlight,
               groupHighlight, selected, cx, cy, cz, wireframe, mode,
-              applyCapture, drawUnlit, partMatrix, false,
-              context.selectionOverlayPass);
+              applyCapture, drawUnlit, partMatrix);
           ++drawCalls;
           glPopMatrix();
         }
@@ -1099,7 +1098,7 @@ void OpaqueFixturePass::Render(
         controller.DrawMeshWithOutline(
             FallbackFixtureCubeMesh(), r, g, b, 0.2f, highlight, groupHighlight,
             selected, cx, cy, cz, fallbackWireframe, mode, applyFixtureCapture,
-            fallbackUnlit, matrix, false, context.selectionOverlayPass);
+            fallbackUnlit, matrix);
         ++drawCalls;
       }
       return drawCalls;

--- a/viewer3d/render/opaque_fixture_pass.cpp
+++ b/viewer3d/render/opaque_fixture_pass.cpp
@@ -777,7 +777,7 @@ void OpaqueFixturePass::Render(
                 *key.mesh, r, g, b, key.scale, false, false, false, draw.cx,
                 draw.cy, draw.cz, key.wireframe, key.mode,
                 [](const std::array<float, 3> &p) { return p; }, key.unlit,
-                draw.worldMatrix.data());
+                draw.worldMatrix.data(), false, context.selectionOverlayPass);
             glPopMatrix();
             ++drawCalls;
           }
@@ -1088,7 +1088,8 @@ void OpaqueFixturePass::Render(
           controller.DrawMeshWithOutline(
               obj.mesh, partR, partG, partB, RENDER_SCALE, highlight,
               groupHighlight, selected, cx, cy, cz, wireframe, mode,
-              applyCapture, drawUnlit, partMatrix);
+              applyCapture, drawUnlit, partMatrix, false,
+              context.selectionOverlayPass);
           ++drawCalls;
           glPopMatrix();
         }
@@ -1100,7 +1101,7 @@ void OpaqueFixturePass::Render(
         controller.DrawMeshWithOutline(
             FallbackFixtureCubeMesh(), r, g, b, 0.2f, highlight, groupHighlight,
             selected, cx, cy, cz, fallbackWireframe, mode, applyFixtureCapture,
-            fallbackUnlit, matrix);
+            fallbackUnlit, matrix, false, context.selectionOverlayPass);
         ++drawCalls;
       }
       return drawCalls;

--- a/viewer3d/render/opaque_fixture_pass.cpp
+++ b/viewer3d/render/opaque_fixture_pass.cpp
@@ -803,13 +803,15 @@ void OpaqueFixturePass::Render(
     }
 
     const bool highlight = !context.idOnlyPass &&
+                           !context.suppressSelectionStyling &&
                            !controller.m_highlightUuid.empty() &&
                            uuid == controller.m_highlightUuid;
     const bool selected =
-        !context.idOnlyPass && controller.m_primarySelectedUuids.find(uuid) !=
+        !context.idOnlyPass && !context.suppressSelectionStyling &&
+        controller.m_primarySelectedUuids.find(uuid) !=
                                    controller.m_primarySelectedUuids.end();
     const bool groupHighlight =
-        !context.idOnlyPass &&
+        !context.idOnlyPass && !context.suppressSelectionStyling &&
         (controller.m_groupHighlightUuids.find(uuid) !=
              controller.m_groupHighlightUuids.end() ||
          (controller.m_selectedUuids.find(uuid) != controller.m_selectedUuids.end() &&

--- a/viewer3d/render/opaque_object_pass.cpp
+++ b/viewer3d/render/opaque_object_pass.cpp
@@ -488,7 +488,8 @@ void OpaqueObjectPass::Render(
               controller.DrawMeshWithOutline(
                   *part.mesh, r, g, b, RENDER_SCALE, isHighlighted,
                   isGroupHighlighted, isSelected, cx, cy, cz, wireframe, mode,
-                  partCaptureTransform, false, partMatrix, disableDepthBias);
+                  partCaptureTransform, false, partMatrix, disableDepthBias,
+                  context.selectionOverlayPass);
               glPopMatrix();
             }
           } else {
@@ -507,7 +508,7 @@ void OpaqueObjectPass::Render(
                 fallbackMesh, r, g, b, 0.3f, isHighlighted, isGroupHighlighted,
                 isSelected, cx, cy, cz, fallbackWireframe, mode,
                 captureTransformFn, useUnlitFallbackFill, matrix,
-                disableDepthBias);
+                disableDepthBias, context.selectionOverlayPass);
           }
         };
 

--- a/viewer3d/render/opaque_object_pass.cpp
+++ b/viewer3d/render/opaque_object_pass.cpp
@@ -486,7 +486,8 @@ void OpaqueObjectPass::Render(
               controller.DrawMeshWithOutline(
                   *part.mesh, r, g, b, RENDER_SCALE, isHighlighted,
                   isGroupHighlighted, isSelected, cx, cy, cz, wireframe, mode,
-                  partCaptureTransform, false, partMatrix, disableDepthBias);
+                  partCaptureTransform, false, partMatrix, disableDepthBias,
+                  context.selectionOverlayPass);
               glPopMatrix();
             }
           } else {
@@ -505,7 +506,7 @@ void OpaqueObjectPass::Render(
                 fallbackMesh, r, g, b, 0.3f, isHighlighted, isGroupHighlighted,
                 isSelected, cx, cy, cz, fallbackWireframe, mode,
                 captureTransformFn, useUnlitFallbackFill, matrix,
-                disableDepthBias);
+                disableDepthBias, context.selectionOverlayPass);
           }
         };
 

--- a/viewer3d/render/opaque_object_pass.cpp
+++ b/viewer3d/render/opaque_object_pass.cpp
@@ -383,13 +383,15 @@ void OpaqueObjectPass::Render(
     }
 
     const bool highlight = !context.idOnlyPass &&
+                           !context.suppressSelectionStyling &&
                            !controller.m_highlightUuid.empty() &&
                            uuid == controller.m_highlightUuid;
     const bool selected =
-        !context.idOnlyPass && controller.m_primarySelectedUuids.find(uuid) !=
+        !context.idOnlyPass && !context.suppressSelectionStyling &&
+        controller.m_primarySelectedUuids.find(uuid) !=
                                    controller.m_primarySelectedUuids.end();
     const bool groupHighlight =
-        !context.idOnlyPass &&
+        !context.idOnlyPass && !context.suppressSelectionStyling &&
         (controller.m_groupHighlightUuids.find(uuid) !=
              controller.m_groupHighlightUuids.end() ||
          (controller.m_selectedUuids.find(uuid) != controller.m_selectedUuids.end() &&

--- a/viewer3d/render/opaque_object_pass.cpp
+++ b/viewer3d/render/opaque_object_pass.cpp
@@ -486,8 +486,7 @@ void OpaqueObjectPass::Render(
               controller.DrawMeshWithOutline(
                   *part.mesh, r, g, b, RENDER_SCALE, isHighlighted,
                   isGroupHighlighted, isSelected, cx, cy, cz, wireframe, mode,
-                  partCaptureTransform, false, partMatrix, disableDepthBias,
-                  context.selectionOverlayPass);
+                  partCaptureTransform, false, partMatrix, disableDepthBias);
               glPopMatrix();
             }
           } else {
@@ -506,7 +505,7 @@ void OpaqueObjectPass::Render(
                 fallbackMesh, r, g, b, 0.3f, isHighlighted, isGroupHighlighted,
                 isSelected, cx, cy, cz, fallbackWireframe, mode,
                 captureTransformFn, useUnlitFallbackFill, matrix,
-                disableDepthBias, context.selectionOverlayPass);
+                disableDepthBias);
           }
         };
 

--- a/viewer3d/render/opaque_truss_pass.cpp
+++ b/viewer3d/render/opaque_truss_pass.cpp
@@ -207,7 +207,8 @@ void OpaqueTrussPass::Render(
             controller.DrawMeshWithOutline(
                 *trussMesh, r, g, b, RENDER_SCALE, isHighlighted,
                 isGroupHighlighted, isSelected, cx, cy, cz, wireframe, mode,
-                captureTransformFn, false, matrix);
+                captureTransformFn, false, matrix, false,
+                context.selectionOverlayPass);
           } else {
             controller.DrawWireframeBox(trussLen, trussHei, trussWid, r, g, b,
                                         isHighlighted, isGroupHighlighted,

--- a/viewer3d/render/opaque_truss_pass.cpp
+++ b/viewer3d/render/opaque_truss_pass.cpp
@@ -205,8 +205,7 @@ void OpaqueTrussPass::Render(
             controller.DrawMeshWithOutline(
                 *trussMesh, r, g, b, RENDER_SCALE, isHighlighted,
                 isGroupHighlighted, isSelected, cx, cy, cz, wireframe, mode,
-                captureTransformFn, false, matrix, false,
-                context.selectionOverlayPass);
+                captureTransformFn, false, matrix);
           } else {
             controller.DrawWireframeBox(trussLen, trussHei, trussWid, r, g, b,
                                         isHighlighted, isGroupHighlighted,

--- a/viewer3d/render/opaque_truss_pass.cpp
+++ b/viewer3d/render/opaque_truss_pass.cpp
@@ -205,7 +205,8 @@ void OpaqueTrussPass::Render(
             controller.DrawMeshWithOutline(
                 *trussMesh, r, g, b, RENDER_SCALE, isHighlighted,
                 isGroupHighlighted, isSelected, cx, cy, cz, wireframe, mode,
-                captureTransformFn, false, matrix);
+                captureTransformFn, false, matrix, false,
+                context.selectionOverlayPass);
           } else {
             controller.DrawWireframeBox(trussLen, trussHei, trussWid, r, g, b,
                                         isHighlighted, isGroupHighlighted,

--- a/viewer3d/render/opaque_truss_pass.cpp
+++ b/viewer3d/render/opaque_truss_pass.cpp
@@ -120,13 +120,15 @@ void OpaqueTrussPass::Render(
     }
 
     const bool highlight = !context.idOnlyPass &&
+                           !context.suppressSelectionStyling &&
                            !controller.m_highlightUuid.empty() &&
                            uuid == controller.m_highlightUuid;
     const bool selected =
-        !context.idOnlyPass && controller.m_primarySelectedUuids.find(uuid) !=
+        !context.idOnlyPass && !context.suppressSelectionStyling &&
+        controller.m_primarySelectedUuids.find(uuid) !=
                                    controller.m_primarySelectedUuids.end();
     const bool groupHighlight =
-        !context.idOnlyPass &&
+        !context.idOnlyPass && !context.suppressSelectionStyling &&
         (controller.m_groupHighlightUuids.find(uuid) !=
              controller.m_groupHighlightUuids.end() ||
          (controller.m_selectedUuids.find(uuid) != controller.m_selectedUuids.end() &&

--- a/viewer3d/render/render_pipeline.cpp
+++ b/viewer3d/render/render_pipeline.cpp
@@ -52,6 +52,10 @@ void RenderPipeline::Execute(const RenderFrameContext &context) {
     RenderFrameContext baseContext = m_context;
     baseContext.whiteModelStyle = false;
     baseContext.sketchBasePass = true;
+    // Keep transient selection colors out of the posterized Sketch image;
+    // the post-composite overlay owns their final filled-style appearance.
+    baseContext.suppressSelectionStyling =
+        ShouldSuppressSketchBaseSelection(true);
     m_controller.SetSketchBasePassActive(true);
     const bool hasIntermediateTarget = m_controller.BeginSketchPostProcess();
     m_controller.RenderOpaqueFrame(baseContext, *m_visibleSet);

--- a/viewer3d/render/scenerenderer.cpp
+++ b/viewer3d/render/scenerenderer.cpp
@@ -315,6 +315,12 @@ void SceneRenderer::DrawMeshWithOutline(
           interactiveSketchMode ? ReadSketchInteractionWireframeMode()
                                 : SketchInteractionWireframeMode::FullQuality;
       bool drawBaseWireframe = true;
+      if (m_controller.IsSketchRenderStyleEnabled() &&
+          (highlight || groupHighlight || selected)) {
+        // The post-composite overlay supplies the colored fill and outline;
+        // avoid repainting black Sketch ink over that visual feedback.
+        drawBaseWireframe = false;
+      }
       int wireframeTriangleStep = 1;
       if (interactiveSketchMode) {
         if (interactionMode == SketchInteractionWireframeMode::Sparse) {
@@ -324,7 +330,8 @@ void SceneRenderer::DrawMeshWithOutline(
           drawBaseWireframe = false;
         } else if (interactionMode ==
                    SketchInteractionWireframeMode::HighlightSelectedOnly) {
-          drawBaseWireframe = highlight || groupHighlight || selected;
+          drawBaseWireframe =
+              drawBaseWireframe && (highlight || groupHighlight || selected);
         }
       }
 

--- a/viewer3d/render/scenerenderer.cpp
+++ b/viewer3d/render/scenerenderer.cpp
@@ -143,13 +143,15 @@ const float *ResolveModelMatrixForMirroring(const float *modelMatrix,
 
 } // namespace
 
+// Draws a mesh with its style-dependent fill and optional selection outline.
 void SceneRenderer::DrawMeshWithOutline(
     const Mesh &mesh, float r, float g, float b, float scale, bool highlight,
     bool groupHighlight, bool selected, float cx, float cy, float cz,
     bool wireframe, Viewer2DRenderMode mode,
     const std::function<std::array<float, 3>(const std::array<float, 3> &)>
         &captureTransform,
-    bool unlit, const float *modelMatrix, bool disableDepthBias) {
+    bool unlit, const float *modelMatrix, bool disableDepthBias,
+    bool selectionOverlayPass) {
   (void)cx;
   (void)cy;
   (void)cz;
@@ -273,7 +275,8 @@ void SceneRenderer::DrawMeshWithOutline(
   }
 
   if (!m_controller.IsCaptureOnly()) {
-    if (m_controller.IsWhiteModelStyleEnabled()) {
+    if (ShouldUseWhiteModelMeshPath(
+            m_controller.IsWhiteModelStyleEnabled(), selectionOverlayPass)) {
       const GLboolean texture2DWhiteModelWasEnabled =
           glIsEnabled(GL_TEXTURE_2D);
       if (texture2DWhiteModelWasEnabled)

--- a/viewer3d/render/scenerenderer.cpp
+++ b/viewer3d/render/scenerenderer.cpp
@@ -275,8 +275,7 @@ void SceneRenderer::DrawMeshWithOutline(
   }
 
   if (!m_controller.IsCaptureOnly()) {
-    if (ShouldUseWhiteModelMeshPath(
-            m_controller.IsWhiteModelStyleEnabled(), selectionOverlayPass)) {
+    if (m_controller.IsWhiteModelStyleEnabled()) {
       const GLboolean texture2DWhiteModelWasEnabled =
           glIsEnabled(GL_TEXTURE_2D);
       if (texture2DWhiteModelWasEnabled)
@@ -318,12 +317,6 @@ void SceneRenderer::DrawMeshWithOutline(
           interactiveSketchMode ? ReadSketchInteractionWireframeMode()
                                 : SketchInteractionWireframeMode::FullQuality;
       bool drawBaseWireframe = true;
-      if (m_controller.IsSketchRenderStyleEnabled() &&
-          (highlight || groupHighlight || selected)) {
-        // The post-composite overlay supplies the colored fill and outline;
-        // avoid repainting black Sketch ink over that visual feedback.
-        drawBaseWireframe = false;
-      }
       int wireframeTriangleStep = 1;
       if (interactiveSketchMode) {
         if (interactionMode == SketchInteractionWireframeMode::Sparse) {
@@ -369,12 +362,18 @@ void SceneRenderer::DrawMeshWithOutline(
       } else if (highlight || groupHighlight || selected) {
         setHighlightOrSelectionColor();
         const GLboolean highlightLightingWasEnabled = glIsEnabled(GL_LIGHTING);
-        if (!highlightLightingWasEnabled)
+        const bool lightSelectionFill =
+            ShouldLightSelectionFill(selectionOverlayPass);
+        if (lightSelectionFill && !highlightLightingWasEnabled)
           glEnable(GL_LIGHTING);
+        else if (!lightSelectionFill && highlightLightingWasEnabled)
+          glDisable(GL_LIGHTING);
         LogMeshVaoDiagnostic(mesh, "before-highlight-draw");
         DrawMesh(mesh, scale, modelMatrix);
         LogMeshVaoDiagnostic(mesh, "after-highlight-draw");
-        if (!highlightLightingWasEnabled)
+        if (highlightLightingWasEnabled)
+          glEnable(GL_LIGHTING);
+        else
           glDisable(GL_LIGHTING);
       } else if (usePureWhiteFillInWhiteMode) {
         const GLboolean fillLightingWasEnabled = glIsEnabled(GL_LIGHTING);

--- a/viewer3d/render/scenerenderer.cpp
+++ b/viewer3d/render/scenerenderer.cpp
@@ -150,7 +150,8 @@ void SceneRenderer::DrawMeshWithOutline(
     bool wireframe, Viewer2DRenderMode mode,
     const std::function<std::array<float, 3>(const std::array<float, 3> &)>
         &captureTransform,
-    bool unlit, const float *modelMatrix, bool disableDepthBias) {
+    bool unlit, const float *modelMatrix, bool disableDepthBias,
+    bool standardSelectionStyle) {
   (void)cx;
   (void)cy;
   (void)cz;
@@ -274,7 +275,8 @@ void SceneRenderer::DrawMeshWithOutline(
   }
 
   if (!m_controller.IsCaptureOnly()) {
-    if (m_controller.IsWhiteModelStyleEnabled()) {
+    if (ShouldUseWhiteModelStyle(m_controller.IsWhiteModelStyleEnabled(),
+                                 standardSelectionStyle)) {
       const GLboolean texture2DWhiteModelWasEnabled =
           glIsEnabled(GL_TEXTURE_2D);
       if (texture2DWhiteModelWasEnabled)

--- a/viewer3d/render/scenerenderer.cpp
+++ b/viewer3d/render/scenerenderer.cpp
@@ -150,8 +150,7 @@ void SceneRenderer::DrawMeshWithOutline(
     bool wireframe, Viewer2DRenderMode mode,
     const std::function<std::array<float, 3>(const std::array<float, 3> &)>
         &captureTransform,
-    bool unlit, const float *modelMatrix, bool disableDepthBias,
-    bool selectionOverlayPass) {
+    bool unlit, const float *modelMatrix, bool disableDepthBias) {
   (void)cx;
   (void)cy;
   (void)cz;
@@ -362,18 +361,12 @@ void SceneRenderer::DrawMeshWithOutline(
       } else if (highlight || groupHighlight || selected) {
         setHighlightOrSelectionColor();
         const GLboolean highlightLightingWasEnabled = glIsEnabled(GL_LIGHTING);
-        const bool lightSelectionFill =
-            ShouldLightSelectionFill(selectionOverlayPass);
-        if (lightSelectionFill && !highlightLightingWasEnabled)
+        if (!highlightLightingWasEnabled)
           glEnable(GL_LIGHTING);
-        else if (!lightSelectionFill && highlightLightingWasEnabled)
-          glDisable(GL_LIGHTING);
         LogMeshVaoDiagnostic(mesh, "before-highlight-draw");
         DrawMesh(mesh, scale, modelMatrix);
         LogMeshVaoDiagnostic(mesh, "after-highlight-draw");
-        if (highlightLightingWasEnabled)
-          glEnable(GL_LIGHTING);
-        else
+        if (!highlightLightingWasEnabled)
           glDisable(GL_LIGHTING);
       } else if (usePureWhiteFillInWhiteMode) {
         const GLboolean fillLightingWasEnabled = glIsEnabled(GL_LIGHTING);

--- a/viewer3d/render/scenerenderer.cpp
+++ b/viewer3d/render/scenerenderer.cpp
@@ -395,6 +395,8 @@ void SceneRenderer::DrawMeshWithOutline(
       if (texture2DWhiteModelWasEnabled)
         glEnable(GL_TEXTURE_2D);
     } else {
+      const bool biasSelectionFill = ShouldBiasStandardSelectionFill(
+          standardSelectionStyle, highlight || groupHighlight || selected);
       const bool useTexture =
           m_controller.IsTexturedRenderStyleEnabled() && !highlight &&
           !groupHighlight && !selected && mesh.textureId != 0 &&
@@ -421,11 +423,17 @@ void SceneRenderer::DrawMeshWithOutline(
 
       if (unlit)
         glDisable(GL_LIGHTING);
+      if (biasSelectionFill) {
+        glEnable(GL_POLYGON_OFFSET_FILL);
+        glPolygonOffset(-2.0f, -2.0f);
+      }
       if (highlight || groupHighlight || selected)
         LogMeshVaoDiagnostic(mesh, "before-highlight-draw");
       DrawMesh(mesh, scale, modelMatrix, useTexture);
       if (highlight || groupHighlight || selected)
         LogMeshVaoDiagnostic(mesh, "after-highlight-draw");
+      if (biasSelectionFill)
+        glDisable(GL_POLYGON_OFFSET_FILL);
       if (unlit)
         glEnable(GL_LIGHTING);
     }

--- a/viewer3d/render/scenerenderer.h
+++ b/viewer3d/render/scenerenderer.h
@@ -5,6 +5,12 @@
 #include "viewer3d_types.h"
 #include <functional>
 
+// Returns whether mesh rendering should use the white-model material path.
+inline bool ShouldUseWhiteModelMeshPath(bool whiteModelStyle,
+                                        bool selectionOverlayPass) {
+  return whiteModelStyle && !selectionOverlayPass;
+}
+
 class SceneRenderer {
 public:
   explicit SceneRenderer(IRenderContext &controller)
@@ -16,7 +22,8 @@ public:
       bool wireframe, Viewer2DRenderMode mode,
       const std::function<std::array<float, 3>(const std::array<float, 3> &)>
           &captureTransform,
-      bool unlit, const float *modelMatrix, bool disableDepthBias = false);
+      bool unlit, const float *modelMatrix, bool disableDepthBias = false,
+      bool selectionOverlayPass = false);
   void DrawMeshWireframe(
       const Mesh &mesh, float scale,
       const std::function<std::array<float, 3>(const std::array<float, 3> &)>

--- a/viewer3d/render/scenerenderer.h
+++ b/viewer3d/render/scenerenderer.h
@@ -5,11 +5,6 @@
 #include "viewer3d_types.h"
 #include <functional>
 
-// Returns whether a highlighted fill should retain scene lighting.
-inline bool ShouldLightSelectionFill(bool selectionOverlayPass) {
-  return !selectionOverlayPass;
-}
-
 class SceneRenderer {
 public:
   explicit SceneRenderer(IRenderContext &controller)
@@ -21,8 +16,7 @@ public:
       bool wireframe, Viewer2DRenderMode mode,
       const std::function<std::array<float, 3>(const std::array<float, 3> &)>
           &captureTransform,
-      bool unlit, const float *modelMatrix, bool disableDepthBias = false,
-      bool selectionOverlayPass = false);
+      bool unlit, const float *modelMatrix, bool disableDepthBias = false);
   void DrawMeshWireframe(
       const Mesh &mesh, float scale,
       const std::function<std::array<float, 3>(const std::array<float, 3> &)>

--- a/viewer3d/render/scenerenderer.h
+++ b/viewer3d/render/scenerenderer.h
@@ -5,6 +5,12 @@
 #include "viewer3d_types.h"
 #include <functional>
 
+// Returns whether a mesh should use the dedicated white-model rendering path.
+inline bool ShouldUseWhiteModelStyle(bool whiteModelStyle,
+                                     bool standardSelectionStyle) {
+  return whiteModelStyle && !standardSelectionStyle;
+}
+
 class SceneRenderer {
 public:
   explicit SceneRenderer(IRenderContext &controller)
@@ -16,7 +22,8 @@ public:
       bool wireframe, Viewer2DRenderMode mode,
       const std::function<std::array<float, 3>(const std::array<float, 3> &)>
           &captureTransform,
-      bool unlit, const float *modelMatrix, bool disableDepthBias = false);
+      bool unlit, const float *modelMatrix, bool disableDepthBias = false,
+      bool standardSelectionStyle = false);
   void DrawMeshWireframe(
       const Mesh &mesh, float scale,
       const std::function<std::array<float, 3>(const std::array<float, 3> &)>

--- a/viewer3d/render/scenerenderer.h
+++ b/viewer3d/render/scenerenderer.h
@@ -11,6 +11,12 @@ inline bool ShouldUseWhiteModelStyle(bool whiteModelStyle,
   return whiteModelStyle && !standardSelectionStyle;
 }
 
+// Returns whether a post-composite selection fill needs a forward depth bias.
+inline bool ShouldBiasStandardSelectionFill(bool standardSelectionStyle,
+                                            bool hasSelectionStyle) {
+  return standardSelectionStyle && hasSelectionStyle;
+}
+
 class SceneRenderer {
 public:
   explicit SceneRenderer(IRenderContext &controller)

--- a/viewer3d/render/scenerenderer.h
+++ b/viewer3d/render/scenerenderer.h
@@ -5,10 +5,9 @@
 #include "viewer3d_types.h"
 #include <functional>
 
-// Returns whether mesh rendering should use the white-model material path.
-inline bool ShouldUseWhiteModelMeshPath(bool whiteModelStyle,
-                                        bool selectionOverlayPass) {
-  return whiteModelStyle && !selectionOverlayPass;
+// Returns whether a highlighted fill should retain scene lighting.
+inline bool ShouldLightSelectionFill(bool selectionOverlayPass) {
+  return !selectionOverlayPass;
 }
 
 class SceneRenderer {

--- a/viewer3d/render/selection_overlay_pass.cpp
+++ b/viewer3d/render/selection_overlay_pass.cpp
@@ -181,6 +181,14 @@ void SelectionOverlayPass::Render(Viewer3DController &controller,
     RenderFrameContext overlayContext = context;
     overlayContext.skipCapture = true;
     overlayContext.selectionOverlayPass = true;
+    // Draw solid highlight geometry after wireframe lines so its visual weight
+    // remains comparable to the filled render styles.
+    if (context.wireframe) {
+      overlayContext.wireframe = false;
+      overlayContext.mode = Viewer2DRenderMode::White;
+      overlayContext.whiteModelStyle = false;
+      overlayContext.texturedStyle = false;
+    }
     GLint previousDepthFunc = GL_LESS;
     glGetIntegerv(GL_DEPTH_FUNC, &previousDepthFunc);
     glDepthFunc(GL_LEQUAL);

--- a/viewer3d/render/selection_overlay_pass.cpp
+++ b/viewer3d/render/selection_overlay_pass.cpp
@@ -189,6 +189,13 @@ void SelectionOverlayPass::Render(Viewer3DController &controller,
       overlayContext.whiteModelStyle = false;
       overlayContext.texturedStyle = false;
     }
+    // Use the regular filled-style lighting profile so highlight colors are
+    // multiplied consistently across light and shadow instead of inheriting
+    // the deliberately muted Sketch base profile.
+    if (ShouldUseStandardSelectionLighting(context.sketchPostProcess)) {
+      controller.SetupBasicLighting(context.useAmbientOcclusion,
+                                    context.ambientOcclusionStrength, false);
+    }
     GLint previousDepthFunc = GL_LESS;
     glGetIntegerv(GL_DEPTH_FUNC, &previousDepthFunc);
     glDepthFunc(GL_LEQUAL);

--- a/viewer3d/render/selection_overlay_pass.h
+++ b/viewer3d/render/selection_overlay_pass.h
@@ -4,6 +4,12 @@
 
 class Viewer3DController;
 
+// Returns whether a post-base selection overlay is needed for the render style.
+inline bool ShouldRenderSelectionOverlay(bool sketchPostProcess, bool wireframe,
+                                         bool idOnlyPass) {
+  return !idOnlyPass && (sketchPostProcess || wireframe);
+}
+
 class SelectionOverlayPass {
 public:
   static void Render(Viewer3DController &controller,

--- a/viewer3d/render/selection_overlay_pass.h
+++ b/viewer3d/render/selection_overlay_pass.h
@@ -10,6 +10,11 @@ inline bool ShouldRenderSelectionOverlay(bool sketchPostProcess, bool wireframe,
   return !idOnlyPass && (sketchPostProcess || wireframe);
 }
 
+// Returns whether the overlay should replace the muted Sketch lighting profile.
+inline bool ShouldUseStandardSelectionLighting(bool sketchPostProcess) {
+  return sketchPostProcess;
+}
+
 class SelectionOverlayPass {
 public:
   static void Render(Viewer3DController &controller,

--- a/viewer3d/render/sketch_post_process_pass.h
+++ b/viewer3d/render/sketch_post_process_pass.h
@@ -13,6 +13,11 @@ inline bool ShouldApplySketchPostProcess(bool sketchStyle, bool wireframe,
   return sketchStyle && !wireframe && !idOnlyPass;
 }
 
+// Returns whether Sketch base rendering should defer selection styling.
+inline bool ShouldSuppressSketchBaseSelection(bool sketchPostProcessActive) {
+  return sketchPostProcessActive;
+}
+
 // Maps neutral-base luminance to the existing three-tone Sketch palette.
 inline SketchTone QuantizeSketchLuminance(float luminance) {
   if (luminance <= kSketchDarkLuminanceThreshold)

--- a/viewer3d/viewer3d_types.h
+++ b/viewer3d/viewer3d_types.h
@@ -79,6 +79,7 @@ struct RenderFrameContext {
   bool skipOutlinesForCurrentFrame = false;
   bool idOnlyPass = false;
   bool selectionOverlayPass = false;
+  bool suppressSelectionStyling = false;
 
   bool colorByFixtureType = false;
   bool colorByLayer = false;

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -1429,7 +1429,8 @@ void Viewer3DController::RenderOpaqueFrame(const RenderFrameContext &context,
 // Renders overlay Frame.
 void Viewer3DController::RenderOverlayFrame(const RenderFrameContext &context,
                                             const VisibleSet &visibleSet) {
-  if (context.sketchPostProcess)
+  if (ShouldRenderSelectionOverlay(context.sketchPostProcess,
+                                   context.wireframe, context.idOnlyPass))
     SelectionOverlayPass::Render(*this, context, visibleSet);
   if (context.drawGridAfterScene) {
     glDisable(GL_DEPTH_TEST);

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -2033,10 +2033,12 @@ void Viewer3DController::DrawMeshWithOutline(
     bool wireframe, Viewer2DRenderMode mode,
     const std::function<std::array<float, 3>(const std::array<float, 3> &)>
         &captureTransform,
-    bool unlit, const float *modelMatrix, bool disableDepthBias) {
+    bool unlit, const float *modelMatrix, bool disableDepthBias,
+    bool selectionOverlayPass) {
   m_impl->sceneRenderer->DrawMeshWithOutline(
       mesh, r, g, b, scale, highlight, groupHighlight, selected, cx, cy, cz,
-      wireframe, mode, captureTransform, unlit, modelMatrix, disableDepthBias);
+      wireframe, mode, captureTransform, unlit, modelMatrix, disableDepthBias,
+      selectionOverlayPass);
 }
 
 // Draws mesh Wireframe.

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -2033,12 +2033,10 @@ void Viewer3DController::DrawMeshWithOutline(
     bool wireframe, Viewer2DRenderMode mode,
     const std::function<std::array<float, 3>(const std::array<float, 3> &)>
         &captureTransform,
-    bool unlit, const float *modelMatrix, bool disableDepthBias,
-    bool selectionOverlayPass) {
+    bool unlit, const float *modelMatrix, bool disableDepthBias) {
   m_impl->sceneRenderer->DrawMeshWithOutline(
       mesh, r, g, b, scale, highlight, groupHighlight, selected, cx, cy, cz,
-      wireframe, mode, captureTransform, unlit, modelMatrix, disableDepthBias,
-      selectionOverlayPass);
+      wireframe, mode, captureTransform, unlit, modelMatrix, disableDepthBias);
 }
 
 // Draws mesh Wireframe.

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -2033,10 +2033,12 @@ void Viewer3DController::DrawMeshWithOutline(
     bool wireframe, Viewer2DRenderMode mode,
     const std::function<std::array<float, 3>(const std::array<float, 3> &)>
         &captureTransform,
-    bool unlit, const float *modelMatrix, bool disableDepthBias) {
+    bool unlit, const float *modelMatrix, bool disableDepthBias,
+    bool standardSelectionStyle) {
   m_impl->sceneRenderer->DrawMeshWithOutline(
       mesh, r, g, b, scale, highlight, groupHighlight, selected, cx, cy, cz,
-      wireframe, mode, captureTransform, unlit, modelMatrix, disableDepthBias);
+      wireframe, mode, captureTransform, unlit, modelMatrix, disableDepthBias,
+      standardSelectionStyle);
 }
 
 // Draws mesh Wireframe.

--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -234,7 +234,7 @@ private:
       const std::function<std::array<float, 3>(const std::array<float, 3> &)>
           &captureTransform = {},
       bool unlit = false, const float *modelMatrix = nullptr,
-      bool disableDepthBias = false);
+      bool disableDepthBias = false, bool standardSelectionStyle = false);
   void DrawMeshWireframe(
       const Mesh &mesh, float scale = RENDER_SCALE,
       const std::function<std::array<float, 3>(const std::array<float, 3> &)>

--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -234,7 +234,7 @@ private:
       const std::function<std::array<float, 3>(const std::array<float, 3> &)>
           &captureTransform = {},
       bool unlit = false, const float *modelMatrix = nullptr,
-      bool disableDepthBias = false);
+      bool disableDepthBias = false, bool selectionOverlayPass = false);
   void DrawMeshWireframe(
       const Mesh &mesh, float scale = RENDER_SCALE,
       const std::function<std::array<float, 3>(const std::array<float, 3> &)>

--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -234,7 +234,7 @@ private:
       const std::function<std::array<float, 3>(const std::array<float, 3> &)>
           &captureTransform = {},
       bool unlit = false, const float *modelMatrix = nullptr,
-      bool disableDepthBias = false, bool selectionOverlayPass = false);
+      bool disableDepthBias = false);
   void DrawMeshWireframe(
       const Mesh &mesh, float scale = RENDER_SCALE,
       const std::function<std::array<float, 3>(const std::array<float, 3> &)>


### PR DESCRIPTION
### Motivation

- Hover/group/selection highlights were not visually consistent in the 3D Viewer Sketch and Wireframe styles because Sketch post-processing or wireframe-only drawing prevented the usual colored overlays from being visible.
- The goal is to make highlight feedback in Sketch and Wireframe comparable to filled render modes while preserving existing sketch post-process behavior and avoiding ID-only passes.

### Description

- Added `ShouldRenderSelectionOverlay(bool sketchPostProcess, bool wireframe, bool idOnlyPass)` in `viewer3d/render/selection_overlay_pass.h` to centralize the decision whether to run the post-base selection overlay.
- Switched `Viewer3DController::RenderOverlayFrame` to use the new `ShouldRenderSelectionOverlay` helper so overlays are applied for Sketch and Wireframe modes but skipped for ID-only passes (`viewer3d/viewer3dcontroller.cpp`).
- Adjusted `SelectionOverlayPass::Render` to render a solid, depth-aware colored overlay when the incoming context is Wireframe by temporarily switching the overlay context to a neutral filled style so highlights remain visible above wireframe lines (`viewer3d/render/selection_overlay_pass.cpp`).
- Updated `SceneRenderer::DrawMeshWithOutline` logic so Sketch-mode ink does not repaint black base wireframe over highlighted items during interactive or reduced-quality sketch rendering by suppressing the base wireframe when post-composite overlays will supply the colored fill and outline (`viewer3d/render/scenerenderer.cpp`).
- Made a small logical tightening to the interactive Sketch branch to preserve prior `drawBaseWireframe` state when `HighlightSelectedOnly` is active (`viewer3d/render/scenerenderer.cpp`).
- Added unit assertions for the new overlay decision in `tests/sketch_post_process_policy_test.cpp` and updated `docs/release-notes-draft.md` with a user-facing note describing the fix.

### Testing

- Ran the unit policy test by compiling and executing `tests/sketch_post_process_policy_test.cpp` with `g++` and it completed successfully (assertions passed).
- Executed `tests/check_sketch_post_process_architecture.sh` and it returned OK confirming sketch post-process architecture requirements passed.
- Executed repository policy checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh` and both returned OK.
- Verified `git diff --check` reported no whitespace or index issues and committed the change as `Fix 3D highlights in sketch and wireframe modes`.
- Note: a full `cmake` build in-tree was not executed because a `build` directory was not present in this environment, so full integration build/test was not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7c84499ef083248112de3dbb6465a2)