### PR TITLE
Derive truss dimensions from measured geometry bounds (replace fixed fallbacks)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -85,6 +85,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/symbols/Symbol2DBuilder.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/symbols/PerastageSvgSymbol.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/trussdictionary.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/truss_dimension_resolution.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/truss_asset_ingestion.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/truss_attachment_candidates.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/truss_screen_snap.cpp

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -41,6 +41,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtf/editor/standalone_gdtf_context.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtfnet.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/geometry/RdpSimplifier.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/geometry_bounds_resolver.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/guiconfigservices.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/hoistpresetlibrary.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/hoist_weight_distribution.cpp

--- a/core/gdtf/editor/project_truss_gdtf_apply_adapter.cpp
+++ b/core/gdtf/editor/project_truss_gdtf_apply_adapter.cpp
@@ -199,6 +199,9 @@ ProjectTrussGdtfApplyResult ProjectTrussGdtfApplyAdapter::Apply(
   prepared.lengthMm = request.values.trussLengthMm.value_or(prepared.lengthMm);
   prepared.widthMm = request.values.trussWidthMm.value_or(prepared.widthMm);
   prepared.heightMm = request.values.trussHeightMm.value_or(prepared.heightMm);
+  if (request.values.trussLengthMm || request.values.trussWidthMm ||
+      request.values.trussHeightMm)
+    prepared.dimensionSource = Truss::DimensionSource::ManualOverride;
   prepared.weightKg = request.values.weightKg.value_or(prepared.weightKg);
   prepared.gdtfDescription = request.values.fixtureTypeDescription.value_or(prepared.gdtfDescription);
   prepared.crossSectionType = request.values.trussCrossSectionType.value_or(prepared.crossSectionType.empty() ? "TrussFramework" : prepared.crossSectionType);

--- a/core/geometry_bounds_resolver.cpp
+++ b/core/geometry_bounds_resolver.cpp
@@ -3,6 +3,7 @@
 #include "filesystem_path_utils.h"
 #include "loader3ds.h"
 #include "loaderglb.h"
+#include "mesh_geometry_conventions.h"
 
 #include <algorithm>
 #include <cctype>
@@ -70,7 +71,9 @@ GeometryBoundsResolver::Resolve(const std::filesystem::path &path,
   std::transform(ext.begin(), ext.end(), ext.begin(),
                  [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
   ++g_parseCount;
-  const bool loaded = ext == ".3ds" ? Load3DS(path.string(), mesh, true, &error)
+  const bool loaded = ext == ".3ds" ? Load3DS(path.string(), mesh,
+                                               viewer3d::kApplyThreeDsObjectTransforms,
+                                               &error)
                                      : ext == ".glb" ? LoadGLB(path.string(), mesh, &error)
                                                      : false;
   auto bounds = loaded ? MeasureMesh(mesh) : std::nullopt;

--- a/core/geometry_bounds_resolver.cpp
+++ b/core/geometry_bounds_resolver.cpp
@@ -1,0 +1,91 @@
+#include "geometry_bounds_resolver.h"
+
+#include "filesystem_path_utils.h"
+#include "loader3ds.h"
+#include "loaderglb.h"
+
+#include <algorithm>
+#include <cctype>
+#include <map>
+#include <mutex>
+
+namespace {
+std::mutex g_cacheMutex;
+std::map<std::string, std::optional<GeometryBounds>> g_cache;
+std::size_t g_parseCount = 0;
+
+// Builds a resource-version key that changes when the underlying file changes.
+std::string BuildVersionKey(const std::filesystem::path &path) {
+  std::error_code ec;
+  const auto absolute = std::filesystem::weakly_canonical(path, ec);
+  if (ec)
+    return {};
+  const auto size = std::filesystem::file_size(absolute, ec);
+  if (ec)
+    return {};
+  const auto timestamp = std::filesystem::last_write_time(absolute, ec);
+  if (ec)
+    return {};
+  return PathUtils::BuildFilesystemIdentityKey(absolute) + "#" +
+         std::to_string(size) + "#" +
+         std::to_string(timestamp.time_since_epoch().count());
+}
+
+// Measures finite vertex positions already converted to renderer millimeters.
+std::optional<GeometryBounds> MeasureMesh(const Mesh &mesh) {
+  if (mesh.vertices.size() < 3 || mesh.vertices.size() % 3 != 0)
+    return std::nullopt;
+  GeometryBounds bounds{{mesh.vertices[0], mesh.vertices[1], mesh.vertices[2]},
+                        {mesh.vertices[0], mesh.vertices[1], mesh.vertices[2]}};
+  for (std::size_t offset = 0; offset < mesh.vertices.size(); offset += 3) {
+    for (int axis = 0; axis < 3; ++axis) {
+      const float value = mesh.vertices[offset + axis];
+      if (!std::isfinite(value))
+        return std::nullopt;
+      bounds.minMm[axis] = std::min(bounds.minMm[axis], value);
+      bounds.maxMm[axis] = std::max(bounds.maxMm[axis], value);
+    }
+  }
+  return bounds.IsValid() ? std::optional<GeometryBounds>(bounds) : std::nullopt;
+}
+} // namespace
+
+// Resolves bounds for a supported 3DS or GLB resource.
+std::optional<GeometryBounds>
+GeometryBoundsResolver::Resolve(const std::filesystem::path &path,
+                                std::string *diagnostic) {
+  const std::string key = BuildVersionKey(path);
+  if (key.empty()) {
+    if (diagnostic)
+      *diagnostic = "Geometry file is missing or unreadable";
+    return std::nullopt;
+  }
+  std::lock_guard<std::mutex> lock(g_cacheMutex);
+  if (const auto found = g_cache.find(key); found != g_cache.end())
+    return found->second;
+
+  Mesh mesh;
+  std::string error;
+  std::string ext = path.extension().string();
+  std::transform(ext.begin(), ext.end(), ext.begin(),
+                 [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+  ++g_parseCount;
+  const bool loaded = ext == ".3ds" ? Load3DS(path.string(), mesh, true, &error)
+                                     : ext == ".glb" ? LoadGLB(path.string(), mesh, &error)
+                                                     : false;
+  auto bounds = loaded ? MeasureMesh(mesh) : std::nullopt;
+  g_cache.emplace(key, bounds);
+  if (!bounds && diagnostic)
+    *diagnostic = error.empty() ? "Geometry has no usable three-dimensional bounds" : error;
+  return bounds;
+}
+
+// Returns the number of physical parses, for cache regression tests.
+std::size_t GeometryBoundsResolver::ParseCountForTesting() { return g_parseCount; }
+
+// Clears process-local cached measurements, for deterministic tests.
+void GeometryBoundsResolver::ClearForTesting() {
+  std::lock_guard<std::mutex> lock(g_cacheMutex);
+  g_cache.clear();
+  g_parseCount = 0;
+}

--- a/core/geometry_bounds_resolver.h
+++ b/core/geometry_bounds_resolver.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "geometry_bounds.h"
+
+#include <cstddef>
+#include <filesystem>
+#include <optional>
+#include <string>
+
+// Resolves and caches CPU-side bounds using the renderers' existing mesh loaders.
+class GeometryBoundsResolver {
+public:
+  // Resolves bounds for a supported 3DS or GLB resource.
+  static std::optional<GeometryBounds>
+  Resolve(const std::filesystem::path &path, std::string *diagnostic = nullptr);
+
+  // Returns the number of physical parses, for cache regression tests.
+  static std::size_t ParseCountForTesting();
+
+  // Clears process-local cached measurements, for deterministic tests.
+  static void ClearForTesting();
+};

--- a/core/truss_attachment_candidates.cpp
+++ b/core/truss_attachment_candidates.cpp
@@ -3,9 +3,11 @@
 #include "filesystem_path_utils.h"
 #include "gdtf_archive_reader.h"
 #include "matrixutils.h"
+#include "geometry_bounds_resolver.h"
 
 #include <algorithm>
 #include <chrono>
+#include <cctype>
 #include <cmath>
 #include <cstdint>
 #include <filesystem>
@@ -323,6 +325,28 @@ CandidateResolution Instantiate(const CandidateResolver::CacheEntry &entry,
 CandidateResolution CandidateResolver::Resolve(const MvrScene &scene,
                                                const Truss &truss) {
   std::vector<Diagnostic> resolutionDiagnostics;
+  auto buildInferred = [&]() {
+    if (truss.localGeometryBounds)
+      return BuildInferredCandidatesFromBounds(*truss.localGeometryBounds,
+                                                truss.transform, truss.uuid);
+    for (const std::string *reference : {&truss.symbolFile, &truss.modelFile}) {
+      const std::filesystem::path resolved =
+          ResolveSceneResource(scene, *reference);
+      std::string extension = resolved.extension().string();
+      std::transform(extension.begin(), extension.end(), extension.begin(),
+                     [](unsigned char value) {
+                       return static_cast<char>(std::tolower(value));
+                     });
+      if (extension != ".3ds" && extension != ".glb")
+        continue;
+      if (const auto bounds = GeometryBoundsResolver::Resolve(resolved))
+        return BuildInferredCandidatesFromBounds(*bounds, truss.transform,
+                                                  truss.uuid);
+    }
+    return BuildInferredCandidates(
+        std::array<float, 3>{truss.lengthMm, truss.widthMm, truss.heightMm},
+        truss.transform, truss.uuid);
+  };
   for (const std::string *reference :
        {&truss.gdtfSpec, &truss.perastageAuxGdtfArchivePath}) {
     if (reference->empty())
@@ -352,13 +376,7 @@ CandidateResolution CandidateResolver::Resolve(const MvrScene &scene,
         continue;
       }
       if (result.candidates.empty())
-        result.candidates = truss.localGeometryBounds
-                                ? BuildInferredCandidatesFromBounds(
-                                      *truss.localGeometryBounds, truss.transform,
-                                      truss.uuid)
-                                : BuildInferredCandidates(
-                                      {truss.lengthMm, truss.widthMm, truss.heightMm},
-                                      truss.transform, truss.uuid);
+        result.candidates = buildInferred();
       return result;
     }
 
@@ -390,25 +408,13 @@ CandidateResolution CandidateResolver::Resolve(const MvrScene &scene,
       continue;
     }
     if (result.candidates.empty())
-      result.candidates = truss.localGeometryBounds
-                              ? BuildInferredCandidatesFromBounds(
-                                    *truss.localGeometryBounds, truss.transform,
-                                    truss.uuid)
-                              : BuildInferredCandidates(
-                                    {truss.lengthMm, truss.widthMm, truss.heightMm},
-                                    truss.transform, truss.uuid);
+      result.candidates = buildInferred();
     return result;
   }
 
   CandidateResolution fallback;
   fallback.diagnostics = std::move(resolutionDiagnostics);
-  fallback.candidates = truss.localGeometryBounds
-                            ? BuildInferredCandidatesFromBounds(
-                                  *truss.localGeometryBounds, truss.transform,
-                                  truss.uuid)
-                            : BuildInferredCandidates(
-                                  {truss.lengthMm, truss.widthMm, truss.heightMm},
-                                  truss.transform, truss.uuid);
+  fallback.candidates = buildInferred();
   return fallback;
 }
 

--- a/core/truss_attachment_candidates.cpp
+++ b/core/truss_attachment_candidates.cpp
@@ -197,9 +197,9 @@ BuildInferredCandidates(const std::array<float, 3> &dimensionsMm,
 
 // Builds inferred candidates from measured local minimum and maximum planes.
 std::vector<Candidate>
-BuildInferredCandidates(const GeometryBounds &bounds,
-                        const Matrix &trussTransform,
-                        const std::string &sourceId) {
+BuildInferredCandidatesFromBounds(const GeometryBounds &bounds,
+                                  const Matrix &trussTransform,
+                                  const std::string &sourceId) {
   if (!bounds.IsValid())
     return {};
   const auto size = bounds.SizeMm();
@@ -353,8 +353,9 @@ CandidateResolution CandidateResolver::Resolve(const MvrScene &scene,
       }
       if (result.candidates.empty())
         result.candidates = truss.localGeometryBounds
-                                ? BuildInferredCandidates(*truss.localGeometryBounds,
-                                                          truss.transform, truss.uuid)
+                                ? BuildInferredCandidatesFromBounds(
+                                      *truss.localGeometryBounds, truss.transform,
+                                      truss.uuid)
                                 : BuildInferredCandidates(
                                       {truss.lengthMm, truss.widthMm, truss.heightMm},
                                       truss.transform, truss.uuid);
@@ -390,8 +391,9 @@ CandidateResolution CandidateResolver::Resolve(const MvrScene &scene,
     }
     if (result.candidates.empty())
       result.candidates = truss.localGeometryBounds
-                              ? BuildInferredCandidates(*truss.localGeometryBounds,
-                                                        truss.transform, truss.uuid)
+                              ? BuildInferredCandidatesFromBounds(
+                                    *truss.localGeometryBounds, truss.transform,
+                                    truss.uuid)
                               : BuildInferredCandidates(
                                     {truss.lengthMm, truss.widthMm, truss.heightMm},
                                     truss.transform, truss.uuid);
@@ -401,8 +403,9 @@ CandidateResolution CandidateResolver::Resolve(const MvrScene &scene,
   CandidateResolution fallback;
   fallback.diagnostics = std::move(resolutionDiagnostics);
   fallback.candidates = truss.localGeometryBounds
-                            ? BuildInferredCandidates(*truss.localGeometryBounds,
-                                                      truss.transform, truss.uuid)
+                            ? BuildInferredCandidatesFromBounds(
+                                  *truss.localGeometryBounds, truss.transform,
+                                  truss.uuid)
                             : BuildInferredCandidates(
                                   {truss.lengthMm, truss.widthMm, truss.heightMm},
                                   truss.transform, truss.uuid);

--- a/core/truss_attachment_candidates.cpp
+++ b/core/truss_attachment_candidates.cpp
@@ -195,6 +195,38 @@ BuildInferredCandidates(const std::array<float, 3> &dimensionsMm,
   return BuildAmbiguousCandidates(safeDimensions, trussTransform, sourceId);
 }
 
+// Builds inferred candidates from measured local minimum and maximum planes.
+std::vector<Candidate>
+BuildInferredCandidates(const GeometryBounds &bounds,
+                        const Matrix &trussTransform,
+                        const std::string &sourceId) {
+  if (!bounds.IsValid())
+    return {};
+  const auto size = bounds.SizeMm();
+  const auto center = bounds.CenterMm();
+  std::vector<Candidate> result;
+  const auto dominant = ClassifyLongitudinalAxis(size);
+  for (int axis = 0; axis < 3; ++axis) {
+    if (dominant && axis != *dominant)
+      continue;
+    for (int sign : {-1, 1}) {
+      Matrix local = MatrixUtils::Identity();
+      local.o = center;
+      local.o[axis] = sign < 0 ? bounds.minMm[axis] : bounds.maxMm[axis];
+      std::array<float, 3> direction{};
+      direction[axis] = static_cast<float>(sign);
+      AppendCandidate(result,
+                      dominant ? CandidateKind::InferredLongitudinalEnd
+                               : CandidateKind::InferredFaceCenter,
+                      (dominant ? "longitudinal-axis-" : "face-axis-") +
+                          std::to_string(axis) +
+                          (sign < 0 ? "-negative" : "-positive"),
+                      local, trussTransform, sourceId, direction);
+    }
+  }
+  return result;
+}
+
 // Builds exactly six deterministic face-center candidates.
 std::vector<Candidate>
 BuildAmbiguousCandidates(const std::array<float, 3> &dimensionsMm,
@@ -320,9 +352,12 @@ CandidateResolution CandidateResolver::Resolve(const MvrScene &scene,
         continue;
       }
       if (result.candidates.empty())
-        result.candidates = BuildInferredCandidates(
-            {truss.lengthMm, truss.widthMm, truss.heightMm}, truss.transform,
-            truss.uuid);
+        result.candidates = truss.localGeometryBounds
+                                ? BuildInferredCandidates(*truss.localGeometryBounds,
+                                                          truss.transform, truss.uuid)
+                                : BuildInferredCandidates(
+                                      {truss.lengthMm, truss.widthMm, truss.heightMm},
+                                      truss.transform, truss.uuid);
       return result;
     }
 
@@ -354,17 +389,23 @@ CandidateResolution CandidateResolver::Resolve(const MvrScene &scene,
       continue;
     }
     if (result.candidates.empty())
-      result.candidates = BuildInferredCandidates(
-          {truss.lengthMm, truss.widthMm, truss.heightMm}, truss.transform,
-          truss.uuid);
+      result.candidates = truss.localGeometryBounds
+                              ? BuildInferredCandidates(*truss.localGeometryBounds,
+                                                        truss.transform, truss.uuid)
+                              : BuildInferredCandidates(
+                                    {truss.lengthMm, truss.widthMm, truss.heightMm},
+                                    truss.transform, truss.uuid);
     return result;
   }
 
   CandidateResolution fallback;
   fallback.diagnostics = std::move(resolutionDiagnostics);
-  fallback.candidates =
-      BuildInferredCandidates({truss.lengthMm, truss.widthMm, truss.heightMm},
-                              truss.transform, truss.uuid);
+  fallback.candidates = truss.localGeometryBounds
+                            ? BuildInferredCandidates(*truss.localGeometryBounds,
+                                                      truss.transform, truss.uuid)
+                            : BuildInferredCandidates(
+                                  {truss.lengthMm, truss.widthMm, truss.heightMm},
+                                  truss.transform, truss.uuid);
   return fallback;
 }
 

--- a/core/truss_attachment_candidates.h
+++ b/core/truss_attachment_candidates.h
@@ -88,6 +88,12 @@ BuildInferredCandidates(const std::array<float, 3> &dimensionsMm,
                         const Matrix &trussTransform,
                         const std::string &sourceId = {});
 
+// Builds inferred candidates from measured local minimum and maximum planes.
+std::vector<Candidate>
+BuildInferredCandidates(const GeometryBounds &bounds,
+                        const Matrix &trussTransform,
+                        const std::string &sourceId = {});
+
 // Builds exactly six deterministic face-center candidates.
 std::vector<Candidate>
 BuildAmbiguousCandidates(const std::array<float, 3> &dimensionsMm,

--- a/core/truss_attachment_candidates.h
+++ b/core/truss_attachment_candidates.h
@@ -90,9 +90,9 @@ BuildInferredCandidates(const std::array<float, 3> &dimensionsMm,
 
 // Builds inferred candidates from measured local minimum and maximum planes.
 std::vector<Candidate>
-BuildInferredCandidates(const GeometryBounds &bounds,
-                        const Matrix &trussTransform,
-                        const std::string &sourceId = {});
+BuildInferredCandidatesFromBounds(const GeometryBounds &bounds,
+                                  const Matrix &trussTransform,
+                                  const std::string &sourceId = {});
 
 // Builds exactly six deterministic face-center candidates.
 std::vector<Candidate>

--- a/core/truss_dimension_resolution.cpp
+++ b/core/truss_dimension_resolution.cpp
@@ -1,0 +1,73 @@
+#include "truss_dimension_resolution.h"
+
+#include <cmath>
+
+namespace {
+constexpr float kLegacyLengthMm = 1000.0f;
+constexpr float kLegacyWidthMm = 400.0f;
+constexpr float kLegacyHeightMm = 400.0f;
+constexpr float kDimensionToleranceMm = 0.01f;
+
+// Reports whether two dimensions are equal within metadata precision.
+bool NearlyEqual(float lhs, float rhs) {
+  return std::fabs(lhs - rhs) <= kDimensionToleranceMm;
+}
+
+// Reports whether legacy Perastage metadata matches the historical fallback.
+bool IsLegacyFallbackMetadata(const Truss &truss,
+                              const GeometryBounds &bounds,
+                              bool legacyMetadataContext) {
+  if (!legacyMetadataContext ||
+      truss.dimensionSource != Truss::DimensionSource::PerastageMetadata)
+    return false;
+  if (!NearlyEqual(truss.lengthMm, kLegacyLengthMm) ||
+      !NearlyEqual(truss.widthMm, kLegacyWidthMm) ||
+      !NearlyEqual(truss.heightMm, kLegacyHeightMm))
+    return false;
+  const auto size = bounds.SizeMm();
+  return !NearlyEqual(size[0], truss.lengthMm) ||
+         !NearlyEqual(size[1], truss.widthMm) ||
+         !NearlyEqual(size[2], truss.heightMm);
+}
+} // namespace
+
+// Reports whether all three stored truss dimensions are finite and positive.
+bool HasValidTrussDimensions(const Truss &truss) {
+  return std::isfinite(truss.lengthMm) && truss.lengthMm > 0.0f &&
+         std::isfinite(truss.widthMm) && truss.widthMm > 0.0f &&
+         std::isfinite(truss.heightMm) && truss.heightMm > 0.0f;
+}
+
+// Resolves recoverable truss dimensions from measured geometry bounds.
+bool ResolveTrussDimensionsFromGeometry(Truss &truss,
+                                        bool legacyMetadataContext) {
+  if (!truss.localGeometryBounds || !truss.localGeometryBounds->IsValid() ||
+      truss.dimensionSource == Truss::DimensionSource::GdtfModel ||
+      truss.dimensionSource == Truss::DimensionSource::ManualOverride)
+    return false;
+
+  const auto size = truss.localGeometryBounds->SizeMm();
+  const bool legacyFallback = IsLegacyFallbackMetadata(
+      truss, *truss.localGeometryBounds, legacyMetadataContext);
+  bool changed = false;
+  if (legacyFallback) {
+    truss.dimensionSource = Truss::DimensionSource::LegacySyntheticFallback;
+    truss.lengthMm = size[0];
+    truss.widthMm = size[1];
+    truss.heightMm = size[2];
+    changed = true;
+  } else {
+    auto recover = [&](float &dimension, float measured) {
+      if (!std::isfinite(dimension) || dimension <= 0.0f) {
+        dimension = measured;
+        changed = true;
+      }
+    };
+    recover(truss.lengthMm, size[0]);
+    recover(truss.widthMm, size[1]);
+    recover(truss.heightMm, size[2]);
+  }
+  if (changed && !legacyFallback)
+    truss.dimensionSource = Truss::DimensionSource::GeometryDerived;
+  return changed;
+}

--- a/core/truss_dimension_resolution.h
+++ b/core/truss_dimension_resolution.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "truss.h"
+
+// Reports whether all three stored truss dimensions are finite and positive.
+bool HasValidTrussDimensions(const Truss &truss);
+
+// Resolves recoverable truss dimensions from measured geometry bounds.
+bool ResolveTrussDimensionsFromGeometry(Truss &truss,
+                                        bool legacyMetadataContext);

--- a/core/truss_gdtf_builder.cpp
+++ b/core/truss_gdtf_builder.cpp
@@ -20,6 +20,7 @@
 #include "filesystem_path_utils.h"
 #include "gdtf_mutation_audit.h"
 #include "geometry_bounds_resolver.h"
+#include "truss_dimension_resolution.h"
 
 #include "json.hpp"
 #include "logger.h"
@@ -94,7 +95,8 @@ struct TrussSourceData {
   std::string crossSectionType = "TrussFramework";
   std::string crossSection;
   std::string revisionText;
-  bool recoverLegacySyntheticDimensions = false;
+  Truss::DimensionSource dimensionSource = Truss::DimensionSource::Unknown;
+  bool legacyMetadataContext = false;
 };
 
 static std::string Trim(std::string value) {
@@ -257,7 +259,8 @@ static bool ReadLegacyGtruss(const fs::path &gtrussPath, TrussSourceData &out,
   out.heightMm = parsed.value("Height_mm", 0.0f);
   out.weightKg = parsed.value("Weight_kg", 0.0f);
   out.geometryPath = geometryName;
-  out.recoverLegacySyntheticDimensions = true;
+  out.dimensionSource = Truss::DimensionSource::PerastageMetadata;
+  out.legacyMetadataContext = true;
   if (!symbolName.empty())
     out.symbolPath = symbolName;
   return true;
@@ -391,24 +394,16 @@ static bool BuildFromSourceData(TrussSourceData data,
 
   const auto bounds = GeometryBoundsResolver::Resolve(data.geometryPath, outError);
   if (bounds) {
-    const auto size = bounds->SizeMm();
-    const bool legacySynthetic =
-        data.recoverLegacySyntheticDimensions && data.lengthMm == 1000.0f &&
-        data.widthMm == 400.0f && data.heightMm == 400.0f &&
-        (std::fabs(size[0] - data.lengthMm) > 0.01f ||
-         std::fabs(size[1] - data.widthMm) > 0.01f ||
-         std::fabs(size[2] - data.heightMm) > 0.01f);
-    if (legacySynthetic) {
-      data.lengthMm = size[0];
-      data.widthMm = size[1];
-      data.heightMm = size[2];
-    }
-    if (!std::isfinite(data.lengthMm) || data.lengthMm <= 0.0f)
-      data.lengthMm = size[0];
-    if (!std::isfinite(data.widthMm) || data.widthMm <= 0.0f)
-      data.widthMm = size[1];
-    if (!std::isfinite(data.heightMm) || data.heightMm <= 0.0f)
-      data.heightMm = size[2];
+    Truss dimensions;
+    dimensions.lengthMm = data.lengthMm;
+    dimensions.widthMm = data.widthMm;
+    dimensions.heightMm = data.heightMm;
+    dimensions.localGeometryBounds = bounds;
+    dimensions.dimensionSource = data.dimensionSource;
+    ResolveTrussDimensionsFromGeometry(dimensions, data.legacyMetadataContext);
+    data.lengthMm = dimensions.lengthMm;
+    data.widthMm = dimensions.widthMm;
+    data.heightMm = dimensions.heightMm;
   }
   if (!std::isfinite(data.lengthMm) || data.lengthMm <= 0.0f ||
       !std::isfinite(data.widthMm) || data.widthMm <= 0.0f ||
@@ -484,8 +479,10 @@ bool BuildTrussGdtfFromInstance(const Truss &truss, const fs::path &outGdtfPath,
   source.crossSectionType = truss.crossSectionType.empty() ? "TrussFramework" : truss.crossSectionType;
   source.crossSection = truss.crossSection;
   source.revisionText = revisionText;
-  source.recoverLegacySyntheticDimensions =
-      truss.sourceRepresentation == Truss::GeometryRepresentation::NativePerastage;
+  source.dimensionSource = truss.dimensionSource;
+  source.legacyMetadataContext =
+      truss.dimensionSource == Truss::DimensionSource::PerastageMetadata &&
+      truss.sourceRepresentation != Truss::GeometryRepresentation::PublicGdtf;
 
   auto pickGeometry = [&](const std::string &path) {
     fs::path p = PathUtils::PathFromUtf8(path);

--- a/core/truss_gdtf_builder.cpp
+++ b/core/truss_gdtf_builder.cpp
@@ -19,6 +19,7 @@
 #include "truss_gdtf_builder.h"
 #include "filesystem_path_utils.h"
 #include "gdtf_mutation_audit.h"
+#include "geometry_bounds_resolver.h"
 
 #include "json.hpp"
 #include "logger.h"
@@ -33,6 +34,7 @@
 #include <array>
 #include <cctype>
 #include <cstdint>
+#include <cmath>
 #include <fstream>
 #include <iomanip>
 #include <memory>
@@ -92,6 +94,7 @@ struct TrussSourceData {
   std::string crossSectionType = "TrussFramework";
   std::string crossSection;
   std::string revisionText;
+  bool recoverLegacySyntheticDimensions = false;
 };
 
 static std::string Trim(std::string value) {
@@ -254,6 +257,7 @@ static bool ReadLegacyGtruss(const fs::path &gtrussPath, TrussSourceData &out,
   out.heightMm = parsed.value("Height_mm", 0.0f);
   out.weightKg = parsed.value("Weight_kg", 0.0f);
   out.geometryPath = geometryName;
+  out.recoverLegacySyntheticDimensions = true;
   if (!symbolName.empty())
     out.symbolPath = symbolName;
   return true;
@@ -375,13 +379,42 @@ static std::string BuildDescriptionXml(const TrussSourceData &data) {
 }
 
 // Builds a truss GDTF archive from normalized source data.
-static bool BuildFromSourceData(const TrussSourceData &data,
+static bool BuildFromSourceData(TrussSourceData data,
                                 const fs::path &outGdtfPath,
                                 std::string *outError) {
   const std::string ext = data.geometryPath.extension().string();
   if (ext != ".glb" && ext != ".3ds") {
     if (outError)
       *outError = "Only .glb and .3ds truss geometry is supported";
+    return false;
+  }
+
+  const auto bounds = GeometryBoundsResolver::Resolve(data.geometryPath, outError);
+  if (bounds) {
+    const auto size = bounds->SizeMm();
+    const bool legacySynthetic =
+        data.recoverLegacySyntheticDimensions && data.lengthMm == 1000.0f &&
+        data.widthMm == 400.0f && data.heightMm == 400.0f &&
+        (std::fabs(size[0] - data.lengthMm) > 0.01f ||
+         std::fabs(size[1] - data.widthMm) > 0.01f ||
+         std::fabs(size[2] - data.heightMm) > 0.01f);
+    if (legacySynthetic) {
+      data.lengthMm = size[0];
+      data.widthMm = size[1];
+      data.heightMm = size[2];
+    }
+    if (!std::isfinite(data.lengthMm) || data.lengthMm <= 0.0f)
+      data.lengthMm = size[0];
+    if (!std::isfinite(data.widthMm) || data.widthMm <= 0.0f)
+      data.widthMm = size[1];
+    if (!std::isfinite(data.heightMm) || data.heightMm <= 0.0f)
+      data.heightMm = size[2];
+  }
+  if (!std::isfinite(data.lengthMm) || data.lengthMm <= 0.0f ||
+      !std::isfinite(data.widthMm) || data.widthMm <= 0.0f ||
+      !std::isfinite(data.heightMm) || data.heightMm <= 0.0f) {
+    if (outError && outError->empty())
+      *outError = "Truss geometry dimensions are missing or invalid";
     return false;
   }
 
@@ -451,6 +484,8 @@ bool BuildTrussGdtfFromInstance(const Truss &truss, const fs::path &outGdtfPath,
   source.crossSectionType = truss.crossSectionType.empty() ? "TrussFramework" : truss.crossSectionType;
   source.crossSection = truss.crossSection;
   source.revisionText = revisionText;
+  source.recoverLegacySyntheticDimensions =
+      truss.sourceRepresentation == Truss::GeometryRepresentation::NativePerastage;
 
   auto pickGeometry = [&](const std::string &path) {
     fs::path p = PathUtils::PathFromUtf8(path);

--- a/core/trussloader.cpp
+++ b/core/trussloader.cpp
@@ -21,8 +21,8 @@
 #include "wx_path_utils.h"
 
 #include "truss_gdtf_builder.h"
+#include "geometry_bounds_resolver.h"
 #include "logger.h"
-#include "truss_defaults.h"
 
 #include <tinyxml2.h>
 #include <wx/filename.h>
@@ -32,6 +32,7 @@
 #include <algorithm>
 #include <cctype>
 #include <cstdint>
+#include <cmath>
 #include <filesystem>
 #include <functional>
 #include <fstream>
@@ -324,6 +325,19 @@ bool LoadTrussGdtf(const std::string &gdtfPath, Truss &outTruss) {
     if (!modelPath.empty())
       outTruss.symbolFile = ToUtf8String(modelPath);
 
+    if (!modelPath.empty()) {
+      outTruss.localGeometryBounds = GeometryBoundsResolver::Resolve(modelPath);
+      if (outTruss.localGeometryBounds) {
+        const auto size = outTruss.localGeometryBounds->SizeMm();
+        if (!std::isfinite(outTruss.lengthMm) || outTruss.lengthMm <= 0.0f)
+          outTruss.lengthMm = size[0];
+        if (!std::isfinite(outTruss.widthMm) || outTruss.widthMm <= 0.0f)
+          outTruss.widthMm = size[1];
+        if (!std::isfinite(outTruss.heightMm) || outTruss.heightMm <= 0.0f)
+          outTruss.heightMm = size[2];
+      }
+    }
+
   }
 
   tinyxml2::XMLElement *phys = fixtureType->FirstChildElement("PhysicalDescriptions");
@@ -379,10 +393,20 @@ bool LoadTrussDefinition(const std::string &path, Truss &outTruss) {
       outTruss = Truss{};
       outTruss.symbolFile = ToUtf8String(inputPath);
       outTruss.modelFile = ToUtf8String(inputPath);
-      outTruss.lengthMm = TrussDefaults::kFallbackLengthMm;
-      outTruss.widthMm = TrussDefaults::kFallbackWidthMm;
-      outTruss.heightMm = TrussDefaults::kFallbackHeightMm;
-      success = true;
+      outTruss.sourceRepresentation = Truss::GeometryRepresentation::NativePerastage;
+      std::string diagnostic;
+      outTruss.localGeometryBounds =
+          GeometryBoundsResolver::Resolve(inputPath, &diagnostic);
+      if (outTruss.localGeometryBounds) {
+        const auto size = outTruss.localGeometryBounds->SizeMm();
+        outTruss.lengthMm = size[0];
+        outTruss.widthMm = size[1];
+        outTruss.heightMm = size[2];
+        success = true;
+      } else {
+        Logger::Instance().Log(Logger::Level::Warn,
+                               "Truss geometry bounds unavailable: " + diagnostic);
+      }
     }
     LogTrussDefinitionLoadResult(inputPath, ext, success, outTruss);
     return success;

--- a/core/trussloader.cpp
+++ b/core/trussloader.cpp
@@ -22,6 +22,7 @@
 
 #include "truss_gdtf_builder.h"
 #include "geometry_bounds_resolver.h"
+#include "truss_dimension_resolution.h"
 #include "logger.h"
 
 #include <tinyxml2.h>
@@ -314,6 +315,8 @@ bool LoadTrussGdtf(const std::string &gdtfPath, Truss &outTruss) {
       outTruss.widthMm = widthM * 1000.0f;
     if (ParseFloatAttr(model, "Height", heightM))
       outTruss.heightMm = heightM * 1000.0f;
+    if (HasValidTrussDimensions(outTruss))
+      outTruss.dimensionSource = Truss::DimensionSource::GdtfModel;
 
     std::string fileBase = "main";
     if (const char *fileAttr = model->Attribute("File"); fileAttr && *fileAttr)
@@ -328,13 +331,7 @@ bool LoadTrussGdtf(const std::string &gdtfPath, Truss &outTruss) {
     if (!modelPath.empty()) {
       outTruss.localGeometryBounds = GeometryBoundsResolver::Resolve(modelPath);
       if (outTruss.localGeometryBounds) {
-        const auto size = outTruss.localGeometryBounds->SizeMm();
-        if (!std::isfinite(outTruss.lengthMm) || outTruss.lengthMm <= 0.0f)
-          outTruss.lengthMm = size[0];
-        if (!std::isfinite(outTruss.widthMm) || outTruss.widthMm <= 0.0f)
-          outTruss.widthMm = size[1];
-        if (!std::isfinite(outTruss.heightMm) || outTruss.heightMm <= 0.0f)
-          outTruss.heightMm = size[2];
+        ResolveTrussDimensionsFromGeometry(outTruss, false);
       }
     }
 
@@ -402,6 +399,7 @@ bool LoadTrussDefinition(const std::string &path, Truss &outTruss) {
         outTruss.lengthMm = size[0];
         outTruss.widthMm = size[1];
         outTruss.heightMm = size[2];
+        outTruss.dimensionSource = Truss::DimensionSource::GeometryDerived;
         success = true;
       } else {
         Logger::Instance().Log(Logger::Level::Warn,

--- a/docs/developer/truss_attachment_candidates.md
+++ b/docs/developer/truss_attachment_candidates.md
@@ -29,13 +29,25 @@ resource-owning cache.
 
 ## Inference
 
+Raw 3DS and GLB trusses are measured through one CPU-only bounds resolver that
+reuses the render mesh loaders and their unit/transform conventions. The
+resolver retains local minimum and maximum coordinates, and caches results by
+normalized path, size, and modification time. Valid standardized dimensions
+read from an existing GDTF remain authoritative metadata; missing or invalid
+values are recovered from measured geometry without modifying that archive.
+Perastage-generated GDTFs validate dimensions before writing, while legacy
+synthetic 1000 x 400 x 400 mm metadata is replaced only for raw/legacy geometry
+whose measured bounds differ. A genuinely matching model and deliberate valid
+metadata remain unchanged.
+
 Dimensions are evaluated in truss-local X, Y, and Z. A shape is longitudinal
 only when its largest positive finite dimension is **strictly greater than
 twice** the second-largest dimension. The strict comparison makes the 2:1
 boundary ambiguous while classifying 3000 x 400 x 400 mm as longitudinal.
 
 Longitudinal shapes expose exactly the negative and positive centers of the
-dominant-axis terminal planes. Ambiguous shapes, including invalid-dimension
+dominant-axis terminal planes using the measured local minimum and maximum,
+not an assumed origin. Ambiguous shapes, including invalid-dimension
 fallbacks, expose the six oriented bounds face centers. These inferred points
 are conservative snapping aids, not verified mechanical connectors.
 

--- a/docs/developer/truss_attachment_candidates.md
+++ b/docs/developer/truss_attachment_candidates.md
@@ -40,6 +40,23 @@ synthetic 1000 x 400 x 400 mm metadata is replaced only for raw/legacy geometry
 whose measured bounds differ. A genuinely matching model and deliberate valid
 metadata remain unchanged.
 
+MVR import resolves both direct `Geometry3D` resources and `Symbol`/`Symdef`
+resources before inserting a truss into the scene. Raw mesh bounds remain in
+mesh-local coordinates; the existing composed truss, Symbol, and Symdef
+matrices are applied later by candidate consumers. Dimension provenance is
+tracked as unknown, authoritative GDTF Model, geometry-derived, Perastage
+metadata, recovered legacy synthetic fallback, or manual override. Geometry
+replaces invalid values and conservatively identified legacy metadata, but
+never valid GDTF Model dimensions or a manual override. Historical
+1000 x 400 x 400 mm
+metadata is considered synthetic only for geometry-backed Perastage metadata
+without GDTF authority and only when measured bounds differ; geometry that
+actually measures 1000 x 400 x 400 mm is therefore preserved.
+
+The bounds resolver and Viewer3D both use the native MVR 3DS vertex convention:
+the optional 3DS object basis is not applied. This keeps measured bounds aligned
+with rendered geometry, including assets that contain a non-identity basis.
+
 Dimensions are evaluated in truss-local X, Y, and Z. A shape is longitudinal
 only when its largest positive finite dimension is **strictly greater than
 twice** the second-largest dimension. The strict comparison makes the 2:1

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -31,6 +31,11 @@ Changes since **v1.5.0**.
 
 ## Compatibility, stability, and performance
 
+- Trusses loaded from 3DS or GLB geometry now use their measured local bounds
+  instead of fixed nominal dimensions. This repairs legacy dimension metadata,
+  generated GDTF sizing, and Magnet endpoints while preserving explicit GDTF
+  dimensions and connector definitions.
+
 - Continuous fixture, truss, and scene-object insertion in the 3D viewer now
   presents each placement update while the pointer is moving and returns the
   preview directly beneath the pointer when axis-constrained movement is

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -34,7 +34,8 @@ Changes since **v1.5.0**.
 - Trusses loaded from 3DS or GLB geometry now use their measured local bounds
   instead of fixed nominal dimensions. This repairs legacy dimension metadata,
   generated GDTF sizing, and Magnet endpoints while preserving explicit GDTF
-  dimensions and connector definitions, with consistent Windows build support.
+  dimensions and connector definitions. The shared geometry parsers are now
+  independent of viewer console state, including in Windows test builds.
 
 - Continuous fixture, truss, and scene-object insertion in the 3D viewer now
   presents each placement update while the pointer is moving and returns the

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -34,7 +34,7 @@ Changes since **v1.5.0**.
 - Trusses loaded from 3DS or GLB geometry now use their measured local bounds
   instead of fixed nominal dimensions. This repairs legacy dimension metadata,
   generated GDTF sizing, and Magnet endpoints while preserving explicit GDTF
-  dimensions and connector definitions.
+  dimensions and connector definitions, with consistent Windows build support.
 
 - Continuous fixture, truss, and scene-object insertion in the 3D viewer now
   presents each placement update while the pointer is moving and returns the

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -36,6 +36,8 @@ Changes since **v1.5.0**.
   generated GDTF sizing, and Magnet endpoints while preserving explicit GDTF
   dimensions and connector definitions. The shared geometry parsers are now
   independent of viewer console state, including in Windows test builds.
+  Geometry-backed MVR trusses using either direct Geometry3D or Symbol/Symdef
+  resources now recover the same coherent dimensions during project loading.
 
 - Continuous fixture, truss, and scene-object insertion in the 3D viewer now
   presents each placement update while the pointer is moving and returns the

--- a/models/geometry_bounds.h
+++ b/models/geometry_bounds.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <array>
+#include <cmath>
+
+// Stores a finite local-space geometry bounding box in millimeters.
+struct GeometryBounds {
+  std::array<float, 3> minMm{};
+  std::array<float, 3> maxMm{};
+
+  // Reports whether every axis has a finite, strictly positive extent.
+  bool IsValid() const {
+    for (int axis = 0; axis < 3; ++axis) {
+      if (!std::isfinite(minMm[axis]) || !std::isfinite(maxMm[axis]) ||
+          maxMm[axis] <= minMm[axis])
+        return false;
+    }
+    return true;
+  }
+
+  // Returns the local-space extent of each axis in millimeters.
+  std::array<float, 3> SizeMm() const {
+    return {maxMm[0] - minMm[0], maxMm[1] - minMm[1],
+            maxMm[2] - minMm[2]};
+  }
+
+  // Returns the local-space center of the bounding box in millimeters.
+  std::array<float, 3> CenterMm() const {
+    return {(minMm[0] + maxMm[0]) * 0.5f,
+            (minMm[1] + maxMm[1]) * 0.5f,
+            (minMm[2] + maxMm[2]) * 0.5f};
+  }
+};

--- a/models/truss.h
+++ b/models/truss.h
@@ -19,6 +19,8 @@
 
 #include <string>
 #include "types.h"
+#include "geometry_bounds.h"
+#include <optional>
 
 // Represents a truss object parsed from MVR
 struct Truss {
@@ -45,6 +47,8 @@ struct Truss {
     float lengthMm = 0.0f;
     float widthMm = 0.0f;
     float heightMm = 0.0f;
+    // Measured render-geometry bounds remain separate from standardized metadata.
+    std::optional<GeometryBounds> localGeometryBounds;
     float weightKg = 0.0f;
     std::string gdtfDescription;
     std::string crossSectionType = "TrussFramework";

--- a/models/truss.h
+++ b/models/truss.h
@@ -24,6 +24,15 @@
 
 // Represents a truss object parsed from MVR
 struct Truss {
+    enum class DimensionSource {
+        Unknown = 0,
+        GdtfModel,
+        GeometryDerived,
+        PerastageMetadata,
+        LegacySyntheticFallback,
+        ManualOverride
+    };
+
     enum class GeometryRepresentation {
         Unknown = 0,
         SymbolSymdef,
@@ -49,6 +58,7 @@ struct Truss {
     float heightMm = 0.0f;
     // Measured render-geometry bounds remain separate from standardized metadata.
     std::optional<GeometryBounds> localGeometryBounds;
+    DimensionSource dimensionSource = DimensionSource::Unknown;
     float weightKg = 0.0f;
     std::string gdtfDescription;
     std::string crossSectionType = "TrussFramework";

--- a/models/truss_defaults.h
+++ b/models/truss_defaults.h
@@ -19,8 +19,9 @@
 
 namespace TrussDefaults {
 
-inline constexpr float kFallbackLengthMm = 1000.0f;
-inline constexpr float kFallbackWidthMm = 400.0f;
-inline constexpr float kFallbackHeightMm = 400.0f;
+// Defines an emergency viewer box only when no physical geometry is available.
+inline constexpr float kViewerFallbackBoxLengthMm = 1000.0f;
+inline constexpr float kViewerFallbackBoxWidthMm = 400.0f;
+inline constexpr float kViewerFallbackBoxHeightMm = 400.0f;
 
 } // namespace TrussDefaults

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -45,6 +45,8 @@
 #include "sceneobject.h"
 #include "support.h"
 #include "trussloader.h"
+#include "geometry_bounds_resolver.h"
+#include "truss_dimension_resolution.h"
 #include "uuidutils.h"
 
 #include "consolepanel.h"
@@ -2888,7 +2890,6 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                               bool hasGdtfMetadataAuthority) {
     if (!info)
       return;
-    (void)hasGdtfMetadataAuthority;
     auto readNumeric = [&](const char *field, float &target) {
       tinyxml2::XMLElement *element = info->FirstChildElement(field);
       if (!element)
@@ -2909,9 +2910,12 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
     if (tinyxml2::XMLElement *mo = info->FirstChildElement("Model"))
       if (mo->GetText())
         truss.model = Trim(mo->GetText());
-    readNumeric("Length", truss.lengthMm);
-    readNumeric("Width", truss.widthMm);
-    readNumeric("Height", truss.heightMm);
+    if (!hasGdtfMetadataAuthority) {
+      readNumeric("Length", truss.lengthMm);
+      readNumeric("Width", truss.widthMm);
+      readNumeric("Height", truss.heightMm);
+      truss.dimensionSource = Truss::DimensionSource::PerastageMetadata;
+    }
     readNumeric("Weight", truss.weightKg);
     if (tinyxml2::XMLElement *desc = info->FirstChildElement("GdtfDescription"))
       if (desc->GetText())
@@ -3035,6 +3039,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
               truss.widthMm = gdtfTruss.widthMm;
             if (gdtfTruss.heightMm > 0.0f)
               truss.heightMm = gdtfTruss.heightMm;
+            truss.localGeometryBounds = gdtfTruss.localGeometryBounds;
+            truss.dimensionSource = gdtfTruss.dimensionSource;
             if (gdtfTruss.weightKg > 0.0f)
               truss.weightKg = gdtfTruss.weightKg;
             if (truss.gdtfMode.empty())
@@ -3165,6 +3171,25 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
         const bool symbolExists =
             symbolRenderable &&
             fs::exists(resolvedSymbolPath, symbolExistsEc) && !symbolExistsEc;
+        if (symbolExists) {
+          std::string boundsDiagnostic;
+          truss.localGeometryBounds = GeometryBoundsResolver::Resolve(
+              resolvedSymbolPath, &boundsDiagnostic);
+          if (truss.localGeometryBounds) {
+            const bool legacyMetadataContext =
+                !hasGdtfMetadataAuthority &&
+                (truss.sourceRepresentation ==
+                     Truss::GeometryRepresentation::SymbolSymdef ||
+                 truss.sourceRepresentation ==
+                     Truss::GeometryRepresentation::Geometry3D);
+            ResolveTrussDimensionsFromGeometry(truss, legacyMetadataContext);
+          } else if (!boundsDiagnostic.empty()) {
+            importResult.diagnostics.push_back(
+                {"truss_geometry_bounds_unavailable",
+                 "Truss '" + truss.uuid + "' geometry bounds could not be measured: " +
+                     boundsDiagnostic});
+          }
+        }
         if (!symbolExists) {
           std::ostringstream reason;
           if (truss.symbolFile.empty()) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -368,11 +368,13 @@ add_executable(magnet_snap_test magnet_snap_test.cpp
     ../core/truss_attachment_candidates.cpp
     ../core/truss_screen_snap.cpp
     ../core/gdtf_archive_reader.cpp
+    ../core/geometry_bounds_resolver.cpp
     ../core/filesystem_path_utils.cpp
     ../core/scene_grouping.cpp ../core/scene_node_operations.cpp
     ../models/mvrscene.cpp
+    ../viewer3d/loader3ds.cpp ../viewer3d/loaderglb.cpp
 )
-target_include_directories(magnet_snap_test PRIVATE ../core ../models)
+target_include_directories(magnet_snap_test PRIVATE ../core ../models ../viewer3d ../third_party)
 target_link_libraries(magnet_snap_test PRIVATE tinyxml2::tinyxml2 ${wxWidgets_LIBRARIES})
 add_test(NAME MagnetSnapCore COMMAND magnet_snap_test)
 
@@ -1142,6 +1144,8 @@ set_library_env(MvrSupportUserDataRoundtrip)
 
 add_executable(mvr_perastage_metadata_recovery_test
                mvr_perastage_metadata_recovery_test.cpp
+               ../core/truss_attachment_candidates.cpp
+               ../core/gdtf_archive_reader.cpp
                build_info_stub.cpp
                ../core/configmanager.cpp ../core/configservices.cpp
                ../core/projectutils.cpp ../core/library/library_bootstrap.cpp
@@ -1932,10 +1936,13 @@ add_test(NAME GdtfLoaderPrimitiveFallback COMMAND gdtfloader_primitive_test)
 set_library_env(GdtfLoaderPrimitiveFallback)
 
 add_executable(loader3ds_native_dimensions_test loader3ds_native_dimensions_test.cpp
+               ../core/geometry_bounds_resolver.cpp
+               ../core/filesystem_path_utils.cpp
                ../viewer3d/loader3ds.cpp
+               ../viewer3d/loaderglb.cpp
                consolepanel_stub.cpp)
 target_include_directories(loader3ds_native_dimensions_test PRIVATE
-                           . ../viewer3d ../models ../gui ../third_party)
+                           . ../core ../viewer3d ../models ../gui ../third_party)
 target_link_libraries(loader3ds_native_dimensions_test PRIVATE ${wxWidgets_LIBRARIES})
 add_test(NAME Loader3dsNativeDimensions COMMAND loader3ds_native_dimensions_test)
 set_library_env(Loader3dsNativeDimensions)
@@ -2583,6 +2590,10 @@ foreach(perastage_geometry_target IN LISTS perastage_geometry_test_targets)
                            ../core/geometry_bounds_resolver.cpp
                            ../viewer3d/loader3ds.cpp
                            ../viewer3d/loaderglb.cpp)
+        endif()
+        if(NOT "../core/truss_dimension_resolution.cpp" IN_LIST perastage_geometry_sources)
+            target_sources(${perastage_geometry_target} PRIVATE
+                           ../core/truss_dimension_resolution.cpp)
         endif()
         target_include_directories(${perastage_geometry_target} PRIVATE ../viewer3d)
     endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -287,14 +287,17 @@ add_executable(trussloader_validation_test
                ../core/diagnostics/DiagnosticPaths.cpp
                ../core/filesystem_path_utils.cpp
                ../core/gdtf_mutation_audit.cpp
+               ../core/geometry_bounds_resolver.cpp
                ../core/logger.cpp
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/trussloader.cpp
                ../core/wx_path_utils.cpp
                ../models/truss.cpp)
+target_sources(trussloader_validation_test PRIVATE
+               ../viewer3d/loader3ds.cpp ../viewer3d/loaderglb.cpp)
 target_include_directories(trussloader_validation_test PRIVATE
-                           . ../core ../models ../third_party)
+                           . ../core ../models ../viewer3d ../third_party)
 target_link_libraries(trussloader_validation_test PRIVATE
                       ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
 add_test(NAME TrussLoaderValidation COMMAND trussloader_validation_test)
@@ -2567,3 +2570,20 @@ target_include_directories(fixture_geometry_bounds_test BEFORE PRIVATE
 target_include_directories(fixture_geometry_bounds_test PRIVATE
                            ../gui ../models)
 add_test(NAME FixtureGeometryBounds COMMAND fixture_geometry_bounds_test)
+
+# Reuse the production mesh parsers in every standalone test that owns truss loading/building.
+get_property(perastage_geometry_test_targets DIRECTORY PROPERTY BUILDSYSTEM_TARGETS)
+foreach(perastage_geometry_target IN LISTS perastage_geometry_test_targets)
+    get_target_property(perastage_geometry_sources ${perastage_geometry_target} SOURCES)
+    if(perastage_geometry_sources AND
+       ("../core/trussloader.cpp" IN_LIST perastage_geometry_sources OR
+        "../core/truss_gdtf_builder.cpp" IN_LIST perastage_geometry_sources))
+        if(NOT "../core/geometry_bounds_resolver.cpp" IN_LIST perastage_geometry_sources)
+            target_sources(${perastage_geometry_target} PRIVATE
+                           ../core/geometry_bounds_resolver.cpp
+                           ../viewer3d/loader3ds.cpp
+                           ../viewer3d/loaderglb.cpp)
+        endif()
+        target_include_directories(${perastage_geometry_target} PRIVATE ../viewer3d)
+    endif()
+endforeach()

--- a/tests/loader3ds_native_dimensions_test.cpp
+++ b/tests/loader3ds_native_dimensions_test.cpp
@@ -17,6 +17,7 @@
 #include <wx/init.h>
 
 #include "filesystem_path_utils.h"
+#include "geometry_bounds_resolver.h"
 #include "loader3ds.h"
 
 namespace fs = std::filesystem;
@@ -245,6 +246,21 @@ int main() {
                       {29.0f, 250.0f, 29.0f}, transformedError,
                       transformedDimensions);
         if (!nativeValid || !transformedValid) {
+          result = 1;
+        }
+
+        GeometryBoundsResolver::ClearForTesting();
+        const auto measuredBounds = GeometryBoundsResolver::Resolve(modelPath);
+        if (!measuredBounds ||
+            !NearlyEqual(measuredBounds->SizeMm()[0], nativeDimensions[0]) ||
+            !NearlyEqual(measuredBounds->SizeMm()[1], nativeDimensions[1]) ||
+            !NearlyEqual(measuredBounds->SizeMm()[2], nativeDimensions[2])) {
+          std::cerr << "bounds resolver does not match rendered native 3DS geometry\n";
+          result = 1;
+        }
+        const auto cachedBounds = GeometryBoundsResolver::Resolve(modelPath);
+        if (!cachedBounds || GeometryBoundsResolver::ParseCountForTesting() != 1) {
+          std::cerr << "bounds resolver did not reuse its unchanged-file cache\n";
           result = 1;
         }
 

--- a/tests/magnet_snap_test.cpp
+++ b/tests/magnet_snap_test.cpp
@@ -116,6 +116,16 @@ int main() {
                   (*longitudinal[0].worldDirection)[0] == -1.0f);
   CHECK_OR_RETURN(longitudinal[1].worldDirection &&
                   (*longitudinal[1].worldDirection)[0] == 1.0f);
+  GeometryBounds offsetBounds{{200.0f, -200.0f, -21.65f},
+                              {3200.0f, 200.0f, 371.65f}};
+  const auto offsetLongitudinal = truss_attachment::BuildInferredCandidates(
+      offsetBounds, MatrixUtils::Identity(), "offset-long");
+  CHECK_OR_RETURN(offsetLongitudinal.size() == 2);
+  CHECK_OR_RETURN(offsetLongitudinal[0].localTransform.o[0] == 200.0f);
+  CHECK_OR_RETURN(offsetLongitudinal[1].localTransform.o[0] == 3200.0f);
+  CHECK_OR_RETURN(std::fabs(offsetLongitudinal[0].localTransform.o[1]) < 0.001f);
+  CHECK_OR_RETURN(std::fabs(offsetLongitudinal[0].localTransform.o[2] - 175.0f) <
+                  0.001f);
   CHECK_OR_RETURN(
       truss_attachment::ClassifyLongitudinalAxis({3000, 400, 400}) == 0);
   CHECK_OR_RETURN(

--- a/tests/magnet_snap_test.cpp
+++ b/tests/magnet_snap_test.cpp
@@ -118,8 +118,9 @@ int main() {
                   (*longitudinal[1].worldDirection)[0] == 1.0f);
   GeometryBounds offsetBounds{{200.0f, -200.0f, -21.65f},
                               {3200.0f, 200.0f, 371.65f}};
-  const auto offsetLongitudinal = truss_attachment::BuildInferredCandidates(
-      offsetBounds, MatrixUtils::Identity(), "offset-long");
+  const auto offsetLongitudinal =
+      truss_attachment::BuildInferredCandidatesFromBounds(
+          offsetBounds, MatrixUtils::Identity(), "offset-long");
   CHECK_OR_RETURN(offsetLongitudinal.size() == 2);
   CHECK_OR_RETURN(offsetLongitudinal[0].localTransform.o[0] == 200.0f);
   CHECK_OR_RETURN(offsetLongitudinal[1].localTransform.o[0] == 3200.0f);

--- a/tests/mvr_perastage_metadata_recovery_test.cpp
+++ b/tests/mvr_perastage_metadata_recovery_test.cpp
@@ -3,7 +3,11 @@
  */
 #include <algorithm>
 #include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
 #include <filesystem>
+#include <fstream>
 #include <memory>
 #include <string>
 #include <tuple>
@@ -16,8 +20,73 @@
 
 #include "mvrimporter.h"
 #include "fixture_visual_color.h"
+#include "gdtf_archive_reader.h"
+#include "truss_attachment_candidates.h"
+#include "truss_dimension_resolution.h"
+#include "truss_gdtf_builder.h"
+#include <tinyxml2.h>
 
 namespace fs = std::filesystem;
+
+// Appends a little-endian integer to a binary test resource.
+template <typename T>
+static void AppendBinaryValue(std::vector<uint8_t> &out, T value) {
+  for (size_t index = 0; index < sizeof(T); ++index)
+    out.push_back(static_cast<uint8_t>((value >> (index * 8)) & 0xffu));
+}
+
+// Appends a little-endian float to a binary test resource.
+static void AppendBinaryFloat(std::vector<uint8_t> &out, float value) {
+  uint32_t bits = 0;
+  std::memcpy(&bits, &value, sizeof(value));
+  AppendBinaryValue(out, bits);
+}
+
+// Wraps a payload in a 3DS chunk header.
+static std::vector<uint8_t> Build3dsChunk(uint16_t id,
+                                          const std::vector<uint8_t> &payload) {
+  std::vector<uint8_t> result;
+  AppendBinaryValue<uint16_t>(result, id);
+  AppendBinaryValue<uint32_t>(result,
+                              static_cast<uint32_t>(payload.size() + 6));
+  result.insert(result.end(), payload.begin(), payload.end());
+  return result;
+}
+
+// Appends one nested 3DS chunk to a payload.
+static void Append3dsChunk(std::vector<uint8_t> &out, uint16_t id,
+                           const std::vector<uint8_t> &payload) {
+  const auto chunk = Build3dsChunk(id, payload);
+  out.insert(out.end(), chunk.begin(), chunk.end());
+}
+
+// Builds a minimal 3DS geometry with offset 3000 x 400 x 393.301 mm bounds.
+static std::string BuildTrussGeometry3ds() {
+  std::vector<uint8_t> vertices;
+  AppendBinaryValue<uint16_t>(vertices, 4);
+  const float points[] = {0.0f, -200.0f, -21.6506f,
+                          3000.0f, -200.0f, -21.6506f,
+                          0.0f, 200.0f, -21.6506f,
+                          0.0f, -200.0f, 371.6506f};
+  for (float value : points)
+    AppendBinaryFloat(vertices, value);
+  std::vector<uint8_t> faces;
+  AppendBinaryValue<uint16_t>(faces, 2);
+  const uint16_t faceData[] = {0, 1, 2, 0, 0, 2, 3, 0};
+  for (uint16_t value : faceData)
+    AppendBinaryValue<uint16_t>(faces, value);
+  std::vector<uint8_t> mesh;
+  Append3dsChunk(mesh, 0x4110, vertices);
+  Append3dsChunk(mesh, 0x4120, faces);
+  std::vector<uint8_t> object{'t', 'r', 'u', 's', 's', 0};
+  Append3dsChunk(object, 0x4100, mesh);
+  std::vector<uint8_t> editor;
+  Append3dsChunk(editor, 0x4000, object);
+  std::vector<uint8_t> root;
+  Append3dsChunk(root, 0x3D3D, editor);
+  const auto bytes = Build3dsChunk(0x4D4D, root);
+  return {reinterpret_cast<const char *>(bytes.data()), bytes.size()};
+}
 
 // Writes ordered ZIP entries without deduplicating their archive names.
 static void WriteArchive(
@@ -72,6 +141,112 @@ static void WriteMetadataArchive(const fs::path &path) {
       "<Truss uuid=\"40000000-0000-4000-8000-000000000001\" name=\"Truss\"><Matrix>1,0,0,0,1,0,0,0,1,0,0,0</Matrix><Geometries/><FixtureID>2</FixtureID><FixtureIDNumeric>2</FixtureIDNumeric><UserData><Data provider=\"Foreign\" ver=\"1.0\"><TrussInfo><Width>777</Width></TrussInfo></Data></UserData></Truss>"
       "</ChildList></Layer></Layers></Scene></GeneralSceneDescription>";
   WriteArchive(path, {{"GeneralSceneDescription.xml", xml}});
+}
+
+// Verifies geometry-backed MVR trusses recover legacy dimensions and endpoints.
+static void TestGeometryBackedTrussRecovery(const fs::path &tempDir) {
+  const fs::path archive = tempDir / "geometry-backed-trusses.mvr";
+  const std::string xml =
+      "<GeneralSceneDescription verMajor=\"1\" verMinor=\"6\" provider=\"Test\" providerVersion=\"1\">"
+      "<UserData><Data provider=\"Perastage\" ver=\"1.0\"><TrussInfoMap>"
+      "<TrussInfo uuid=\"40000000-0000-4000-8000-000000000010\"><Length>1000</Length><Width>400</Width><Height>400</Height><Representation>SymbolSymdef</Representation></TrussInfo>"
+      "<TrussInfo uuid=\"40000000-0000-4000-8000-000000000011\"><Length>1000</Length><Width>400</Width><Height>400</Height><Representation>Geometry3D</Representation></TrussInfo>"
+      "</TrussInfoMap></Data></UserData><Scene><AUXData>"
+      "<Symdef uuid=\"50000000-0000-4000-8000-000000000010\"><ChildList><Geometry3D fileName=\"truss.3ds\"><Matrix>1,0,0,0,1,0,0,0,1,200,0,0</Matrix></Geometry3D></ChildList></Symdef>"
+      "</AUXData><Layers><Layer uuid=\"10000000-0000-4000-8000-000000000001\" name=\"Default\"><ChildList>"
+      "<Truss uuid=\"40000000-0000-4000-8000-000000000010\" name=\"Symbol\"><Matrix>1,0,0,0,1,0,0,0,1,0,0,0</Matrix><Geometries><Symbol symdef=\"50000000-0000-4000-8000-000000000010\"><Matrix>1,0,0,0,1,0,0,0,1,100,0,0</Matrix></Symbol></Geometries></Truss>"
+      "<Truss uuid=\"40000000-0000-4000-8000-000000000011\" name=\"Direct\"><Matrix>1,0,0,0,1,0,0,0,1,0,0,0</Matrix><Geometries><Geometry3D fileName=\"truss.3ds\"><Matrix>1,0,0,0,1,0,0,0,1,0,0,0</Matrix></Geometry3D></Geometries></Truss>"
+      "</ChildList></Layer></Layers></Scene></GeneralSceneDescription>";
+  WriteArchive(archive, {{"GeneralSceneDescription.xml", xml},
+                         {"truss.3ds", BuildTrussGeometry3ds()}});
+  MvrImporter importer;
+  MvrImportResult result;
+  assert(importer.ImportFromFile(archive.string(), result,
+                                 MvrImportMode::ParseOnly, false, false));
+  for (const std::string uuid : {
+           "40000000-0000-4000-8000-000000000010",
+           "40000000-0000-4000-8000-000000000011"}) {
+    const Truss &truss = result.scene.trusses.at(uuid);
+    assert(truss.localGeometryBounds);
+    assert(std::fabs(truss.lengthMm - 3000.0f) < 0.01f);
+    assert(std::fabs(truss.widthMm - 400.0f) < 0.01f);
+    assert(std::fabs(truss.heightMm - 393.3012f) < 0.01f);
+    assert(truss.dimensionSource ==
+           Truss::DimensionSource::LegacySyntheticFallback);
+    const auto candidates =
+        truss_attachment::BuildInferredCandidatesFromBounds(
+            *truss.localGeometryBounds, truss.transform, truss.uuid);
+    assert(candidates.size() == 2);
+    assert(std::fabs(candidates[0].localTransform.o[0]) < 0.01f);
+    assert(std::fabs(candidates[1].localTransform.o[0] - 3000.0f) < 0.01f);
+    const float expectedWorldStart =
+        truss.sourceRepresentation == Truss::GeometryRepresentation::SymbolSymdef
+            ? 300.0f
+            : 0.0f;
+    assert(std::fabs(candidates[0].worldTransform.o[0] - expectedWorldStart) <
+           0.01f);
+    assert(std::fabs(candidates[1].worldTransform.o[0] -
+                     (expectedWorldStart + 3000.0f)) < 0.01f);
+  }
+  assert(result.scene.trusses.at("40000000-0000-4000-8000-000000000010")
+             .sourceRepresentation == Truss::GeometryRepresentation::SymbolSymdef);
+  assert(result.scene.trusses.at("40000000-0000-4000-8000-000000000011")
+             .sourceRepresentation == Truss::GeometryRepresentation::Geometry3D);
+
+  const fs::path generated = tempDir / "recovered-symbol.gdtf";
+  const fs::path retainedGeometry = tempDir / "retained-truss.3ds";
+  {
+    std::ofstream geometry(retainedGeometry, std::ios::binary);
+    const std::string bytes = BuildTrussGeometry3ds();
+    geometry.write(bytes.data(), static_cast<std::streamsize>(bytes.size()));
+  }
+  std::string buildError;
+  Truss recovered =
+      result.scene.trusses.at("40000000-0000-4000-8000-000000000010");
+  recovered.symbolFile = retainedGeometry.string();
+  assert(BuildTrussGdtfFromInstance(recovered, generated, &buildError));
+  const auto generatedArchive = gdtf::ReadGdtfArchive(generated.string());
+  assert(generatedArchive.Success());
+  tinyxml2::XMLDocument description;
+  assert(description.Parse(generatedArchive.descriptionXml.c_str()) ==
+         tinyxml2::XML_SUCCESS);
+  auto *model = description.FirstChildElement("GDTF")
+                    ->FirstChildElement("FixtureType")
+                    ->FirstChildElement("Models")
+                    ->FirstChildElement("Model");
+  assert(model);
+  assert(std::fabs(model->FloatAttribute("Length") - 3.0f) < 0.0001f);
+  assert(std::fabs(model->FloatAttribute("Width") - 0.4f) < 0.0001f);
+  assert(std::fabs(model->FloatAttribute("Height") - 0.3933012f) < 0.0001f);
+}
+
+// Verifies legitimate metadata and manual or GDTF authority are preserved.
+static void TestDimensionProvenancePolicy() {
+  const GeometryBounds bounds{{0.0f, -200.0f, 0.0f},
+                              {1000.0f, 200.0f, 400.0f}};
+  for (Truss::DimensionSource source : {
+           Truss::DimensionSource::PerastageMetadata,
+           Truss::DimensionSource::GdtfModel,
+           Truss::DimensionSource::ManualOverride}) {
+    Truss truss;
+    truss.lengthMm = 1000.0f;
+    truss.widthMm = 400.0f;
+    truss.heightMm = 400.0f;
+    truss.localGeometryBounds = bounds;
+    truss.dimensionSource = source;
+    assert(!ResolveTrussDimensionsFromGeometry(truss, true));
+    assert(truss.dimensionSource == source);
+  }
+
+  Truss partial;
+  partial.lengthMm = 0.0f;
+  partial.widthMm = 400.0f;
+  partial.heightMm = -1.0f;
+  partial.localGeometryBounds = bounds;
+  assert(ResolveTrussDimensionsFromGeometry(partial, false));
+  assert(partial.lengthMm == 1000.0f);
+  assert(partial.widthMm == 400.0f);
+  assert(partial.heightMm == 400.0f);
 }
 
 // Writes project-only fixture metadata covering supported recovery branches.
@@ -361,6 +536,8 @@ int main() {
   fs::remove_all(tempDir, ec);
   fs::create_directories(tempDir, ec);
   TestMetadataRecoveryMatrix(tempDir);
+  TestGeometryBackedTrussRecovery(tempDir);
+  TestDimensionProvenancePolicy();
   TestProjectFixtureMetadataRecovery(tempDir);
   TestLegacyFixtureColorRecovery(tempDir);
   TestAuxiliaryValuePolicy(tempDir);

--- a/tests/trussloader_validation_test.cpp
+++ b/tests/trussloader_validation_test.cpp
@@ -141,14 +141,15 @@ int main() {
   Truss truss;
   ok &= Check(IsSupportedTrussDefinitionExtension(ToUtf8String(glbPath)),
               "GLB extension was not recognized.");
-  ok &= Check(LoadTrussDefinition(ToUtf8String(glbPath), truss),
-              "direct GLB truss definition did not load.");
+  ok &= Check(!LoadTrussDefinition(ToUtf8String(glbPath), truss),
+              "malformed direct GLB truss definition unexpectedly loaded.");
   ok &= Check(truss.symbolFile == ToUtf8String(glbPath),
               "direct GLB symbol path changed unexpectedly.");
   ok &= Check(truss.modelFile == ToUtf8String(glbPath),
               "direct GLB model path changed unexpectedly.");
-  ok &= Check(truss.lengthMm > 0.0f && truss.widthMm > 0.0f && truss.heightMm > 0.0f,
-              "direct GLB dimensions were not populated.");
+  ok &= Check(truss.lengthMm == 0.0f && truss.widthMm == 0.0f &&
+                  truss.heightMm == 0.0f,
+              "malformed direct GLB received bogus dimensions.");
 
   Truss missingModel;
   ok &= Check(!LoadTrussDefinition(ToUtf8String(tempRoot / "missing.glb"), missingModel),

--- a/viewer3d/culling/bounds_cache_system.cpp
+++ b/viewer3d/culling/bounds_cache_system.cpp
@@ -256,11 +256,11 @@ void BoundsCacheSystem::RebuildIfDirty(
     }
 
     if (!found) {
-      float len = (t.lengthMm > 0 ? t.lengthMm : TrussDefaults::kFallbackLengthMm) *
+      float len = (t.lengthMm > 0 ? t.lengthMm : TrussDefaults::kViewerFallbackBoxLengthMm) *
                   RENDER_SCALE;
-      float halfy = (t.widthMm > 0 ? t.widthMm : TrussDefaults::kFallbackWidthMm) *
+      float halfy = (t.widthMm > 0 ? t.widthMm : TrussDefaults::kViewerFallbackBoxWidthMm) *
                     RENDER_SCALE * 0.5f;
-      float z1 = (t.heightMm > 0 ? t.heightMm : TrussDefaults::kFallbackHeightMm) *
+      float z1 = (t.heightMm > 0 ? t.heightMm : TrussDefaults::kViewerFallbackBoxHeightMm) *
                  RENDER_SCALE;
       std::array<std::array<float, 3>, 8> corners = {
           std::array<float, 3>{0.0f, -halfy, 0.0f},

--- a/viewer3d/loader3ds.cpp
+++ b/viewer3d/loader3ds.cpp
@@ -25,13 +25,10 @@
 #include <algorithm>
 #include <filesystem>
 #include <cmath>
-#include "consolepanel.h"
 #include <wx/wx.h>
 #include <wx/image.h>
 
 namespace fs = std::filesystem;
-
-constexpr bool kLog3dsMessages = false;
 
 struct Chunk {
     uint16_t id;
@@ -527,17 +524,5 @@ bool Load3DS(const std::string& path, Mesh& outMesh, bool applyObjectLocalTransf
         LoadTextureImage(modelDir, textureFilename, outMesh);
     if (ok)
         ComputeNormals(outMesh);
-    if (kLog3dsMessages && ConsolePanel::Instance()) {
-        if (ok) {
-            wxString msg = wxString::Format("3DS: %s -> v=%zu i=%zu",
-                                           wxString::FromUTF8(path),
-                                           outMesh.vertices.size()/3,
-                                           outMesh.indices.size()/3);
-            ConsolePanel::Instance()->AppendMessage(msg);
-        } else {
-            wxString msg = wxString::Format("3DS: parsed but empty %s", wxString::FromUTF8(path));
-            ConsolePanel::Instance()->AppendMessage(msg);
-        }
-    }
     return ok;
 }

--- a/viewer3d/loader3ds.h
+++ b/viewer3d/loader3ds.h
@@ -18,6 +18,9 @@
 #pragma once
 #include <string>
 #include "mesh.h"
+#include "mesh_geometry_conventions.h"
 
 // Loads a 3DS mesh and optionally applies per-object local pivot/basis transforms.
-bool Load3DS(const std::string& path, Mesh& outMesh, bool applyObjectLocalTransform = true, std::string* error = nullptr);
+bool Load3DS(const std::string& path, Mesh& outMesh,
+             bool applyObjectLocalTransform = viewer3d::kApplyThreeDsObjectTransforms,
+             std::string* error = nullptr);

--- a/viewer3d/loaderglb.cpp
+++ b/viewer3d/loaderglb.cpp
@@ -17,7 +17,6 @@
  */
 #include "loaderglb.h"
 #include "filesystem_path_utils.h"
-#include "consolepanel.h"
 #include "json.hpp"
 #include "matrixutils.h"
 #include <fstream>
@@ -31,8 +30,6 @@
 #include <wx/base64.h>
 #include <optional>
 #include <filesystem>
-
-constexpr bool kLogGlbMessages = false;
 
 using json = nlohmann::json;
 
@@ -180,12 +177,6 @@ bool LoadGLB(const std::string& path, Mesh& outMesh, std::string* error)
     std::string parseError;
     auto glbFile = ParseGLBFile(path, parseError);
     if (!glbFile) {
-        if (kLogGlbMessages && ConsolePanel::Instance()) {
-            ConsolePanel::Instance()->AppendMessage(
-                wxString::Format("GLB: %s (se omite carga - %s)",
-                                 wxString::FromUTF8(path),
-                                 wxString::FromUTF8(parseError)));
-        }
         if (error)
             *error = parseError;
         return false;
@@ -677,17 +668,5 @@ bool LoadGLB(const std::string& path, Mesh& outMesh, std::string* error)
     if (!ok && error)
         *error = "unsupported glTF structure or missing positions/indices";
 
-    if(kLogGlbMessages && ConsolePanel::Instance()) {
-        wxString msg;
-        if(ok) {
-            msg = wxString::Format("GLB: %s -> v=%zu i=%zu",
-                                   wxString::FromUTF8(path),
-                                   outMesh.vertices.size()/3,
-                                   outMesh.indices.size()/3);
-        } else {
-            msg = wxString::Format("GLB: parsed but empty %s", wxString::FromUTF8(path));
-        }
-        ConsolePanel::Instance()->AppendMessage(msg);
-    }
     return ok;
 }

--- a/viewer3d/mesh_geometry_conventions.h
+++ b/viewer3d/mesh_geometry_conventions.h
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace viewer3d {
+
+// Matches the established renderer convention for native MVR 3DS vertices.
+inline constexpr bool kApplyThreeDsObjectTransforms = false;
+
+} // namespace viewer3d

--- a/viewer3d/render/opaque_truss_pass.cpp
+++ b/viewer3d/render/opaque_truss_pass.cpp
@@ -188,11 +188,11 @@ void OpaqueTrussPass::Render(
     }
 
     float trussLengthMm =
-        (t.lengthMm > 0 ? t.lengthMm : TrussDefaults::kFallbackLengthMm);
+        (t.lengthMm > 0 ? t.lengthMm : TrussDefaults::kViewerFallbackBoxLengthMm);
     float trussWidthMm =
-        (t.widthMm > 0 ? t.widthMm : TrussDefaults::kFallbackWidthMm);
+        (t.widthMm > 0 ? t.widthMm : TrussDefaults::kViewerFallbackBoxWidthMm);
     float trussHeightMm =
-        (t.heightMm > 0 ? t.heightMm : TrussDefaults::kFallbackHeightMm);
+        (t.heightMm > 0 ? t.heightMm : TrussDefaults::kViewerFallbackBoxHeightMm);
     const auto trussWorldDimensionsMm = ComputeWorldTrussDimensionsMm(
         t.transform, trussLengthMm, trussWidthMm, trussHeightMm);
     float trussLen = trussWorldDimensionsMm[0] * RENDER_SCALE;

--- a/viewer3d/resources/mesh_processing.h
+++ b/viewer3d/resources/mesh_processing.h
@@ -5,13 +5,14 @@
 
 #include "gdtf_geometry_types.h"
 #include "mesh.h"
+#include "mesh_geometry_conventions.h"
 
 namespace viewer3d::resources {
 
 struct MeshProcessingOptions {
   bool enableMeshOptimization = true;
   bool enableDiskCache = true;
-  bool applyThreeDsObjectTransforms = false;
+  bool applyThreeDsObjectTransforms = viewer3d::kApplyThreeDsObjectTransforms;
 };
 
 void OptimizeMeshForRuntime(Mesh &mesh);


### PR DESCRIPTION
### Motivation

- Remove the legacy assumption that raw `.3ds`/`.glb` truss geometry can be represented by a fixed 1000×400×400 mm fallback and ensure measured geometry is authoritative when available.
- Provide a small, GUI-independent geometry bounds value+resolver that can be reused by loaders, importers, GDTF generation, and attachment inference without duplicating parser logic.
- Preserve precedence: keep valid GDTF Model dimensions authoritative, recover missing/invalid dimensions from measured geometry, and conservatively repair legacy synthetic fallbacks only when provenance indicates a raw/legacy source.

### Description

- Added a small value type `GeometryBounds` that preserves local `minMm`/`maxMm`, and exposes `IsValid()`, `SizeMm()` and `CenterMm()`; file: `models/geometry_bounds.h`.
- Implemented `GeometryBoundsResolver` (cache + resolver) that reuses the existing mesh loaders `Load3DS` and `LoadGLB`, measures vertex positions in renderer millimetres, and caches by normalized path, size and last-write timestamp; files: `core/geometry_bounds_resolver.h` and `core/geometry_bounds_resolver.cpp`.
- Plumbed measured bounds into truss loading and metadata recovery: `LoadTrussDefinition()` and `LoadTrussGdtf()` populate `Truss::localGeometryBounds` and only derive `lengthMm/widthMm/heightMm` from the measured bounds when the GDTF-provided values are missing/invalid; file: `core/trussloader.cpp` and `models/truss.h`.
- Normalized GDTF generation: `BuildFromSourceData()` now resolves geometry bounds via the resolver and recovers missing/invalid dimensions before writing `description.xml`, and will repair legacy synthetic `1000×400×400` dimensions only when the source is clearly a raw/native geometry resource; file: `core/truss_gdtf_builder.cpp`.
- Attachment inference now prefers true measured local min/max terminal planes and centers (instead of inferring end planes from an assumed origin); added an overload of `BuildInferredCandidates` that accepts `GeometryBounds` and updated candidate resolution to use `Truss::localGeometryBounds` when present; files: `core/truss_attachment_candidates.cpp` / `.h`.
- Tests and build glue: updated test CMake settings to include the new resolver and reuse production mesh parsers for test binaries that exercise truss loading; added an offset-origin case to `tests/magnet_snap_test.cpp` to assert inferred endpoints use measured min/max planes and center-derived Z; adjusted `tests/trussloader_validation_test.cpp` expectations for malformed direct-model loads; changes to `tests/CMakeLists.txt`.
- Documentation and release notes updated to describe the new bounds resolver, cache behaviour, precedence rules, and that measured runtime bounds are runtime-only data (docs: `docs/developer/truss_attachment_candidates.md`, `docs/release-notes-draft.md`).

### Testing

- Ran repository checks: `git diff --check` (no whitespace/verification issues) and the mandatory project checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`; all passed.
- Exercised CMake/test build configuration in this environment but full test binaries could not be built because the environment lacks the platform `wxWidgets` development libraries (CMake reported missing `wxWidgets_LIBRARIES`/include dirs), so `trussloader_validation_test` and `magnet_snap_test` were not produced here.
- Updated/added test sources and assertions: `tests/magnet_snap_test.cpp` gained the non-zero-local-origin/offset bounds assertions; `tests/trussloader_validation_test.cpp` expectations adjusted for malformed direct-model handling; `tests/CMakeLists.txt` updated to link the resolver and production mesh parsers into relevant test targets.
- Note: in a CI environment with `wxWidgets` available the following should be run and must pass: `trussloader_validation_test`, `magnet_snap_test`, and the added/modified regression checks that validate geometry-derived dimensions, legacy-recovery, and inferred attachment endpoints.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7cc9ec3d40832496d31f9d77a7015a)