### PR TITLE
Add Lucide icons for Cut, Copy and Paste

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -14,6 +14,9 @@ Changes since **v1.5.0**.
 
 ## New features and workflow improvements
 
+- Cut, Copy, and Paste now use their matching Lucide icons in the Edit toolbar,
+  making the scene clipboard controls easier to identify at a glance.
+
 - Added a unified fixture distribution dialog on `Alt+D`. Alongside the
   existing uniform full-truss and two-point systems, fixtures can now use an
   exact configurable center or edge gap, distributed outside-in between two

--- a/resources/icons/icons-usage.json
+++ b/resources/icons/icons-usage.json
@@ -37,6 +37,24 @@
       "group": "FileToolbar"
     },
     {
+      "name": "Cut",
+      "icon": "outline/scissors.svg",
+      "description": "Cuts the selected scene elements.",
+      "group": "EditToolbar"
+    },
+    {
+      "name": "Copy",
+      "icon": "outline/copy.svg",
+      "description": "Copies the selected scene elements.",
+      "group": "EditToolbar"
+    },
+    {
+      "name": "Paste",
+      "icon": "outline/clipboard-paste.svg",
+      "description": "Pastes copied scene elements.",
+      "group": "EditToolbar"
+    },
+    {
       "name": "Layout 3D View",
       "icon": "outline/box.svg",
       "description": "Switches to the 3D layout view preset.",

--- a/resources/icons/outline/clipboard-paste.svg
+++ b/resources/icons/outline/clipboard-paste.svg
@@ -1,0 +1,2 @@
+<!-- @license lucide-static v0.562.0 - ISC -->
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-clipboard-paste"><path d="M11 14h10"/><path d="M16 4h2a2 2 0 0 1 2 2v1.344"/><path d="m17 18 4-4-4-4"/><path d="M8 4H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 1.793-1.113"/><rect x="8" y="2" width="8" height="4" rx="1"/></svg>

--- a/resources/icons/outline/copy.svg
+++ b/resources/icons/outline/copy.svg
@@ -1,0 +1,2 @@
+<!-- @license lucide-static v0.562.0 - ISC -->
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-copy"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>

--- a/resources/icons/outline/scissors.svg
+++ b/resources/icons/outline/scissors.svg
@@ -1,0 +1,2 @@
+<!-- @license lucide-static v0.562.0 - ISC -->
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-scissors"><circle cx="6" cy="6" r="3"/><path d="M8.12 8.12 12 12"/><path d="M20 4 8.12 15.88"/><circle cx="6" cy="18" r="3"/><path d="M14.8 14.8 20 20"/></svg>


### PR DESCRIPTION
### Motivation

- Make the Edit toolbar Cut/Copy/Paste controls use matching Lucide icons so the scene clipboard controls are visually consistent and easier to identify.

### Description

- Added three Lucide SVG assets at `resources/icons/outline/scissors.svg`, `resources/icons/outline/copy.svg`, and `resources/icons/outline/clipboard-paste.svg` (Lucide static v0.562.0). 
- Registered the new icons in `resources/icons/icons-usage.json` under the `EditToolbar` group and added a short release-note entry in `docs/release-notes-draft.md` documenting the visible toolbar improvement.

### Testing

- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both succeeded. 
- Validated `resources/icons/icons-usage.json` with `python3 -m json.tool` and parsed the added SVGs with Python's XML parser, and ran `git diff --check`, all of which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8aa52a0e8c83248ab7a2325708c6b5)