### PR TITLE
Fix truss Magnet guidance rendering

### DIFF
--- a/core/magnet_snap.cpp
+++ b/core/magnet_snap.cpp
@@ -591,27 +591,9 @@ struct JointMatch {
   std::size_t second = 0;
 };
 
-// Builds real unoccupied member candidates for a truss group.
-std::vector<truss_attachment::Candidate>
-BuildGroupCandidatesImpl(const MvrScene &scene, const Bounds &bounds,
-                         const std::string &groupUuid,
-                         truss_attachment::CandidateResolver &resolver) {
-  std::vector<std::string> memberUuids;
-  CollectGroupTrussUuids(scene, groupUuid, memberUuids);
-  std::sort(memberUuids.begin(), memberUuids.end());
-  memberUuids.erase(std::unique(memberUuids.begin(), memberUuids.end()),
-                    memberUuids.end());
-  std::vector<truss_attachment::Candidate> candidates;
-  for (const std::string &uuid : memberUuids) {
-    const auto trussIt = scene.trusses.find(uuid);
-    if (trussIt == scene.trusses.end())
-      continue;
-    auto memberCandidates =
-        truss_attachment::BuildCandidates(scene, trussIt->second, resolver)
-            .candidates;
-    candidates.insert(candidates.end(), memberCandidates.begin(),
-                      memberCandidates.end());
-  }
+// Removes connector candidates already paired with an opposing nearby truss connector.
+std::vector<truss_attachment::Candidate> FilterOccupiedCandidates(
+    std::vector<truss_attachment::Candidate> candidates) {
   std::sort(candidates.begin(), candidates.end(),
             [](const auto &left, const auto &right) {
               return std::tie(left.ownerTrussUuid, left.stableId) <
@@ -660,7 +642,33 @@ BuildGroupCandidatesImpl(const MvrScene &scene, const Bounds &bounds,
     if (!occupied[index])
       exposed.push_back(candidates[index]);
   }
-  if (!candidates.empty())
+  return exposed;
+}
+
+// Builds real unoccupied member candidates for a truss group.
+std::vector<truss_attachment::Candidate>
+BuildGroupCandidatesImpl(const MvrScene &scene, const Bounds &bounds,
+                         const std::string &groupUuid,
+                         truss_attachment::CandidateResolver &resolver) {
+  std::vector<std::string> memberUuids;
+  CollectGroupTrussUuids(scene, groupUuid, memberUuids);
+  std::sort(memberUuids.begin(), memberUuids.end());
+  memberUuids.erase(std::unique(memberUuids.begin(), memberUuids.end()),
+                    memberUuids.end());
+  std::vector<truss_attachment::Candidate> candidates;
+  for (const std::string &uuid : memberUuids) {
+    const auto trussIt = scene.trusses.find(uuid);
+    if (trussIt == scene.trusses.end())
+      continue;
+    auto memberCandidates =
+        truss_attachment::BuildCandidates(scene, trussIt->second, resolver)
+            .candidates;
+    candidates.insert(candidates.end(), memberCandidates.begin(),
+                      memberCandidates.end());
+  }
+  const bool hasMemberCandidates = !candidates.empty();
+  auto exposed = FilterOccupiedCandidates(std::move(candidates));
+  if (hasMemberCandidates)
     return exposed;
 
   Matrix insertionTransform = bounds.transform;
@@ -703,11 +711,15 @@ BuildAnchorReferences(const MvrScene &scene, const SnapSource &source,
 
   if (source.type == ObjectType::Truss ||
       source.type == ObjectType::TrussGroup) {
+    std::vector<truss_attachment::Candidate> candidates;
     for (const auto &[uuid, truss] : scene.trusses) {
       (void)uuid;
-      appendCandidates(
-          truss_attachment::BuildCandidates(scene, truss, resolver).candidates);
+      auto trussCandidates =
+          truss_attachment::BuildCandidates(scene, truss, resolver).candidates;
+      candidates.insert(candidates.end(), trussCandidates.begin(),
+                        trussCandidates.end());
     }
+    appendCandidates(FilterOccupiedCandidates(std::move(candidates)));
     return references;
   }
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -50,6 +50,10 @@ Changes since **v1.5.0**.
   expose their real unoccupied member connectors, and straight extensions
   choose the non-overlapping end when approaching an assembly from either side.
 
+- Magnet guidance now hides truss connectors that are already joined. Fixture
+  attachment paths remain consistently vivid red in Sketch mode and no longer
+  produce unbounded lines when a path crosses behind the 3D camera.
+
 - Added **Selection & Movement** preferences for choosing, independently for
   fixtures, trusses, supports/hoists, and scene objects, whether mouse,
   command-bar, and Magnet transforms move an exact grouped object or its

--- a/tests/magnet_snap_test.cpp
+++ b/tests/magnet_snap_test.cpp
@@ -159,6 +159,17 @@ int main() {
   CHECK_OR_RETURN(anchorReferences.front().positionMm[0] == 100.0f);
   CHECK_OR_RETURN(anchorReferences.front().direction.has_value());
 
+  SetStage("occupied anchor references");
+  MvrScene joinedAnchorScene;
+  AddTruss(joinedAnchorScene, "joined-left", 0.0f);
+  AddTruss(joinedAnchorScene, "joined-right", 3000.0f);
+  const auto freeAnchorReferences = magnet_snap::BuildAnchorReferences(
+      joinedAnchorScene, {magnet_snap::ObjectType::Truss, "joined-left"},
+      anchorResolver);
+  CHECK_OR_RETURN(freeAnchorReferences.size() == 2);
+  CHECK_OR_RETURN(freeAnchorReferences.front().positionMm[0] == 0.0f);
+  CHECK_OR_RETURN(freeAnchorReferences.back().positionMm[0] == 6000.0f);
+
   SceneObject referenceObject;
   referenceObject.uuid = "reference-object";
   referenceObject.transform = Translated(500.0f, 0.0f, 0.0f);

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -780,6 +780,10 @@ std::optional<std::array<float, 2>> ProjectWorldToFramebuffer(
                    viewport, &winX, &winY, &winZ) != GL_TRUE) {
         return std::nullopt;
     }
+    if (!std::isfinite(winX) || !std::isfinite(winY) ||
+        !std::isfinite(winZ) || winZ < 0.0 || winZ > 1.0) {
+        return std::nullopt;
+    }
     return std::array<float, 2>{static_cast<float>(winX),
                                 static_cast<float>(winY)};
 }

--- a/viewer_common/magnet_anchor_overlay.cpp
+++ b/viewer_common/magnet_anchor_overlay.cpp
@@ -16,8 +16,17 @@ void DrawFixtureAttachmentPathOverlay(
   glGetFloatv(GL_LINE_WIDTH, &previousLineWidth);
   glGetFloatv(GL_CURRENT_COLOR, previousColor);
   const GLboolean depthEnabled = glIsEnabled(GL_DEPTH_TEST);
+  const GLboolean lightingEnabled = glIsEnabled(GL_LIGHTING);
+  const GLboolean textureEnabled = glIsEnabled(GL_TEXTURE_2D);
+  const GLboolean scissorEnabled = glIsEnabled(GL_SCISSOR_TEST);
+  GLint previousScissorBox[4] = {};
+  glGetIntegerv(GL_SCISSOR_BOX, previousScissorBox);
   if (depthEnabled)
     glDisable(GL_DEPTH_TEST);
+  glDisable(GL_LIGHTING);
+  glDisable(GL_TEXTURE_2D);
+  glEnable(GL_SCISSOR_TEST);
+  glScissor(0, 0, framebufferWidth, framebufferHeight);
   glMatrixMode(GL_PROJECTION);
   glPushMatrix();
   glLoadIdentity();
@@ -39,6 +48,14 @@ void DrawFixtureAttachmentPathOverlay(
   glMatrixMode(GL_MODELVIEW);
   if (depthEnabled)
     glEnable(GL_DEPTH_TEST);
+  if (lightingEnabled)
+    glEnable(GL_LIGHTING);
+  if (textureEnabled)
+    glEnable(GL_TEXTURE_2D);
+  if (!scissorEnabled)
+    glDisable(GL_SCISSOR_TEST);
+  glScissor(previousScissorBox[0], previousScissorBox[1],
+            previousScissorBox[2], previousScissorBox[3]);
   glLineWidth(previousLineWidth);
   glColor4fv(previousColor);
 }


### PR DESCRIPTION
### Motivation

- Fix visual errors in Magnet guidance so only truly free truss connector anchors are shown, fixture attachment path overlays remain a consistent red regardless of scene lighting, and projected overlay lines do not extend to infinity when points project behind or produce invalid framebuffer coordinates.

### Description

- Added `FilterOccupiedCandidates` to `core/magnet_snap.cpp` and reused it to filter out occupied/paired truss connector candidates for both group candidate building and anchor-reference generation. 
- Updated `viewer_common/magnet_anchor_overlay.cpp` to draw fixture attachment paths and anchor overlays with lighting and texturing disabled and confined to the framebuffer via a scissor box so the red overlay is visually unchanged by scene lights or textures.
- Hardened projection logic in `viewer3d/viewer3dpanel.cpp::ProjectWorldToFramebuffer` to reject non-finite results and behind-camera (`winZ` out-of-range) projections to prevent unbounded overlay lines.
- Added a regression test in `tests/magnet_snap_test.cpp` that exercises joined trusses and verifies only the remaining free anchors are exposed, and updated `docs/release-notes-draft.md` with a short note about these fixes.

### Testing

- `tests/check_perastage_tree_modules.sh` succeeded. 
- `tests/check_no_configmanager_get_in_gui.sh` succeeded. 
- `git diff --check` passed (no whitespace or index issues detected). 
- CMake configure / building of `magnet_snap_test` could not be completed in this environment because `wxWidgets` is not available, so the new unit test was added but the compiled test run is blocked by the missing dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7f84772e588324af60d1663036792b)