### PR TITLE
Centralize MainWindow command IDs and add menu-routing contract

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -7,6 +7,9 @@ Changes since **v1.5.0**.
 - Project reopening is faster for typical projects by loading packaged scene
   and configuration data directly, while retaining a safe large-project
   fallback and all existing MVR resource compatibility.
+- Help menu commands now consistently open their intended help, documentation,
+  log, diagnostic, update, and About actions instead of unrelated Tools
+  workflows.
 - Deferred fixture-symbol preparation now reuses unchanged GDTF inspection
   results instead of repeatedly scanning the same profile.
 

--- a/gui/mainwindow/ids/edit_ids.h
+++ b/gui/mainwindow/ids/edit_ids.h
@@ -1,31 +1,3 @@
 #pragma once
 
-#include "tools_ids.h"
-
-constexpr int ID_Help_Help = ID_Tools_OpenUserLibraryFolder + 1;
-constexpr int ID_Help_OnlineDocumentation = ID_Help_Help + 1;
-constexpr int ID_Help_OpenLogsFolder = ID_Help_OnlineDocumentation + 1;
-constexpr int ID_Help_ExportDiagnosticReport = ID_Help_OpenLogsFolder + 1;
-constexpr int ID_Help_About = ID_Help_ExportDiagnosticReport + 1;
-constexpr int ID_Help_CheckForUpdates = ID_Help_About + 1;
-constexpr int ID_Select_Fixtures = ID_Help_CheckForUpdates + 1;
-constexpr int ID_Select_Trusses = ID_Select_Fixtures + 1;
-constexpr int ID_Select_Supports = ID_Select_Trusses + 1;
-constexpr int ID_Select_Objects = ID_Select_Supports + 1;
-constexpr int ID_Edit_Undo = ID_Select_Objects + 1;
-constexpr int ID_Edit_Redo = ID_Edit_Undo + 1;
-constexpr int ID_Edit_Cut = ID_Edit_Redo + 1;
-constexpr int ID_Edit_Copy = ID_Edit_Cut + 1;
-constexpr int ID_Edit_Paste = ID_Edit_Copy + 1;
-constexpr int ID_Edit_AddFixture = ID_Edit_Paste + 1;
-constexpr int ID_Edit_AddTruss = ID_Edit_AddFixture + 1;
-constexpr int ID_Edit_AddSceneObject = ID_Edit_AddTruss + 1;
-constexpr int ID_Edit_AddPrimitiveSphere = ID_Edit_AddSceneObject + 1;
-constexpr int ID_Edit_AddPrimitiveCube = ID_Edit_AddPrimitiveSphere + 1;
-constexpr int ID_Edit_AddPrimitiveCylinder = ID_Edit_AddPrimitiveCube + 1;
-constexpr int ID_Edit_Delete = ID_Edit_AddPrimitiveCylinder + 1;
-constexpr int ID_Edit_Group = ID_Edit_Delete + 1;
-constexpr int ID_Edit_Ungroup = ID_Edit_Group + 1;
-constexpr int ID_Edit_ReplaceFixtures = ID_Edit_Ungroup + 1;
-constexpr int ID_Edit_ReplaceTrusses = ID_Edit_ReplaceFixtures + 1;
-constexpr int ID_Edit_Preferences = ID_Edit_ReplaceTrusses + 1;
+#include "mainwindow_command_ids.h"

--- a/gui/mainwindow/ids/io_ids.h
+++ b/gui/mainwindow/ids/io_ids.h
@@ -1,18 +1,3 @@
 #pragma once
 
-#include <wx/defs.h>
-
-constexpr int ID_File_New = wxID_HIGHEST + 1;
-constexpr int ID_File_Load = ID_File_New + 1;
-constexpr int ID_File_Save = ID_File_Load + 1;
-constexpr int ID_File_SaveAs = ID_File_Save + 1;
-constexpr int ID_File_ImportRider = ID_File_SaveAs + 1;
-constexpr int ID_File_ImportMVR = ID_File_ImportRider + 1;
-constexpr int ID_File_ExportMVR = ID_File_ImportMVR + 1;
-constexpr int ID_File_MvrXchange = ID_File_ExportMVR + 1;
-constexpr int ID_File_PrintViewer2D = ID_File_MvrXchange + 1;
-constexpr int ID_File_PrintLayout = ID_File_PrintViewer2D + 1;
-constexpr int ID_File_PrintTable = ID_File_PrintLayout + 1;
-constexpr int ID_File_PrintMenu = ID_File_PrintTable + 1;
-constexpr int ID_File_ExportCSV = ID_File_PrintMenu + 1;
-constexpr int ID_File_Close = ID_File_ExportCSV + 1;
+#include "mainwindow_command_ids.h"

--- a/gui/mainwindow/ids/layout_ids.h
+++ b/gui/mainwindow/ids/layout_ids.h
@@ -1,3 +1,3 @@
 #pragma once
 
-#include "view_ids.h"
+#include "mainwindow_command_ids.h"

--- a/gui/mainwindow/ids/mainwindow_command_ids.h
+++ b/gui/mainwindow/ids/mainwindow_command_ids.h
@@ -1,0 +1,157 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+
+#include <wx/defs.h>
+
+// Defines every distinct command routed by MainWindow in one contiguous sequence.
+enum MainWindowCommandId {
+  ID_File_New = wxID_HIGHEST + 1,
+  ID_File_Load,
+  ID_File_Save,
+  ID_File_SaveAs,
+  ID_File_ImportRider,
+  ID_File_ImportMVR,
+  ID_File_ExportMVR,
+  ID_File_MvrXchange,
+  ID_File_PrintViewer2D,
+  ID_File_PrintLayout,
+  ID_File_PrintTable,
+  ID_File_PrintMenu,
+  ID_File_ExportCSV,
+  ID_File_Close,
+  ID_Edit_Undo,
+  ID_Edit_Redo,
+  ID_Edit_Cut,
+  ID_Edit_Copy,
+  ID_Edit_Paste,
+  ID_Edit_AddFixture,
+  ID_Edit_AddTruss,
+  ID_Edit_AddSceneObject,
+  ID_Edit_AddPrimitiveSphere,
+  ID_Edit_AddPrimitiveCube,
+  ID_Edit_AddPrimitiveCylinder,
+  ID_Edit_Delete,
+  ID_Edit_Group,
+  ID_Edit_Ungroup,
+  ID_Edit_ReplaceFixtures,
+  ID_Edit_ReplaceTrusses,
+  ID_Edit_Preferences,
+  ID_View_ToggleConsole,
+  ID_View_ToggleFixtures,
+  ID_View_ToggleViewport,
+  ID_View_ToggleViewport2D,
+  ID_View_ToggleRender2D,
+  ID_View_ToggleLayers,
+  ID_View_ToggleLayouts,
+  ID_View_ToggleSummary,
+  ID_View_ToggleRigging,
+  ID_View_Layout_Default,
+  ID_View_Layout_2D,
+  ID_View_Layout_Mode,
+  ID_View_Layout_2DView,
+  ID_View_Layout_Legend,
+  ID_View_Layout_EventTable,
+  ID_View_Layout_Text,
+  ID_View_Layout_Image,
+  ID_View_Viewport_Top,
+  ID_View_Viewport_Front,
+  ID_View_Viewport_Side,
+  ID_View_Viewport_SelectTool,
+  ID_View_Viewport_MeasureTool,
+  ID_View_Viewport_GapMeasureTool,
+  ID_View_Viewport_AxisConstraint,
+  ID_View_Viewport_LeftDragMove,
+  ID_View_Viewport_LocalAxes,
+  ID_View_Viewport_Magnet,
+  ID_View_Viewport_CrossTableActions,
+  ID_Tools_DownloadGdtf,
+  ID_Tools_EditDictionaries,
+  ID_Tools_ImportRiderText,
+  ID_Tools_DistributeHoistWeights,
+  ID_Tools_ExportFixture,
+  ID_Tools_ExportTruss,
+  ID_Tools_ExportSceneObject,
+  ID_Tools_AutoPatch,
+  ID_Tools_AutoColor,
+  ID_Tools_ConvertToHoist,
+  ID_Tools_ConvertSceneObjectsToTruss,
+  ID_Tools_GenerateFixtureSymbols,
+  ID_Tools_AssignSelectedFixtureCategory,
+  ID_Tools_OpenUserLibraryFolder,
+  ID_Tools_DistributeFixturesOnTruss,
+  ID_Tools_DistributeFixturesBetweenPoints,
+  ID_Tools_DistributeFixtures,
+  ID_Help_Help,
+  ID_Help_OnlineDocumentation,
+  ID_Help_OpenLogsFolder,
+  ID_Help_ExportDiagnosticReport,
+  ID_Help_About,
+  ID_Help_CheckForUpdates,
+  ID_Select_Fixtures,
+  ID_Select_Trusses,
+  ID_Select_Supports,
+  ID_Select_Objects,
+  ID_MainWindowCommand_End
+};
+
+namespace mainwindow::commands {
+
+inline constexpr std::array kAllDistinctCommandIds = {
+    ID_File_New,
+    ID_File_Load, ID_File_Save, ID_File_SaveAs, ID_File_ImportRider,
+    ID_File_ImportMVR, ID_File_ExportMVR, ID_File_MvrXchange,
+    ID_File_PrintViewer2D, ID_File_PrintLayout, ID_File_PrintTable,
+    ID_File_PrintMenu, ID_File_ExportCSV, ID_File_Close, ID_Edit_Undo,
+    ID_Edit_Redo, ID_Edit_Cut, ID_Edit_Copy, ID_Edit_Paste,
+    ID_Edit_AddFixture, ID_Edit_AddTruss, ID_Edit_AddSceneObject,
+    ID_Edit_AddPrimitiveSphere, ID_Edit_AddPrimitiveCube,
+    ID_Edit_AddPrimitiveCylinder, ID_Edit_Delete, ID_Edit_Group,
+    ID_Edit_Ungroup, ID_Edit_ReplaceFixtures, ID_Edit_ReplaceTrusses,
+    ID_Edit_Preferences, ID_View_ToggleConsole, ID_View_ToggleFixtures,
+    ID_View_ToggleViewport, ID_View_ToggleViewport2D,
+    ID_View_ToggleRender2D, ID_View_ToggleLayers, ID_View_ToggleLayouts,
+    ID_View_ToggleSummary, ID_View_ToggleRigging, ID_View_Layout_Default,
+    ID_View_Layout_2D, ID_View_Layout_Mode, ID_View_Layout_2DView,
+    ID_View_Layout_Legend, ID_View_Layout_EventTable, ID_View_Layout_Text,
+    ID_View_Layout_Image, ID_View_Viewport_Top, ID_View_Viewport_Front,
+    ID_View_Viewport_Side, ID_View_Viewport_SelectTool,
+    ID_View_Viewport_MeasureTool, ID_View_Viewport_GapMeasureTool,
+    ID_View_Viewport_AxisConstraint, ID_View_Viewport_LeftDragMove,
+    ID_View_Viewport_LocalAxes, ID_View_Viewport_Magnet,
+    ID_View_Viewport_CrossTableActions, ID_Tools_DownloadGdtf,
+    ID_Tools_EditDictionaries, ID_Tools_ImportRiderText,
+    ID_Tools_DistributeHoistWeights, ID_Tools_ExportFixture,
+    ID_Tools_ExportTruss, ID_Tools_ExportSceneObject, ID_Tools_AutoPatch,
+    ID_Tools_AutoColor, ID_Tools_ConvertToHoist,
+    ID_Tools_ConvertSceneObjectsToTruss, ID_Tools_GenerateFixtureSymbols,
+    ID_Tools_AssignSelectedFixtureCategory, ID_Tools_OpenUserLibraryFolder,
+    ID_Tools_DistributeFixturesOnTruss,
+    ID_Tools_DistributeFixturesBetweenPoints, ID_Tools_DistributeFixtures,
+    ID_Help_Help, ID_Help_OnlineDocumentation, ID_Help_OpenLogsFolder,
+    ID_Help_ExportDiagnosticReport, ID_Help_About, ID_Help_CheckForUpdates,
+    ID_Select_Fixtures, ID_Select_Trusses, ID_Select_Supports,
+    ID_Select_Objects};
+
+// Reports whether every distinct MainWindow action has a unique numeric ID.
+constexpr bool AllCommandIdsAreUnique() {
+  for (std::size_t left = 0; left < kAllDistinctCommandIds.size(); ++left) {
+    for (std::size_t right = left + 1; right < kAllDistinctCommandIds.size();
+         ++right) {
+      if (kAllDistinctCommandIds[left] == kAllDistinctCommandIds[right]) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+static_assert(AllCommandIdsAreUnique(),
+              "MainWindow command IDs must be unique for distinct actions");
+static_assert(kAllDistinctCommandIds.size() ==
+                  static_cast<std::size_t>(ID_MainWindowCommand_End -
+                                           ID_File_New),
+              "The MainWindow command registry must contain every command ID");
+
+} // namespace mainwindow::commands

--- a/gui/mainwindow/ids/tools_ids.h
+++ b/gui/mainwindow/ids/tools_ids.h
@@ -1,28 +1,3 @@
 #pragma once
 
-#include "view_ids.h"
-
-constexpr int ID_Tools_DownloadGdtf = ID_View_Viewport_CrossTableActions + 1;
-constexpr int ID_Tools_EditDictionaries = ID_Tools_DownloadGdtf + 1;
-constexpr int ID_Tools_ImportRiderText = ID_Tools_EditDictionaries + 1;
-constexpr int ID_Tools_DistributeHoistWeights =
-    ID_Tools_ImportRiderText + 1;
-constexpr int ID_Tools_ExportFixture =
-    ID_Tools_DistributeHoistWeights + 1;
-constexpr int ID_Tools_ExportTruss = ID_Tools_ExportFixture + 1;
-constexpr int ID_Tools_ExportSceneObject = ID_Tools_ExportTruss + 1;
-constexpr int ID_Tools_AutoPatch = ID_Tools_ExportSceneObject + 1;
-constexpr int ID_Tools_AutoColor = ID_Tools_AutoPatch + 1;
-constexpr int ID_Tools_ConvertToHoist = ID_Tools_AutoColor + 1;
-constexpr int ID_Tools_ConvertSceneObjectsToTruss = ID_Tools_ConvertToHoist + 1;
-constexpr int ID_Tools_GenerateFixtureSymbols = ID_Tools_ConvertSceneObjectsToTruss + 1;
-constexpr int ID_Tools_AssignSelectedFixtureCategory =
-    ID_Tools_GenerateFixtureSymbols + 1;
-constexpr int ID_Tools_OpenUserLibraryFolder =
-    ID_Tools_AssignSelectedFixtureCategory + 1;
-constexpr int ID_Tools_DistributeFixturesOnTruss =
-    ID_Tools_OpenUserLibraryFolder + 1;
-constexpr int ID_Tools_DistributeFixturesBetweenPoints =
-    ID_Tools_DistributeFixturesOnTruss + 1;
-constexpr int ID_Tools_DistributeFixtures =
-    ID_Tools_DistributeFixturesBetweenPoints + 1;
+#include "mainwindow_command_ids.h"

--- a/gui/mainwindow/ids/view_ids.h
+++ b/gui/mainwindow/ids/view_ids.h
@@ -1,32 +1,3 @@
 #pragma once
 
-#include "io_ids.h"
-
-constexpr int ID_View_ToggleConsole = ID_File_Close + 1;
-constexpr int ID_View_ToggleFixtures = ID_View_ToggleConsole + 1;
-constexpr int ID_View_ToggleViewport = ID_View_ToggleFixtures + 1;
-constexpr int ID_View_ToggleViewport2D = ID_View_ToggleViewport + 1;
-constexpr int ID_View_ToggleRender2D = ID_View_ToggleViewport2D + 1;
-constexpr int ID_View_ToggleLayers = ID_View_ToggleRender2D + 1;
-constexpr int ID_View_ToggleLayouts = ID_View_ToggleLayers + 1;
-constexpr int ID_View_ToggleSummary = ID_View_ToggleLayouts + 1;
-constexpr int ID_View_ToggleRigging = ID_View_ToggleSummary + 1;
-constexpr int ID_View_Layout_Default = ID_View_ToggleRigging + 1;
-constexpr int ID_View_Layout_2D = ID_View_Layout_Default + 1;
-constexpr int ID_View_Layout_Mode = ID_View_Layout_2D + 1;
-constexpr int ID_View_Layout_2DView = ID_View_Layout_Mode + 1;
-constexpr int ID_View_Layout_Legend = ID_View_Layout_2DView + 1;
-constexpr int ID_View_Layout_EventTable = ID_View_Layout_Legend + 1;
-constexpr int ID_View_Layout_Text = ID_View_Layout_EventTable + 1;
-constexpr int ID_View_Layout_Image = ID_View_Layout_Text + 1;
-constexpr int ID_View_Viewport_Top = ID_View_Layout_Image + 1;
-constexpr int ID_View_Viewport_Front = ID_View_Viewport_Top + 1;
-constexpr int ID_View_Viewport_Side = ID_View_Viewport_Front + 1;
-constexpr int ID_View_Viewport_SelectTool = ID_View_Viewport_Side + 1;
-constexpr int ID_View_Viewport_MeasureTool = ID_View_Viewport_SelectTool + 1;
-constexpr int ID_View_Viewport_GapMeasureTool = ID_View_Viewport_MeasureTool + 1;
-constexpr int ID_View_Viewport_AxisConstraint = ID_View_Viewport_GapMeasureTool + 1;
-constexpr int ID_View_Viewport_LeftDragMove = ID_View_Viewport_AxisConstraint + 1;
-constexpr int ID_View_Viewport_LocalAxes = ID_View_Viewport_LeftDragMove + 1;
-constexpr int ID_View_Viewport_Magnet = ID_View_Viewport_LocalAxes + 1;
-constexpr int ID_View_Viewport_CrossTableActions = ID_View_Viewport_Magnet + 1;
+#include "mainwindow_command_ids.h"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2316,6 +2316,9 @@ add_test(NAME LayoutViewPreset COMMAND layout_view_preset_test)
 add_bash_policy_test(MainToolbarContract
                      ${CMAKE_CURRENT_SOURCE_DIR}/check_main_toolbar_contract.sh
                      LABELS "gui;architecture")
+add_bash_policy_test(MainWindowMenuRoutingContract
+                     ${CMAKE_CURRENT_SOURCE_DIR}/check_mainwindow_menu_routing_contract.sh
+                     LABELS "gui;architecture")
 add_bash_policy_test(StartupWindowPublication
                      ${CMAKE_CURRENT_SOURCE_DIR}/check_startup_window_publication.sh
                      LABELS "gui;startup;architecture")

--- a/tests/check_mainwindow_menu_routing_contract.sh
+++ b/tests/check_mainwindow_menu_routing_contract.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+"${PERASTAGE_TEST_PYTHON:-python3}" - \
+    "$repo_root/gui/mainwindow/ids/mainwindow_command_ids.h" \
+    "$repo_root/gui/mainwindow_menu_builders.cpp" \
+    "$repo_root/gui/mainwindow.cpp" <<'PY'
+import re
+import sys
+
+ids_text, menu_text, window_text = (
+    open(path, encoding="utf-8").read() for path in sys.argv[1:]
+)
+
+enum_body = re.search(
+    r"enum MainWindowCommandId\s*\{(.*?)ID_MainWindowCommand_End", ids_text, re.S
+)
+if not enum_body:
+    raise SystemExit("MainWindow command IDs must use the central command enum")
+
+entries = re.findall(r"\b(ID_(?:File|Edit|View|Tools|Help|Select)_[A-Za-z0-9_]+)\b", enum_body.group(1))
+if len(entries) != len(set(entries)):
+    raise SystemExit("Duplicate symbolic command in MainWindow command enum")
+assignments = re.findall(r"\bID_[A-Za-z0-9_]+\s*=", enum_body.group(1))
+if assignments != ["ID_File_New ="]:
+    raise SystemExit("Only the first MainWindow command may set an explicit value")
+if "static_assert(AllCommandIdsAreUnique()" not in ids_text:
+    raise SystemExit("Missing compile-time MainWindow command-ID uniqueness guard")
+
+expected_routes = {
+    "ID_File_New": "OnNew", "ID_File_Load": "OnLoad",
+    "ID_File_Save": "OnSave", "ID_File_SaveAs": "OnSaveAs",
+    "ID_File_ImportMVR": "OnImportMVR", "ID_File_ExportMVR": "OnExportMVR",
+    "ID_File_MvrXchange": "OnMvrXchange",
+    "ID_File_PrintViewer2D": "OnPrintViewer2D",
+    "ID_File_PrintLayout": "OnPrintLayout", "ID_File_PrintTable": "OnPrintTable",
+    "ID_File_ExportCSV": "OnExportCSV", "ID_File_Close": "OnClose",
+    "ID_Edit_Undo": "OnUndo", "ID_Edit_Redo": "OnRedo",
+    "ID_Edit_Cut": "OnCut", "ID_Edit_Copy": "OnCopy", "ID_Edit_Paste": "OnPaste",
+    "ID_Edit_AddFixture": "OnAddFixture", "ID_Edit_AddTruss": "OnAddTruss",
+    "ID_Edit_AddSceneObject": "OnAddSceneObject",
+    "ID_Edit_AddPrimitiveSphere": "OnAddPrimitiveSphere",
+    "ID_Edit_AddPrimitiveCube": "OnAddPrimitiveCube",
+    "ID_Edit_AddPrimitiveCylinder": "OnAddPrimitiveCylinder",
+    "ID_Edit_Delete": "OnDelete", "ID_Edit_Group": "OnGroupSelection",
+    "ID_Edit_Ungroup": "OnUngroupSelection",
+    "ID_Edit_ReplaceFixtures": "OnReplaceSelectedFixtures",
+    "ID_Edit_ReplaceTrusses": "OnReplaceSelectedTrusses",
+    "ID_Edit_Preferences": "OnPreferences",
+    "ID_View_ToggleConsole": "OnToggleConsole",
+    "ID_View_ToggleFixtures": "OnToggleFixtures",
+    "ID_View_ToggleViewport": "OnToggleViewport",
+    "ID_View_ToggleViewport2D": "OnToggleViewport2D",
+    "ID_View_ToggleRender2D": "OnToggleRender2D",
+    "ID_View_ToggleLayers": "OnToggleLayers",
+    "ID_View_ToggleLayouts": "OnToggleLayouts",
+    "ID_View_ToggleSummary": "OnToggleSummary",
+    "ID_View_ToggleRigging": "OnToggleRigging",
+    "ID_View_Layout_Default": "OnApplyDefaultLayout",
+    "ID_View_Layout_2D": "OnApply2DLayout",
+    "ID_View_Layout_Mode": "OnApplyLayoutModeLayout",
+    "ID_Tools_DownloadGdtf": "OnDownloadGdtf",
+    "ID_Tools_EditDictionaries": "OnEditDictionaries",
+    "ID_Tools_OpenUserLibraryFolder": "OnOpenUserLibraryFolder",
+    "ID_Tools_ImportRiderText": "OnImportRiderText",
+    "ID_Tools_DistributeHoistWeights": "OnDistributeHoistWeights",
+    "ID_Tools_DistributeFixtures": "OnDistributeFixtures",
+    "ID_Tools_ExportFixture": "OnExportFixture",
+    "ID_Tools_ExportTruss": "OnExportTruss",
+    "ID_Tools_ExportSceneObject": "OnExportSceneObject",
+    "ID_Tools_AutoPatch": "OnAutoPatch", "ID_Tools_AutoColor": "OnAutoColor",
+    "ID_Tools_ConvertToHoist": "OnConvertToHoist",
+    "ID_Tools_ConvertSceneObjectsToTruss": "OnConvertSceneObjectsToTruss",
+    "ID_Tools_GenerateFixtureSymbols": "OnGenerateFixtureSymbols",
+    "ID_Tools_AssignSelectedFixtureCategory": "OnAssignSelectedFixtureCategory",
+    "ID_Help_Help": "OnShowHelp",
+    "ID_Help_OnlineDocumentation": "OnOpenOnlineDocumentation",
+    "ID_Help_CheckForUpdates": "OnCheckForUpdates",
+    "ID_Help_OpenLogsFolder": "OnOpenLogsFolder",
+    "ID_Help_ExportDiagnosticReport": "OnExportDiagnosticReport",
+    "ID_Help_About": "OnShowAbout",
+}
+
+menu_ids = re.findall(
+    r"->Append(?:CheckItem)?\s*\(\s*(ID_[A-Za-z0-9_]+)", menu_text, re.S
+)
+if set(menu_ids) != set(expected_routes):
+    missing = sorted(set(expected_routes) - set(menu_ids))
+    unexpected = sorted(set(menu_ids) - set(expected_routes))
+    raise SystemExit(f"Main menu contract changed; missing={missing}, unexpected={unexpected}")
+if len(menu_ids) != len(set(menu_ids)):
+    raise SystemExit("A visible MainWindow menu command is registered more than once")
+
+event_pairs = re.findall(
+    r"EVT_MENU\s*\(\s*(ID_[A-Za-z0-9_]+)\s*,\s*MainWindow::(On[A-Za-z0-9_]+)\s*\)",
+    window_text,
+    re.S,
+)
+event_routes = {}
+for command_id, handler in event_pairs:
+    if command_id in event_routes:
+        raise SystemExit(f"Duplicate EVT_MENU registration for {command_id}")
+    event_routes[command_id] = handler
+
+for command_id, expected_handler in expected_routes.items():
+    actual_handler = event_routes.get(command_id)
+    if actual_handler != expected_handler:
+        raise SystemExit(
+            f"Wrong route for {command_id}: expected {expected_handler}, found {actual_handler}"
+        )
+
+distribution_ids = {
+    "ID_Tools_DistributeFixturesOnTruss": "OnDistributeFixturesOnTruss",
+    "ID_Tools_DistributeFixturesBetweenPoints": "OnDistributeFixturesBetweenPoints",
+    "ID_Tools_DistributeFixtures": "OnDistributeFixtures",
+}
+for command_id, expected_handler in distribution_ids.items():
+    if event_routes.get(command_id) != expected_handler:
+        raise SystemExit(f"Wrong specialized distribution route for {command_id}")
+
+help_ids = {"ID_Help_Help", "ID_Help_OnlineDocumentation", "ID_Help_OpenLogsFolder"}
+numeric_ids = {command_id: offset for offset, command_id in enumerate(entries)}
+if ({numeric_ids[command_id] for command_id in help_ids} &
+        {numeric_ids[command_id] for command_id in distribution_ids}):
+    raise SystemExit("Help and fixture-distribution commands must be distinct actions")
+if not set(event_routes).issubset(set(entries)):
+    raise SystemExit("EVT_MENU uses a command outside the central MainWindow command enum")
+
+# Menu and toolbar controls may intentionally reuse one ID for the same action;
+# this contract requires uniqueness only among the distinct IDs in the registry.
+print("OK: MainWindow menu IDs and routes match the complete command contract.")
+PY


### PR DESCRIPTION
### Motivation

- Fix a routing regression where Help actions (for example `Help > Open Logs Folder`) invoked Tools handlers because per-family ID arithmetic created duplicate numeric IDs across headers. 
- Prevent future silent collisions by replacing cross-header +1 arithmetic with a single authoritative command-ID sequence and an automated uniqueness guard.

### Description

- Add a single source-of-truth header `gui/mainwindow/ids/mainwindow_command_ids.h` that declares an `enum MainWindowCommandId` covering all File/Edit/View/Tools/Help/selection commands and a `constexpr` registry with `static_assert` checks for uniqueness and completeness. 
- Convert the scattered per-family ID headers to compatibility includes by changing `gui/mainwindow/ids/{io,view,tools,edit,layout}_ids.h` to `#include "mainwindow_command_ids.h"`, preserving existing symbolic names at call sites. 
- Add a repository-level menu-routing contract `tests/check_mainwindow_menu_routing_contract.sh` which validates that every visible menu item uses a central ID, that expected menu-to-handler routes exist, that Help and distribution commands do not collide, and that `EVT_MENU` registrations are unique; register it in `tests/CMakeLists.txt` as `MainWindowMenuRoutingContract`. 
- Update `docs/release-notes-draft.md` with the Help menu routing fix and keep user-visible behavior unchanged; preserve intentional toolbar/menu ID reuse.

Files touched: `gui/mainwindow/ids/mainwindow_command_ids.h` (new), `gui/mainwindow/ids/{io,view,tools,edit,layout}_ids.h` (updated to include the new header), `tests/check_mainwindow_menu_routing_contract.sh` (new), `tests/CMakeLists.txt` (registered test), and `docs/release-notes-draft.md` (release note). 

### Testing

- Ran `./tests/check_mainwindow_menu_routing_contract.sh` which reported: OK (menu IDs and routes match the contract). 
- Ran `./tests/check_main_toolbar_contract.sh`, `./tests/check_perastage_tree_modules.sh`, and `./tests/check_no_configmanager_get_in_gui.sh`; all returned OK in this environment. 
- Attempted a full configure/build (`cmake -S . -B /tmp/perastage-build -DBUILD_TESTING=ON` and a small compile to exercise the compile-time guard), but the build could not complete because `wxWidgets` development files (`wx-config` and headers) are not available in this execution environment, so GUI target compilation and CTest execution for compiled tests were blocked.

If a CI/test runner with `wxWidgets` dev packages is available, the added `static_assert` and the new bash contract test will prevent reintroduction of duplicate MainWindow command IDs and will run as part of the normal test/CI path.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8acd6760188324bf021c95db3f8a57)