### PR TITLE
Skip automatic symbol generation for fallback-only GDTFs

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -7,7 +7,8 @@ Changes since **v1.5.0**.
 - Fixture profiles that contain neither stored symbols nor usable GDTF
   geometry now use Perastage's deterministic runtime fallback directly. This
   avoids repeated symbol preparation delays when opening projects while
-  preserving automatic symbol generation for renderable fixture profiles.
+  preserving reliable automatic symbol generation for renderable fixture
+  profiles across supported build environments.
 
 ## New features and workflow improvements
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -4,6 +4,11 @@ Changes since **v1.5.0**.
 
 ## Highlights
 
+- Fixture profiles that contain neither stored symbols nor usable GDTF
+  geometry now use Perastage's deterministic runtime fallback directly. This
+  avoids repeated symbol preparation delays when opening projects while
+  preserving automatic symbol generation for renderable fixture profiles.
+
 ## New features and workflow improvements
 
 - Added a unified fixture distribution dialog on `Alt+D`. Alongside the

--- a/gui/services/fixture_symbol_preparation_service.cpp
+++ b/gui/services/fixture_symbol_preparation_service.cpp
@@ -18,6 +18,7 @@
 #include "symbols/fixture_symbol_resource_revision.h"
 #include "tools/scene_model_symbol_capture_service.h"
 #include "tools/symbol_physical_calibration.h"
+#include "fixture_symbol_source.h"
 #include "viewer2doffscreenrenderer.h"
 #include "windows/symbol_fixture_applier.h"
 
@@ -64,6 +65,7 @@ void FixtureSymbolPreparationService::BeginProjectEpoch(bool scheduleScan) {
   epoch_ = coordinator_.BeginProjectEpoch();
   work_.clear();
   manualWork_.clear();
+  fallbackDiagnostics_.clear();
   currentKey_.reset();
   stepScheduled_ = false;
   UpdateStatus();
@@ -95,11 +97,21 @@ void FixtureSymbolPreparationService::Request(
     if (manualKey == key)
       return;
   }
-  if (symbol_cache::InspectFixtureSymbolAvailability(key.effectiveGdtfPath)
-          .storedSvgUsable) {
+  const auto source = symbols::InspectFixtureSymbolSource(
+      key.effectiveGdtfPath, key.exactGdtfMode);
+  if (source.source == symbols::FixtureSymbolSource::StoredGdtfSvg) {
     diagnostics::DiagnosticLogger::Info(
         "Fixture symbol preparation skipped because required SVGs are valid for resource '" +
         key.effectiveGdtfPath + "' mode '" + key.exactGdtfMode + "'.");
+    return;
+  }
+  if (source.source == symbols::FixtureSymbolSource::PerastageFallback) {
+    if (fallbackDiagnostics_.insert(key).second) {
+      diagnostics::DiagnosticLogger::Info(
+          "Fixture symbol generation skipped for resource '" +
+          key.effectiveGdtfPath + "' mode '" + key.exactGdtfMode +
+          "': " + source.diagnostic);
+    }
     return;
   }
   const std::string fixtureUuid = FindFixtureUuid(key);
@@ -229,14 +241,24 @@ void FixtureSymbolPreparationService::RunNextStep() {
       if (fixtureIt != scene.fixtures.end() &&
           fixtures::ResolveFixtureGdtfDeterministic(fixtureIt->second, scene,
                                                     resolution, resolutionError,
-                                                    "symbol-reinspect") &&
-          symbol_cache::InspectFixtureSymbolAvailability(resolution.selectedPath)
-              .storedSvgUsable) {
-        coordinator_.Skip(*currentKey_, epoch_);
-        currentKey_.reset();
-        UpdateStatus();
-        ScheduleNextStep();
-        return;
+                                                    "symbol-reinspect")) {
+        const auto source = symbols::InspectFixtureSymbolSource(
+            resolution.selectedPath, currentKey_->exactGdtfMode);
+        if (source.source !=
+            symbols::FixtureSymbolSource::RenderableGdtfGeometry) {
+          if (source.source == symbols::FixtureSymbolSource::PerastageFallback &&
+              fallbackDiagnostics_.insert(*currentKey_).second) {
+            diagnostics::DiagnosticLogger::Info(
+                "Fixture symbol generation skipped during reinspection: " +
+                source.diagnostic);
+          }
+          coordinator_.Skip(*currentKey_, epoch_);
+          work_.erase(*currentKey_);
+          currentKey_.reset();
+          UpdateStatus();
+          ScheduleNextStep();
+          return;
+        }
       }
     }
     if (!coordinator_.BeginCapture(*currentKey_, epoch_)) {

--- a/gui/services/fixture_symbol_preparation_service.h
+++ b/gui/services/fixture_symbol_preparation_service.h
@@ -5,6 +5,7 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "symbols/FixtureSymbolDiagnostics.h"
@@ -68,6 +69,9 @@ private:
       work_;
   std::unordered_map<std::string, symbols::FixtureSymbolPreparationKey>
       manualWork_;
+  std::unordered_set<symbols::FixtureSymbolPreparationKey,
+                     symbols::FixtureSymbolPreparationKeyHash>
+      fallbackDiagnostics_;
   std::shared_ptr<int> lifetime_ = std::make_shared<int>(0);
   std::uint64_t epoch_ = 0;
   bool stepScheduled_ = false;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -146,6 +146,7 @@ if(BASH_EXECUTABLE)
     add_bash_policy_test(LayoutProjectLoadCacheReset ${CMAKE_CURRENT_SOURCE_DIR}/check_layout_project_load_cache_reset.sh)
     add_bash_policy_test(FixtureSymbolSvgCacheBoundary ${CMAKE_CURRENT_SOURCE_DIR}/check_fixture_symbol_svg_cache_boundary.sh)
     add_bash_policy_test(FixtureSymbolAvailabilityBoundary ${CMAKE_CURRENT_SOURCE_DIR}/check_fixture_symbol_availability_boundary.sh)
+    add_bash_policy_test(FixtureSymbolSourceArchitecture ${CMAKE_CURRENT_SOURCE_DIR}/check_fixture_symbol_source_architecture.sh)
     add_bash_policy_test(FixtureSymbolCaptureIsolation ${CMAKE_CURRENT_SOURCE_DIR}/check_fixture_symbol_capture_isolation.sh)
     add_bash_policy_test(FixtureSymbolPreparationArchitecture ${CMAKE_CURRENT_SOURCE_DIR}/check_fixture_symbol_preparation_architecture.sh)
     add_bash_policy_test(FixtureSymbol3DRefresh ${CMAKE_CURRENT_SOURCE_DIR}/check_fixture_symbol_3d_refresh.sh)
@@ -1972,6 +1973,32 @@ target_include_directories(gdtfloader_primitive_test PRIVATE
 target_link_libraries(gdtfloader_primitive_test PRIVATE ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2 perastage_test_gdtf_archive_reader)
 add_test(NAME GdtfLoaderPrimitiveFallback COMMAND gdtfloader_primitive_test)
 set_library_env(GdtfLoaderPrimitiveFallback)
+
+add_executable(fixture_symbol_source_test fixture_symbol_source_test.cpp
+               build_info_stub.cpp
+               ../viewer3d/resources/fixture_symbol_source.cpp
+               ../viewer3d/gdtfloader.cpp
+               ../viewer3d/loader3ds.cpp
+               ../viewer3d/loaderglb.cpp
+               ../viewer3d/meshprimitives.cpp
+               ../core/symbols/fixture_symbol_availability.cpp
+               ../core/symbols/fixture_symbol_svg_cache.cpp
+               ../core/symbols/fixture_symbol_resource_revision.cpp
+               ../core/symbols/PerastageSvgSymbol.cpp
+               ../core/filesystem_path_utils.cpp
+               ../core/runtime_storage.cpp
+               ../core/logger.cpp
+               ../core/gdtf_canonicalizer.cpp
+               ../core/gdtf_mutation_audit.cpp
+               consolepanel_stub.cpp)
+target_include_directories(fixture_symbol_source_test PRIVATE
+                           . ../core ../viewer3d ../viewer3d/resources
+                           ../models ../gui ../third_party)
+target_link_libraries(fixture_symbol_source_test PRIVATE
+                      ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2
+                      perastage_test_gdtf_archive_reader)
+add_test(NAME FixtureSymbolSource COMMAND fixture_symbol_source_test)
+set_library_env(FixtureSymbolSource)
 
 add_executable(loader3ds_native_dimensions_test loader3ds_native_dimensions_test.cpp
                ../core/geometry_bounds_resolver.cpp

--- a/tests/check_fixture_symbol_source_architecture.sh
+++ b/tests/check_fixture_symbol_source_architecture.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+classifier="$root/viewer3d/resources/fixture_symbol_source.cpp"
+service="$root/gui/services/fixture_symbol_preparation_service.cpp"
+fallback="$root/viewer3d/render/fixture_fallback_visual.cpp"
+renderer="$root/viewer3d/render/opaque_fixture_pass.cpp"
+
+rg -q 'LoadGdtf\(physicalGdtfPath, objects, exactGdtfMode' "$classifier"
+rg -q 'InspectFixtureSymbolSource' "$service"
+rg -q 'FixtureCubeMesh' "$fallback"
+if rg -q 'FallbackFixtureCubeMesh' "$renderer"; then
+  echo "Renderer must use the shared Perastage fixture fallback visual." >&2
+  exit 1
+fi
+
+echo "Fixture symbol source classification and fallback ownership remain centralized."

--- a/tests/check_fixture_symbol_source_architecture.sh
+++ b/tests/check_fixture_symbol_source_architecture.sh
@@ -8,6 +8,7 @@ fallback="$root/viewer3d/render/fixture_fallback_visual.cpp"
 renderer="$root/viewer3d/render/opaque_fixture_pass.cpp"
 
 rg -q 'LoadGdtf\(physicalGdtfPath, objects, exactGdtfMode' "$classifier"
+rg -q '#include "\.\./gdtfloader\.h"' "$classifier"
 rg -q 'InspectFixtureSymbolSource' "$service"
 rg -q 'FixtureCubeMesh' "$fallback"
 if rg -q 'FallbackFixtureCubeMesh' "$renderer"; then

--- a/tests/fixture_symbol_source_test.cpp
+++ b/tests/fixture_symbol_source_test.cpp
@@ -1,0 +1,114 @@
+#include "fixture_symbol_source.h"
+
+#include <cassert>
+#include <filesystem>
+#include <string>
+
+#include <wx/filename.h>
+#include <wx/wfstream.h>
+class wxZipStreamLink;
+#include <wx/zipstrm.h>
+
+namespace {
+
+// Creates a temporary GDTF archive from one fixture-type XML body.
+std::string MakeGdtf(const std::string &fixtureBody,
+                     bool includeStoredSymbols = false) {
+  wxFileName temporary(wxFileName::CreateTempFileName("symbol_source_"));
+  const std::string path = temporary.GetFullPath().ToStdString() + ".gdtf";
+  wxRemoveFile(temporary.GetFullPath());
+  wxFFileOutputStream file(path);
+  wxZipOutputStream archive(file);
+  archive.PutNextEntry("description.xml");
+  const std::string xml =
+      "<?xml version=\"1.0\"?><GDTF DataVersion=\"1.2\"><FixtureType "
+      "Name=\"SourceTest\">" +
+      fixtureBody + "</FixtureType></GDTF>";
+  archive.Write(xml.data(), xml.size());
+  if (includeStoredSymbols) {
+    const std::string svg =
+        "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 10 10\">"
+        "<polygon points=\"0,0 10,0 10,10\"/></svg>";
+    for (const std::string entry : {"models/svg/Base.svg",
+                                    "models/svg/Base_bottom.svg",
+                                    "models/svg_front/Base.svg",
+                                    "models/svg_side/Base.svg"}) {
+      archive.PutNextEntry(entry);
+      archive.Write(svg.data(), svg.size());
+    }
+  }
+  archive.Close();
+  return path;
+}
+
+// Verifies mode-specific classification without treating runtime fallback as geometry.
+int RunClassificationChecks() {
+  const std::string placeholder = MakeGdtf(
+      "<Models><Model Name=\"Base\"/></Models><Geometries><Geometry "
+      "Name=\"Root\" Model=\"Base\"/></Geometries><DMXModes><DMXMode "
+      "Name=\"Standard\" Geometry=\"Root\"/></DMXModes>");
+  const auto placeholderResult =
+      symbols::InspectFixtureSymbolSource(placeholder, "Standard");
+  assert(placeholderResult.source ==
+         symbols::FixtureSymbolSource::PerastageFallback);
+  assert(!placeholderResult.renderableGeometry);
+
+  const std::string stored = MakeGdtf(
+      "<Models><Model Name=\"Base\"/></Models><Geometries><Geometry "
+      "Name=\"Root\" Model=\"Base\"/></Geometries><DMXModes><DMXMode "
+      "Name=\"Standard\" Geometry=\"Root\"/></DMXModes>",
+      true);
+  const auto storedResult =
+      symbols::InspectFixtureSymbolSource(stored, "Standard");
+  assert(storedResult.source == symbols::FixtureSymbolSource::StoredGdtfSvg);
+
+  const std::string primitive = MakeGdtf(
+      "<Models><Model Name=\"Base\" PrimitiveType=\"Cube\"/></Models>"
+      "<Geometries><Geometry Name=\"Root\" Model=\"Base\"/></Geometries>"
+      "<DMXModes><DMXMode Name=\"Standard\" Geometry=\"Root\"/>"
+      "</DMXModes>");
+  const auto primitiveResult =
+      symbols::InspectFixtureSymbolSource(primitive, "Standard");
+  assert(primitiveResult.source ==
+         symbols::FixtureSymbolSource::RenderableGdtfGeometry);
+
+  const std::string dimensions = MakeGdtf(
+      "<Models><Model Name=\"Base\" Length=\"0.4\" Width=\"0.3\" "
+      "Height=\"0.2\"/></Models><Geometries><Geometry Name=\"Root\" "
+      "Model=\"Base\"/></Geometries><DMXModes><DMXMode Name=\"Standard\" "
+      "Geometry=\"Root\"/></DMXModes>");
+  assert(symbols::InspectFixtureSymbolSource(dimensions, "Standard").source ==
+         symbols::FixtureSymbolSource::RenderableGdtfGeometry);
+
+  const std::string brokenFile = MakeGdtf(
+      "<Models><Model Name=\"Base\" File=\"missing\"/></Models>"
+      "<Geometries><Geometry Name=\"Root\" Model=\"Base\"/></Geometries>"
+      "<DMXModes><DMXMode Name=\"Standard\" Geometry=\"Root\"/>"
+      "</DMXModes>");
+  assert(symbols::InspectFixtureSymbolSource(brokenFile, "Standard").source ==
+         symbols::FixtureSymbolSource::PerastageFallback);
+
+  const std::string modes = MakeGdtf(
+      "<Models><Model Name=\"Real\" PrimitiveType=\"Cube\"/><Model "
+      "Name=\"Empty\"/></Models><Geometries><Geometry Name=\"RealRoot\" "
+      "Model=\"Real\"/><Geometry Name=\"EmptyRoot\" Model=\"Empty\"/>"
+      "</Geometries><DMXModes><DMXMode Name=\"RealMode\" "
+      "Geometry=\"RealRoot\"/><DMXMode Name=\"EmptyMode\" "
+      "Geometry=\"EmptyRoot\"/></DMXModes>");
+  assert(symbols::InspectFixtureSymbolSource(modes, "RealMode").source ==
+         symbols::FixtureSymbolSource::RenderableGdtfGeometry);
+  assert(symbols::InspectFixtureSymbolSource(modes, "EmptyMode").source ==
+         symbols::FixtureSymbolSource::PerastageFallback);
+
+  for (const auto &path :
+       {placeholder, stored, primitive, dimensions, brokenFile, modes}) {
+    std::error_code error;
+    std::filesystem::remove(path, error);
+  }
+  return 0;
+}
+
+} // namespace
+
+// Runs fixture symbol source regression checks.
+int main() { return RunClassificationChecks(); }

--- a/viewer3d/CMakeLists.txt
+++ b/viewer3d/CMakeLists.txt
@@ -15,6 +15,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/picking/picking_coordinate_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/gl_primitive_renderer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/base_pass_framebuffer_cache.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/render/fixture_fallback_visual.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/hoist_symbol_renderer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/lighting_profile.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/opaque_fixture_pass.cpp
@@ -30,6 +31,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/render/viewer3d_render_style.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/scenerenderer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/resources/mesh_processing.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/resources/fixture_symbol_source.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/resources/resource_path_search.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/resources/resource_sync_system.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/viewer3dcamera.cpp

--- a/viewer3d/render/fixture_fallback_visual.cpp
+++ b/viewer3d/render/fixture_fallback_visual.cpp
@@ -1,0 +1,31 @@
+#include "fixture_fallback_visual.h"
+
+namespace viewer3d::fallback {
+
+// Returns the canonical Perastage-owned emergency fixture cube.
+const Mesh &FixtureCubeMesh() {
+  static const Mesh mesh = []() {
+    Mesh cube;
+    cube.vertices = {
+        -0.5f, -0.5f, -0.5f, 0.5f,  -0.5f, -0.5f,
+        0.5f,  0.5f,  -0.5f, -0.5f, 0.5f,  -0.5f,
+        -0.5f, -0.5f, 0.5f,  0.5f,  -0.5f, 0.5f,
+        0.5f,  0.5f,  0.5f,  -0.5f, 0.5f,  0.5f};
+    cube.indices = {0, 1, 2, 0, 2, 3, 4, 6, 5, 4, 7, 6,
+                    0, 4, 5, 0, 5, 1, 3, 2, 6, 3, 6, 7,
+                    0, 3, 7, 0, 7, 4, 1, 5, 6, 1, 6, 2};
+    ComputeNormals(cube);
+    return cube;
+  }();
+  return mesh;
+}
+
+// Returns the deterministic square shared by every orthographic cube projection.
+const FixtureProjectionOutline &FixtureOrthographicOutline() {
+  static constexpr FixtureProjectionOutline outline = {
+      std::array<float, 2>{-0.5f, -0.5f}, {0.5f, -0.5f},
+      {0.5f, 0.5f}, {-0.5f, 0.5f}};
+  return outline;
+}
+
+} // namespace viewer3d::fallback

--- a/viewer3d/render/fixture_fallback_visual.h
+++ b/viewer3d/render/fixture_fallback_visual.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <array>
+
+#include "mesh.h"
+
+namespace viewer3d::fallback {
+
+using FixtureProjectionOutline = std::array<std::array<float, 2>, 4>;
+
+const Mesh &FixtureCubeMesh();
+const FixtureProjectionOutline &FixtureOrthographicOutline();
+
+} // namespace viewer3d::fallback

--- a/viewer3d/render/opaque_fixture_pass.cpp
+++ b/viewer3d/render/opaque_fixture_pass.cpp
@@ -30,6 +30,7 @@
 
 #include "configmanager.h"
 #include "fixture_mesh_color.h"
+#include "fixture_fallback_visual.h"
 #include "logger.h"
 #include "matrixutils.h"
 #include "mesh.h"
@@ -70,33 +71,6 @@ std::string BuildFixtureSymbolModelKey(const Fixture &fixture,
   if (modelKey.empty())
     modelKey = "unknown";
   return modelKey;
-}
-
-const Mesh &FallbackFixtureCubeMesh() {
-  static const Mesh mesh = []() {
-    Mesh cube;
-    cube.vertices = {
-        -0.5f, -0.5f, -0.5f, // 0
-        0.5f,  -0.5f, -0.5f, // 1
-        0.5f,  0.5f,  -0.5f, // 2
-        -0.5f, 0.5f,  -0.5f, // 3
-        -0.5f, -0.5f, 0.5f,  // 4
-        0.5f,  -0.5f, 0.5f,  // 5
-        0.5f,  0.5f,  0.5f,  // 6
-        -0.5f, 0.5f,  0.5f   // 7
-    };
-    cube.indices = {
-        0, 1, 2, 0, 2, 3, // back
-        4, 6, 5, 4, 7, 6, // front
-        0, 4, 5, 0, 5, 1, // bottom
-        3, 2, 6, 3, 6, 7, // top
-        0, 3, 7, 0, 7, 4, // left
-        1, 5, 6, 1, 6, 2  // right
-    };
-    ComputeNormals(cube);
-    return cube;
-  }();
-  return mesh;
 }
 
 struct SvgSymbolCacheKey {
@@ -713,7 +687,7 @@ void OpaqueFixturePass::Render(
           glPopMatrix();
         }
       } else {
-        DrawMeshSolidForPick(FallbackFixtureCubeMesh(), 0.2f, fixture, uuid,
+        DrawMeshSolidForPick(viewer3d::fallback::FixtureCubeMesh(), 0.2f, fixture, uuid,
                              gdtfPath, "fallback-cube");
       }
       glPopMatrix();
@@ -1019,7 +993,7 @@ void OpaqueFixturePass::Render(
                     context.whiteModelStyle &&
                     !controller.IsSketchRenderStyleEnabled();
                 controller.DrawMeshWithOutline(
-                    FallbackFixtureCubeMesh(), r, g, b, 0.2f, false, false,
+                    viewer3d::fallback::FixtureCubeMesh(), r, g, b, 0.2f, false, false,
                     false, 0.0f, 0.0f, 0.0f, fallbackWireframe, mode,
                     [](const std::array<float, 3> &p) { return p; },
                     fallbackUnlit);
@@ -1099,7 +1073,7 @@ void OpaqueFixturePass::Render(
                                    context.whiteModelStyle &&
                                    !controller.IsSketchRenderStyleEnabled();
         controller.DrawMeshWithOutline(
-            FallbackFixtureCubeMesh(), r, g, b, 0.2f, highlight, groupHighlight,
+            viewer3d::fallback::FixtureCubeMesh(), r, g, b, 0.2f, highlight, groupHighlight,
             selected, cx, cy, cz, fallbackWireframe, mode, applyFixtureCapture,
             fallbackUnlit, matrix, false, context.selectionOverlayPass);
         ++drawCalls;
@@ -1152,7 +1126,7 @@ void OpaqueFixturePass::Render(
         }
       } else {
         AddFixtureInstancedDraw(
-            fixtureInstancedBatches, FallbackFixtureCubeMesh(), r, g, b, false,
+            fixtureInstancedBatches, viewer3d::fallback::FixtureCubeMesh(), r, g, b, false,
             wireframe, mode, 0.2f, cx, cy, cz, matrix, nullptr, matrix);
       }
       glPopMatrix();
@@ -1201,7 +1175,7 @@ void OpaqueFixturePass::Render(
         }
       } else {
         AddFixtureInstancedDraw(
-            fixtureInstancedBatches, FallbackFixtureCubeMesh(), r, g, b, false,
+            fixtureInstancedBatches, viewer3d::fallback::FixtureCubeMesh(), r, g, b, false,
             wireframe, mode, 0.2f, cx, cy, cz, matrix, nullptr, matrix);
       }
     } else {

--- a/viewer3d/resources/fixture_symbol_source.cpp
+++ b/viewer3d/resources/fixture_symbol_source.cpp
@@ -3,7 +3,7 @@
 #include <utility>
 #include <vector>
 
-#include "gdtfloader.h"
+#include "../gdtfloader.h"
 #include "symbols/fixture_symbol_availability.h"
 
 namespace symbols {

--- a/viewer3d/resources/fixture_symbol_source.cpp
+++ b/viewer3d/resources/fixture_symbol_source.cpp
@@ -1,0 +1,40 @@
+#include "fixture_symbol_source.h"
+
+#include <utility>
+#include <vector>
+
+#include "gdtfloader.h"
+#include "symbols/fixture_symbol_availability.h"
+
+namespace symbols {
+
+// Classifies the authoritative symbol source for one resolved GDTF and exact mode.
+FixtureSymbolSourceInspection
+InspectFixtureSymbolSource(const std::string &physicalGdtfPath,
+                           const std::string &exactGdtfMode) {
+  const auto availability =
+      symbol_cache::InspectFixtureSymbolAvailability(physicalGdtfPath);
+  if (availability.storedSvgUsable) {
+    return {FixtureSymbolSource::StoredGdtfSvg, true, false,
+            "The GDTF contains a complete usable stored SVG set."};
+  }
+
+  std::vector<GdtfObject> objects;
+  std::string geometryDiagnostic;
+  if (LoadGdtf(physicalGdtfPath, objects, exactGdtfMode,
+               &geometryDiagnostic) &&
+      !objects.empty()) {
+    return {FixtureSymbolSource::RenderableGdtfGeometry, false, true,
+            "The selected GDTF mode provides renderable geometry."};
+  }
+
+  std::string diagnostic =
+      "The selected GDTF mode has no renderable geometry; using the "
+      "Perastage runtime fallback symbol.";
+  if (!geometryDiagnostic.empty())
+    diagnostic += " " + geometryDiagnostic;
+  return {FixtureSymbolSource::PerastageFallback, false, false,
+          std::move(diagnostic)};
+}
+
+} // namespace symbols

--- a/viewer3d/resources/fixture_symbol_source.h
+++ b/viewer3d/resources/fixture_symbol_source.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <string>
+
+namespace symbols {
+
+enum class FixtureSymbolSource {
+  StoredGdtfSvg,
+  RenderableGdtfGeometry,
+  PerastageFallback
+};
+
+struct FixtureSymbolSourceInspection {
+  FixtureSymbolSource source = FixtureSymbolSource::PerastageFallback;
+  bool storedSvgUsable = false;
+  bool renderableGeometry = false;
+  std::string diagnostic;
+};
+
+FixtureSymbolSourceInspection
+InspectFixtureSymbolSource(const std::string &physicalGdtfPath,
+                           const std::string &exactGdtfMode);
+
+} // namespace symbols


### PR DESCRIPTION
### Motivation
- Prevent repeated expensive automatic symbol capture/vectorization for GDTFs that do not provide any renderable geometry while keeping stored GDTF SVGs authoritative. 
- Provide a centralized, testable eligibility classifier so the automatic pipeline only runs when the selected exact DMX mode actually yields renderable GDTF geometry. 
- Make the Perastage runtime fallback explicit and reusable so the renderer and symbol code reuse the same deterministic visual instead of rasterizing and vectorizing a rendered cube. 

### Description
- Added a centralized classifier API `symbols::InspectFixtureSymbolSource(...)` and `symbols::FixtureSymbolSource` (values: `StoredGdtfSvg`, `RenderableGdtfGeometry`, `PerastageFallback`) that inspects exact physical GDTF path + mode, reuses `LoadGdtf` for canonical geometry interpretation, and returns a concise diagnostic. (new: `viewer3d/resources/fixture_symbol_source.{h,cpp}`)
- Updated `FixtureSymbolPreparationService` to consult the classifier before queuing automatic work and during reinspection so only `RenderableGdtfGeometry` jobs are enqueued; `StoredGdtfSvg` is skipped and `PerastageFallback` is never queued and emits a single deduplicated informational diagnostic per resource+mode/epoch. (modified: `gui/services/fixture_symbol_preparation_service.{cpp,h}`)
- Extracted the renderer's emergency cube into a shared deterministic runtime fallback module providing the canonical cube mesh and its orthographic projection outline, and wired the renderer to use it instead of an internal local fallback. (new: `viewer3d/render/fixture_fallback_visual.{h,cpp}`, updated: `viewer3d/render/opaque_fixture_pass.cpp`)
- Added regression and architecture tests that exercise the classifier and ownership boundaries, and updated build/test registration and release notes. (added: `tests/fixture_symbol_source_test.cpp`, `tests/check_fixture_symbol_source_architecture.sh`, updated: `tests/CMakeLists.txt`, `docs/release-notes-draft.md`, and `viewer3d/CMakeLists.txt`)
- Preserved existing behavior for: stored GDTF SVGs (still authoritative), renderable GDTF geometry (still auto-generates and publishes), manual preview/apply (unchanged), and no mutation of source GDTF data is performed by the runtime fallback. 

### Testing
- Ran repository policy and architecture checks which passed: `tests/check_perastage_tree_modules.sh`, `tests/check_no_configmanager_get_in_gui.sh`, `tests/check_fixture_symbol_preparation_architecture.sh`, `tests/check_fixture_symbol_availability_boundary.sh`, and the new `tests/check_fixture_symbol_source_architecture.sh` all succeeded. 
- Performed a smoke compile of the new fallback module with `g++ -std=c++20 -Iviewer3d -Iviewer3d/render -c viewer3d/render/fixture_fallback_visual.cpp` which succeeded. 
- Verified `bash -n tests/check_fixture_symbol_source_architecture.sh` and the classifier-based checks locally; these succeeded. 
- CMake configuration and building of the focused test executables could not be completed in this environment because the system lacked the wxWidgets development libraries, so the new unit test binary (`FixtureSymbolSource`) was not built here; test sources and CMake integration are included for CI where wxWidgets is available. 
- The change includes a release-note entry in `docs/release-notes-draft.md` describing the user-visible reliability improvement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a88e88bd14c8324819260d7e4517f7a)