### PR TITLE
Fix macOS 15 Release DMG compilation (replace std::jthread with std::thread)

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -37,6 +37,12 @@ Changes since **v1.5.0**.
   models that intentionally omit a file and primitive type while retaining
   fallback behavior for explicitly undefined models.
 
+## Fixes
+
+- Restored macOS 15 Apple Silicon packaging compatibility by avoiding newer
+  standard-library thread APIs that are unavailable in its hosted Xcode
+  toolchain, without changing fixture symbol processing behavior.
+
 ## New features and workflow improvements
 
 - Cut, Copy, and Paste now use their matching Lucide icons in the Edit toolbar,

--- a/gui/services/fixture_symbol_processing_worker.cpp
+++ b/gui/services/fixture_symbol_processing_worker.cpp
@@ -8,12 +8,16 @@ namespace gui {
 
 // Starts the single managed worker used for pure symbol processing.
 FixtureSymbolProcessingWorker::FixtureSymbolProcessingWorker()
-    : thread_([this](std::stop_token stopToken) { Run(stopToken); }) {}
+    : thread_([this]() { Run(); }) {}
 
 // Stops and joins the managed processing worker during application shutdown.
 FixtureSymbolProcessingWorker::~FixtureSymbolProcessingWorker() {
-  thread_.request_stop();
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    stopping_ = true;
+  }
   condition_.notify_all();
+  thread_.join();
 }
 
 // Submits one immutable processing request when the worker is available.
@@ -38,15 +42,15 @@ FixtureSymbolProcessingWorker::TakeResult() {
   return result;
 }
 
-// Processes copied render data without accessing wx, OpenGL, or live scene state.
-void FixtureSymbolProcessingWorker::Run(std::stop_token stopToken) {
-  while (!stopToken.stop_requested()) {
+// Processes copied render data independently of GUI and scene state.
+void FixtureSymbolProcessingWorker::Run() {
+  while (true) {
     FixtureSymbolProcessingRequest request;
     {
       std::unique_lock<std::mutex> lock(mutex_);
-      condition_.wait(lock, stopToken,
-                      [this]() { return !requests_.empty(); });
-      if (stopToken.stop_requested())
+      condition_.wait(lock,
+                      [this]() { return stopping_ || !requests_.empty(); });
+      if (stopping_)
         return;
       request = std::move(requests_.front());
       requests_.pop_front();

--- a/gui/services/fixture_symbol_processing_worker.h
+++ b/gui/services/fixture_symbol_processing_worker.h
@@ -36,14 +36,15 @@ public:
   std::optional<FixtureSymbolProcessingResult> TakeResult();
 
 private:
-  void Run(std::stop_token stopToken);
+  void Run();
 
   std::mutex mutex_;
   std::condition_variable_any condition_;
   std::deque<FixtureSymbolProcessingRequest> requests_;
   std::deque<FixtureSymbolProcessingResult> results_;
   bool busy_ = false;
-  std::jthread thread_;
+  bool stopping_ = false;
+  std::thread thread_;
 };
 
 } // namespace gui

--- a/tests/check_fixture_symbol_preparation_architecture.sh
+++ b/tests/check_fixture_symbol_preparation_architecture.sh
@@ -5,6 +5,7 @@ root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 service="$root/gui/services/fixture_symbol_preparation_service.cpp"
 renderer="$root/viewer3d/render/opaque_fixture_pass.cpp"
 worker="$root/gui/services/fixture_symbol_processing_worker.cpp"
+worker_header="$root/gui/services/fixture_symbol_processing_worker.h"
 capture="$root/gui/tools/scene_model_symbol_capture_service.cpp"
 
 if rg -n 'wxProgressDialog|wxWindowDisabler|wxMessageBox|wxYield|detach\(' "$service"; then
@@ -21,6 +22,10 @@ if rg -n 'SymbolCacheManifest|perastage_symbol_cache_manifest|SaveProject|LoadPr
 fi
 if rg -n '#include .*wx|ConfigManager::|MainWindow::|Viewer2D|Viewer3D|gl[A-Z]' "$worker"; then
   echo "Fixture symbol processing workers must operate only on copied plain data." >&2
+  exit 1
+fi
+if rg -n 'std::jthread|std::stop_token' "$worker" "$worker_header"; then
+  echo "Fixture symbol processing must remain compatible with the macOS 15 Xcode standard library." >&2
   exit 1
 fi
 if rg -n 'CaptureSceneModelOrthographicStep|nextCaptureStep|captureSnapshot' "$root/gui"; then


### PR DESCRIPTION
### Motivation
- The macOS 15 packaging workflow was failing during the build step because Xcode 16.4's libc++ on the hosted macOS 15 runner does not provide `std::jthread` or `std::stop_token`, causing compilation errors in the fixture symbol worker.

### Description
- Replace `std::jthread` / `std::stop_token` usage in `gui/services/fixture_symbol_processing_worker` with a `std::thread` plus a protected `stopping_` flag, condition-variable wakeup, and explicit `join()` to preserve shutdown behavior without requiring newer libc++ APIs.
- Add a small portability/regression check to `tests/check_fixture_symbol_preparation_architecture.sh` to prevent reintroduction of `std::jthread`/`std::stop_token`, and add a short release-note entry in `docs/release-notes-draft.md` describing the fix.

### Testing
- Ran `git diff --check` and `clang-format --dry-run --Werror` on the modified files and they passed.
- Ran project policy and workflow checks: `tests/check_perastage_tree_modules.sh`, `tests/check_no_configmanager_get_in_gui.sh`, `tests/check_fixture_symbol_preparation_architecture.sh`, `python3 tests/check_ci_workflow_architecture.py`, `PERASTAGE_TEST_PYTHON=$(command -v python3) tests/check_ci_cmake_language_policy.sh`, and `PERASTAGE_TEST_PYTHON=$(command -v python3) tests/check_securestore_build_policy.sh`, all of which completed successfully in the test harness.
- Performed a local `g++ -std=c++20 -fsyntax-only` check which could not complete inside this Linux container because `wx` headers are not available here (expected and unrelated to the portability fix).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8af432f1748324a3c50db455cc450b)