### PR TITLE
Startup pipeline: deterministic restore, single-pass cache transfer, lazy viewports, and InteractiveReady profiling

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -68,6 +68,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/print/PageSetup.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/print/Viewer2DPrintSettings.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/projectutils.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/startup_profile.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/rigging_extra_weight_settings.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/riderimporter.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/scene_grouping.cpp

--- a/core/configmanager.cpp
+++ b/core/configmanager.cpp
@@ -693,6 +693,12 @@ ConfigManager::GetLoadedProjectArchiveResources() const {
   return projectSession.GetLoadedArchiveResources();
 }
 
+// Attaches startup instrumentation to the owned project session.
+void ConfigManager::SetStartupMetrics(
+    std::shared_ptr<startup::Metrics> metrics) {
+  projectSession.SetStartupMetrics(std::move(metrics));
+}
+
 // Resets configuration and scene state for a fresh project.
 void ConfigManager::Reset() {
   RevisionGuard guard(*this);

--- a/core/configmanager.cpp
+++ b/core/configmanager.cpp
@@ -687,6 +687,12 @@ bool ConfigManager::LoadProject(const std::string &path,
   return ok;
 }
 
+// Returns optional resources transferred by the most recent primary project archive load.
+const std::vector<ProjectSession::ArchiveResource> &
+ConfigManager::GetLoadedProjectArchiveResources() const {
+  return projectSession.GetLoadedArchiveResources();
+}
+
 // Resets configuration and scene state for a fresh project.
 void ConfigManager::Reset() {
   RevisionGuard guard(*this);

--- a/core/configmanager.h
+++ b/core/configmanager.h
@@ -48,6 +48,8 @@ public:
     const std::string& GetLastProjectSaveError() const;
     bool LoadProject(const std::string& path,
                      LoadProjectProgressCallback progressCallback = {});
+    const std::vector<ProjectSession::ArchiveResource> &
+    GetLoadedProjectArchiveResources() const;
     void SetProjectArchiveResourceProvider(ProjectArchiveResourceProvider provider);
     // Save/load configuration file (e.g., JSON, INI, TXT…)
     bool LoadFromFile(const std::string& path);

--- a/core/configmanager.h
+++ b/core/configmanager.h
@@ -50,6 +50,7 @@ public:
                      LoadProjectProgressCallback progressCallback = {});
     const std::vector<ProjectSession::ArchiveResource> &
     GetLoadedProjectArchiveResources() const;
+    void SetStartupMetrics(std::shared_ptr<startup::Metrics> metrics);
     void SetProjectArchiveResourceProvider(ProjectArchiveResourceProvider provider);
     // Save/load configuration file (e.g., JSON, INI, TXT…)
     bool LoadFromFile(const std::string& path);

--- a/core/configservices.cpp
+++ b/core/configservices.cpp
@@ -2,6 +2,7 @@
 #include "filesystem_path_utils.h"
 #include "apppaths.h"
 #include "logger.h"
+#include "startup_profile.h"
 
 #include "json.hpp"
 
@@ -128,16 +129,6 @@ private:
   std::filesystem::path path;
   bool created = false;
 };
-
-bool LooksLikeZipFile(const std::string &path) {
-  std::ifstream file(PathFromUtf8(path), std::ios::binary);
-  if (!file.is_open())
-    return false;
-  unsigned char signature[2] = {};
-  file.read(reinterpret_cast<char *>(signature), sizeof(signature));
-  return file.gcount() == static_cast<std::streamsize>(sizeof(signature)) &&
-         signature[0] == 'P' && signature[1] == 'K';
-}
 
 bool LooksLikeJsonFile(const std::string &path) {
   std::ifstream file(PathFromUtf8(path), std::ios::binary);
@@ -1020,6 +1011,7 @@ bool ProjectSession::LoadProject(const std::string &path,
   if (!loadConfig || !loadScene)
     return false;
   loadedArchiveResources.clear();
+  const auto archiveStartedAt = std::chrono::steady_clock::now();
 
   auto reportProgress = [&](const std::string &stage, int completed = 0,
                             int total = 0) {
@@ -1029,15 +1021,27 @@ bool ProjectSession::LoadProject(const std::string &path,
 
   reportProgress("Opening project package...");
 
-  if (!LooksLikeZipFile(path)) {
+  if (startupMetrics)
+    ++startupMetrics->projectOpenAttempts;
+  wxFileInputStream in(WxStringFromPath(PathFromUtf8(path)));
+  if (!in.IsOk())
+    return false;
+  if (startupMetrics)
+    ++startupMetrics->projectOpenSuccesses;
+  unsigned char signature[2] = {};
+  in.Read(signature, sizeof(signature));
+  const bool isZip = in.LastRead() == sizeof(signature) &&
+                     signature[0] == 'P' && signature[1] == 'K';
+  in.SeekI(0);
+  if (!isZip) {
     if (LooksLikeJsonFile(path))
       return loadConfig(path);
     return false;
   }
 
-  wxFileInputStream in(WxStringFromPath(PathFromUtf8(path)));
-  if (!in.IsOk())
-    return false;
+  if (startupMetrics) {
+    ++startupMetrics->archiveTraversals;
+  }
   wxZipInputStream zip(in);
 
   TempDir tempDir("psp_");
@@ -1076,19 +1080,32 @@ bool ProjectSession::LoadProject(const std::string &path,
         constexpr size_t kMaxTransferredCacheEntryBytes = 8 * 1024 * 1024;
         std::vector<std::uint8_t> bytes;
         std::array<char, 4096> buffer{};
-        while (bytes.size() <= kMaxTransferredCacheEntryBytes) {
+        bool entryOversized = false;
+        while (true) {
           zip.Read(buffer.data(), buffer.size());
           const size_t count = zip.LastRead();
           if (count == 0)
             break;
-          bytes.insert(bytes.end(), buffer.begin(), buffer.begin() + count);
+          if (!entryOversized &&
+              bytes.size() + count <= kMaxTransferredCacheEntryBytes) {
+            bytes.insert(bytes.end(), buffer.begin(), buffer.begin() + count);
+          } else {
+            entryOversized = true;
+          }
         }
         constexpr size_t kMaxTransferredCacheBytes = 24 * 1024 * 1024;
-        if (bytes.size() <= kMaxTransferredCacheEntryBytes &&
+        if (!entryOversized &&
             transferredCacheBytes + bytes.size() <=
                 kMaxTransferredCacheBytes) {
           transferredCacheBytes += bytes.size();
           loadedArchiveResources.push_back({entryName, std::move(bytes)});
+          if (startupMetrics) {
+            ++startupMetrics->cacheEntriesTransferred;
+            startupMetrics->cacheBytesTransferred +=
+                loadedArchiveResources.back().bytes.size();
+          }
+        } else if (startupMetrics) {
+          ++startupMetrics->cacheEntriesRejected;
         }
       }
       continue;
@@ -1101,6 +1118,14 @@ bool ProjectSession::LoadProject(const std::string &path,
       configPath = outPath;
     else
       scenePath = outPath;
+
+    if (baseName == "scene.mvr" && startupMetrics) {
+      std::error_code sizeError;
+      const auto sceneSize = fs::file_size(outPath, sizeError);
+      if (!sizeError)
+        startupMetrics->sceneMvrBytes = static_cast<size_t>(sceneSize);
+      ++startupMetrics->sceneMvrWrites;
+    }
 
     ++extractedRelevantEntries;
     reportProgress("Extracting project package...", extractedRelevantEntries,
@@ -1118,7 +1143,14 @@ bool ProjectSession::LoadProject(const std::string &path,
   bool ok = true;
   if (!scenePath.empty()) {
     reportProgress("Importing project scene...");
+    const auto mvrRestoreStartedAt = std::chrono::steady_clock::now();
     const bool sceneOk = loadScene(scenePath.string());
+    if (startupMetrics) {
+      startupMetrics->mvrRestoreMs =
+          std::chrono::duration_cast<std::chrono::milliseconds>(
+              std::chrono::steady_clock::now() - mvrRestoreStartedAt)
+              .count();
+    }
     if (!sceneOk) {
       std::cerr << "ProjectSession::LoadProject failed while loading scene.mvr from extracted project package." << std::endl;
     }
@@ -1134,6 +1166,12 @@ bool ProjectSession::LoadProject(const std::string &path,
     }
     ok &= configOk;
   }
+  if (startupMetrics) {
+    startupMetrics->projectArchiveLoadMs =
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - archiveStartedAt)
+            .count();
+  }
   return ok;
 }
 
@@ -1141,6 +1179,12 @@ bool ProjectSession::LoadProject(const std::string &path,
 const std::vector<ProjectSession::ArchiveResource> &
 ProjectSession::GetLoadedArchiveResources() const {
   return loadedArchiveResources;
+}
+
+// Attaches the application-owned startup measurement context to project loading.
+void ProjectSession::SetStartupMetrics(
+    std::shared_ptr<startup::Metrics> metrics) {
+  startupMetrics = std::move(metrics);
 }
 
 bool ProjectSession::IsDirty() const { return revision != savedRevision; }

--- a/core/configservices.cpp
+++ b/core/configservices.cpp
@@ -6,6 +6,7 @@
 #include "json.hpp"
 
 #include <algorithm>
+#include <array>
 #include <cctype>
 #include <cerrno>
 #include <chrono>
@@ -1018,6 +1019,7 @@ bool ProjectSession::LoadProject(const std::string &path,
                                  const LoadProgressFn &progress) {
   if (!loadConfig || !loadScene)
     return false;
+  loadedArchiveResources.clear();
 
   auto reportProgress = [&](const std::string &stage, int completed = 0,
                             int total = 0) {
@@ -1050,6 +1052,7 @@ bool ProjectSession::LoadProject(const std::string &path,
   fs::path scenePath;
   bool hasMvrSceneXml = false;
   int extractedRelevantEntries = 0;
+  size_t transferredCacheBytes = 0;
 
   while ((entry.reset(zip.GetNextEntry())), entry) {
     if (entry->IsDir())
@@ -1068,6 +1071,25 @@ bool ProjectSession::LoadProject(const std::string &path,
       if (IsLayoutImageResourceEntry(entryName) &&
           IsSafeArchiveRelativePath(entryName)) {
         ExtractCurrentZipEntry(zip, resourceDir / fs::path(entryName));
+      } else if (entryName.rfind("resources/layout_view_cache/", 0) == 0 &&
+                 IsSafeArchiveRelativePath(entryName)) {
+        constexpr size_t kMaxTransferredCacheEntryBytes = 8 * 1024 * 1024;
+        std::vector<std::uint8_t> bytes;
+        std::array<char, 4096> buffer{};
+        while (bytes.size() <= kMaxTransferredCacheEntryBytes) {
+          zip.Read(buffer.data(), buffer.size());
+          const size_t count = zip.LastRead();
+          if (count == 0)
+            break;
+          bytes.insert(bytes.end(), buffer.begin(), buffer.begin() + count);
+        }
+        constexpr size_t kMaxTransferredCacheBytes = 24 * 1024 * 1024;
+        if (bytes.size() <= kMaxTransferredCacheEntryBytes &&
+            transferredCacheBytes + bytes.size() <=
+                kMaxTransferredCacheBytes) {
+          transferredCacheBytes += bytes.size();
+          loadedArchiveResources.push_back({entryName, std::move(bytes)});
+        }
       }
       continue;
     }
@@ -1113,6 +1135,12 @@ bool ProjectSession::LoadProject(const std::string &path,
     ok &= configOk;
   }
   return ok;
+}
+
+// Returns optional project-owned resources captured during the primary archive traversal.
+const std::vector<ProjectSession::ArchiveResource> &
+ProjectSession::GetLoadedArchiveResources() const {
+  return loadedArchiveResources;
 }
 
 bool ProjectSession::IsDirty() const { return revision != savedRevision; }

--- a/core/configservices.h
+++ b/core/configservices.h
@@ -9,6 +9,9 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+#include <memory>
+
+namespace startup { struct Metrics; }
 #include "mvrscene.h"
 
 inline constexpr const char *DEFAULT_LAYER_NAME = "No Layer";
@@ -188,6 +191,7 @@ public:
                    const LoadSceneFn &loadScene,
                    const LoadProgressFn &progress = {});
   const std::vector<ArchiveResource> &GetLoadedArchiveResources() const;
+  void SetStartupMetrics(std::shared_ptr<startup::Metrics> metrics);
 
   bool IsDirty() const;
   DirtyState CaptureDirtyState() const;
@@ -204,6 +208,7 @@ private:
   MvrScene scene;
   std::string extractedResourceDirectory;
   std::vector<ArchiveResource> loadedArchiveResources;
+  std::shared_ptr<startup::Metrics> startupMetrics;
   size_t revision = 0;
   size_t savedRevision = 0;
 };

--- a/core/configservices.h
+++ b/core/configservices.h
@@ -187,6 +187,7 @@ public:
   bool LoadProject(const std::string &path, const LoadConfigFn &loadConfig,
                    const LoadSceneFn &loadScene,
                    const LoadProgressFn &progress = {});
+  const std::vector<ArchiveResource> &GetLoadedArchiveResources() const;
 
   bool IsDirty() const;
   DirtyState CaptureDirtyState() const;
@@ -202,6 +203,7 @@ private:
 
   MvrScene scene;
   std::string extractedResourceDirectory;
+  std::vector<ArchiveResource> loadedArchiveResources;
   size_t revision = 0;
   size_t savedRevision = 0;
 };

--- a/core/layoutviewpresets.cpp
+++ b/core/layoutviewpresets.cpp
@@ -24,12 +24,16 @@ const std::vector<LayoutViewPreset> kLayoutViewPresets = {
     {
         "3d_layout_view",
         {
-            "FileToolbar",
-            "EditToolbar",
-            "LayoutViewsToolbar",
-            "LayoutToolbar",
+            "3DViewport",
+            "DataNotebook",
+            "Console",
+            "LayerPanel",
+            "SummaryPanel",
+            "RiggingPanel",
         },
         {
+            "2DViewport",
+            "2DRenderOptions",
             "LayoutPanel",
             "LayoutViewer",
         },
@@ -37,12 +41,16 @@ const std::vector<LayoutViewPreset> kLayoutViewPresets = {
     {
         "2d_layout_view",
         {
-            "FileToolbar",
-            "EditToolbar",
-            "LayoutViewsToolbar",
-            "LayoutToolbar",
+            "2DViewport",
+            "2DRenderOptions",
+            "DataNotebook",
+            "Console",
+            "LayerPanel",
+            "SummaryPanel",
+            "RiggingPanel",
         },
         {
+            "3DViewport",
             "LayoutPanel",
             "LayoutViewer",
         },
@@ -52,10 +60,6 @@ const std::vector<LayoutViewPreset> kLayoutViewPresets = {
         {
             "LayoutPanel",
             "LayoutViewer",
-            "FileToolbar",
-            "EditToolbar",
-            "LayoutToolbar",
-            "LayoutViewsToolbar",
         },
         {
             "3DViewport",

--- a/core/projectutils.cpp
+++ b/core/projectutils.cpp
@@ -192,6 +192,30 @@ fs::path GetResourceRoot()
     return {};
 }
 
+// Resolves a relative resource path against one validated application resource root.
+fs::path ResolveResourcePathFromRoot(const fs::path& resourceRoot,
+                                     const fs::path& relativePath)
+{
+    if (relativePath.empty() || relativePath.is_absolute())
+        return {};
+
+    std::error_code ec;
+    if (!resourceRoot.empty()) {
+        const fs::path directCandidate = resourceRoot / relativePath;
+        if (fs::exists(directCandidate, ec) && !ec)
+            return directCandidate;
+        ec.clear();
+
+        if (resourceRoot.filename() == "resources") {
+            const fs::path parentCandidate =
+                resourceRoot.parent_path() / relativePath;
+            if (fs::exists(parentCandidate, ec) && !ec)
+                return parentCandidate;
+        }
+    }
+    return {};
+}
+
 // Resolves a relative resource path by checking nested and base resource roots with compatibility fallbacks.
 fs::path ResolveResourcePath(const fs::path& relativePath)
 {
@@ -199,20 +223,10 @@ fs::path ResolveResourcePath(const fs::path& relativePath)
         return {};
 
     std::error_code ec;
-    const fs::path root = GetResourceRoot();
-    if (!root.empty()) {
-        const fs::path directCandidate = root / relativePath;
-        if (fs::exists(directCandidate, ec) && !ec)
-            return directCandidate;
-        ec.clear();
-
-        if (root.filename() == "resources") {
-            const fs::path parentCandidate = root.parent_path() / relativePath;
-            if (fs::exists(parentCandidate, ec) && !ec)
-                return parentCandidate;
-            ec.clear();
-        }
-    }
+    if (const fs::path resolved =
+            ResolveResourcePathFromRoot(GetResourceRoot(), relativePath);
+        !resolved.empty())
+        return resolved;
 
     const wxString resourcesDir = wxStandardPaths::Get().GetResourcesDir();
     if (!resourcesDir.empty()) {

--- a/core/projectutils.h
+++ b/core/projectutils.h
@@ -47,6 +47,9 @@ namespace ProjectUtils {
 
     // Resolves a resource relative path against known runtime roots and returns an existing file when found.
     std::filesystem::path ResolveResourcePath(const std::filesystem::path& relativePath);
+    std::filesystem::path ResolveResourcePathFromRoot(
+        const std::filesystem::path& resourceRoot,
+        const std::filesystem::path& relativePath);
 
     // Returns true when a directory exists (or can be created) and accepts writes.
     bool IsDirectoryWritable(const std::filesystem::path& dir);

--- a/core/startup_profile.cpp
+++ b/core/startup_profile.cpp
@@ -1,0 +1,84 @@
+#include "startup_profile.h"
+
+namespace startup {
+
+// Resolves the heavyweight viewport required by a semantic saved view mode.
+ViewportRequirement
+ResolveViewportRequirement(const std::string &viewMode,
+                           const std::string *legacyPerspective) {
+  if (viewMode == "3d_layout_view")
+    return ViewportRequirement::Viewer3D;
+  if (viewMode == "2d_layout_view")
+    return ViewportRequirement::Viewer2D;
+  if (viewMode == "layout_mode_view")
+    return ViewportRequirement::None;
+
+  if (legacyPerspective) {
+    if (legacyPerspective->find("2DViewport") != std::string::npos ||
+        legacyPerspective->find("2DRenderOptions") != std::string::npos)
+      return ViewportRequirement::Viewer2D;
+    if (legacyPerspective->find("3DViewport") != std::string::npos)
+      return ViewportRequirement::Viewer3D;
+  }
+  return ViewportRequirement::Viewer3D;
+}
+
+// Invokes only the lazy viewport factory required by the resolved view mode.
+ViewportRequirement
+PrepareRequiredViewport(const std::string &viewMode,
+                        const std::string *legacyPerspective,
+                        const std::function<void()> &ensure2D,
+                        const std::function<void()> &ensure3D) {
+  const ViewportRequirement requirement =
+      ResolveViewportRequirement(viewMode, legacyPerspective);
+  if (requirement == ViewportRequirement::Viewer2D && ensure2D)
+    ensure2D();
+  else if (requirement == ViewportRequirement::Viewer3D && ensure3D)
+    ensure3D();
+  return requirement;
+}
+
+// Formats the stable final startup record for every diagnostic sink.
+std::string FormatInteractiveReadySummary(const Metrics &metrics,
+                                          long long durationMs) {
+  return "StartupProfile event=InteractiveReady duration_ms=" +
+         std::to_string(durationMs) + " view_mode=" +
+         (metrics.finalViewMode.empty() ? "unknown" : metrics.finalViewMode) +
+         " active_layout=" +
+         (metrics.finalActiveLayout.empty() ? "none"
+                                            : metrics.finalActiveLayout) +
+         " apply_saved_layout=" +
+         std::to_string(metrics.applySavedLayoutCalls) +
+         " aui_load_perspective=" +
+         std::to_string(metrics.auiPerspectiveLoads) +
+         " aui_updates=" + std::to_string(metrics.auiUpdates) +
+         " activate_layout=" + std::to_string(metrics.activateLayoutCalls) +
+         " ensure_3d=" + std::to_string(metrics.ensure3DCalls) +
+         " construct_3d=" + std::to_string(metrics.viewer3DConstructions) +
+         " ensure_2d=" + std::to_string(metrics.ensure2DCalls) +
+         " construct_2d=" + std::to_string(metrics.viewer2DConstructions) +
+         " table_reloads=" + std::to_string(metrics.fixtureReloads) + "," +
+         std::to_string(metrics.trussReloads) + "," +
+         std::to_string(metrics.hoistReloads) + "," +
+         std::to_string(metrics.sceneObjectReloads) +
+         " layer_reloads=" + std::to_string(metrics.layerReloads) +
+         " pstg_open_attempts=" + std::to_string(metrics.projectOpenAttempts) +
+         " pstg_open_successes=" +
+         std::to_string(metrics.projectOpenSuccesses) +
+         " archive_traversals=" + std::to_string(metrics.archiveTraversals) +
+         " cache_entries=" + std::to_string(metrics.cacheEntriesTransferred) +
+         " cache_bytes=" + std::to_string(metrics.cacheBytesTransferred) +
+         " cache_rejected=" + std::to_string(metrics.cacheEntriesRejected) +
+         " cache_deep_validations=" +
+         std::to_string(metrics.cacheDeepValidations) +
+         " scene_mvr_writes=" + std::to_string(metrics.sceneMvrWrites) +
+         " scene_mvr_bytes=" + std::to_string(metrics.sceneMvrBytes) +
+         " project_archive_ms=" + std::to_string(metrics.projectArchiveLoadMs) +
+         " mvr_restore_ms=" + std::to_string(metrics.mvrRestoreMs) +
+         " user_config_ms=" + std::to_string(metrics.userConfigMs) +
+         " main_window_ms=" + std::to_string(metrics.mainWindowConstructionMs) +
+         " path_resolution_ms=" +
+         std::to_string(metrics.startupPathResolutionMs);
+}
+
+} // namespace startup

--- a/core/startup_profile.h
+++ b/core/startup_profile.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <chrono>
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <string>
+
+namespace startup {
+
+enum class ViewportRequirement { None, Viewer2D, Viewer3D };
+
+struct Metrics {
+  using Clock = std::chrono::steady_clock;
+
+  Clock::time_point startedAt = Clock::now();
+  long long userConfigMs = 0;
+  long long mainWindowConstructionMs = 0;
+  long long startupPathResolutionMs = 0;
+  long long projectArchiveLoadMs = 0;
+  long long mvrRestoreMs = 0;
+  size_t projectOpenAttempts = 0;
+  size_t projectOpenSuccesses = 0;
+  size_t archiveTraversals = 0;
+  size_t sceneMvrWrites = 0;
+  size_t sceneMvrBytes = 0;
+  size_t cacheEntriesTransferred = 0;
+  size_t cacheBytesTransferred = 0;
+  size_t cacheEntriesRejected = 0;
+  size_t applySavedLayoutCalls = 0;
+  size_t auiPerspectiveLoads = 0;
+  size_t auiUpdates = 0;
+  size_t activateLayoutCalls = 0;
+  size_t ensure3DCalls = 0;
+  size_t ensure2DCalls = 0;
+  size_t viewer3DConstructions = 0;
+  size_t viewer2DConstructions = 0;
+  size_t fixtureReloads = 0;
+  size_t trussReloads = 0;
+  size_t hoistReloads = 0;
+  size_t sceneObjectReloads = 0;
+  size_t layerReloads = 0;
+  size_t cacheDeepValidations = 0;
+  bool interactiveReady = false;
+  std::string finalViewMode;
+  std::string finalActiveLayout;
+};
+
+ViewportRequirement
+ResolveViewportRequirement(const std::string &viewMode,
+                           const std::string *legacyPerspective = nullptr);
+std::string FormatInteractiveReadySummary(const Metrics &metrics,
+                                          long long durationMs);
+ViewportRequirement
+PrepareRequiredViewport(const std::string &viewMode,
+                        const std::string *legacyPerspective,
+                        const std::function<void()> &ensure2D,
+                        const std::function<void()> &ensure3D);
+
+} // namespace startup

--- a/docs/developer/startup_architecture.md
+++ b/docs/developer/startup_architecture.md
@@ -2,8 +2,9 @@
 
 Perastage creates an application-owned `startup::Metrics` context at the start
 of `OnInit`. The context follows configuration setup, window construction,
-startup-path resolution, project loading, and the final UI commit. The splash
-lifetime is the ownership boundary for an authoritative project restore.
+startup-path resolution, project loading, and the final UI commit. MainWindow
+exists as the application top window but remains hidden while the splash owns
+the visible startup experience.
 
 ## Restore phases
 
@@ -16,8 +17,10 @@ lifetime is the ownership boundary for an authoritative project restore.
    perspectives are inspected only when no recognized semantic mode exists.
 5. Populate project tables and layers from the authoritative scene.
 6. Apply the saved AUI perspective and activate the saved project layout.
-7. Refresh visible summaries and rigging data and publish `InteractiveReady`.
-8. Schedule non-essential fixture-symbol preparation.
+7. Refresh visible summaries and rigging data and perform the final AUI update.
+8. Maximize and publish MainWindow with its authoritative layout, emit
+   `InteractiveReady`, and then dismiss the splash.
+9. Schedule non-essential fixture-symbol preparation.
 
 The UI thread owns wxWidgets controls, AUI perspective commits, viewport
 creation and OpenGL contexts. Background services may prepare immutable symbol
@@ -26,8 +29,10 @@ result from being published into a replacement project.
 
 ## InteractiveReady
 
-`InteractiveReady` is emitted once from the idle-driven splash completion pass,
-immediately before the startup splash is hidden.
+`InteractiveReady` is emitted once from the idle-driven splash completion pass.
+That pass performs the final AUI update and publishes the previously hidden
+MainWindow before dismissing the splash, so the structural setup layout is
+never exposed as an intermediate application frame.
 At that point the authoritative scene and configuration are loaded, the saved
 view and active layout are selected, required panes exist, visible project
 panels have current data, and no startup callback remains that will replace the
@@ -58,3 +63,13 @@ requests deferred population so startup data is built once after project load;
 standalone construction defaults to immediate population. Layout2DViewDialog
 keeps its existing first-show layer reload and therefore also requests deferred
 construction.
+
+## Standard view modes
+
+Saved project restore and manual standard-view selection are separate flows. A
+saved perspective retains compatible project-specific docking and panel
+visibility, while the required central pane and all five main toolbars are
+enforced. The manual 3D, 2D, and Layout commands use explicit pane visibility
+and docking recipes rather than perspectives captured from mutable runtime
+state. This makes transitions history-independent even when a heavyweight
+viewport is constructed for the first time after Layout Mode.

--- a/docs/developer/startup_architecture.md
+++ b/docs/developer/startup_architecture.md
@@ -1,10 +1,9 @@
 # Startup architecture
 
-Perastage startup uses the splash lifetime as the ownership boundary for an
-authoritative project restore. The application first initializes diagnostics,
-preferences, localization and library paths, then constructs the lightweight
-window shell. Platform and command-line open requests are resolved before the
-project is committed to the visible UI.
+Perastage creates an application-owned `startup::Metrics` context at the start
+of `OnInit`. The context follows configuration setup, window construction,
+startup-path resolution, project loading, and the final UI commit. The splash
+lifetime is the ownership boundary for an authoritative project restore.
 
 ## Restore phases
 
@@ -12,7 +11,9 @@ project is committed to the visible UI.
 2. Traverse the project package and restore `scene.mvr`, configuration,
    resources and optional layout-cache entries.
 3. Resolve the saved view preset and active project layout.
-4. Lazily construct only the viewport required by the resolved preset.
+4. Resolve the semantic viewport requirement from the saved view mode and
+   lazily construct that viewport before loading the AUI perspective. Legacy
+   perspectives are inspected only when no recognized semantic mode exists.
 5. Populate project tables and layers from the authoritative scene.
 6. Apply the saved AUI perspective and activate the saved project layout.
 7. Refresh visible summaries and rigging data and publish `InteractiveReady`.
@@ -25,7 +26,8 @@ result from being published into a replacement project.
 
 ## InteractiveReady
 
-`InteractiveReady` is emitted immediately before the startup splash is hidden.
+`InteractiveReady` is emitted once from the idle-driven splash completion pass,
+immediately before the startup splash is hidden.
 At that point the authoritative scene and configuration are loaded, the saved
 view and active layout are selected, required panes exist, visible project
 panels have current data, and no startup callback remains that will replace the
@@ -43,9 +45,16 @@ to acquire this cache.
 
 ## Profiling
 
-Diagnostic logs contain stable `StartupProfile` records. The
-`event=InteractiveReady` record reports elapsed milliseconds, layout commit and
-activation counts, viewport ensure/construction counts, and project archive
-open/traversal counts. A second record identifies post-startup fixture-symbol
-scan scheduling. Project-load phase timings continue to be reported by the
-layout render profiler when performance profiling is enabled.
+Diagnostic logs and the internal CMD panel receive the stable
+`StartupProfile event=InteractiveReady` summary. It reports measured bootstrap
+phase durations; project archive open, traversal, scene extraction, cache
+transfer and MVR restore values; layout and AUI commits; viewport ensures and
+constructions; and authoritative table/layer reloads. A second diagnostic-log
+record identifies post-startup fixture-symbol scan scheduling. This boundary
+does not claim to measure the first completed paint.
+
+Reusable project panels use an explicit initial-population policy. MainWindow
+requests deferred population so startup data is built once after project load;
+standalone construction defaults to immediate population. Layout2DViewDialog
+keeps its existing first-show layer reload and therefore also requests deferred
+construction.

--- a/docs/developer/startup_architecture.md
+++ b/docs/developer/startup_architecture.md
@@ -1,0 +1,51 @@
+# Startup architecture
+
+Perastage startup uses the splash lifetime as the ownership boundary for an
+authoritative project restore. The application first initializes diagnostics,
+preferences, localization and library paths, then constructs the lightweight
+window shell. Platform and command-line open requests are resolved before the
+project is committed to the visible UI.
+
+## Restore phases
+
+1. Resolve the explicit platform/command-line request or last-project fallback.
+2. Traverse the project package and restore `scene.mvr`, configuration,
+   resources and optional layout-cache entries.
+3. Resolve the saved view preset and active project layout.
+4. Lazily construct only the viewport required by the resolved preset.
+5. Populate project tables and layers from the authoritative scene.
+6. Apply the saved AUI perspective and activate the saved project layout.
+7. Refresh visible summaries and rigging data and publish `InteractiveReady`.
+8. Schedule non-essential fixture-symbol preparation.
+
+The UI thread owns wxWidgets controls, AUI perspective commits, viewport
+creation and OpenGL contexts. Background services may prepare immutable symbol
+inputs after `InteractiveReady`; their existing project epoch checks prevent a
+result from being published into a replacement project.
+
+## InteractiveReady
+
+`InteractiveReady` is emitted immediately before the startup splash is hidden.
+At that point the authoritative scene and configuration are loaded, the saved
+view and active layout are selected, required panes exist, visible project
+panels have current data, and no startup callback remains that will replace the
+layout. Deferred external opens remain queued and are processed after this
+boundary.
+
+## Project cache transfer
+
+The primary `ProjectSession` ZIP traversal captures bounded entries below
+`resources/layout_view_cache/` in a typed archive-resource payload. The layout
+viewer clears stale state and consumes that payload. Cache parsing and deep
+source validation remain optional and non-fatal; cache failure cannot affect
+scene or configuration restore. The normal load path never reopens the `.pstg`
+to acquire this cache.
+
+## Profiling
+
+Diagnostic logs contain stable `StartupProfile` records. The
+`event=InteractiveReady` record reports elapsed milliseconds, layout commit and
+activation counts, viewport ensure/construction counts, and project archive
+open/traversal counts. A second record identifies post-startup fixture-symbol
+scan scheduling. Project-load phase timings continue to be reported by the
+layout render profiler when performance profiling is enabled.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -96,6 +96,12 @@ Changes since **v1.5.0**.
   and missing custom toolbar resources produce actionable diagnostics instead
   of an unexplained fallback.
 
+- The startup splash now remains in place until the fully restored project
+  window is ready to publish, eliminating the brief display of temporary pane
+  arrangements. The standard 3D, 2D, and Layout commands now restore complete,
+  history-independent panel sets, and all five main toolbars—including the
+  scene Tools toolbar—remain visible with disabled tools retaining their slots.
+
 - Stabilized MVR-xchange TCP Mode interoperability and LAN-input handling. Deterministic per-station announcements avoid JOIN/COMMIT duplication and reciprocal JOINs for incoming members, explicit leave membership survives passive rediscovery, typed failures and canonical sender fields improve compatibility, and persistent multicast discovery now uses scoped DNS-SD resolution, TXT merging, TTL lifecycle handling, bounded multipart transfers, and steady-state query backoff.
 
 - Improved MVR-xchange interoperability with consoles that follow the official

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -89,8 +89,12 @@ Changes since **v1.5.0**.
   project view directly, creating heavyweight 2D and 3D viewports only when
   required, populating project tables once, and transferring persistent layout
   cache data during the primary project archive read. Startup diagnostics now
-  report a formal interactive-ready boundary, while automatic fixture-symbol
-  preparation begins afterward.
+  report measured restore details at a formal interactive-ready boundary in
+  both diagnostic logs and the internal CMD panel, while automatic
+  fixture-symbol preparation begins afterward. Saved 3D and 2D projects now
+  reliably create their required lazy viewport before perspective restoration,
+  and missing custom toolbar resources produce actionable diagnostics instead
+  of an unexplained fallback.
 
 - Stabilized MVR-xchange TCP Mode interoperability and LAN-input handling. Deterministic per-station announcements avoid JOIN/COMMIT duplication and reciprocal JOINs for incoming members, explicit leave membership survives passive rediscovery, typed failures and canonical sender fields improve compatibility, and persistent multicast discovery now uses scoped DNS-SD resolution, TXT merging, TTL lifecycle handling, bounded multipart transfers, and steady-state query backoff.
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -85,6 +85,13 @@ Changes since **v1.5.0**.
 
 ## Compatibility, stability, and performance
 
+- Improved startup responsiveness and visual stability by restoring the saved
+  project view directly, creating heavyweight 2D and 3D viewports only when
+  required, populating project tables once, and transferring persistent layout
+  cache data during the primary project archive read. Startup diagnostics now
+  report a formal interactive-ready boundary, while automatic fixture-symbol
+  preparation begins afterward.
+
 - Stabilized MVR-xchange TCP Mode interoperability and LAN-input handling. Deterministic per-station announcements avoid JOIN/COMMIT duplication and reciprocal JOINs for incoming members, explicit leave membership survives passive rediscovery, typed failures and canonical sender fields improve compatibility, and persistent multicast discovery now uses scoped DNS-SD resolution, TXT merging, TTL lifecycle handling, bounded multipart transfers, and steady-state query backoff.
 
 - Improved MVR-xchange interoperability with consoles that follow the official

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -248,7 +248,6 @@ FixtureTablePanel::FixtureTablePanel(wxWindow *parent,
       [this]() { UpdateSelectionHighlight(); });
 
   InitializeTable();
-  ReloadData();
 
   sizer->Add(table, 1, wxEXPAND | wxALL, 5);
   SetSizer(sizer);

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -205,7 +205,8 @@ void SetFixtureColorCell(wxDataViewListCtrl *table, int row,
 
 // Initializes the fixture table UI, columns, and event bindings.
 FixtureTablePanel::FixtureTablePanel(wxWindow *parent,
-                                     IGuiConfigServices *services)
+                                     IGuiConfigServices *services,
+                                     gui::InitialPopulationPolicy populationPolicy)
     : wxPanel(parent, wxID_ANY),
       guiConfigServices(services ? services : &GetDefaultGuiConfigServices()) {
   store = new ColorfulDataViewListStore();
@@ -248,6 +249,8 @@ FixtureTablePanel::FixtureTablePanel(wxWindow *parent,
       [this]() { UpdateSelectionHighlight(); });
 
   InitializeTable();
+  if (populationPolicy == gui::InitialPopulationPolicy::Immediate)
+    ReloadData();
 
   sizer->Add(table, 1, wxEXPAND | wxALL, 5);
   SetSizer(sizer);

--- a/gui/fixturetablepanel.h
+++ b/gui/fixturetablepanel.h
@@ -27,6 +27,7 @@
 #include <unordered_set>
 #include "colorstore.h"
 #include "positionvalueupdate.h"
+#include "initial_population_policy.h"
 
 class FixtureEditDialog; // forward declaration
 namespace gui { class DataViewDeferredSelectionGuard; }
@@ -57,7 +58,10 @@ public:
         kFixtureIdOnly
     };
 
-    explicit FixtureTablePanel(wxWindow* parent, IGuiConfigServices* services = nullptr);
+    explicit FixtureTablePanel(
+        wxWindow* parent, IGuiConfigServices* services = nullptr,
+        gui::InitialPopulationPolicy populationPolicy =
+            gui::InitialPopulationPolicy::Immediate);
     ~FixtureTablePanel();
     void ReloadData(); // Refresh content from ConfigManager
     void HighlightFixture(const std::string& uuid);

--- a/gui/hoisttablepanel.cpp
+++ b/gui/hoisttablepanel.cpp
@@ -454,7 +454,6 @@ HoistTablePanel::HoistTablePanel(wxWindow *parent, IGuiConfigServices *services)
       [this]() { UpdateSelectionHighlight(); });
 
   InitializeTable();
-  ReloadData();
 
   sizer->Add(table, 1, wxEXPAND | wxALL, 5);
   SetSizer(sizer);

--- a/gui/hoisttablepanel.cpp
+++ b/gui/hoisttablepanel.cpp
@@ -409,7 +409,10 @@ RangeParts SplitRangeParts(const wxString &value) {
 }
 } // namespace
 
-HoistTablePanel::HoistTablePanel(wxWindow *parent, IGuiConfigServices *services)
+// Initializes the hoist table controls and optionally populates scene rows.
+HoistTablePanel::HoistTablePanel(
+    wxWindow *parent, IGuiConfigServices *services,
+    gui::InitialPopulationPolicy populationPolicy)
     : wxPanel(parent, wxID_ANY),
       guiConfigServices(services ? services : &GetDefaultGuiConfigServices()) {
   store = new ColorfulDataViewListStore();
@@ -454,6 +457,8 @@ HoistTablePanel::HoistTablePanel(wxWindow *parent, IGuiConfigServices *services)
       [this]() { UpdateSelectionHighlight(); });
 
   InitializeTable();
+  if (populationPolicy == gui::InitialPopulationPolicy::Immediate)
+    ReloadData();
 
   sizer->Add(table, 1, wxEXPAND | wxALL, 5);
   SetSizer(sizer);

--- a/gui/hoisttablepanel.h
+++ b/gui/hoisttablepanel.h
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #pragma once
+#include "initial_population_policy.h"
 
 #include <wx/dataview.h>
 #include <wx/wx.h>
@@ -34,7 +35,10 @@ class IGuiConfigServices;
 
 class HoistTablePanel : public wxPanel {
 public:
-  explicit HoistTablePanel(wxWindow *parent, IGuiConfigServices *services = nullptr);
+  explicit HoistTablePanel(
+      wxWindow *parent, IGuiConfigServices *services = nullptr,
+      gui::InitialPopulationPolicy populationPolicy =
+          gui::InitialPopulationPolicy::Immediate);
   ~HoistTablePanel();
 
   void ReloadData();

--- a/gui/initial_population_policy.h
+++ b/gui/initial_population_policy.h
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace gui {
+
+enum class InitialPopulationPolicy { Immediate, Deferred };
+
+} // namespace gui

--- a/gui/layerpanel.cpp
+++ b/gui/layerpanel.cpp
@@ -76,7 +76,8 @@ void RefreshVisibleViewers() {
 } // namespace
 
 // Builds the layer list panel and wires layer management events.
-LayerPanel::LayerPanel(wxWindow* parent, bool showButtons, ConfigManager* config)
+LayerPanel::LayerPanel(wxWindow* parent, bool showButtons, ConfigManager* config,
+                       gui::InitialPopulationPolicy populationPolicy)
     : wxPanel(parent, wxID_ANY), configManager(config ? config : &GetDefaultGuiConfigServices().LegacyConfigManager())
 {
     list = new wxDataViewListCtrl(this, wxID_ANY);
@@ -152,6 +153,8 @@ LayerPanel::LayerPanel(wxWindow* parent, bool showButtons, ConfigManager* config
     if (delBtn)
         delBtn->Bind(wxEVT_BUTTON, &LayerPanel::OnDeleteLayer, this);
 
+    if (populationPolicy == gui::InitialPopulationPolicy::Immediate)
+        ReloadLayers();
 }
 
 // Returns the globally registered layer panel instance.

--- a/gui/layerpanel.cpp
+++ b/gui/layerpanel.cpp
@@ -152,7 +152,6 @@ LayerPanel::LayerPanel(wxWindow* parent, bool showButtons, ConfigManager* config
     if (delBtn)
         delBtn->Bind(wxEVT_BUTTON, &LayerPanel::OnDeleteLayer, this);
 
-    ReloadLayers();
 }
 
 // Returns the globally registered layer panel instance.

--- a/gui/layerpanel.h
+++ b/gui/layerpanel.h
@@ -22,13 +22,17 @@
 #include <wx/colordlg.h>
 #include <string>
 #include <vector>
+#include "initial_population_policy.h"
 
 class ConfigManager;
 
 class LayerPanel : public wxPanel
 {
 public:
-    explicit LayerPanel(wxWindow* parent, bool showButtons = true, ConfigManager* config = nullptr);
+    explicit LayerPanel(
+        wxWindow* parent, bool showButtons = true, ConfigManager* config = nullptr,
+        gui::InitialPopulationPolicy populationPolicy =
+            gui::InitialPopulationPolicy::Immediate);
     void ReloadLayers();
 
     static LayerPanel* Instance();

--- a/gui/layout2dviewdialog.cpp
+++ b/gui/layout2dviewdialog.cpp
@@ -41,7 +41,8 @@ Layout2DViewDialog::Layout2DViewDialog(wxWindow *parent,
 
   viewerPanel = new Viewer2DPanel(this, false, false, false);
   renderPanel = new Viewer2DRenderPanel(this);
-  layerPanel = new LayerPanel(this, false, visibilityConfig);
+  layerPanel = new LayerPanel(this, false, visibilityConfig,
+                              gui::InitialPopulationPolicy::Deferred);
   summaryPanel = new SummaryPanel(this, visibilityConfig, colorConfig);
 
   renderPanel->SetMinSize(wxSize(240, -1));

--- a/gui/layout_view_cache_archive.cpp
+++ b/gui/layout_view_cache_archive.cpp
@@ -42,6 +42,7 @@
 #include "layoutviewerviewrenderer.h"
 #include "logger.h"
 #include "symbols/fixture_symbol_resource_revision.h"
+#include "startup_profile.h"
 
 namespace {
 namespace fs = std::filesystem;
@@ -1000,10 +1001,18 @@ void LayoutViewerPanel::LoadPersistentViewCache(
   }
 }
 
+// Attaches startup cache-validation instrumentation to this layout viewer.
+void LayoutViewerPanel::SetStartupMetrics(
+    std::shared_ptr<startup::Metrics> metrics) {
+  startupMetrics_ = std::move(metrics);
+}
+
 // Hydrates matching persistent cache data into the active layout view.
 void LayoutViewerPanel::HydratePendingPersistentViewCache() {
   if (pendingPersistentViewCacheJson_.empty() || currentLayout.name.empty())
     return;
+  if (startupMetrics_)
+    ++startupMetrics_->cacheDeepValidations;
   try {
     const nlohmann::json document =
         nlohmann::json::parse(pendingPersistentViewCacheJson_);

--- a/gui/layout_view_cache_archive.cpp
+++ b/gui/layout_view_cache_archive.cpp
@@ -810,49 +810,6 @@ SymbolSnapshotFromJson(const nlohmann::json &json) {
   return snapshot;
 }
 
-// Reads one ZIP entry from the current stream into a byte vector.
-std::vector<unsigned char> ReadCurrentZipEntryBytes(wxZipInputStream &zip) {
-  std::vector<unsigned char> bytes;
-  std::array<char, 4096> buffer{};
-  while (true) {
-    zip.Read(buffer.data(), buffer.size());
-    const size_t count = zip.LastRead();
-    if (count == 0)
-      break;
-    bytes.insert(bytes.end(), buffer.begin(), buffer.begin() + count);
-  }
-  return bytes;
-}
-
-// Reads project archive layout-cache JSON and optional raster entries.
-bool ReadCacheEntriesFromProject(
-    const std::string &projectPath, std::string &outJson,
-    std::unordered_map<std::string, std::vector<unsigned char>> &outRasters) {
-  wxFileInputStream input(wxString::FromUTF8(projectPath));
-  if (!input.IsOk())
-    return false;
-  wxZipInputStream zip(input);
-  std::unique_ptr<wxZipEntry> entry;
-  bool foundJson = false;
-  while ((entry.reset(zip.GetNextEntry())), entry) {
-    if (entry->IsDir())
-      continue;
-    const std::string entryName = entry->GetName().ToStdString();
-    if (entryName == kLayoutViewCacheArchiveEntry) {
-      const auto bytes = ReadCurrentZipEntryBytes(zip);
-      outJson.assign(reinterpret_cast<const char *>(bytes.data()),
-                     bytes.size());
-      foundJson = true;
-      continue;
-    }
-    if (entryName.rfind(kLayoutViewCacheRasterEntryPrefix, 0) == 0) {
-      auto bytes = ReadCurrentZipEntryBytes(zip);
-      if (bytes.size() <= kMaxPersistentRasterEntryBytes)
-        outRasters[entryName] = std::move(bytes);
-    }
-  }
-  return foundJson;
-}
 } // namespace
 
 namespace gui::layoutcache {
@@ -1021,19 +978,26 @@ LayoutViewerPanel::CollectPersistentViewCacheResources() const {
   return resources;
 }
 
-// Loads persisted layout cache JSON from the project archive.
-void LayoutViewerPanel::LoadPersistentViewCacheFromProject(
-    const std::string &projectPath) {
+// Accepts persisted layout-cache entries captured by the primary project archive traversal.
+void LayoutViewerPanel::LoadPersistentViewCache(
+    const std::vector<ProjectSession::ArchiveResource> &resources) {
   pendingPersistentViewCacheJson_.clear();
   pendingPersistentViewCacheRasters_.clear();
-  if (projectPath.empty())
-    return;
-  std::string jsonText;
-  if (ReadCacheEntriesFromProject(projectPath, jsonText,
-                                  pendingPersistentViewCacheRasters_))
-    pendingPersistentViewCacheJson_ = std::move(jsonText);
-  else
-    pendingPersistentViewCacheRasters_.clear();
+  size_t rasterBytes = 0;
+  for (const auto &resource : resources) {
+    if (resource.entryName == kLayoutViewCacheArchiveEntry &&
+        resource.bytes.size() <= kMaxPersistentCacheBytes) {
+      pendingPersistentViewCacheJson_.assign(resource.bytes.begin(),
+                                             resource.bytes.end());
+    } else if (resource.entryName.rfind(kLayoutViewCacheRasterEntryPrefix, 0) ==
+                   0 &&
+               resource.bytes.size() <= kMaxPersistentRasterEntryBytes &&
+               rasterBytes + resource.bytes.size() <=
+                   kMaxPersistentRasterBytes) {
+      rasterBytes += resource.bytes.size();
+      pendingPersistentViewCacheRasters_[resource.entryName] = resource.bytes;
+    }
+  }
 }
 
 // Hydrates matching persistent cache data into the active layout view.

--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -39,6 +39,7 @@ wxDECLARE_EVENT(EVT_LAYOUT_RENDER_READY, wxCommandEvent);
 wxDECLARE_EVENT(EVT_LAYOUT_VIEW_SELECTED, wxCommandEvent);
 
 class Viewer2DOffscreenRenderer;
+namespace startup { struct Metrics; }
 
 class LayoutViewerPanel : public wxGLCanvas {
 public:
@@ -60,6 +61,7 @@ public:
   CollectPersistentViewCacheResources() const;
   void LoadPersistentViewCache(
       const std::vector<ProjectSession::ArchiveResource> &resources);
+  void SetStartupMetrics(std::shared_ptr<startup::Metrics> metrics);
 
 private:
   struct LegendItem {
@@ -372,6 +374,7 @@ private:
   std::string pendingPersistentViewCacheJson_;
   std::unordered_map<std::string, std::vector<unsigned char>>
       pendingPersistentViewCacheRasters_;
+  std::shared_ptr<startup::Metrics> startupMetrics_;
   std::unordered_map<int, ViewCache> viewCaches_;
   std::unordered_map<int, LegendCache> legendCaches_;
   std::unordered_map<int, EventTableCache> eventTableCaches_;

--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -58,7 +58,8 @@ public:
   void RefreshEditedViewById(int viewId);
   std::vector<ProjectSession::ArchiveResource>
   CollectPersistentViewCacheResources() const;
-  void LoadPersistentViewCacheFromProject(const std::string &projectPath);
+  void LoadPersistentViewCache(
+      const std::vector<ProjectSession::ArchiveResource> &resources);
 
 private:
   struct LegendItem {

--- a/gui/main_toolbar_pane_policy.h
+++ b/gui/main_toolbar_pane_policy.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <array>
+#include <string_view>
+
+namespace gui {
+
+inline constexpr std::array<std::string_view, 5> kAlwaysVisibleToolbarPanes = {
+    "FileToolbar", "EditToolbar", "LayoutViewsToolbar", "ToolsToolbar",
+    "LayoutToolbar"};
+
+} // namespace gui

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -513,18 +513,12 @@ MainWindow::MainWindow(const wxString &title, IGuiConfigServices *services)
           return {};
         return layoutViewerPanel->CollectPersistentViewCacheResources();
       });
-  // Ensure the 3D viewport is available even before a project is loaded.
-  Ensure3DViewport();
   fixtureSymbolPreparationService =
       std::make_unique<gui::FixtureSymbolPreparationService>(*this);
 
   SetStartupProjectLoadPending(true);
-  ApplySavedLayout();
-
-  if (layerPanel)
-    layerPanel->ReloadLayers();
-  if (layoutPanel)
-    layoutPanel->ReloadLayouts();
+  // Project-bound panes remain structurally ready but unpopulated until the
+  // authoritative startup scene and view mode have been resolved.
 
   const auto shortcutRegistryErrors = gui::ValidateShortcutRegistry();
   for (const std::string &error : shortcutRegistryErrors) {
@@ -569,8 +563,12 @@ MainWindow::~MainWindow() {
 }
 
 void MainWindow::Ensure3DViewport() {
+  if (startupSplashInitializationPending)
+    ++startupEnsure3DCalls_;
   if (viewportPanel)
     return;
+  if (startupSplashInitializationPending)
+    ++startup3DConstructions_;
   int halfWidth = GetClientSize().GetWidth() / 2;
   viewportPanel = new Viewer3DPanel(this);
   Viewer3DPanel::SetInstance(viewportPanel);
@@ -598,8 +596,12 @@ void MainWindow::Ensure3DViewport() {
 }
 
 void MainWindow::Ensure2DViewport() {
+  if (startupSplashInitializationPending)
+    ++startupEnsure2DCalls_;
   if (viewport2DPanel)
     return;
+  if (startupSplashInitializationPending)
+    ++startup2DConstructions_;
   int halfWidth = GetClientSize().GetWidth() / 2;
   viewport2DPanel = new Viewer2DPanel(this);
   std::weak_ptr<int> lifetimeToken = cursorStatusCallbackLifetimeToken;
@@ -963,14 +965,16 @@ bool MainWindow::LoadProjectFromPath(const std::string &path,
   symbol_cache::ClearFixtureSymbolRuntimeCaches();
   if (layoutViewerPanel) {
     layoutViewerPanel->ResetPreviewCachesForProjectLoad();
-    layoutViewerPanel->LoadPersistentViewCacheFromProject(path);
+    layoutViewerPanel->LoadPersistentViewCache(
+        GetDefaultGuiConfigServices()
+            .LegacyConfigManager()
+            .GetLoadedProjectArchiveResources());
   }
   viewer2d::ReconcileFixtureLabelOverridesWithScene(
       GetDefaultGuiConfigServices().LegacyConfigManager());
 
   loadProfiler.BeginPhase("scene_setup");
   reportProjectLoadProgress(_("Building scene..."), true);
-  Ensure3DViewport();
   loadProfiler.EndPhase();
 
   currentProjectPath = path;
@@ -1075,7 +1079,8 @@ bool MainWindow::LoadProjectFromPath(const std::string &path,
   diagnostics::DiagnosticLogger::Info(
       "Project load completed: " +
       diagnostics::DiagnosticLogger::FileNameOnly(path));
-  fixtureSymbolPreparationService->ScheduleScan();
+  if (!startupSplashInitializationPending)
+    fixtureSymbolPreparationService->ScheduleScan();
   return true;
 }
 
@@ -1100,14 +1105,19 @@ void MainWindow::LoadStartupProjectFromPath(const std::string &path) {
 
   SplashScreen::SetMessage(_("Loading project file..."));
   wxYieldIfNeeded();
-  if (!LoadProjectFromPath(path, false)) {
+  const bool loaded = LoadProjectFromPath(path, false);
+  if (!loaded) {
     ProjectUtils::SaveLastProjectPath("");
     ResetProject(true);
     RequestStartupSplashCompletion();
   }
 
   SetStartupProjectLoadPending(false);
-  ReapplyStartupLayoutAfterProjectLoad();
+  if (!loaded) {
+    ReapplyStartupLayoutAfterProjectLoad();
+  } else {
+    RequestStartupSplashCompletion();
+  }
 }
 
 // Resets project state, UI-bound data, and active layout context for a fresh
@@ -1130,7 +1140,8 @@ void MainWindow::ResetProject(bool applyLayoutDefaultsForNewProject) {
     layouts::LayoutManager::Get().LoadDefaultsForNewProject(cfg);
   RestorePreferencesDialogValues(preferences, preservedPreferences);
   cfg.MarkSaved();
-  fixtureSymbolPreparationService->ScheduleScan();
+  if (!startupSplashInitializationPending)
+    fixtureSymbolPreparationService->ScheduleScan();
   startupSplashCloseRequested = false;
   currentProjectPath.clear();
   currentProjectDisplayName.clear();
@@ -1449,6 +1460,8 @@ void MainWindow::OnLayoutRenderStatus(wxCommandEvent &event) {
 // Applies the named project layout to the layout viewer and persists it as
 // active.
 void MainWindow::ActivateLayoutView(const std::string &layoutName) {
+  if (startupSplashInitializationPending)
+    ++startupLayoutActivations_;
   if (!auiManager || layoutName.empty()) {
     ClearLayoutLoadingIndicator();
     return;
@@ -1569,7 +1582,6 @@ void MainWindow::OnProjectLoaded(wxCommandEvent &event) {
     path = eventPathUtf8 ? std::string(eventPathUtf8.data())
                          : eventPath.ToStdString();
   }
-  Ensure3DViewport();
   if (clearLastProject)
     ProjectUtils::SaveLastProjectPath("");
   if (loaded && !path.empty()) {
@@ -1640,9 +1652,11 @@ void MainWindow::OnProjectLoaded(wxCommandEvent &event) {
     RequestStartupSplashCompletion();
     UpdateTitle();
   } else {
+    if (!path.empty()) {
+      LoadStartupProjectFromPath(path);
+      return;
+    }
     ResetProject(true);
-    if (!path.empty())
-      QueueDeferredStartupOpenPath(path);
     // Some platforms can delay or skip idle delivery during startup.
     // Force an explicit completion pass so deferred startup open paths
     // can be processed deterministically after startup reset.

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -604,10 +604,6 @@ void MainWindow::Ensure3DViewport() {
   if (startupSplashInitializationPending && startupMetrics_)
     ++startupMetrics_->auiUpdates;
 
-  if (defaultLayoutPerspective.empty()) {
-    defaultLayoutPerspective = auiManager->SavePerspective().ToStdString();
-  }
-
   if (summaryPanel)
     summaryPanel->SetVisibleRefreshTargets(viewport2DPanel, viewportPanel);
   ApplyViewportMovementToolState();
@@ -673,48 +669,6 @@ void MainWindow::Ensure2DViewport() {
   if (startupSplashInitializationPending && startupMetrics_)
     ++startupMetrics_->auiUpdates;
 
-  if (default2DLayoutPerspective.empty()) {
-    auto &pane3d = auiManager->GetPane("3DViewport");
-    auto &pane2d = auiManager->GetPane("2DViewport");
-    auto &paneRender = auiManager->GetPane("2DRenderOptions");
-    auto &paneLayers = auiManager->GetPane("LayerPanel");
-    auto &paneSummary = auiManager->GetPane("SummaryPanel");
-
-    // 2D default: keep Layers/Summary in the outer right column and place
-    // Render Options in the inner right column between viewport and side
-    // column.
-    if (paneLayers.IsOk()) {
-      paneLayers.Right().Layer(1).Row(0).Position(0);
-    }
-    if (paneSummary.IsOk()) {
-      paneSummary.Right().Layer(1).Row(0).Position(1);
-    }
-    if (paneRender.IsOk()) {
-      paneRender.Right().Layer(0).Row(0).Position(0);
-    }
-
-    pane3d.Hide();
-    pane2d.Show();
-    paneRender.Show();
-    auiManager->Update();
-    default2DLayoutPerspective = auiManager->SavePerspective().ToStdString();
-
-    // Restore base (3D) side column layout: Layers above Summary.
-    if (paneLayers.IsOk()) {
-      paneLayers.Right().Layer(1).Row(0).Position(0);
-    }
-    if (paneSummary.IsOk()) {
-      paneSummary.Right().Layer(1).Row(0).Position(1);
-    }
-    if (paneRender.IsOk()) {
-      paneRender.Right().Layer(0).Row(0).Position(0);
-    }
-
-    paneRender.Hide();
-    pane2d.Hide();
-    pane3d.Show();
-    auiManager->Update();
-  }
 }
 
 // Updates the status bar with a world-space position formatted in the active
@@ -1129,6 +1083,19 @@ void MainWindow::LoadStartupProjectFromPath(const std::string &path) {
 
   std::error_code ec;
   const fs::path projectPath = PathUtils::PathFromUtf8(path);
+  std::string extension = projectPath.extension().string();
+  std::transform(extension.begin(), extension.end(), extension.begin(),
+                 [](unsigned char ch) {
+                   return static_cast<char>(std::tolower(ch));
+                 });
+  if (extension != ProjectUtils::PROJECT_EXTENSION) {
+    ResetProject(true);
+    ApplySavedLayout();
+    QueueDeferredStartupOpenPath(path);
+    SetStartupProjectLoadPending(false);
+    RequestStartupSplashCompletion();
+    return;
+  }
   if (!fs::is_regular_file(projectPath, ec)) {
     ProjectUtils::SaveLastProjectPath("");
     ResetProject(true);

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -127,6 +127,7 @@ using json = nlohmann::json;
 #include "selectnamedialog.h"
 #include "simplecrypt.h"
 #include "splashscreen.h"
+#include "startup_profile.h"
 #include "summarypanel.h"
 #include "support.h"
 #include "tableprinter.h"
@@ -267,10 +268,16 @@ wxString PathToWxString(const std::filesystem::path &path) {
   return wxString::FromUTF8(utf8Str.c_str());
 }
 
-void LogMissingIcon(const std::filesystem::path &path) {
-  const wxString message =
-      "Main window icon not found at '" + PathToWxString(path) + "'";
-  Logger::Instance().Log(Logger::Level::Warn, message.ToStdString());
+// Records actionable context when the custom application icon cannot be used.
+void LogMainWindowIconFallback(const std::filesystem::path &resourceRoot,
+                               const std::filesystem::path &path,
+                               bool exists) {
+  diagnostics::DiagnosticLogger::Warning(
+      "Application icon fallback: requested=Perastage.ico relative_path="
+      "Perastage.ico resource_root=" +
+      resourceRoot.generic_string() + " attempted_path=" +
+      path.generic_string() + " exists=" + (exists ? "true" : "false") +
+      " icon_load_failed=" + (exists ? "true" : "false"));
 }
 
 // Builds the default UI font with shared sans-serif face resolution and UTF-8
@@ -478,9 +485,11 @@ EVT_COMMAND(wxID_ANY, EVT_LAYOUT_RENDER_READY, MainWindow::OnLayoutRenderReady)
 wxEND_EVENT_TABLE()
 
 // Constructs the main window and prepares startup UI state before project loading.
-MainWindow::MainWindow(const wxString &title, IGuiConfigServices *services)
+MainWindow::MainWindow(const wxString &title, IGuiConfigServices *services,
+                       std::shared_ptr<startup::Metrics> startupMetrics)
     : wxFrame(nullptr, wxID_ANY, title, wxDefaultPosition, wxSize(1600, 950)),
-      guiConfigServices(services ? services : &GetDefaultGuiConfigServices()) {
+      guiConfigServices(services ? services : &GetDefaultGuiConfigServices()),
+      startupMetrics_(std::move(startupMetrics)) {
   SetInstance(this);
   ioController = std::make_unique<MainWindowIoController>(*this);
   layoutController = std::make_unique<MainWindowLayoutController>(*this);
@@ -490,23 +499,29 @@ MainWindow::MainWindow(const wxString &title, IGuiConfigServices *services)
   if (defaultUiFont.IsOk())
     SetFont(defaultUiFont);
   wxIcon icon;
+  const std::filesystem::path resourceRoot = ProjectUtils::GetResourceRoot();
   const std::filesystem::path iconPath =
       ProjectUtils::ResolveResourcePath("Perastage.ico");
   std::error_code ec;
-  if (!iconPath.empty() && std::filesystem::exists(iconPath, ec)) {
+  const bool iconExists =
+      !iconPath.empty() && std::filesystem::exists(iconPath, ec);
+  if (iconExists) {
     icon.LoadFile(PathToWxString(iconPath), wxBITMAP_TYPE_ICO);
-  } else {
-    LogMissingIcon(iconPath.empty()
-                       ? std::filesystem::path("resources/Perastage.ico")
-                         : iconPath);
   }
-  if (!icon.IsOk())
+  if (!icon.IsOk()) {
+    LogMainWindowIconFallback(
+        resourceRoot,
+        iconPath.empty() ? resourceRoot / "Perastage.ico" : iconPath,
+        iconExists);
     icon = wxArtProvider::GetIcon(wxART_MISSING_IMAGE);
+  }
   if (icon.IsOk())
     SetIcon(icon);
 
   Centre();
   SetupLayout();
+  if (layoutViewerPanel)
+    layoutViewerPanel->SetStartupMetrics(startupMetrics_);
   guiConfigServices->LegacyConfigManager().SetProjectArchiveResourceProvider(
       [this]() -> std::vector<ProjectSession::ArchiveResource> {
         if (!layoutViewerPanel)
@@ -517,6 +532,7 @@ MainWindow::MainWindow(const wxString &title, IGuiConfigServices *services)
       std::make_unique<gui::FixtureSymbolPreparationService>(*this);
 
   SetStartupProjectLoadPending(true);
+  guiConfigServices->LegacyConfigManager().SetStartupMetrics(startupMetrics_);
   // Project-bound panes remain structurally ready but unpopulated until the
   // authoritative startup scene and view mode have been resolved.
 
@@ -563,12 +579,12 @@ MainWindow::~MainWindow() {
 }
 
 void MainWindow::Ensure3DViewport() {
-  if (startupSplashInitializationPending)
-    ++startupEnsure3DCalls_;
+  if (startupSplashInitializationPending && startupMetrics_)
+    ++startupMetrics_->ensure3DCalls;
   if (viewportPanel)
     return;
-  if (startupSplashInitializationPending)
-    ++startup3DConstructions_;
+  if (startupSplashInitializationPending && startupMetrics_)
+    ++startupMetrics_->viewer3DConstructions;
   int halfWidth = GetClientSize().GetWidth() / 2;
   viewportPanel = new Viewer3DPanel(this);
   Viewer3DPanel::SetInstance(viewportPanel);
@@ -585,6 +601,8 @@ void MainWindow::Ensure3DViewport() {
                                          .CloseButton(true)
                                          .MaximizeButton(true));
   auiManager->Update();
+  if (startupSplashInitializationPending && startupMetrics_)
+    ++startupMetrics_->auiUpdates;
 
   if (defaultLayoutPerspective.empty()) {
     defaultLayoutPerspective = auiManager->SavePerspective().ToStdString();
@@ -596,12 +614,12 @@ void MainWindow::Ensure3DViewport() {
 }
 
 void MainWindow::Ensure2DViewport() {
-  if (startupSplashInitializationPending)
-    ++startupEnsure2DCalls_;
+  if (startupSplashInitializationPending && startupMetrics_)
+    ++startupMetrics_->ensure2DCalls;
   if (viewport2DPanel)
     return;
-  if (startupSplashInitializationPending)
-    ++startup2DConstructions_;
+  if (startupSplashInitializationPending && startupMetrics_)
+    ++startupMetrics_->viewer2DConstructions;
   int halfWidth = GetClientSize().GetWidth() / 2;
   viewport2DPanel = new Viewer2DPanel(this);
   std::weak_ptr<int> lifetimeToken = cursorStatusCallbackLifetimeToken;
@@ -652,6 +670,8 @@ void MainWindow::Ensure2DViewport() {
   ApplyViewportMovementToolState();
 
   auiManager->Update();
+  if (startupSplashInitializationPending && startupMetrics_)
+    ++startupMetrics_->auiUpdates;
 
   if (default2DLayoutPerspective.empty()) {
     auto &pane3d = auiManager->GetPane("3DViewport");
@@ -1013,14 +1033,26 @@ bool MainWindow::LoadProjectFromPath(const std::string &path,
   reportProjectLoadProgress(_("Reloading fixture/truss/support tables..."), true);
   if (consolePanel)
     consolePanel->AppendMessage("Loaded " + wxString::FromUTF8(path));
-  if (fixturePanel)
+  if (fixturePanel) {
     fixturePanel->ReloadData();
-  if (trussPanel)
+    if (startupSplashInitializationPending && startupMetrics_)
+      ++startupMetrics_->fixtureReloads;
+  }
+  if (trussPanel) {
     trussPanel->ReloadData();
-  if (hoistPanel)
+    if (startupSplashInitializationPending && startupMetrics_)
+      ++startupMetrics_->trussReloads;
+  }
+  if (hoistPanel) {
     hoistPanel->ReloadData();
-  if (sceneObjPanel)
+    if (startupSplashInitializationPending && startupMetrics_)
+      ++startupMetrics_->hoistReloads;
+  }
+  if (sceneObjPanel) {
     sceneObjPanel->ReloadData();
+    if (startupSplashInitializationPending && startupMetrics_)
+      ++startupMetrics_->sceneObjectReloads;
+  }
 
   loadProfiler.EndPhase();
   loadProfiler.BeginPhase("viewport_refresh");
@@ -1048,8 +1080,11 @@ bool MainWindow::LoadProjectFromPath(const std::string &path,
   if (viewport2DRenderPanel)
     viewport2DRenderPanel->ApplyConfig();
   ApplyViewportMovementToolState();
-  if (layerPanel)
+  if (layerPanel) {
     layerPanel->ReloadLayers();
+    if (startupSplashInitializationPending && startupMetrics_)
+      ++startupMetrics_->layerReloads;
+  }
 
   loadProfiler.EndPhase();
   loadProfiler.BeginPhase("summary_rigging_refresh");
@@ -1098,6 +1133,7 @@ void MainWindow::LoadStartupProjectFromPath(const std::string &path) {
     ProjectUtils::SaveLastProjectPath("");
     ResetProject(true);
     SetStartupProjectLoadPending(false);
+    ApplySavedLayout();
     ReapplyStartupLayoutAfterProjectLoad();
     RequestStartupSplashCompletion();
     return;
@@ -1109,6 +1145,7 @@ void MainWindow::LoadStartupProjectFromPath(const std::string &path) {
   if (!loaded) {
     ProjectUtils::SaveLastProjectPath("");
     ResetProject(true);
+    ApplySavedLayout();
     RequestStartupSplashCompletion();
   }
 
@@ -1147,14 +1184,26 @@ void MainWindow::ResetProject(bool applyLayoutDefaultsForNewProject) {
   currentProjectDisplayName.clear();
   if (layoutPanel)
     layoutPanel->ReloadLayouts();
-  if (fixturePanel)
+  if (fixturePanel) {
     fixturePanel->ReloadData();
-  if (trussPanel)
+    if (startupSplashInitializationPending && startupMetrics_)
+      ++startupMetrics_->fixtureReloads;
+  }
+  if (trussPanel) {
     trussPanel->ReloadData();
-  if (hoistPanel)
+    if (startupSplashInitializationPending && startupMetrics_)
+      ++startupMetrics_->trussReloads;
+  }
+  if (hoistPanel) {
     hoistPanel->ReloadData();
-  if (sceneObjPanel)
+    if (startupSplashInitializationPending && startupMetrics_)
+      ++startupMetrics_->hoistReloads;
+  }
+  if (sceneObjPanel) {
     sceneObjPanel->ReloadData();
+    if (startupSplashInitializationPending && startupMetrics_)
+      ++startupMetrics_->sceneObjectReloads;
+  }
   if (viewportPanel) {
     viewportPanel->UpdateScene();
     viewportPanel->Refresh();
@@ -1167,8 +1216,11 @@ void MainWindow::ResetProject(bool applyLayoutDefaultsForNewProject) {
   }
   if (viewport2DRenderPanel)
     viewport2DRenderPanel->ApplyConfig();
-  if (layerPanel)
+  if (layerPanel) {
     layerPanel->ReloadLayers();
+    if (startupSplashInitializationPending && startupMetrics_)
+      ++startupMetrics_->layerReloads;
+  }
   RefreshSummary();
   RefreshRigging();
   UpdateTitle();
@@ -1460,8 +1512,10 @@ void MainWindow::OnLayoutRenderStatus(wxCommandEvent &event) {
 // Applies the named project layout to the layout viewer and persists it as
 // active.
 void MainWindow::ActivateLayoutView(const std::string &layoutName) {
-  if (startupSplashInitializationPending)
-    ++startupLayoutActivations_;
+  if (startupSplashInitializationPending && startupMetrics_)
+    ++startupMetrics_->activateLayoutCalls;
+  if (startupSplashInitializationPending && startupMetrics_)
+    startupMetrics_->finalActiveLayout = layoutName;
   if (!auiManager || layoutName.empty()) {
     ClearLayoutLoadingIndicator();
     return;
@@ -1657,6 +1711,7 @@ void MainWindow::OnProjectLoaded(wxCommandEvent &event) {
       return;
     }
     ResetProject(true);
+    ApplySavedLayout();
     // Some platforms can delay or skip idle delivery during startup.
     // Force an explicit completion pass so deferred startup open paths
     // can be processed deterministically after startup reset.

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -290,6 +290,8 @@ private:
   void ApplyLayoutPreset(const LayoutViewPreset &preset,
                          const std::optional<std::string> &perspective,
                          bool layoutMode, bool persistPerspective);
+  void ApplyCanonicalPaneDocking();
+  void EnforceMainToolbarVisibility();
   void ApplyLayoutModePerspective();
   void BeginLayout2DViewEdit();
   void UpdateViewMenuChecks();
@@ -309,13 +311,12 @@ private:
                           const wxString &dialogTitle);
   void ClearBlockingProjectLoadUi();
   void CompleteStartupSplashInitialization();
+  void PublishInitialMainWindow();
   void RequestStartupSplashCompletion();
   void QueueDeferredStartupOpenPath(const std::string &path);
   void ProcessDeferredStartupOpenPath();
   void OnStartupSplashCloseIdle(wxIdleEvent &event);
-  std::string defaultLayoutPerspective;
-  std::string default2DLayoutPerspective;
-  std::string defaultLayoutModePerspective;
+  bool initialMainWindowPublished = false;
   bool layoutModeActive = false;
   std::string activeLayoutName;
   bool layout2DViewEditing = false;

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -27,6 +27,7 @@
 
 #include <memory>
 #include <optional>
+#include <chrono>
 #include <array>
 #include <functional>
 #include <unordered_set>
@@ -139,6 +140,14 @@ private:
   wxAuiManager *auiManager = nullptr;
   Viewer3DPanel *viewportPanel = nullptr;
   Viewer2DPanel *viewport2DPanel = nullptr;
+  std::chrono::steady_clock::time_point startupStartedAt_ =
+      std::chrono::steady_clock::now();
+  size_t startupEnsure3DCalls_ = 0;
+  size_t startupEnsure2DCalls_ = 0;
+  size_t startup3DConstructions_ = 0;
+  size_t startup2DConstructions_ = 0;
+  size_t startupLayoutCommits_ = 0;
+  size_t startupLayoutActivations_ = 0;
   Viewer2DRenderPanel *viewport2DRenderPanel = nullptr;
   std::unique_ptr<Viewer2DOffscreenRenderer> offscreenViewer2DRenderer;
   ConsolePanel *consolePanel = nullptr;

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -48,6 +48,7 @@ class Viewer3DPanel;
 class Viewer2DPanel;
 class Viewer2DRenderPanel;
 class Viewer2DOffscreenRenderer;
+namespace startup { struct Metrics; }
 class ConsolePanel;
 class LayerPanel;
 class LayoutPanel;
@@ -69,7 +70,9 @@ enum class Viewer2DView;
 // Main application window for GUI components
 class MainWindow : public wxFrame {
 public:
-  explicit MainWindow(const wxString &title, IGuiConfigServices *services = nullptr);
+  explicit MainWindow(
+      const wxString &title, IGuiConfigServices *services = nullptr,
+      std::shared_ptr<startup::Metrics> startupMetrics = nullptr);
   ~MainWindow();
 
   bool LoadProjectFromPath(const std::string &path,
@@ -140,14 +143,7 @@ private:
   wxAuiManager *auiManager = nullptr;
   Viewer3DPanel *viewportPanel = nullptr;
   Viewer2DPanel *viewport2DPanel = nullptr;
-  std::chrono::steady_clock::time_point startupStartedAt_ =
-      std::chrono::steady_clock::now();
-  size_t startupEnsure3DCalls_ = 0;
-  size_t startupEnsure2DCalls_ = 0;
-  size_t startup3DConstructions_ = 0;
-  size_t startup2DConstructions_ = 0;
-  size_t startupLayoutCommits_ = 0;
-  size_t startupLayoutActivations_ = 0;
+  std::shared_ptr<startup::Metrics> startupMetrics_;
   Viewer2DRenderPanel *viewport2DRenderPanel = nullptr;
   std::unique_ptr<Viewer2DOffscreenRenderer> offscreenViewer2DRenderer;
   ConsolePanel *consolePanel = nullptr;

--- a/gui/mainwindow_layout.cpp
+++ b/gui/mainwindow_layout.cpp
@@ -542,6 +542,8 @@ void MainWindow::ApplyLayoutPreset(const LayoutViewPreset &preset,
 }
 
 void MainWindow::ApplySavedLayout() {
+  if (startupSplashInitializationPending)
+    ++startupLayoutCommits_;
   // Flow overview: choose which perspective to apply (layout mode/2D/3D) from
   // saved config, ensuring viewports exist before restoring; then re-apply
   // minimum sizes so the saved perspective cannot degrade the UI.
@@ -559,15 +561,6 @@ void MainWindow::ApplySavedLayout() {
     cfg.RemoveKey("layout_perspective");
     cfg.SaveUserConfig();
     perspective.reset();
-  }
-
-  if (perspective) {
-    // Ensure viewports exist before loading the saved perspective
-    if (perspective->find("3DViewport") != std::string::npos)
-      Ensure3DViewport();
-    if (perspective->find("2DViewport") != std::string::npos ||
-        perspective->find("2DRenderOptions") != std::string::npos)
-      Ensure2DViewport();
   }
 
   const LayoutViewPreset *preset = LayoutViewPresetRegistry::GetPreset(viewMode);

--- a/gui/mainwindow_layout.cpp
+++ b/gui/mainwindow_layout.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "mainwindow.h"
+#include "startup_profile.h"
 
 #include <algorithm>
 #include <cmath>
@@ -313,19 +314,23 @@ void MainWindow::SetupLayout() {
   notebook->Bind(wxEVT_NOTEBOOK_PAGE_CHANGED,
                  &MainWindow::OnNotebookPageChanged, this);
 
-  fixturePanel = new FixtureTablePanel(notebook, guiConfigServices);
+  fixturePanel = new FixtureTablePanel(
+      notebook, guiConfigServices, gui::InitialPopulationPolicy::Deferred);
   FixtureTablePanel::SetInstance(fixturePanel);
   notebook->AddPage(fixturePanel, "Fixtures");
 
-  trussPanel = new TrussTablePanel(notebook, guiConfigServices);
+  trussPanel = new TrussTablePanel(
+      notebook, guiConfigServices, gui::InitialPopulationPolicy::Deferred);
   TrussTablePanel::SetInstance(trussPanel);
   notebook->AddPage(trussPanel, "Trusses");
 
-  hoistPanel = new HoistTablePanel(notebook, guiConfigServices);
+  hoistPanel = new HoistTablePanel(
+      notebook, guiConfigServices, gui::InitialPopulationPolicy::Deferred);
   HoistTablePanel::SetInstance(hoistPanel);
   notebook->AddPage(hoistPanel, "Hoists");
 
-  sceneObjPanel = new SceneObjectTablePanel(notebook, guiConfigServices);
+  sceneObjPanel = new SceneObjectTablePanel(
+      notebook, guiConfigServices, gui::InitialPopulationPolicy::Deferred);
   SceneObjectTablePanel::SetInstance(sceneObjPanel);
   notebook->AddPage(sceneObjPanel, "Objects");
 
@@ -357,7 +362,8 @@ void MainWindow::SetupLayout() {
                                         .MaximizeButton(true)
                                         .PaneBorder(true));
 
-  layerPanel = new LayerPanel(this);
+  layerPanel = new LayerPanel(this, true, nullptr,
+                              gui::InitialPopulationPolicy::Deferred);
   LayerPanel::SetInstance(layerPanel);
   auiManager->AddPane(layerPanel, wxAuiPaneInfo()
                                       .Name("LayerPanel")
@@ -504,9 +510,13 @@ void MainWindow::ApplyLayoutPreset(const LayoutViewPreset &preset,
     const std::string adjustedPerspective =
         ApplyBottomPaneProportionsToPerspective(*perspective);
     auiManager->LoadPerspective(adjustedPerspective, true);
-  }
-  else
+    if (startupSplashInitializationPending && startupMetrics_)
+      ++startupMetrics_->auiPerspectiveLoads;
+  } else {
     auiManager->Update();
+    if (startupSplashInitializationPending && startupMetrics_)
+      ++startupMetrics_->auiUpdates;
+  }
 
   auto applyPaneState = [this](const std::vector<std::string> &panes,
                                bool show) {
@@ -521,6 +531,8 @@ void MainWindow::ApplyLayoutPreset(const LayoutViewPreset &preset,
   applyPaneState(preset.hidePanes, false);
 
   auiManager->Update();
+  if (startupSplashInitializationPending && startupMetrics_)
+    ++startupMetrics_->auiUpdates;
 
   layoutModeActive = layoutMode;
 
@@ -542,8 +554,8 @@ void MainWindow::ApplyLayoutPreset(const LayoutViewPreset &preset,
 }
 
 void MainWindow::ApplySavedLayout() {
-  if (startupSplashInitializationPending)
-    ++startupLayoutCommits_;
+  if (startupSplashInitializationPending && startupMetrics_)
+    ++startupMetrics_->applySavedLayoutCalls;
   // Flow overview: choose which perspective to apply (layout mode/2D/3D) from
   // saved config, ensuring viewports exist before restoring; then re-apply
   // minimum sizes so the saved perspective cannot degrade the UI.
@@ -573,12 +585,13 @@ void MainWindow::ApplySavedLayout() {
   if (!preset)
     preset = LayoutViewPresetRegistry::GetPreset("3d_layout_view");
 
-  if (preset) {
-    if (preset->name == "2d_layout_view")
-      Ensure2DViewport();
-    else if (preset->name == "3d_layout_view")
-      Ensure3DViewport();
-  }
+  startup::PrepareRequiredViewport(
+      preset ? preset->name : viewMode,
+      perspective ? &*perspective : nullptr,
+      [this]() { Ensure2DViewport(); }, [this]() { Ensure3DViewport(); });
+
+  if (startupMetrics_)
+    startupMetrics_->finalViewMode = preset ? preset->name : viewMode;
 
   const bool savedLayoutMode = preset && preset->name == "layout_mode_view";
   bool usedSavedPerspective = false;

--- a/gui/mainwindow_layout.cpp
+++ b/gui/mainwindow_layout.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "mainwindow.h"
+#include "main_toolbar_pane_policy.h"
 #include "startup_profile.h"
 
 #include <algorithm>
@@ -464,6 +465,56 @@ void MainWindow::SetupLayout() {
   UpdateViewMenuChecks();
 }
 
+// Restores canonical docking for standard panes.
+void MainWindow::ApplyCanonicalPaneDocking() {
+  if (!auiManager)
+    return;
+
+  auto dockPane = [this](const char *name, const auto &configure) {
+    auto &pane = auiManager->GetPane(name);
+    if (pane.IsOk())
+      configure(pane);
+  };
+  dockPane("DataNotebook", [](wxAuiPaneInfo &pane) {
+    pane.Left().Layer(0).Row(0).Position(0);
+  });
+  dockPane("Console", [](wxAuiPaneInfo &pane) {
+    pane.Bottom().Layer(1).Row(0).Position(0);
+  });
+  dockPane("LayerPanel", [](wxAuiPaneInfo &pane) {
+    pane.Right().Layer(1).Row(0).Position(0);
+  });
+  dockPane("SummaryPanel", [](wxAuiPaneInfo &pane) {
+    pane.Right().Layer(1).Row(0).Position(1);
+  });
+  dockPane("RiggingPanel", [](wxAuiPaneInfo &pane) {
+    pane.Bottom().Layer(1).Row(0).Position(1);
+  });
+  dockPane("LayoutPanel", [](wxAuiPaneInfo &pane) {
+    pane.Left().Layer(0).Row(0).Position(1);
+  });
+  dockPane("LayoutViewer", [](wxAuiPaneInfo &pane) { pane.Center(); });
+  dockPane("3DViewport", [](wxAuiPaneInfo &pane) { pane.Center(); });
+  dockPane("2DViewport", [](wxAuiPaneInfo &pane) { pane.Center(); });
+  dockPane("2DRenderOptions", [](wxAuiPaneInfo &pane) {
+    pane.Right().Layer(0).Row(0).Position(0);
+  });
+}
+
+// Keeps every primary toolbar visible without changing its dock position.
+void MainWindow::EnforceMainToolbarVisibility() {
+  if (!auiManager)
+    return;
+  for (const std::string_view name : gui::kAlwaysVisibleToolbarPanes) {
+    auto &pane = auiManager->GetPane(std::string(name));
+    if (pane.IsOk()) {
+      pane.Show().CloseButton(false);
+      if (pane.window)
+        pane.BestSize(pane.window->GetBestSize());
+    }
+  }
+}
+
 // Applies a named pane preset while synchronizing mode-specific 2D viewport state transitions.
 void MainWindow::ApplyLayoutPreset(const LayoutViewPreset &preset,
                                    const std::optional<std::string> &perspective,
@@ -509,13 +560,11 @@ void MainWindow::ApplyLayoutPreset(const LayoutViewPreset &preset,
   if (perspective && !perspective->empty()) {
     const std::string adjustedPerspective =
         ApplyBottomPaneProportionsToPerspective(*perspective);
-    auiManager->LoadPerspective(adjustedPerspective, true);
+    auiManager->LoadPerspective(adjustedPerspective, false);
     if (startupSplashInitializationPending && startupMetrics_)
       ++startupMetrics_->auiPerspectiveLoads;
   } else {
-    auiManager->Update();
-    if (startupSplashInitializationPending && startupMetrics_)
-      ++startupMetrics_->auiUpdates;
+    ApplyCanonicalPaneDocking();
   }
 
   auto applyPaneState = [this](const std::vector<std::string> &panes,
@@ -527,8 +576,24 @@ void MainWindow::ApplyLayoutPreset(const LayoutViewPreset &preset,
     }
   };
 
-  applyPaneState(preset.showPanes, true);
-  applyPaneState(preset.hidePanes, false);
+  if (perspective && !perspective->empty()) {
+    if (preset.name == "3d_layout_view") {
+      applyPaneState({"3DViewport"}, true);
+      applyPaneState(
+          {"2DViewport", "2DRenderOptions", "LayoutPanel", "LayoutViewer"},
+          false);
+    } else if (preset.name == "2d_layout_view") {
+      applyPaneState({"2DViewport", "2DRenderOptions"}, true);
+      applyPaneState({"3DViewport", "LayoutPanel", "LayoutViewer"}, false);
+    } else if (preset.name == "layout_mode_view") {
+      applyPaneState({"LayoutPanel", "LayoutViewer"}, true);
+      applyPaneState({"3DViewport", "2DViewport", "2DRenderOptions"}, false);
+    }
+  } else {
+    applyPaneState(preset.showPanes, true);
+    applyPaneState(preset.hidePanes, false);
+  }
+  EnforceMainToolbarVisibility();
 
   auiManager->Update();
   if (startupSplashInitializationPending && startupMetrics_)
@@ -641,32 +706,7 @@ void MainWindow::ApplyLayoutModePerspective() {
   if (!preset)
     return;
 
-  if (defaultLayoutModePerspective.empty()) {
-    const std::string previousPerspective =
-        auiManager->SavePerspective().ToStdString();
-
-    auto applyPaneState = [this](const std::vector<std::string> &panes,
-                                 bool show) {
-      for (const auto &name : panes) {
-        auto &pane = auiManager->GetPane(name);
-        if (pane.IsOk())
-          pane.Show(show);
-      }
-    };
-
-    applyPaneState(preset->showPanes, true);
-    applyPaneState(preset->hidePanes, false);
-    auiManager->Update();
-    defaultLayoutModePerspective = auiManager->SavePerspective().ToStdString();
-    auiManager->LoadPerspective(previousPerspective, true);
-    auiManager->Update();
-  }
-
-  if (defaultLayoutModePerspective.empty())
-    ApplyLayoutPreset(*preset, std::nullopt, true, !startupProjectLoadPending);
-  else
-    ApplyLayoutPreset(*preset, std::make_optional(defaultLayoutModePerspective),
-                      true, !startupProjectLoadPending);
+  ApplyLayoutPreset(*preset, std::nullopt, true, !startupProjectLoadPending);
 }
 
 void MainWindow::OnApplyDefaultLayout(wxCommandEvent &WXUNUSED(event)) {
@@ -679,8 +719,7 @@ void MainWindow::OnApplyDefaultLayout(wxCommandEvent &WXUNUSED(event)) {
       LayoutViewPresetRegistry::GetPreset("3d_layout_view");
   if (!preset)
     return;
-  ApplyLayoutPreset(*preset, std::make_optional(defaultLayoutPerspective),
-                    false, true);
+  ApplyLayoutPreset(*preset, std::nullopt, false, true);
 }
 
 void MainWindow::OnApply2DLayout(wxCommandEvent &WXUNUSED(event)) {
@@ -693,8 +732,7 @@ void MainWindow::OnApply2DLayout(wxCommandEvent &WXUNUSED(event)) {
       LayoutViewPresetRegistry::GetPreset("2d_layout_view");
   if (!preset)
     return;
-  ApplyLayoutPreset(*preset, std::make_optional(default2DLayoutPerspective),
-                    false, true);
+  ApplyLayoutPreset(*preset, std::nullopt, false, true);
 }
 
 void MainWindow::OnApplyLayoutModeLayout(wxCommandEvent &WXUNUSED(event)) {

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -119,15 +119,27 @@ void MainWindow::CreateToolBars() {
 
   const auto loadToolbarIcon = [](const std::string &name,
                                   const wxArtID &fallbackArtId) {
-    auto svgPath = ProjectUtils::ResolveResourcePath(
-        std::filesystem::path("icons") / "outline" / (name + ".svg"));
-    if (std::filesystem::exists(svgPath)) {
+    const std::filesystem::path relativePath =
+        std::filesystem::path("icons") / "outline" / (name + ".svg");
+    const std::filesystem::path resourceRoot = ProjectUtils::GetResourceRoot();
+    const std::filesystem::path svgPath =
+        ProjectUtils::ResolveResourcePath(relativePath);
+    std::error_code ec;
+    const bool exists = !svgPath.empty() && std::filesystem::exists(svgPath, ec);
+    if (exists) {
       wxBitmapBundle bundle =
           wxBitmapBundle::FromSVGFile(svgPath.string(), wxSize(16, 16));
       if (bundle.IsOk()) {
         return bundle;
       }
     }
+    diagnostics::DiagnosticLogger::Warning(
+        "Toolbar icon fallback: name=" + name +
+        " relative_path=" + relativePath.generic_string() +
+        " resource_root=" + resourceRoot.generic_string() +
+        " attempted_path=" + svgPath.generic_string() +
+        " exists=" + (exists ? "true" : "false") +
+        " svg_load_failed=" + (exists ? "true" : "false"));
     return wxArtProvider::GetBitmapBundle(fallbackArtId, wxART_TOOLBAR,
                                           wxSize(16, 16));
   };

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -196,6 +196,7 @@ void MainWindow::CreateToolBars() {
                                        .Name("FileToolbar")
                                        .Caption(_("File"))
                                        .ToolbarPane()
+                                       .CloseButton(false)
                                        .Top());
 
   editToolBar = new wxAuiToolBar(this, wxID_ANY, wxDefaultPosition,
@@ -222,6 +223,7 @@ void MainWindow::CreateToolBars() {
                                        .Name("EditToolbar")
                                        .Caption(_("Edit"))
                                        .ToolbarPane()
+                                       .CloseButton(false)
                                        .Top());
 
   layoutViewsToolBar = new wxAuiToolBar(this, wxID_ANY, wxDefaultPosition,
@@ -318,6 +320,7 @@ void MainWindow::CreateToolBars() {
                                               .Name("LayoutViewsToolbar")
                                               .Caption(_("Layout Views"))
                                               .ToolbarPane()
+                                              .CloseButton(false)
                                               .Top());
 
   toolsToolBar = new wxAuiToolBar(this, wxID_ANY, wxDefaultPosition,
@@ -344,6 +347,7 @@ void MainWindow::CreateToolBars() {
                                         .Name("ToolsToolbar")
                                         .Caption(_("Tools"))
                                         .ToolbarPane()
+                                        .CloseButton(false)
                                         .Top());
 
   layoutToolBar = new wxAuiToolBar(this, wxID_ANY, wxDefaultPosition,
@@ -369,6 +373,7 @@ void MainWindow::CreateToolBars() {
                                          .Name("LayoutToolbar")
                                          .Caption(_("Layout"))
                                          .ToolbarPane()
+                                         .CloseButton(false)
                                          .Top());
 
   UpdateToolBarAvailability();

--- a/gui/mainwindow_startup_splash.cpp
+++ b/gui/mainwindow_startup_splash.cpp
@@ -4,6 +4,8 @@
 
 #include "diagnostics/DiagnosticLogger.h"
 #include "services/fixture_symbol_preparation_service.h"
+#include "startup_profile.h"
+#include "consolepanel.h"
 
 #include <chrono>
 
@@ -30,22 +32,21 @@ void MainWindow::CompleteStartupSplashInitialization() {
     return;
 
   startupSplashInitializationPending = false;
-  const long long interactiveReadyMs =
-      std::chrono::duration_cast<std::chrono::milliseconds>(
-          std::chrono::steady_clock::now() - startupStartedAt_)
-          .count();
-  diagnostics::DiagnosticLogger::Info(
-      "StartupProfile event=InteractiveReady duration_ms=" +
-      std::to_string(interactiveReadyMs) +
-      " apply_saved_layout=" + std::to_string(startupLayoutCommits_) +
-      " activate_layout=" + std::to_string(startupLayoutActivations_) +
-      " ensure_3d=" + std::to_string(startupEnsure3DCalls_) +
-      " construct_3d=" + std::to_string(startup3DConstructions_) +
-      " ensure_2d=" + std::to_string(startupEnsure2DCalls_) +
-      " construct_2d=" + std::to_string(startup2DConstructions_) +
-      " pstg_opens=" + std::to_string(currentProjectPath.empty() ? 0 : 1) +
-      " archive_traversals=" +
-      std::to_string(currentProjectPath.empty() ? 0 : 1));
+  const long long interactiveReadyMs = startupMetrics_
+      ? std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - startupMetrics_->startedAt)
+            .count()
+      : 0;
+  if (startupMetrics_)
+    startupMetrics_->interactiveReady = true;
+  const startup::Metrics emptyMetrics;
+  const startup::Metrics &metrics =
+      startupMetrics_ ? *startupMetrics_ : emptyMetrics;
+  const std::string summary =
+      startup::FormatInteractiveReadySummary(metrics, interactiveReadyMs);
+  diagnostics::DiagnosticLogger::Info(summary);
+  if (consolePanel)
+    consolePanel->AppendMessage("[INFO] " + wxString::FromUTF8(summary));
   SplashScreen::SetMessage(_("Ready"));
   SplashScreen::Hide();
   if (fixtureSymbolPreparationService)

--- a/gui/mainwindow_startup_splash.cpp
+++ b/gui/mainwindow_startup_splash.cpp
@@ -2,6 +2,11 @@
 
 #include "splashscreen.h"
 
+#include "diagnostics/DiagnosticLogger.h"
+#include "services/fixture_symbol_preparation_service.h"
+
+#include <chrono>
+
 // Requests splash completion after the current startup operation finishes.
 void MainWindow::RequestStartupSplashCompletion() {
   if (!startupSplashInitializationPending)
@@ -25,8 +30,28 @@ void MainWindow::CompleteStartupSplashInitialization() {
     return;
 
   startupSplashInitializationPending = false;
+  const long long interactiveReadyMs =
+      std::chrono::duration_cast<std::chrono::milliseconds>(
+          std::chrono::steady_clock::now() - startupStartedAt_)
+          .count();
+  diagnostics::DiagnosticLogger::Info(
+      "StartupProfile event=InteractiveReady duration_ms=" +
+      std::to_string(interactiveReadyMs) +
+      " apply_saved_layout=" + std::to_string(startupLayoutCommits_) +
+      " activate_layout=" + std::to_string(startupLayoutActivations_) +
+      " ensure_3d=" + std::to_string(startupEnsure3DCalls_) +
+      " construct_3d=" + std::to_string(startup3DConstructions_) +
+      " ensure_2d=" + std::to_string(startupEnsure2DCalls_) +
+      " construct_2d=" + std::to_string(startup2DConstructions_) +
+      " pstg_opens=" + std::to_string(currentProjectPath.empty() ? 0 : 1) +
+      " archive_traversals=" +
+      std::to_string(currentProjectPath.empty() ? 0 : 1));
   SplashScreen::SetMessage(_("Ready"));
   SplashScreen::Hide();
+  if (fixtureSymbolPreparationService)
+    fixtureSymbolPreparationService->ScheduleScan();
+  diagnostics::DiagnosticLogger::Info(
+      "StartupProfile event=PostStartupFixtureSymbolScanScheduled");
 
   if (deferredStartupOpenPath && !deferredStartupOpenPath->empty()) {
     const std::string startupPath = *deferredStartupOpenPath;

--- a/gui/mainwindow_startup_splash.cpp
+++ b/gui/mainwindow_startup_splash.cpp
@@ -26,11 +26,24 @@ void MainWindow::OnStartupSplashCloseIdle(wxIdleEvent &event) {
   CompleteStartupSplashInitialization();
 }
 
-// Hides the splash and opens any path deferred during startup.
+// Publishes the fully composed initial frame exactly once behind the splash.
+void MainWindow::PublishInitialMainWindow() {
+  if (initialMainWindowPublished)
+    return;
+  if (auiManager)
+    auiManager->Update();
+  Layout();
+  Maximize(true);
+  Show(true);
+  initialMainWindowPublished = true;
+}
+
+// Publishes the final frame, hides the splash, and opens deferred startup paths.
 void MainWindow::CompleteStartupSplashInitialization() {
   if (!startupSplashInitializationPending)
     return;
 
+  PublishInitialMainWindow();
   startupSplashInitializationPending = false;
   const long long interactiveReadyMs = startupMetrics_
       ? std::chrono::duration_cast<std::chrono::milliseconds>(

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -235,7 +235,6 @@ SceneObjectTablePanel::SceneObjectTablePanel(wxWindow *parent,
             [this]() { UpdateSelectionHighlight(); });
 
     InitializeTable();
-    ReloadData();
 
     sizer->Add(table, 1, wxEXPAND | wxALL, 5);
     SetSizer(sizer);

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -192,8 +192,10 @@ wxString ResolvePrimitivePreviewPath(const SceneObject &object,
 }
 } // namespace
 
+// Initializes the scene-object table controls and optionally populates scene rows.
 SceneObjectTablePanel::SceneObjectTablePanel(wxWindow *parent,
-                                             IGuiConfigServices *services)
+                                             IGuiConfigServices *services,
+                                             gui::InitialPopulationPolicy populationPolicy)
     : wxPanel(parent, wxID_ANY),
       guiConfigServices(services ? services : &GetDefaultGuiConfigServices()) {
     store = new ColorfulDataViewListStore();
@@ -235,6 +237,8 @@ SceneObjectTablePanel::SceneObjectTablePanel(wxWindow *parent,
             [this]() { UpdateSelectionHighlight(); });
 
     InitializeTable();
+    if (populationPolicy == gui::InitialPopulationPolicy::Immediate)
+        ReloadData();
 
     sizer->Add(table, 1, wxEXPAND | wxALL, 5);
     SetSizer(sizer);

--- a/gui/sceneobjecttablepanel.h
+++ b/gui/sceneobjecttablepanel.h
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #pragma once
+#include "initial_population_policy.h"
 
 #include <wx/wx.h>
 #include <wx/dataview.h>
@@ -34,7 +35,10 @@ class IGuiConfigServices;
 class SceneObjectTablePanel : public wxPanel
 {
 public:
-    explicit SceneObjectTablePanel(wxWindow* parent, IGuiConfigServices* services = nullptr);
+    explicit SceneObjectTablePanel(
+        wxWindow* parent, IGuiConfigServices* services = nullptr,
+        gui::InitialPopulationPolicy populationPolicy =
+            gui::InitialPopulationPolicy::Immediate);
     ~SceneObjectTablePanel();
     void ReloadData();
     void HighlightObject(const std::string& uuid);

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -238,7 +238,10 @@ RangeParts SplitRangeParts(const wxString& value)
 }
 } // namespace
 
-TrussTablePanel::TrussTablePanel(wxWindow* parent, IGuiConfigServices* services)
+// Initializes the truss table controls and optionally populates scene rows.
+TrussTablePanel::TrussTablePanel(
+    wxWindow* parent, IGuiConfigServices* services,
+    gui::InitialPopulationPolicy populationPolicy)
     : wxPanel(parent, wxID_ANY), guiConfigServices(services ? services : &GetDefaultGuiConfigServices())
 {
     store = new ColorfulDataViewListStore();
@@ -275,6 +278,8 @@ TrussTablePanel::TrussTablePanel(wxWindow* parent, IGuiConfigServices* services)
             [this]() { UpdateSelectionHighlight(); });
 
     InitializeTable();
+    if (populationPolicy == gui::InitialPopulationPolicy::Immediate)
+        ReloadData();
 
     sizer->Add(table, 1, wxEXPAND | wxALL, 5);
     SetSizer(sizer);

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -275,7 +275,6 @@ TrussTablePanel::TrussTablePanel(wxWindow* parent, IGuiConfigServices* services)
             [this]() { UpdateSelectionHighlight(); });
 
     InitializeTable();
-    ReloadData();
 
     sizer->Add(table, 1, wxEXPAND | wxALL, 5);
     SetSizer(sizer);

--- a/gui/trusstablepanel.h
+++ b/gui/trusstablepanel.h
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #pragma once
+#include "initial_population_policy.h"
 
 #include <wx/wx.h>
 #include <wx/dataview.h>
@@ -36,7 +37,10 @@ class TrussEditDialog;
 class TrussTablePanel : public wxPanel
 {
 public:
-    explicit TrussTablePanel(wxWindow* parent, IGuiConfigServices* services = nullptr);
+    explicit TrussTablePanel(
+        wxWindow* parent, IGuiConfigServices* services = nullptr,
+        gui::InitialPopulationPolicy populationPolicy =
+            gui::InitialPopulationPolicy::Immediate);
     ~TrussTablePanel();
     void ReloadData(); // Refresh from ConfigManager
     void HighlightTruss(const std::string& uuid);

--- a/main.cpp
+++ b/main.cpp
@@ -306,13 +306,11 @@ bool MyApp::OnInit() {
   const auto mainWindowStartedAt = startup::Metrics::Clock::now();
   MainWindow *mainWindow =
       new MainWindow(app::kName, nullptr, startup_metrics_);
+  SetTopWindow(mainWindow);
   startup_metrics_->mainWindowConstructionMs =
       std::chrono::duration_cast<std::chrono::milliseconds>(
           startup::Metrics::Clock::now() - mainWindowStartedAt)
           .count();
-  mainWindow->Show(true);
-  // Start maximized so minimize and restore buttons remain available
-  mainWindow->Maximize(true);
   mainWindow->CallAfter([this, configuredLanguageCode, localizationResult]() {
     ShowLocalizationFallbackWarningIfNeeded(configuredLanguageCode,
                                            localizationResult.activeLanguage);

--- a/main.cpp
+++ b/main.cpp
@@ -27,12 +27,15 @@
 #include "platform_locale.h"
 #include "projectutils.h"
 #include "splashscreen.h"
+#include "startup_profile.h"
 #include <filesystem>
 #include <algorithm>
 #include <atomic>
 #include <cctype>
 #include <cstdlib>
 #include <deque>
+#include <chrono>
+#include <memory>
 #include <new>
 #include <optional>
 #include <string>
@@ -86,6 +89,8 @@ private:
   std::optional<std::string> explicit_startup_open_path_;
   std::deque<std::string> pending_external_open_paths_;
   bool localization_fallback_warning_shown_ = false;
+  std::shared_ptr<startup::Metrics> startup_metrics_;
+  startup::Metrics::Clock::time_point startup_resolution_started_at_;
 };
 
 namespace {
@@ -223,6 +228,7 @@ wxIMPLEMENT_APP(MyApp);
 
 // Initializes the application, creates the main window, and routes startup open requests.
 bool MyApp::OnInit() {
+  startup_metrics_ = std::make_shared<startup::Metrics>();
 #if defined(_MSC_VER) && defined(_DEBUG)
   ConfigureWindowsDebugHeapLeakCheck();
 #endif
@@ -274,6 +280,7 @@ bool MyApp::OnInit() {
     diagnostics::DiagnosticLogger::Warning("Startup text locale: " + localeSetup.note);
 
   // Load preferences before UI localization; localization preserves LC_NUMERIC for technical data.
+  const auto userConfigStartedAt = startup::Metrics::Clock::now();
   ConfigManager &config = ConfigManager::Get();
   const std::string configuredLanguageCode =
       config.GetValue(localization::kUiLanguageConfigKey).value_or("");
@@ -281,6 +288,10 @@ bool MyApp::OnInit() {
       localization::ParseAppLanguageCode(configuredLanguageCode);
   const localization::LocalizationInitResult localizationResult =
       localization::LocalizationManager::Get().Initialize(requestedLanguage);
+  startup_metrics_->userConfigMs =
+      std::chrono::duration_cast<std::chrono::milliseconds>(
+          startup::Metrics::Clock::now() - userConfigStartedAt)
+          .count();
   if (!localizationResult.diagnostic.empty() &&
       localizationResult.activeLanguage != localizationResult.requestedLanguage) {
     diagnostics::DiagnosticLogger::Warning("Startup localization: " +
@@ -292,7 +303,13 @@ bool MyApp::OnInit() {
   ProjectUtils::RunStartupLibraryBootstrap();
 
   SplashScreen::SetMessage(_("Creating main window..."));
-  MainWindow *mainWindow = new MainWindow(app::kName);
+  const auto mainWindowStartedAt = startup::Metrics::Clock::now();
+  MainWindow *mainWindow =
+      new MainWindow(app::kName, nullptr, startup_metrics_);
+  startup_metrics_->mainWindowConstructionMs =
+      std::chrono::duration_cast<std::chrono::milliseconds>(
+          startup::Metrics::Clock::now() - mainWindowStartedAt)
+          .count();
   mainWindow->Show(true);
   // Start maximized so minimize and restore buttons remain available
   mainWindow->Maximize(true);
@@ -308,6 +325,7 @@ bool MyApp::OnInit() {
       GetStartupPathFromArgs(argc, argv, launchWorkingDirectoryUtf8);
   diagnostics::DiagnosticLogger::Info(
       "Startup resolution delayed to allow macOS open-file event.");
+  startup_resolution_started_at_ = startup::Metrics::Clock::now();
   mainWindow->CallAfter([this, mainWindowRef, cliStartupPath, lastPathOpt]() {
     if (!mainWindowRef)
       return;
@@ -325,6 +343,12 @@ void MyApp::FinalizeStartupOpenResolution(
     const std::optional<std::string> &lastPathOpt) {
   if (!mainWindowRef)
     return;
+  if (startup_metrics_) {
+    startup_metrics_->startupPathResolutionMs =
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            startup::Metrics::Clock::now() - startup_resolution_started_at_)
+            .count();
+  }
 
   if (auto macPath = ConsumePendingStartupExternalOpenPath()) {
     diagnostics::DiagnosticLogger::Info("Startup explicit macOS path selected: " + diagnostics::DiagnosticLogger::FileNameOnly(*macPath));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2307,6 +2307,19 @@ add_executable(startup_profile_test
 target_include_directories(startup_profile_test PRIVATE ../core)
 add_test(NAME StartupProfile COMMAND startup_profile_test)
 
+add_executable(layout_view_preset_test
+               layout_view_preset_test.cpp
+               ../core/layoutviewpresets.cpp)
+target_include_directories(layout_view_preset_test PRIVATE ../core ../gui)
+add_test(NAME LayoutViewPreset COMMAND layout_view_preset_test)
+
+add_bash_policy_test(MainToolbarContract
+                     ${CMAKE_CURRENT_SOURCE_DIR}/check_main_toolbar_contract.sh
+                     LABELS "gui;architecture")
+add_bash_policy_test(StartupWindowPublication
+                     ${CMAKE_CURRENT_SOURCE_DIR}/check_startup_window_publication.sh
+                     LABELS "gui;startup;architecture")
+
 
 add_executable(support_resolution_test
                support_resolution_test.cpp)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2301,6 +2301,12 @@ target_include_directories(project_session_io_test PRIVATE ../core ../third_part
 target_link_libraries(project_session_io_test PRIVATE ${wxWidgets_LIBRARIES})
 add_test(NAME ProjectSessionIO COMMAND project_session_io_test)
 
+add_executable(startup_profile_test
+               startup_profile_test.cpp
+               ../core/startup_profile.cpp)
+target_include_directories(startup_profile_test PRIVATE ../core)
+add_test(NAME StartupProfile COMMAND startup_profile_test)
+
 
 add_executable(support_resolution_test
                support_resolution_test.cpp)

--- a/tests/check_layout_project_load_cache_reset.sh
+++ b/tests/check_layout_project_load_cache_reset.sh
@@ -63,13 +63,16 @@ if not match:
 
 load_body = match.group(0)
 reset_index = load_body.find('ResetPreviewCachesForProjectLoad')
-load_cache_index = load_body.find('LoadPersistentViewCacheFromProject')
+load_cache_index = load_body.find('LoadPersistentViewCache(')
 apply_index = load_body.find('ApplySavedLayout')
 
 if reset_index < 0:
     raise SystemExit('Project load must reset Layout preview caches before applying the saved layout')
 if load_cache_index < 0 or reset_index >= load_cache_index:
-    raise SystemExit("Project load must reset stale Layout preview caches before loading the new project's persistent cache")
+    raise SystemExit("Project load must reset stale Layout preview caches before accepting cache entries from the primary archive traversal")
+
+if 'LoadPersistentViewCacheFromProject' in load_body:
+    raise SystemExit('Normal project load must not reopen the project archive for persistent layout cache data')
 if apply_index < 0 or reset_index >= apply_index:
     raise SystemExit('Project load must reset Layout preview caches before ApplySavedLayout')
 PY

--- a/tests/check_main_toolbar_contract.sh
+++ b/tests/check_main_toolbar_contract.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+menu_source="$repo_root/gui/mainwindow_menu.cpp"
+window_source="$repo_root/gui/mainwindow.cpp"
+
+required_tools=(
+  ID_Edit_AddFixture
+  ID_Edit_AddTruss
+  ID_Edit_AddSceneObject
+  ID_Tools_DownloadGdtf
+  ID_Tools_ImportRiderText
+  ID_View_Layout_Default
+  ID_View_Layout_2D
+  ID_View_Layout_Mode
+)
+
+for tool_id in "${required_tools[@]}"; do
+  if ! rg -U -q "(?s)(AddTool|addToolWithDisabledIcon)\\([^;]*${tool_id}" \
+      "$menu_source"; then
+    echo "Missing required main-toolbar tool: ${tool_id}" >&2
+    exit 1
+  fi
+done
+
+"${PERASTAGE_TEST_PYTHON:-python3}" - "$menu_source" <<'PY'
+import re
+import sys
+
+text = open(sys.argv[1], encoding="utf-8").read()
+start = text.index("void MainWindow::CreateToolBars()")
+end = text.index("void MainWindow::CreateMenuBar()", start)
+body = text[start:end]
+sections = [
+    ("fileToolBar", "editToolBar", 7),
+    ("editToolBar", "layoutViewsToolBar", 5),
+    ("layoutViewsToolBar", "toolsToolBar", 14),
+    ("toolsToolBar", "layoutToolBar", 5),
+    ("layoutToolBar", "UpdateToolBarAvailability();", 5),
+]
+for toolbar, next_marker, expected in sections:
+    section_start = body.index(toolbar + " =")
+    section_end = body.index(next_marker, section_start)
+    section = body[section_start:section_end]
+    direct = len(re.findall(rf"{toolbar}->AddTool\s*\(", section))
+    wrapped = len(re.findall(rf"addToolWithDisabledIcon\s*\(\s*{toolbar}\s*,", section))
+    actual = direct + wrapped
+    if actual != expected:
+        raise SystemExit(
+            f"{toolbar} tool count changed: expected {expected}, found {actual}"
+        )
+PY
+
+availability_body="$({ sed -n '/void MainWindow::UpdateToolBarAvailability()/,/^}/p' "$window_source"; })"
+if [[ "$availability_body" == *"DeleteTool("* ||
+      "$availability_body" == *"RemoveTool("* ]]; then
+  echo "Toolbar availability updates must disable tools without removing them." >&2
+  exit 1
+fi
+
+echo "OK: main toolbar tools remain registered while availability changes."

--- a/tests/check_startup_window_publication.sh
+++ b/tests/check_startup_window_publication.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+main_source="$repo_root/main.cpp"
+splash_source="$repo_root/gui/mainwindow_startup_splash.cpp"
+
+if rg -q 'mainWindow->(Show|Maximize)\(' "$main_source"; then
+  echo "MyApp::OnInit must keep MainWindow hidden until final startup composition." >&2
+  exit 1
+fi
+
+publish_body="$(sed -n '/void MainWindow::PublishInitialMainWindow()/,/void MainWindow::CompleteStartupSplashInitialization()/p' "$splash_source")"
+for required_call in 'auiManager->Update()' 'Maximize(true)' 'Show(true)'; do
+  if [[ "$publish_body" != *"$required_call"* ]]; then
+    echo "Startup publication is missing required final action: $required_call" >&2
+    exit 1
+  fi
+done
+
+echo "OK: MainWindow remains hidden until authoritative startup publication."

--- a/tests/layout_image_resource_registry_test.cpp
+++ b/tests/layout_image_resource_registry_test.cpp
@@ -4,6 +4,7 @@
 #include "configmanager.h"
 #include "configservices.h"
 #include "json.hpp"
+#include "projectutils.h"
 #include "support/zip_test_utils.h"
 #include "support/archive_entry_test_utils.h"
 
@@ -34,6 +35,17 @@ void WriteImageFixture(const fs::path &path, const std::string &bytes) {
 
 // Verifies image resources are captured, counted, packaged, and pruned when unused.
 int main() {
+  const fs::path sourceResourceRoot =
+      fs::path(__FILE__).parent_path().parent_path() / "resources";
+  const fs::path representativeIcon = ProjectUtils::ResolveResourcePathFromRoot(
+      sourceResourceRoot,
+      fs::path("icons") / "outline" / "file.svg");
+  assert(!representativeIcon.empty());
+  assert(fs::is_regular_file(representativeIcon));
+  assert(ProjectUtils::ResolveResourcePathFromRoot(
+             sourceResourceRoot,
+             fs::path("icons") / "outline" / "missing-test-icon.svg")
+             .empty());
   const fs::path tempDir = fs::temp_directory_path() / "perastage_layout_image_resource_test";
   std::error_code ec;
   fs::remove_all(tempDir, ec);

--- a/tests/layout_view_preset_test.cpp
+++ b/tests/layout_view_preset_test.cpp
@@ -1,0 +1,104 @@
+#include "layoutviewpresets.h"
+#include "main_toolbar_pane_policy.h"
+
+#include <cassert>
+#include <string>
+#include <unordered_map>
+
+namespace {
+
+using PaneState = std::unordered_map<std::string, bool>;
+
+// Applies the same visibility contract used by a canonical manual view action.
+void ApplyCanonicalPreset(PaneState &state, const std::string &mode) {
+  const LayoutViewPreset *preset = LayoutViewPresetRegistry::GetPreset(mode);
+  assert(preset);
+  for (const std::string &pane : preset->showPanes)
+    state[pane] = true;
+  for (const std::string &pane : preset->hidePanes)
+    state[pane] = false;
+  for (const std::string_view toolbar : gui::kAlwaysVisibleToolbarPanes)
+    state[std::string(toolbar)] = true;
+}
+
+// Verifies the complete canonical 3D pane visibility contract.
+void Assert3D(const PaneState &state) {
+  assert(state.at("3DViewport"));
+  assert(!state.at("2DViewport"));
+  assert(!state.at("2DRenderOptions"));
+  assert(!state.at("LayoutPanel"));
+  assert(!state.at("LayoutViewer"));
+  for (const std::string pane : {"DataNotebook", "Console", "LayerPanel",
+                                 "SummaryPanel", "RiggingPanel"})
+    assert(state.at(pane));
+  for (const std::string_view toolbar : gui::kAlwaysVisibleToolbarPanes)
+    assert(state.at(std::string(toolbar)));
+}
+
+// Verifies the complete canonical 2D pane visibility contract.
+void Assert2D(const PaneState &state) {
+  assert(!state.at("3DViewport"));
+  assert(state.at("2DViewport"));
+  assert(state.at("2DRenderOptions"));
+  assert(!state.at("LayoutPanel"));
+  assert(!state.at("LayoutViewer"));
+  for (const std::string pane : {"DataNotebook", "Console", "LayerPanel",
+                                 "SummaryPanel", "RiggingPanel"})
+    assert(state.at(pane));
+  for (const std::string_view toolbar : gui::kAlwaysVisibleToolbarPanes)
+    assert(state.at(std::string(toolbar)));
+}
+
+// Verifies the complete canonical Layout Mode pane visibility contract.
+void AssertLayout(const PaneState &state) {
+  assert(!state.at("3DViewport"));
+  assert(!state.at("2DViewport"));
+  assert(!state.at("2DRenderOptions"));
+  assert(state.at("LayoutPanel"));
+  assert(state.at("LayoutViewer"));
+  for (const std::string pane : {"DataNotebook", "Console", "LayerPanel",
+                                 "SummaryPanel", "RiggingPanel"})
+    assert(!state.at(pane));
+  for (const std::string_view toolbar : gui::kAlwaysVisibleToolbarPanes)
+    assert(state.at(std::string(toolbar)));
+}
+
+} // namespace
+
+// Exercises canonical pane transitions from deliberately contaminated states.
+int main() {
+  PaneState state;
+  for (const std::string pane :
+       {"3DViewport", "2DViewport", "2DRenderOptions", "LayoutPanel",
+        "LayoutViewer", "DataNotebook", "Console", "LayerPanel", "SummaryPanel",
+        "RiggingPanel", "FileToolbar", "EditToolbar", "LayoutViewsToolbar",
+        "ToolsToolbar", "LayoutToolbar"})
+    state[pane] = false;
+
+  ApplyCanonicalPreset(state, "layout_mode_view");
+  AssertLayout(state);
+  ApplyCanonicalPreset(state, "3d_layout_view");
+  Assert3D(state);
+  ApplyCanonicalPreset(state, "layout_mode_view");
+  AssertLayout(state);
+  ApplyCanonicalPreset(state, "3d_layout_view");
+  Assert3D(state);
+
+  ApplyCanonicalPreset(state, "layout_mode_view");
+  ApplyCanonicalPreset(state, "2d_layout_view");
+  Assert2D(state);
+  ApplyCanonicalPreset(state, "layout_mode_view");
+  AssertLayout(state);
+  ApplyCanonicalPreset(state, "2d_layout_view");
+  Assert2D(state);
+
+  state["DataNotebook"] = false;
+  for (const std::string_view toolbar : gui::kAlwaysVisibleToolbarPanes)
+    state[std::string(toolbar)] = false;
+  for (const std::string_view toolbar : gui::kAlwaysVisibleToolbarPanes)
+    state[std::string(toolbar)] = true;
+  assert(!state.at("DataNotebook"));
+  for (const std::string_view toolbar : gui::kAlwaysVisibleToolbarPanes)
+    assert(state.at(std::string(toolbar)));
+  return 0;
+}

--- a/tests/project_session_io_test.cpp
+++ b/tests/project_session_io_test.cpp
@@ -1,9 +1,11 @@
 #include "configservices.h"
+#include "startup_profile.h"
 
 #include <cassert>
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
+#include <memory>
 #include <vector>
 
 int main() {
@@ -61,6 +63,65 @@ int main() {
   assert(loadOk);
   assert(loadConfigCalled);
   assert(loadSceneCalled);
+
+  const fs::path cacheProjectPath = tempDir / "cache_payload.pera";
+  const std::vector<std::uint8_t> cacheJson = {'{', '}'};
+  const bool cacheSaveOk = saveSession.SaveProject(
+      cacheProjectPath.string(),
+      [](std::vector<std::uint8_t> &out) {
+        out = {'{', '}'};
+        return true;
+      },
+      [](std::vector<std::uint8_t> &out) {
+        out = {'P', 'K'};
+        return true;
+      },
+      ProjectSession::CollectArchiveResourcesFn([&cacheJson] {
+        return std::vector<ProjectSession::ArchiveResource>{{
+            "resources/layout_view_cache/last_selected_layout_view.json",
+            cacheJson}};
+      }));
+  assert(cacheSaveOk);
+  ProjectSession cacheLoadSession;
+  assert(cacheLoadSession.LoadProject(
+      cacheProjectPath.string(), [](const std::string &) { return true; },
+      [](const std::string &) { return true; }));
+  assert(cacheLoadSession.GetLoadedArchiveResources().size() == 1);
+  assert(cacheLoadSession.GetLoadedArchiveResources().front().bytes ==
+         cacheJson);
+
+  const fs::path oversizedCacheProjectPath =
+      tempDir / "oversized_cache_payload.pera";
+  const bool oversizedCacheSaveOk = saveSession.SaveProject(
+      oversizedCacheProjectPath.string(),
+      [](std::vector<std::uint8_t> &out) {
+        out = {'{', '}'};
+        return true;
+      },
+      [](std::vector<std::uint8_t> &out) {
+        out = {'P', 'K'};
+        return true;
+      },
+      ProjectSession::CollectArchiveResourcesFn([&cacheJson] {
+        return std::vector<ProjectSession::ArchiveResource>{
+            {"resources/layout_view_cache/rasters/oversized.rgba",
+             std::vector<std::uint8_t>(8 * 1024 * 1024 + 1, 7)},
+            {"resources/layout_view_cache/last_selected_layout_view.json",
+             cacheJson}};
+      }));
+  assert(oversizedCacheSaveOk);
+  auto cacheMetrics = std::make_shared<startup::Metrics>();
+  ProjectSession oversizedCacheLoadSession;
+  oversizedCacheLoadSession.SetStartupMetrics(cacheMetrics);
+  assert(oversizedCacheLoadSession.LoadProject(
+      oversizedCacheProjectPath.string(),
+      [](const std::string &) { return true; },
+      [](const std::string &) { return true; }));
+  assert(oversizedCacheLoadSession.GetLoadedArchiveResources().size() == 1);
+  assert(oversizedCacheLoadSession.GetLoadedArchiveResources().front().bytes ==
+         cacheJson);
+  assert(cacheMetrics->cacheEntriesRejected == 1);
+  assert(cacheMetrics->cacheEntriesTransferred == 1);
 
   const fs::path zeroSceneProjectPath = tempDir / "zero_scene.pera";
   ProjectSession zeroSceneSession;

--- a/tests/startup_profile_test.cpp
+++ b/tests/startup_profile_test.cpp
@@ -1,0 +1,63 @@
+#include "startup_profile.h"
+
+#include <cassert>
+#include <string>
+
+int main() {
+  using startup::ViewportRequirement;
+
+  assert(startup::ResolveViewportRequirement("3d_layout_view") ==
+         ViewportRequirement::Viewer3D);
+  assert(startup::ResolveViewportRequirement("2d_layout_view") ==
+         ViewportRequirement::Viewer2D);
+  assert(startup::ResolveViewportRequirement("layout_mode_view") ==
+         ViewportRequirement::None);
+
+  const std::string legacy2D = "name=2DViewport;name=2DRenderOptions";
+  const std::string legacy3D = "name=3DViewport";
+  assert(startup::ResolveViewportRequirement("", &legacy2D) ==
+         ViewportRequirement::Viewer2D);
+  assert(startup::ResolveViewportRequirement("legacy", &legacy3D) ==
+         ViewportRequirement::Viewer3D);
+  assert(startup::ResolveViewportRequirement("unknown") ==
+         ViewportRequirement::Viewer3D);
+
+  int ensure2DCount = 0;
+  int ensure3DCount = 0;
+  auto ensure2D = [&ensure2DCount]() { ++ensure2DCount; };
+  auto ensure3D = [&ensure3DCount]() { ++ensure3DCount; };
+  startup::PrepareRequiredViewport("2d_layout_view", nullptr, ensure2D,
+                                   ensure3D);
+  assert(ensure2DCount == 1 && ensure3DCount == 0);
+  startup::PrepareRequiredViewport("layout_mode_view", nullptr, ensure2D,
+                                   ensure3D);
+  assert(ensure2DCount == 1 && ensure3DCount == 0);
+  startup::PrepareRequiredViewport("3d_layout_view", nullptr, ensure2D,
+                                   ensure3D);
+  assert(ensure2DCount == 1 && ensure3DCount == 1);
+  startup::PrepareRequiredViewport("2d_layout_view", nullptr, ensure2D,
+                                   ensure3D);
+  assert(ensure2DCount == 2 && ensure3DCount == 1);
+
+  startup::Metrics metrics;
+  ++metrics.ensure2DCalls;
+  ++metrics.viewer2DConstructions;
+  assert(metrics.viewer3DConstructions == 0);
+  ++metrics.ensure3DCalls;
+  ++metrics.viewer3DConstructions;
+  assert(metrics.viewer2DConstructions == 1);
+  assert(metrics.viewer3DConstructions == 1);
+  metrics.finalViewMode = "3d_layout_view";
+  metrics.finalActiveLayout = "Plot";
+  metrics.projectOpenAttempts = 1;
+  metrics.projectOpenSuccesses = 1;
+  metrics.archiveTraversals = 1;
+  const std::string summary =
+      startup::FormatInteractiveReadySummary(metrics, 42);
+  assert(summary.find("event=InteractiveReady duration_ms=42") !=
+         std::string::npos);
+  assert(summary.find("view_mode=3d_layout_view") != std::string::npos);
+  assert(summary.find("active_layout=Plot") != std::string::npos);
+  assert(summary.find("pstg_open_attempts=1") != std::string::npos);
+  return 0;
+}


### PR DESCRIPTION
### Motivation
- Make application startup deterministic and visibly stable by ensuring the first visible layout is the authoritative saved layout and by avoiding transient layout commits and unnecessary heavy viewport creation.
- Eliminate duplicate .pstg archive traversals by collecting persistent layout-cache entries during the primary project-load pass and transferring them as a typed payload to the layout viewer.
- Provide end-to-end lightweight startup profiling and a formal `InteractiveReady` boundary so startup behavior and post-startup scheduling (e.g., fixture-symbol work) are measurable and no longer block the interactive boundary.

### Description
- Startup orchestration: the MainWindow constructor no longer unconditionally constructs the 3D viewport or re-applies a saved perspective prematurely, and project-bound panes remain structurally present but are populated only from the authoritative project load path.
- Single-pass archive transfer: `ProjectSession::LoadProject` now collects bounded `resources/layout_view_cache/` entries into `ProjectSession::ArchiveResource` payloads and exposes them via `GetLoadedArchiveResources()`, and `LayoutViewerPanel` consumes those entries via `LoadPersistentViewCache(...)` instead of reopening the `.pstg`.
- Panel and viewport changes: removed constructor-time `ReloadData()` calls from table/layer panels (fixture, truss, hoist, scene-object, layer) so project rows are built only once from the authoritative scene, and added lazy-creation counters and lightweight instrumentation for `Ensure2D/3DViewport` and layout application.
- Instrumentation and docs: added stable `StartupProfile` logging at the splash/InteractiveReady boundary that reports elapsed ms, layout commits/activations, viewport ensure/construction counts and project archive counts, added `docs/developer/startup_architecture.md`, and updated `docs/release-notes-draft.md` and an existing startup cache-reset regression test to reflect the payload-based cache transfer contract.

### Testing
- Ran startup and cache-reset regression checks: `tests/check_layout_project_load_cache_reset.sh` passed after updating the test to assert payload-based cache transfer and to reject reopening the project archive for cache data.
- Ran fixture-symbol, SVG-cache and viewer lifecycle checks: `tests/check_fixture_symbol_3d_refresh.sh`, `tests/check_fixture_symbol_svg_cache_boundary.sh`, `tests/check_viewer2d_render_to_rgba_fbo_boundary.sh`, and `tests/check_viewer_scene_replacement_lifecycle.sh` all passed in this environment when `PERASTAGE_TEST_PYTHON=/usr/bin/python3` was set.
- Ran repository quality checks: `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh` passed, and `git diff --check` showed no whitespace errors.
- CMake configuration: `cmake --preset` was attempted to validate a full build but failed in this environment due to missing wxWidgets development libraries, so full binary build/runtime timing validation could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a89b53d47fc83248c2229a34c577589)