### PR TITLE
Make resource caches revision-aware and invalidate stale GDTF/mesh resources; fix Viewer2D state restore

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -46,8 +46,9 @@ Changes since **v1.5.0**.
   inheriting instance translation, rotation, scale, shear, or parent placement,
   and restores the exact offscreen 2D viewer state after Layout capture work.
   Resource synchronization, visibility, rendering, and bounds calculation now
-  share one platform-neutral reference-key contract, while fixture capture fits
-  directly from the authoritative GDTF bounds already used for calibration.
+  share one platform-neutral reference-key contract. Fixture capture now uses
+  the renderer's loaded GDTF bounds for its established framing, while physical
+  calibration uses the same metre/millimetre transform contract as rendering.
   Together these changes prevent renderable fixtures from being framed with the
   small unresolved-resource fallback solely because their path uses a different
   slash or relative-path spelling.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -42,9 +42,12 @@ Changes since **v1.5.0**.
 - Fixture-symbol rendering now notices GDTF files replaced at the same path,
   rejects stale runtime and disk geometry caches, keeps the authoritative
   dimensions of file-backed GDTF models isolated when several definitions
-  share one mesh, and restores the exact offscreen 2D viewer state after Layout
-  capture work. This prevents symbol output from depending on which resource
-  revision, fixture mode, or capture ran earlier in the application session.
+  share one mesh, generates fixture-type symbols at a canonical origin without
+  inheriting instance translation, rotation, scale, shear, or parent placement,
+  and restores the exact offscreen 2D viewer state after Layout capture work.
+  This prevents symbol output from depending on which fixture instance,
+  resource revision, fixture mode, or capture ran earlier in the application
+  session.
 
 - Layout 2D View elements now refresh after any visual scene change, including
   adding, moving, editing, or removing scene elements as well as opening or

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -39,6 +39,12 @@ Changes since **v1.5.0**.
 
 ## Fixes
 
+- Fixture-symbol rendering now notices GDTF files replaced at the same path,
+  rejects stale runtime and disk geometry caches, and restores the exact
+  offscreen 2D viewer state after Layout capture work. This prevents symbol
+  output from depending on which resource revision or capture ran earlier in
+  the application session.
+
 - Layout 2D View elements now refresh after any visual scene change, including
   adding, moving, editing, or removing scene elements as well as opening or
   merging MVR files, so saved layouts cannot continue showing stale content.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -40,10 +40,11 @@ Changes since **v1.5.0**.
 ## Fixes
 
 - Fixture-symbol rendering now notices GDTF files replaced at the same path,
-  rejects stale runtime and disk geometry caches, and restores the exact
-  offscreen 2D viewer state after Layout capture work. This prevents symbol
-  output from depending on which resource revision or capture ran earlier in
-  the application session.
+  rejects stale runtime and disk geometry caches, keeps the authoritative
+  dimensions of file-backed GDTF models isolated when several definitions
+  share one mesh, and restores the exact offscreen 2D viewer state after Layout
+  capture work. This prevents symbol output from depending on which resource
+  revision, fixture mode, or capture ran earlier in the application session.
 
 - Layout 2D View elements now refresh after any visual scene change, including
   adding, moving, editing, or removing scene elements as well as opening or

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -45,9 +45,12 @@ Changes since **v1.5.0**.
   share one mesh, generates fixture-type symbols at a canonical origin without
   inheriting instance translation, rotation, scale, shear, or parent placement,
   and restores the exact offscreen 2D viewer state after Layout capture work.
-  This prevents symbol output from depending on which fixture instance,
-  resource revision, fixture mode, or capture ran earlier in the application
-  session.
+  Resource synchronization, visibility, rendering, and bounds calculation now
+  share one platform-neutral reference-key contract, while fixture capture fits
+  directly from the authoritative GDTF bounds already used for calibration.
+  Together these changes prevent renderable fixtures from being framed with the
+  small unresolved-resource fallback solely because their path uses a different
+  slash or relative-path spelling.
 
 - Layout 2D View elements now refresh after any visual scene change, including
   adding, moving, editing, or removing scene elements as well as opening or

--- a/gui/services/fixture_symbol_preparation_service.cpp
+++ b/gui/services/fixture_symbol_preparation_service.cpp
@@ -304,9 +304,8 @@ void FixtureSymbolPreparationService::RunNextStep() {
       FailCurrent("Fixture symbol preparation could not acquire a renderer.");
       return;
     }
-    tools::SceneModelSymbolCaptureOptions options;
-    options.alignToLocalAxes = true;
-    options.forcedFixtureColor = "#3FA9F5";
+    tools::SceneModelSymbolCaptureOptions options =
+        tools::BuildFixtureTypeSymbolCaptureOptions("automatic");
     if (work.bounds.valid)
       options.fixtureBoundsOverride = work.bounds;
     auto capture = tools::CaptureSceneModelOrthographicRenders(

--- a/gui/services/fixture_symbol_preparation_service.cpp
+++ b/gui/services/fixture_symbol_preparation_service.cpp
@@ -316,6 +316,16 @@ void FixtureSymbolPreparationService::RunNextStep() {
       FailCurrent(capture.error);
       return;
     }
+    const symbol_cache::GdtfFileRevision capturedRevision =
+        symbol_cache::ReadGdtfFileRevision(
+            currentKey_->effectiveGdtfPath);
+    if (!work.sourceRevision.metadataAvailable ||
+        !capturedRevision.metadataAvailable ||
+        capturedRevision != work.sourceRevision) {
+      FailCurrent(
+          "Fixture symbol source changed during capture; retry is required.");
+      return;
+    }
     work.bounds = capture.fixtureBoundsMm;
     work.renders = std::move(capture.renders);
     if (!coordinator_.CompleteCapture(*currentKey_, epoch_)) {

--- a/gui/tools/fixture_geometry_bounds.cpp
+++ b/gui/tools/fixture_geometry_bounds.cpp
@@ -1,42 +1,12 @@
 #include "tools/fixture_geometry_bounds.h"
 
-#include <algorithm>
-#include <array>
-#include <cfloat>
 #include <vector>
 
+#include "culling/gdtf_object_bounds.h"
 #include "gdtfloader.h"
-#include "types.h"
+#include "viewer3d_types.h"
 
 namespace tools {
-namespace {
-
-// Transforms a mesh point into fixture space.
-std::array<float, 3> TransformPoint(const Matrix &m,
-                                    const std::array<float, 3> &p) {
-  return {m.u[0] * p[0] + m.v[0] * p[1] + m.w[0] * p[2] + m.o[0],
-          m.u[1] * p[0] + m.v[1] * p[1] + m.w[1] * p[2] + m.o[1],
-          m.u[2] * p[0] + m.v[2] * p[1] + m.w[2] * p[2] + m.o[2]};
-}
-
-// Expands bounds to include one transformed point.
-void ExtendBounds(FixtureGeometryBounds &bounds,
-                  const std::array<float, 3> &p) {
-  if (!bounds.valid) {
-    bounds.min = p;
-    bounds.max = p;
-    bounds.valid = true;
-    return;
-  }
-  bounds.min[0] = std::min(bounds.min[0], p[0]);
-  bounds.min[1] = std::min(bounds.min[1], p[1]);
-  bounds.min[2] = std::min(bounds.min[2], p[2]);
-  bounds.max[0] = std::max(bounds.max[0], p[0]);
-  bounds.max[1] = std::max(bounds.max[1], p[1]);
-  bounds.max[2] = std::max(bounds.max[2], p[2]);
-}
-
-} // namespace
 
 // Computes renderer-consistent fixture mesh bounds for an exact GDTF mode.
 bool ComputeFixtureGeometryBoundsMm(const std::string &gdtfPath,
@@ -48,20 +18,18 @@ bool ComputeFixtureGeometryBoundsMm(const std::string &gdtfPath,
   if (!LoadGdtf(gdtfPath, objects, gdtfMode, &errorMessage))
     return false;
 
-  for (const auto &object : objects) {
-    for (size_t vi = 0; vi + 2 < object.mesh.vertices.size(); vi += 3) {
-      const std::array<float, 3> local = {object.mesh.vertices[vi],
-                                          object.mesh.vertices[vi + 1],
-                                          object.mesh.vertices[vi + 2]};
-      ExtendBounds(bounds, TransformPoint(object.transform, local));
-    }
-  }
-
-  if (!bounds.valid) {
+  Viewer3DBoundingBox boundsMeters;
+  if (!viewer3d::culling::ComputeGdtfObjectBoundsMeters(objects,
+                                                        boundsMeters)) {
     errorMessage =
         "Could not determine fixture geometry bounds from GDTF meshes.";
     return false;
   }
+  for (size_t axis = 0; axis < 3; ++axis) {
+    bounds.min[axis] = boundsMeters.min[axis] / RENDER_SCALE;
+    bounds.max[axis] = boundsMeters.max[axis] / RENDER_SCALE;
+  }
+  bounds.valid = true;
   return true;
 }
 

--- a/gui/tools/fixture_symbol_generation_tool.cpp
+++ b/gui/tools/fixture_symbol_generation_tool.cpp
@@ -118,16 +118,12 @@ void RunFixtureSymbolGeneration(MainWindow &window) {
   }
   window.PromoteManualFixtureSymbolPreparation(selectedFixtureUuid);
 
-  const std::string forcedFixtureColor = "#3FA9F5";
-  SceneModelSymbolCaptureOptions captureOptions;
-  captureOptions.forcedFixtureColor = forcedFixtureColor;
-  // Captured symbols must be orientation-neutral so per-instance rotation can be applied later in rendering/printing.
-  captureOptions.alignToLocalAxes = true;
+  SceneModelSymbolCaptureOptions captureOptions =
+      BuildFixtureTypeSymbolCaptureOptions("manual");
   auto capture = CaptureSceneModelOrthographicSymbols(
       *offscreenRenderer, cfg,
       SceneModelSymbolTarget{SceneModelKind::Fixture, selectedFixtureUuid},
       captureOptions);
-  captureOptions.alignToLocalAxes = false;
   if (!capture.ok) {
     window.CompleteManualFixtureSymbolPreparation(selectedFixtureUuid, false);
     wxMessageBox(capture.error, "Generate Fixture Symbols", wxOK | wxICON_ERROR,

--- a/gui/tools/scene_model_symbol_capture_service.cpp
+++ b/gui/tools/scene_model_symbol_capture_service.cpp
@@ -22,6 +22,7 @@
 #include "truss.h"
 #include "viewer2doffscreenrenderer.h"
 #include "viewer2dpanel.h"
+#include "viewer2dviewfit.h"
 
 namespace tools {
 namespace {
@@ -418,7 +419,26 @@ SceneModelSymbolRenderResult CaptureSceneModelOrthographicRenders(
     else if (request.viewerView == symbols::SymbolCaptureViewerView::Side)
       viewerView = Viewer2DView::Side;
     capturePanel->SetView(viewerView);
-    capturePanel->FitViewToScene();
+    bool fittedAuthoritativeBounds = false;
+    if (target.kind == SceneModelKind::Fixture && fixtureBounds.valid) {
+      Viewer3DBoundingBox boundsMeters;
+      for (size_t axis = 0; axis < 3; ++axis) {
+        boundsMeters.min[axis] = fixtureBounds.min[axis] * 0.001f;
+        boundsMeters.max[axis] = fixtureBounds.max[axis] * 0.001f;
+      }
+      const Viewer2DViewState viewportState = capturePanel->GetViewState();
+      viewer2d::ViewFitResult fit;
+      fittedAuthoritativeBounds = viewer2d::ComputeViewFitForBounds(
+          boundsMeters, viewerView, viewportState.viewportWidth,
+          viewportState.viewportHeight, fit);
+      if (fittedAuthoritativeBounds) {
+        capturePanel->ApplyViewState(fit.offsetXPixels, fit.offsetYPixels,
+                                     fit.zoom, viewerView,
+                                     Viewer2DRenderMode::ByFixtureType);
+      }
+    }
+    if (!fittedAuthoritativeBounds)
+      capturePanel->FitViewToScene();
 #ifndef NDEBUG
     const Viewer2DViewState fittedState = capturePanel->GetViewState();
     diagnostics::DiagnosticLogger::Debug(

--- a/gui/tools/scene_model_symbol_capture_service.cpp
+++ b/gui/tools/scene_model_symbol_capture_service.cpp
@@ -22,7 +22,6 @@
 #include "truss.h"
 #include "viewer2doffscreenrenderer.h"
 #include "viewer2dpanel.h"
-#include "viewer2dviewfit.h"
 
 namespace tools {
 namespace {
@@ -419,26 +418,7 @@ SceneModelSymbolRenderResult CaptureSceneModelOrthographicRenders(
     else if (request.viewerView == symbols::SymbolCaptureViewerView::Side)
       viewerView = Viewer2DView::Side;
     capturePanel->SetView(viewerView);
-    bool fittedAuthoritativeBounds = false;
-    if (target.kind == SceneModelKind::Fixture && fixtureBounds.valid) {
-      Viewer3DBoundingBox boundsMeters;
-      for (size_t axis = 0; axis < 3; ++axis) {
-        boundsMeters.min[axis] = fixtureBounds.min[axis] * 0.001f;
-        boundsMeters.max[axis] = fixtureBounds.max[axis] * 0.001f;
-      }
-      const Viewer2DViewState viewportState = capturePanel->GetViewState();
-      viewer2d::ViewFitResult fit;
-      fittedAuthoritativeBounds = viewer2d::ComputeViewFitForBounds(
-          boundsMeters, viewerView, viewportState.viewportWidth,
-          viewportState.viewportHeight, fit);
-      if (fittedAuthoritativeBounds) {
-        capturePanel->ApplyViewState(fit.offsetXPixels, fit.offsetYPixels,
-                                     fit.zoom, viewerView,
-                                     Viewer2DRenderMode::ByFixtureType);
-      }
-    }
-    if (!fittedAuthoritativeBounds)
-      capturePanel->FitViewToScene();
+    capturePanel->FitViewToScene();
 #ifndef NDEBUG
     const Viewer2DViewState fittedState = capturePanel->GetViewState();
     diagnostics::DiagnosticLogger::Debug(

--- a/gui/tools/scene_model_symbol_capture_service.cpp
+++ b/gui/tools/scene_model_symbol_capture_service.cpp
@@ -1,14 +1,20 @@
 #include "tools/scene_model_symbol_capture_service.h"
 
 #include <array>
+#include <atomic>
 #include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <sstream>
 #include <string>
 
 #include "configmanager.h"
+#include "diagnostics/DiagnosticLogger.h"
 #include "fixture.h"
 #include "fixtures/fixture_gdtf_resolution.h"
 #include "sceneobject.h"
 #include "symbols/Symbol2DImageBuilder.h"
+#include "symbols/fixture_symbol_resource_revision.h"
 #include "symbols/SymbolGeometrySimplifier.h"
 #include "tools/fixture_geometry_bounds.h"
 #include "tools/scoped_scene_replacement_lifecycle.h"
@@ -21,6 +27,88 @@ namespace tools {
 namespace {
 
 constexpr float kSymbolRdpEpsilon = 1.0f;
+std::atomic<std::uint64_t> s_captureJobId{0};
+
+// Returns the stable diagnostic name for a capture transform policy.
+const char *TransformPolicyName(SymbolCaptureTransformPolicy policy) {
+  switch (policy) {
+  case SymbolCaptureTransformPolicy::PreserveInstanceTransform:
+    return "preserve_instance";
+  case SymbolCaptureTransformPolicy::AlignRotationPreserveScale:
+    return "align_rotation_preserve_scale";
+  case SymbolCaptureTransformPolicy::CanonicalFixtureType:
+    return "canonical_fixture_type";
+  }
+  return "unknown";
+}
+
+// Formats a complete scene transform for capture diagnostics.
+std::string FormatTransform(const Matrix &matrix) {
+  std::ostringstream output;
+  output << "u=" << matrix.u[0] << ',' << matrix.u[1] << ',' << matrix.u[2]
+         << " v=" << matrix.v[0] << ',' << matrix.v[1] << ',' << matrix.v[2]
+         << " w=" << matrix.w[0] << ',' << matrix.w[1] << ',' << matrix.w[2]
+         << " o=" << matrix.o[0] << ',' << matrix.o[1] << ',' << matrix.o[2];
+  return output.str();
+}
+
+// Formats scale, determinant, and orthogonality metrics for a transform basis.
+std::string FormatTransformMetrics(const Matrix &matrix) {
+  const auto length = [](const std::array<float, 3> &axis) {
+    return std::sqrt(axis[0] * axis[0] + axis[1] * axis[1] +
+                     axis[2] * axis[2]);
+  };
+  const auto dot = [](const std::array<float, 3> &left,
+                      const std::array<float, 3> &right) {
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2];
+  };
+  const float determinant =
+      matrix.u[0] * (matrix.v[1] * matrix.w[2] - matrix.v[2] * matrix.w[1]) -
+      matrix.v[0] * (matrix.u[1] * matrix.w[2] - matrix.u[2] * matrix.w[1]) +
+      matrix.w[0] * (matrix.u[1] * matrix.v[2] - matrix.u[2] * matrix.v[1]);
+  std::ostringstream output;
+  output << " scale=" << length(matrix.u) << ',' << length(matrix.v) << ','
+         << length(matrix.w) << " determinant=" << determinant
+         << " basis_dot=" << dot(matrix.u, matrix.v) << ','
+         << dot(matrix.u, matrix.w) << ',' << dot(matrix.v, matrix.w);
+  return output.str();
+}
+
+// Builds a lightweight hash and content bounds for one raw RGBA capture.
+std::string BuildRgbaFingerprint(const symbols::RenderedSymbolImage &render) {
+  std::uint64_t hash = 1469598103934665603ULL;
+  int minX = render.width;
+  int minY = render.height;
+  int maxX = -1;
+  int maxY = -1;
+  for (int y = 0; y < render.height; ++y) {
+    for (int x = 0; x < render.width; ++x) {
+      const size_t offset =
+          (static_cast<size_t>(y) * static_cast<size_t>(render.width) + x) * 4;
+      if (offset + 3 >= render.rgba.size())
+        continue;
+      for (size_t channel = 0; channel < 4; ++channel) {
+        hash ^= render.rgba[offset + channel];
+        hash *= 1099511628211ULL;
+      }
+      if (render.rgba[offset] < 250 || render.rgba[offset + 1] < 250 ||
+          render.rgba[offset + 2] < 250 || render.rgba[offset + 3] < 250) {
+        minX = std::min(minX, x);
+        minY = std::min(minY, y);
+        maxX = std::max(maxX, x);
+        maxY = std::max(maxY, y);
+      }
+    }
+  }
+  std::ostringstream output;
+  output << "size=" << render.width << 'x' << render.height << " content=";
+  if (maxX < minX || maxY < minY)
+    output << "empty";
+  else
+    output << minX << ',' << minY << '-' << maxX << ',' << maxY;
+  output << " rgba_hash=" << std::hex << hash;
+  return output.str();
+}
 
 // Temporarily overrides the isolated fixture color used for extraction.
 class ScopedFixtureCaptureColor {
@@ -187,6 +275,17 @@ float ComputeCaptureAspectForView(const FixtureGeometryBounds &bounds,
 
 } // namespace
 
+// Builds the canonical options shared by automatic and manual fixture symbols.
+SceneModelSymbolCaptureOptions BuildFixtureTypeSymbolCaptureOptions(
+    std::string diagnosticOrigin) {
+  SceneModelSymbolCaptureOptions options;
+  options.transformPolicy =
+      SymbolCaptureTransformPolicy::CanonicalFixtureType;
+  options.diagnosticOrigin = std::move(diagnosticOrigin);
+  options.forcedFixtureColor = "#3FA9F5";
+  return options;
+}
+
 // Captures all orthographic source images in one non-yielding scene scope.
 SceneModelSymbolRenderResult CaptureSceneModelOrthographicRenders(
     Viewer2DOffscreenRenderer &renderer, ConfigManager &cfg,
@@ -199,9 +298,56 @@ SceneModelSymbolRenderResult CaptureSceneModelOrthographicRenders(
     return result;
   }
 
+  const std::uint64_t captureJobId = ++s_captureJobId;
+  std::optional<Fixture> originalFixture;
+  if (target.kind == SceneModelKind::Fixture) {
+    const auto fixtureIt = cfg.GetScene().fixtures.find(target.uuid);
+    if (fixtureIt != cfg.GetScene().fixtures.end())
+      originalFixture = fixtureIt->second;
+  }
+#ifndef NDEBUG
+  if (originalFixture) {
+    gui::fixtures::FixtureGdtfResolution resolution;
+    std::string resolutionError;
+    const bool resolved = gui::fixtures::ResolveFixtureGdtfDeterministic(
+        *originalFixture, cfg.GetScene(), resolution, resolutionError);
+    const symbol_cache::GdtfFileRevision revision =
+        symbol_cache::ReadGdtfFileRevision(resolved ? resolution.selectedPath
+                                                    : std::string());
+    diagnostics::DiagnosticLogger::Debug(
+        "fixture_symbol_capture_start job=" + std::to_string(captureJobId) +
+        " origin=" + options.diagnosticOrigin + " fixture_uuid=" + target.uuid +
+        " fixture_type=\"" + originalFixture->typeName + "\" gdtf=\"" +
+        originalFixture->gdtfSpec + "\" physical_gdtf=\"" +
+        (resolved ? resolution.selectedPath : std::string("<unresolved>")) +
+        "\" revision=\"" + revision.Key() + "\" mode=\"" +
+        originalFixture->gdtfMode + "\" policy=" +
+        TransformPolicyName(options.transformPolicy) +
+        " parent=\"" + originalFixture->parentGroupUuid + "\" has_local=" +
+        (originalFixture->hasLocalTransform ? "1" : "0") + " original_" +
+        FormatTransform(originalFixture->transform) +
+        FormatTransformMetrics(originalFixture->transform) + " local_" +
+        FormatTransform(originalFixture->localTransform));
+  }
+#endif
+
   ScopedViewer2DCaptureState scopedPanelState(*capturePanel);
   ScopedSingleModelCaptureScene isolatedScene(cfg, target,
-                                              options.alignToLocalAxes);
+                                              options.transformPolicy);
+#ifndef NDEBUG
+  if (target.kind == SceneModelKind::Fixture) {
+    const auto isolatedIt = cfg.GetScene().fixtures.find(target.uuid);
+    if (isolatedIt != cfg.GetScene().fixtures.end()) {
+      diagnostics::DiagnosticLogger::Debug(
+          "fixture_symbol_capture_isolated job=" +
+          std::to_string(captureJobId) + " fixture_uuid=" + target.uuid + ' ' +
+          FormatTransform(isolatedIt->second.transform) + " parent=\"" +
+          isolatedIt->second.parentGroupUuid + "\" has_local=" +
+          (isolatedIt->second.hasLocalTransform ? "1" : "0") +
+          FormatTransformMetrics(isolatedIt->second.transform));
+    }
+  }
+#endif
   ScopedFixtureCaptureColor captureColor(
       cfg, target.kind == SceneModelKind::Fixture ? target.uuid : std::string(),
       options.forcedFixtureColor);
@@ -273,6 +419,17 @@ SceneModelSymbolRenderResult CaptureSceneModelOrthographicRenders(
       viewerView = Viewer2DView::Side;
     capturePanel->SetView(viewerView);
     capturePanel->FitViewToScene();
+#ifndef NDEBUG
+    const Viewer2DViewState fittedState = capturePanel->GetViewState();
+    diagnostics::DiagnosticLogger::Debug(
+        "fixture_symbol_capture_view job=" + std::to_string(captureJobId) +
+        " view=" + std::to_string(static_cast<int>(request.symbolView)) +
+        " viewport=" + std::to_string(fittedState.viewportWidth) + 'x' +
+        std::to_string(fittedState.viewportHeight) + " zoom=" +
+        std::to_string(fittedState.zoom) + " offset=" +
+        std::to_string(fittedState.offsetPixelsX) + ',' +
+        std::to_string(fittedState.offsetPixelsY));
+#endif
 
     symbols::RenderedSymbolImage render;
     render.view = request.symbolView;
@@ -284,6 +441,12 @@ SceneModelSymbolRenderResult CaptureSceneModelOrthographicRenders(
     }
     if (request.mirrorHorizontally)
       MirrorImageHorizontally(render);
+#ifndef NDEBUG
+    diagnostics::DiagnosticLogger::Debug(
+        "fixture_symbol_capture_rgba job=" + std::to_string(captureJobId) +
+        " view=" + std::to_string(static_cast<int>(render.view)) + ' ' +
+        BuildRgbaFingerprint(render));
+#endif
     result.renders.push_back(std::move(render));
   }
   result.ok = result.renders.size() == requests.size();

--- a/gui/tools/scene_model_symbol_capture_service.h
+++ b/gui/tools/scene_model_symbol_capture_service.h
@@ -11,6 +11,7 @@
 #include "symbols/Symbol2DImageBuilder.h"
 #include "tools/fixture_geometry_bounds.h"
 #include "tools/scene_model_symbol_target.h"
+#include "tools/symbol_capture_transform_policy.h"
 
 class ConfigManager;
 class Viewer2DOffscreenRenderer;
@@ -18,12 +19,17 @@ class Viewer2DOffscreenRenderer;
 namespace tools {
 
 struct SceneModelSymbolCaptureOptions {
-  bool alignToLocalAxes = false;
+  SymbolCaptureTransformPolicy transformPolicy =
+      SymbolCaptureTransformPolicy::PreserveInstanceTransform;
+  std::string diagnosticOrigin;
   std::optional<std::string> forcedFixtureColor;
   wxSize viewportSize = wxSize(1200, 1200);
   std::optional<FixtureGeometryBounds> fixtureBoundsOverride;
   symbols::FixtureSymbolTimings *timings = nullptr;
 };
+
+SceneModelSymbolCaptureOptions BuildFixtureTypeSymbolCaptureOptions(
+    std::string diagnosticOrigin);
 
 struct SceneModelSymbolCaptureResult {
   bool ok = false;

--- a/gui/tools/scoped_single_model_capture_scene.cpp
+++ b/gui/tools/scoped_single_model_capture_scene.cpp
@@ -8,7 +8,7 @@ namespace tools {
 // Replaces renderable scene containers with one aligned capture target.
 ScopedSingleModelCaptureScene::ScopedSingleModelCaptureScene(
     ConfigManager &cfg, const SceneModelSymbolTarget &target,
-    bool alignToLocalAxes)
+    SymbolCaptureTransformPolicy transformPolicy)
     : cfg_(cfg) {
   auto &scene = cfg_.GetScene();
   originalFixtures_.swap(scene.fixtures);
@@ -22,8 +22,16 @@ ScopedSingleModelCaptureScene::ScopedSingleModelCaptureScene(
       const auto it = originalFixtures_.find(target.uuid);
       if (it != originalFixtures_.end()) {
         Fixture fixture = it->second;
-        if (alignToLocalAxes)
+        if (transformPolicy ==
+            SymbolCaptureTransformPolicy::CanonicalFixtureType) {
+          fixture.transform = MatrixUtils::Identity();
+          fixture.parentGroupUuid.clear();
+          fixture.hasLocalTransform = false;
+          fixture.localTransform = MatrixUtils::Identity();
+        } else if (transformPolicy ==
+                   SymbolCaptureTransformPolicy::AlignRotationPreserveScale) {
           fixture.transform = AlignTransform(fixture.transform);
+        }
         scene.fixtures.emplace(it->first, std::move(fixture));
       }
       break;
@@ -32,7 +40,8 @@ ScopedSingleModelCaptureScene::ScopedSingleModelCaptureScene(
       const auto it = originalTrusses_.find(target.uuid);
       if (it != originalTrusses_.end()) {
         Truss truss = it->second;
-        if (alignToLocalAxes)
+        if (transformPolicy ==
+            SymbolCaptureTransformPolicy::AlignRotationPreserveScale)
           truss.transform = AlignTransform(truss.transform);
         scene.trusses.emplace(it->first, std::move(truss));
       }
@@ -42,7 +51,8 @@ ScopedSingleModelCaptureScene::ScopedSingleModelCaptureScene(
       const auto it = originalSceneObjects_.find(target.uuid);
       if (it != originalSceneObjects_.end()) {
         SceneObject object = it->second;
-        if (alignToLocalAxes)
+        if (transformPolicy ==
+            SymbolCaptureTransformPolicy::AlignRotationPreserveScale)
           object.transform = AlignTransform(object.transform);
         scene.sceneObjects.emplace(it->first, std::move(object));
       }

--- a/gui/tools/scoped_single_model_capture_scene.h
+++ b/gui/tools/scoped_single_model_capture_scene.h
@@ -7,6 +7,7 @@
 #include "sceneobject.h"
 #include "support.h"
 #include "tools/scene_model_symbol_target.h"
+#include "tools/symbol_capture_transform_policy.h"
 #include "truss.h"
 
 class ConfigManager;
@@ -18,7 +19,7 @@ class ScopedSingleModelCaptureScene {
 public:
   ScopedSingleModelCaptureScene(ConfigManager &cfg,
                                 const SceneModelSymbolTarget &target,
-                                bool alignToLocalAxes);
+                                SymbolCaptureTransformPolicy transformPolicy);
   ~ScopedSingleModelCaptureScene();
 
   ScopedSingleModelCaptureScene(const ScopedSingleModelCaptureScene &) = delete;

--- a/gui/tools/symbol_capture_transform_policy.h
+++ b/gui/tools/symbol_capture_transform_policy.h
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace tools {
+
+enum class SymbolCaptureTransformPolicy {
+  PreserveInstanceTransform,
+  AlignRotationPreserveScale,
+  CanonicalFixtureType
+};
+
+} // namespace tools

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2747,6 +2747,8 @@ target_include_directories(viewer2d_bounds_fit_test PRIVATE
                            ../viewer3d/interfaces)
 add_test(NAME Viewer2DFallbackFitDiagnosis COMMAND viewer2d_bounds_fit_test)
 add_test(NAME Viewer2DExplicitBoundsFitParity COMMAND viewer2d_bounds_fit_test)
+add_test(NAME Viewer2DAsymmetricProjectionFit COMMAND viewer2d_bounds_fit_test)
+add_test(NAME QuantumWashKnownGoodFitRegression COMMAND viewer2d_bounds_fit_test)
 add_test(NAME FixtureSymbolInstanceTransformIndependence
          COMMAND scoped_single_model_capture_scene_test)
 add_test(NAME FixtureSymbolRepresentativeUuidIndependence
@@ -2762,6 +2764,10 @@ target_include_directories(fixture_geometry_bounds_test BEFORE PRIVATE
 target_include_directories(fixture_geometry_bounds_test PRIVATE
                            ../gui ../models)
 add_test(NAME FixtureGeometryBounds COMMAND fixture_geometry_bounds_test)
+add_test(NAME FixtureGeometryBoundsRendererUnitParity
+         COMMAND fixture_geometry_bounds_test)
+add_test(NAME FixtureGeometryBoundsTranslatedChild
+         COMMAND fixture_geometry_bounds_test)
 
 # Reuse the production mesh parsers in every standalone test that owns truss loading/building.
 get_property(perastage_geometry_test_targets DIRECTORY PROPERTY BUILDSYSTEM_TARGETS)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2052,6 +2052,27 @@ target_link_libraries(gdtfloader_geometry_roots_test PRIVATE
 add_test(NAME GdtfLoaderGeometryRoots COMMAND gdtfloader_geometry_roots_test)
 set_library_env(GdtfLoaderGeometryRoots)
 
+add_executable(gdtfloader_file_model_cache_identity_test
+               gdtfloader_file_model_cache_identity_test.cpp
+               build_info_stub.cpp
+               ../viewer3d/gdtfloader.cpp
+               ../core/runtime_storage.cpp
+               ../core/logger.cpp
+               ../core/gdtf_canonicalizer.cpp
+               ../core/gdtf_mutation_audit.cpp
+               ../viewer3d/loader3ds.cpp
+               ../viewer3d/loaderglb.cpp
+               ../viewer3d/meshprimitives.cpp
+               consolepanel_stub.cpp)
+target_include_directories(gdtfloader_file_model_cache_identity_test PRIVATE
+                           . ../viewer3d ../models ../gui ../third_party)
+target_link_libraries(gdtfloader_file_model_cache_identity_test PRIVATE
+                      ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2
+                      perastage_test_gdtf_archive_reader)
+add_test(NAME GdtfLoaderFileModelCacheIdentity
+         COMMAND gdtfloader_file_model_cache_identity_test)
+set_library_env(GdtfLoaderFileModelCacheIdentity)
+
 add_executable(gdtfloader_set_properties_test gdtfloader_set_properties_test.cpp
                support/gdtf_test_fixture_builder.cpp
                build_info_stub.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2721,6 +2721,12 @@ target_link_libraries(scoped_single_model_capture_scene_test PRIVATE
                       ${wxWidgets_LIBRARIES})
 add_test(NAME ScopedSingleModelCaptureScene
          COMMAND scoped_single_model_capture_scene_test)
+add_test(NAME FixtureSymbolInstanceTransformIndependence
+         COMMAND scoped_single_model_capture_scene_test)
+add_test(NAME FixtureSymbolRepresentativeUuidIndependence
+         COMMAND scoped_single_model_capture_scene_test)
+add_test(NAME ProjectReplacementFixtureSymbolParity
+         COMMAND scoped_single_model_capture_scene_test)
 
 add_executable(fixture_geometry_bounds_test
                fixture_geometry_bounds_test.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -152,6 +152,7 @@ if(BASH_EXECUTABLE)
     add_bash_policy_test(FixtureSymbolAvailabilityBoundary ${CMAKE_CURRENT_SOURCE_DIR}/check_fixture_symbol_availability_boundary.sh)
     add_bash_policy_test(FixtureSymbolSourceArchitecture ${CMAKE_CURRENT_SOURCE_DIR}/check_fixture_symbol_source_architecture.sh)
     add_bash_policy_test(FixtureSymbolCaptureIsolation ${CMAKE_CURRENT_SOURCE_DIR}/check_fixture_symbol_capture_isolation.sh)
+    add_bash_policy_test(ResourceReferenceCacheKey ${CMAKE_CURRENT_SOURCE_DIR}/check_resource_reference_cache_key.sh)
     add_bash_policy_test(FixtureSymbolPreparationArchitecture ${CMAKE_CURRENT_SOURCE_DIR}/check_fixture_symbol_preparation_architecture.sh)
     add_bash_policy_test(FixtureSymbol3DRefresh ${CMAKE_CURRENT_SOURCE_DIR}/check_fixture_symbol_3d_refresh.sh)
     add_bash_policy_test(LayoutViewerFitLifecycle ${CMAKE_CURRENT_SOURCE_DIR}/check_layout_viewer_fit_lifecycle.sh)
@@ -2721,6 +2722,31 @@ target_link_libraries(scoped_single_model_capture_scene_test PRIVATE
                       ${wxWidgets_LIBRARIES})
 add_test(NAME ScopedSingleModelCaptureScene
          COMMAND scoped_single_model_capture_scene_test)
+
+add_executable(resource_reference_bounds_regression_test
+               resource_reference_bounds_regression_test.cpp
+               configmanager_layoutmanager_stub.cpp
+               resource_sync_key_stub.cpp
+               ../viewer3d/culling/bounds_cache_system.cpp
+               ../viewer3d/culling/primitive_bounds_utils.cpp
+               ../viewer3d/meshprimitives.cpp)
+target_include_directories(resource_reference_bounds_regression_test PRIVATE
+                           ../core ../models ../gui ../viewer3d
+                           ../viewer3d/culling ../viewer3d/resources)
+target_link_libraries(resource_reference_bounds_regression_test PRIVATE
+                      ${wxWidgets_LIBRARIES} perastage_test_diagnostics)
+add_test(NAME ResourceReferenceCacheKeyEquivalence
+         COMMAND resource_reference_bounds_regression_test)
+add_test(NAME BoundsCacheResolvedGdtfReferenceKeyRegression
+         COMMAND resource_reference_bounds_regression_test)
+
+add_executable(viewer2d_bounds_fit_test viewer2d_bounds_fit_test.cpp
+               ../viewer2d/viewer2dviewfit.cpp)
+target_include_directories(viewer2d_bounds_fit_test PRIVATE
+                           ../models ../viewer2d ../viewer3d
+                           ../viewer3d/interfaces)
+add_test(NAME Viewer2DFallbackFitDiagnosis COMMAND viewer2d_bounds_fit_test)
+add_test(NAME Viewer2DExplicitBoundsFitParity COMMAND viewer2d_bounds_fit_test)
 add_test(NAME FixtureSymbolInstanceTransformIndependence
          COMMAND scoped_single_model_capture_scene_test)
 add_test(NAME FixtureSymbolRepresentativeUuidIndependence

--- a/tests/check_fixture_symbol_capture_isolation.sh
+++ b/tests/check_fixture_symbol_capture_isolation.sh
@@ -8,6 +8,8 @@ compatibility="$root/gui/tools/scoped_single_model_capture_scene.cpp"
 resource_sync="$root/viewer3d/resources/resource_sync_system.cpp"
 resource_header="$root/viewer3d/resources/resource_sync_system.h"
 revision_header="$root/viewer3d/resources/physical_asset_revision.h"
+manual="$root/gui/tools/fixture_symbol_generation_tool.cpp"
+policy="$root/gui/tools/symbol_capture_transform_policy.h"
 
 rg -q 'ScopedSingleModelCaptureScene' "$capture"
 rg -q 'originalFixtures_\.swap\(scene\.fixtures\)' "$compatibility"
@@ -17,6 +19,9 @@ rg -q 'loadedGdtfRevisions' "$resource_header"
 rg -q 'ReadPhysicalAssetRevision' "$resource_sync" "$revision_header"
 rg -q 'InvalidatePhysicalAsset' "$resource_sync" "$resource_header"
 rg -q 'capturedRevision != work.sourceRevision' "$service"
+rg -q 'CanonicalFixtureType' "$policy"
+rg -Fq 'BuildFixtureTypeSymbolCaptureOptions("automatic")' "$service"
+rg -Fq 'BuildFixtureTypeSymbolCaptureOptions("manual")' "$manual"
 if rg -n 'CaptureSceneModelOrthographicStep|nextCaptureStep|captureSnapshot' "$capture" "$service"; then
   echo "Fixture capture must not yield between orthographic views." >&2
   exit 1

--- a/tests/check_fixture_symbol_capture_isolation.sh
+++ b/tests/check_fixture_symbol_capture_isolation.sh
@@ -5,11 +5,18 @@ root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 capture="$root/gui/tools/scene_model_symbol_capture_service.cpp"
 service="$root/gui/services/fixture_symbol_preparation_service.cpp"
 compatibility="$root/gui/tools/scoped_single_model_capture_scene.cpp"
+resource_sync="$root/viewer3d/resources/resource_sync_system.cpp"
+resource_header="$root/viewer3d/resources/resource_sync_system.h"
+revision_header="$root/viewer3d/resources/physical_asset_revision.h"
 
 rg -q 'ScopedSingleModelCaptureScene' "$capture"
 rg -q 'originalFixtures_\.swap\(scene\.fixtures\)' "$compatibility"
 rg -q 'scene\.fixtures\.swap\(originalFixtures_\)' "$compatibility"
 rg -Fq 'PrepareForSceneReplacement();' "$capture"
+rg -q 'loadedGdtfRevisions' "$resource_header"
+rg -q 'ReadPhysicalAssetRevision' "$resource_sync" "$revision_header"
+rg -q 'InvalidatePhysicalAsset' "$resource_sync" "$resource_header"
+rg -q 'capturedRevision != work.sourceRevision' "$service"
 if rg -n 'CaptureSceneModelOrthographicStep|nextCaptureStep|captureSnapshot' "$capture" "$service"; then
   echo "Fixture capture must not yield between orthographic views." >&2
   exit 1

--- a/tests/check_resource_reference_cache_key.sh
+++ b/tests/check_resource_reference_cache_key.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+key_header="$root/viewer3d/resources/resource_reference_cache_key.h"
+files=(
+  "$root/viewer3d/resources/resource_sync_system.cpp"
+  "$root/viewer3d/culling/bounds_cache_system.cpp"
+  "$root/viewer3d/culling/visibilitysystem.cpp"
+  "$root/viewer3d/render/opaque_pass_utils.cpp"
+)
+
+rg -q 'BuildResourceReferenceCacheKey' "$key_header"
+for file in "${files[@]}"; do
+  rg -q 'BuildResourceReferenceCacheKey' "$file"
+done
+if rg -n 'static std::string ResolveCacheKey' \
+  "$root/viewer3d/resources/resource_sync_system.cpp" \
+  "$root/viewer3d/culling/bounds_cache_system.cpp" \
+  "$root/viewer3d/culling/visibilitysystem.cpp"; then
+  echo "Resource reference map owners must use the shared cache-key builder." >&2
+  exit 1
+fi
+
+echo "Resource reference cache maps share one canonical key contract."

--- a/tests/check_viewer2d_state_ownership_boundary.sh
+++ b/tests/check_viewer2d_state_ownership_boundary.sh
@@ -35,6 +35,12 @@ for token in "ScopedViewer2DState" "CaptureState" "ApplyState" "FromLayoutDefini
   fi
 done
 
+if rg -n 'restorePanel_ \? restorePanel_\.get\(\) : Viewer2DPanel::Instance\(\)|restoreRenderPanel_.*Viewer2DRenderPanel::Instance' "$state_source" >/dev/null; then
+  echo "Scoped Viewer2D state must restore its apply targets by default." >&2
+  exit 1
+fi
+rg -q 'restorePanel_ \? restorePanel_\.get\(\) : applyPanel_\.get\(\)' "$state_source"
+
 for file in "$capture_file" "$rasterizer_file"; do
   if [[ ! -f "$file" ]]; then
     echo "Missing Layout preview state boundary file: ${file#$repo_root/}" >&2

--- a/tests/fixture_geometry_bounds_test.cpp
+++ b/tests/fixture_geometry_bounds_test.cpp
@@ -1,6 +1,7 @@
 #include "tools/fixture_geometry_bounds.h"
 
 #include <cassert>
+#include <cmath>
 #include <string>
 #include <vector>
 
@@ -11,14 +12,20 @@ namespace {
 
 bool legacyLoaderCalled = false;
 
-// Creates one mesh object whose vertex establishes a distinct extent.
+// Creates translated and rotated geometry in the loader's mixed unit domain.
 GdtfObject MakeObject(float x, bool isLens) {
   GdtfObject object;
   object.transform = MatrixUtils::Identity();
-  object.mesh.vertices = {0.0f, 0.0f, 0.0f, x, 1.0f, 1.0f};
+  object.transform.u = {0.0f, 1.0f, 0.0f};
+  object.transform.v = {-1.0f, 0.0f, 0.0f};
+  object.transform.o = {1.0f, -2.0f, 0.5f};
+  object.mesh.vertices = {-x, -20.0f, -10.0f, x, 20.0f, 10.0f};
   object.isLens = isLens;
   return object;
 }
+
+// Reports whether two bounds coordinates agree within loader precision.
+bool Near(float left, float right) { return std::fabs(left - right) < 0.001f; }
 
 } // namespace
 
@@ -46,7 +53,15 @@ int main() {
   assert(tools::ComputeFixtureGeometryBoundsMm("fixture.gdtf", "Wide", wide,
                                                error));
   assert(!legacyLoaderCalled);
-  assert(narrow.valid && narrow.max[0] == 10.0f);
-  assert(wide.valid && wide.max[0] == 40.0f);
+  assert(narrow.valid);
+  assert(Near(narrow.min[0], 980.0f));
+  assert(Near(narrow.max[0], 1020.0f));
+  assert(Near(narrow.min[1], -2010.0f));
+  assert(Near(narrow.max[1], -1990.0f));
+  assert(Near(narrow.min[2], 490.0f));
+  assert(Near(narrow.max[2], 510.0f));
+  assert(wide.valid);
+  assert(Near(wide.min[1], -2040.0f));
+  assert(Near(wide.max[1], -1960.0f));
   return 0;
 }

--- a/tests/gdtfloader_file_model_cache_identity_test.cpp
+++ b/tests/gdtfloader_file_model_cache_identity_test.cpp
@@ -1,0 +1,213 @@
+#include "../viewer3d/gdtfloader.h"
+
+#include <array>
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <wx/filename.h>
+#include <wx/wfstream.h>
+class wxZipStreamLink;
+#include <wx/zipstrm.h>
+
+namespace {
+
+struct MeshSize {
+  float x = 0.0f;
+  float y = 0.0f;
+  float z = 0.0f;
+};
+
+// Appends a trivially copyable value to a binary string.
+template <typename T> void AppendBinary(std::string &bytes, const T &value) {
+  const char *data = reinterpret_cast<const char *>(&value);
+  bytes.append(data, sizeof(T));
+}
+
+// Builds a deterministic GLB containing a unit cuboid mesh.
+std::string BuildSharedGlb() {
+  const std::array<float, 24> positions = {
+      0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f,
+      0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 1.0f,
+      1.0f, 1.0f, 1.0f, 0.0f, 1.0f, 1.0f};
+  const std::array<std::uint16_t, 36> indices = {
+      0, 1, 2, 0, 2, 3, 4, 6, 5, 4, 7, 6, 0, 4, 5, 0, 5, 1,
+      1, 5, 6, 1, 6, 2, 2, 6, 7, 2, 7, 3, 3, 7, 4, 3, 4, 0};
+  std::string binary;
+  for (float value : positions)
+    AppendBinary(binary, value);
+  for (std::uint16_t value : indices)
+    AppendBinary(binary, value);
+
+  std::ostringstream json;
+  json << "{\"asset\":{\"version\":\"2.0\"},"
+          "\"scene\":0,\"scenes\":[{\"nodes\":[0]}],"
+          "\"nodes\":[{\"mesh\":0}],\"meshes\":[{\"primitives\":[{"
+          "\"attributes\":{\"POSITION\":0},\"indices\":1}]}],"
+          "\"buffers\":[{\"byteLength\":"
+       << binary.size()
+       << "}],\"bufferViews\":[{\"buffer\":0,\"byteOffset\":0,"
+          "\"byteLength\":96,\"target\":34962},{\"buffer\":0,"
+          "\"byteOffset\":96,\"byteLength\":72,\"target\":34963}],"
+          "\"accessors\":[{\"bufferView\":0,\"componentType\":5126,"
+          "\"count\":8,\"type\":\"VEC3\",\"min\":[0,0,0],"
+          "\"max\":[1,1,1]},{\"bufferView\":1,\"componentType\":5123,"
+          "\"count\":36,\"type\":\"SCALAR\"}]}";
+  std::string jsonBytes = json.str();
+  while (jsonBytes.size() % 4 != 0)
+    jsonBytes.push_back(' ');
+  while (binary.size() % 4 != 0)
+    binary.push_back('\0');
+
+  std::string glb;
+  const std::uint32_t totalLength =
+      static_cast<std::uint32_t>(12 + 8 + jsonBytes.size() + 8 + binary.size());
+  AppendBinary(glb, std::uint32_t{0x46546c67});
+  AppendBinary(glb, std::uint32_t{2});
+  AppendBinary(glb, totalLength);
+  AppendBinary(glb, static_cast<std::uint32_t>(jsonBytes.size()));
+  AppendBinary(glb, std::uint32_t{0x4e4f534a});
+  glb += jsonBytes;
+  AppendBinary(glb, static_cast<std::uint32_t>(binary.size()));
+  AppendBinary(glb, std::uint32_t{0x004e4942});
+  glb += binary;
+  return glb;
+}
+
+// Writes the deterministic multi-model GDTF under a unique cache identity.
+std::string WriteGdtf(const std::string &prefix) {
+  wxFileName temporary(wxFileName::CreateTempFileName(prefix));
+  const std::string path = temporary.GetFullPath().ToStdString() + ".gdtf";
+  wxRemoveFile(temporary.GetFullPath());
+  const std::string xml =
+      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+      "<GDTF DataVersion=\"1.2\"><FixtureType Name=\"CacheIdentity\">"
+      "<Models>"
+      "<Model Name=\"ModelA\" File=\"shared\" Length=\"1.0\" Width=\"0.5\" Height=\"0.25\"/>"
+      "<Model Name=\"ModelB\" File=\"shared\" Length=\"0.2\" Width=\"0.8\" Height=\"0.4\"/>"
+      "</Models><Geometries>"
+      "<Geometry Name=\"Both\"><Geometry Name=\"PartA\" Model=\"ModelA\"/>"
+      "<Geometry Name=\"PartB\" Model=\"ModelB\"/></Geometry>"
+      "<Geometry Name=\"RootA\" Model=\"ModelA\"/>"
+      "<Geometry Name=\"RootB\" Model=\"ModelB\"/>"
+      "</Geometries><DMXModes>"
+      "<DMXMode Name=\"ModeA\" Geometry=\"RootA\"/>"
+      "<DMXMode Name=\"ModeB\" Geometry=\"RootB\"/>"
+      "<DMXMode Name=\"ModeBoth\" Geometry=\"Both\"/>"
+      "</DMXModes></FixtureType></GDTF>";
+  wxFFileOutputStream output(path);
+  assert(output.IsOk());
+  wxZipOutputStream zip(output);
+  zip.PutNextEntry("description.xml");
+  zip.Write(xml.data(), xml.size());
+  zip.PutNextEntry("models/gltf/shared.glb");
+  const std::string glb = BuildSharedGlb();
+  zip.Write(glb.data(), glb.size());
+  zip.Close();
+  return path;
+}
+
+// Computes axis-aligned mesh dimensions from vertex coordinates.
+MeshSize GetMeshSize(const Mesh &mesh) {
+  assert(mesh.vertices.size() >= 3);
+  MeshSize minimum{mesh.vertices[0], mesh.vertices[1], mesh.vertices[2]};
+  MeshSize maximum = minimum;
+  for (std::size_t index = 3; index + 2 < mesh.vertices.size(); index += 3) {
+    minimum.x = std::min(minimum.x, mesh.vertices[index]);
+    minimum.y = std::min(minimum.y, mesh.vertices[index + 1]);
+    minimum.z = std::min(minimum.z, mesh.vertices[index + 2]);
+    maximum.x = std::max(maximum.x, mesh.vertices[index]);
+    maximum.y = std::max(maximum.y, mesh.vertices[index + 1]);
+    maximum.z = std::max(maximum.z, mesh.vertices[index + 2]);
+  }
+  return {maximum.x - minimum.x, maximum.y - minimum.y,
+          maximum.z - minimum.z};
+}
+
+// Returns true when dimensions are equal within loader precision.
+bool NearlyEqual(float left, float right) {
+  return std::fabs(left - right) < 0.01f;
+}
+
+// Builds a deterministic structural signature for loaded GDTF objects.
+std::string BuildSignature(const std::vector<GdtfObject> &objects) {
+  std::ostringstream signature;
+  signature.precision(9);
+  signature << objects.size();
+  for (const GdtfObject &object : objects) {
+    const MeshSize size = GetMeshSize(object.mesh);
+    signature << '|' << object.mesh.vertices.size() << ','
+              << object.mesh.indices.size() << ',' << size.x << ',' << size.y
+              << ',' << size.z;
+    for (float value : object.transform.o)
+      signature << ',' << value;
+    std::uint64_t hash = 1469598103934665603ULL;
+    for (float value : object.mesh.vertices) {
+      std::uint32_t bits = 0;
+      std::memcpy(&bits, &value, sizeof(bits));
+      hash = (hash ^ bits) * 1099511628211ULL;
+    }
+    signature << ',' << hash;
+  }
+  return signature.str();
+}
+
+// Loads one exact mode and requires production loader success.
+std::vector<GdtfObject> LoadMode(const std::string &path,
+                                 const std::string &mode) {
+  std::vector<GdtfObject> objects;
+  std::string error;
+  assert(LoadGdtf(path, objects, mode, &error));
+  return objects;
+}
+
+} // namespace
+
+// Proves file-backed model dimensions and mode load order are cache-independent.
+int main() {
+  const std::string sameModePath = WriteGdtf("gdtf_model_cache_same_mode_");
+  const std::string orderAbPath = WriteGdtf("gdtf_model_cache_order_ab_");
+  const std::string orderBaPath = WriteGdtf("gdtf_model_cache_order_ba_");
+  const std::string coldAPath = WriteGdtf("gdtf_model_cache_cold_a_");
+  const std::string coldBPath = WriteGdtf("gdtf_model_cache_cold_b_");
+  const std::string defaultPath = WriteGdtf("gdtf_model_cache_default_");
+
+  const auto both = LoadMode(sameModePath, "ModeBoth");
+  assert(both.size() == 2);
+  const MeshSize modelA = GetMeshSize(both[0].mesh);
+  const MeshSize modelB = GetMeshSize(both[1].mesh);
+  assert(NearlyEqual(modelA.x, 1000.0f) && NearlyEqual(modelA.y, 500.0f) &&
+         NearlyEqual(modelA.z, 250.0f));
+  assert(NearlyEqual(modelB.x, 200.0f) && NearlyEqual(modelB.y, 800.0f) &&
+         NearlyEqual(modelB.z, 400.0f));
+
+  LoadMode(orderAbPath, "ModeA");
+  const auto warmB = LoadMode(orderAbPath, "ModeB");
+  const auto coldB = LoadMode(coldBPath, "ModeB");
+  assert(BuildSignature(warmB) == BuildSignature(coldB));
+  LoadMode(orderBaPath, "ModeB");
+  const auto warmA = LoadMode(orderBaPath, "ModeA");
+  const auto coldA = LoadMode(coldAPath, "ModeA");
+  assert(BuildSignature(warmA) == BuildSignature(coldA));
+
+  std::vector<GdtfObject> defaultObjects;
+  std::string error;
+  assert(LoadGdtf(defaultPath, defaultObjects, &error));
+  const auto defaultThenB = LoadMode(defaultPath, "ModeB");
+  assert(BuildSignature(defaultThenB) == BuildSignature(coldB));
+  assert(BuildSignature(LoadMode(defaultPath, "ModeB")) ==
+         BuildSignature(coldB));
+
+  for (const std::string &path :
+       {sameModePath, orderAbPath, orderBaPath, coldAPath, coldBPath,
+        defaultPath}) {
+    std::error_code removeError;
+    std::filesystem::remove(path, removeError);
+  }
+  return 0;
+}

--- a/tests/resource_reference_bounds_regression_test.cpp
+++ b/tests/resource_reference_bounds_regression_test.cpp
@@ -1,0 +1,73 @@
+#include "bounds_cache_system.h"
+#include "configmanager.h"
+#include "resource_reference_cache_key.h"
+
+#include <cassert>
+#include <cmath>
+#include <mutex>
+
+namespace {
+
+// Returns one axis span from a computed viewer bounding box.
+float Span(const Viewer3DBoundingBox &bounds, size_t axis) {
+  return bounds.max[axis] - bounds.min[axis];
+}
+
+} // namespace
+
+// Keeps all fixture types visible for the focused bounds-cache regression.
+bool ConfigManager::IsFixtureTypeVisible(const std::string &) const {
+  return true;
+}
+
+// Verifies canonical reference equivalence and producer-to-bounds lookup parity.
+int main() {
+  using viewer3d::resources::BuildResourceReferenceCacheKey;
+  const std::string expected = BuildResourceReferenceCacheKey("fixtures/Foo.gdtf");
+  assert(expected == BuildResourceReferenceCacheKey("fixtures\\Foo.gdtf"));
+  assert(expected == BuildResourceReferenceCacheKey("./fixtures/Foo.gdtf"));
+  assert(expected == BuildResourceReferenceCacheKey("  fixtures/Foo.gdtf  "));
+  assert(expected == BuildResourceReferenceCacheKey("\"fixtures/Foo.gdtf\""));
+  assert(BuildResourceReferenceCacheKey("C:/root/fixtures/Foo.gdtf") ==
+         BuildResourceReferenceCacheKey("C:\\root\\fixtures\\Foo.gdtf"));
+
+  ResourceSyncState resources;
+  ResourceSyncState::PathResolutionEntry resolved;
+  resolved.attempted = true;
+  resolved.resolvedPath = "/physical/Foo.gdtf";
+  resources.resolvedGdtfSpecs[expected] = resolved;
+
+  Mesh mesh;
+  mesh.vertices = {-500.0f, -300.0f, -200.0f, 500.0f, 300.0f, 200.0f};
+  mesh.indices = {0, 1};
+  resources.loadedGdtf[BuildGdtfResourceKey(resolved.resolvedPath, "Basic")] =
+      {GdtfObject{mesh, Matrix{}, false}};
+
+  Fixture fixture;
+  fixture.uuid = "fixture";
+  fixture.gdtfSpec = "./fixtures/Foo.gdtf";
+  fixture.gdtfMode = "Basic";
+  std::unordered_map<std::string, Fixture> fixtures = {{fixture.uuid, fixture}};
+  std::unordered_map<std::string, Viewer3DBoundingBox> modelBounds;
+  std::unordered_map<std::string, Viewer3DBoundingBox> fixtureBounds;
+  std::unordered_map<std::string, Viewer3DBoundingBox> trussBounds;
+  std::unordered_map<std::string, Viewer3DBoundingBox> objectBounds;
+  std::unordered_set<std::string> boundsHiddenLayers;
+  size_t cachedVersion = 0;
+  bool sceneChanged = true;
+  bool assetsChanged = true;
+  bool visibilityChanged = true;
+  std::mutex sortedListsMutex;
+  bool sortedListsDirty = false;
+  BoundsCacheSystem::Context context{
+      resources,       modelBounds,       fixtureBounds,      trussBounds,
+      objectBounds,    boundsHiddenLayers, 1,                  cachedVersion,
+      sceneChanged,    assetsChanged,     visibilityChanged,  sortedListsMutex,
+      sortedListsDirty};
+  BoundsCacheSystem::RebuildIfDirty(context, {}, {}, {}, fixtures);
+  const auto bounds = fixtureBounds.at(fixture.uuid);
+  assert(std::fabs(Span(bounds, 0) - 1.0f) < 0.0001f);
+  assert(std::fabs(Span(bounds, 1) - 0.6f) < 0.0001f);
+  assert(std::fabs(Span(bounds, 2) - 0.4f) < 0.0001f);
+  return 0;
+}

--- a/tests/scoped_single_model_capture_scene_test.cpp
+++ b/tests/scoped_single_model_capture_scene_test.cpp
@@ -1,10 +1,9 @@
 #include "tools/scoped_single_model_capture_scene.h"
 
 #include "configmanager.h"
+#include "matrixutils.h"
 
-#include <array>
 #include <cassert>
-#include <cmath>
 
 namespace {
 
@@ -14,9 +13,12 @@ bool SameMatrix(const Matrix &left, const Matrix &right) {
          left.o == right.o;
 }
 
-// Returns the length of one transform basis vector.
-float AxisLength(const std::array<float, 3> &axis) {
-  return std::sqrt(axis[0] * axis[0] + axis[1] * axis[1] + axis[2] * axis[2]);
+// Returns the isolated fixture clone produced for one representative UUID.
+Fixture CaptureFixtureClone(ConfigManager &cfg, const std::string &uuid) {
+  tools::ScopedSingleModelCaptureScene isolated(
+      cfg, {tools::SceneModelKind::Fixture, uuid},
+      tools::SymbolCaptureTransformPolicy::CanonicalFixtureType);
+  return cfg.GetScene().fixtures.at(uuid);
 }
 
 } // namespace
@@ -33,6 +35,15 @@ int main() {
   target.transform.v = {-3.0f, 0.0f, 0.0f};
   target.transform.w = {0.0f, 0.0f, 4.0f};
   target.transform.o = {10.0f, 20.0f, 30.0f};
+  target.parentGroupUuid = "parent";
+  target.hasLocalTransform = true;
+  target.localTransform = target.transform;
+  GroupObject parentGroup;
+  parentGroup.uuid = target.parentGroupUuid;
+  parentGroup.transform.u = {0.0f, 1.0f, 0.0f};
+  parentGroup.transform.v = {-1.0f, 0.0f, 0.0f};
+  parentGroup.transform.o = {500.0f, -300.0f, 80.0f};
+  scene.groupObjects.emplace(parentGroup.uuid, parentGroup);
   scene.fixtures.emplace(target.uuid, target);
   Fixture unrelated;
   unrelated.uuid = "unrelated";
@@ -50,18 +61,19 @@ int main() {
   const MvrScene original = scene;
   {
     tools::ScopedSingleModelCaptureScene isolated(
-        cfg, {tools::SceneModelKind::Fixture, target.uuid}, true);
+        cfg, {tools::SceneModelKind::Fixture, target.uuid},
+        tools::SymbolCaptureTransformPolicy::CanonicalFixtureType);
     assert(scene.fixtures.size() == 1);
     assert(scene.fixtures.contains(target.uuid));
     assert(scene.trusses.empty());
     assert(scene.sceneObjects.empty());
     assert(scene.supports.empty());
     const Matrix &aligned = scene.fixtures.at(target.uuid).transform;
-    assert(aligned.o == target.transform.o);
-    assert(!SameMatrix(aligned, target.transform));
-    assert(AxisLength(aligned.u) == AxisLength(target.transform.u));
-    assert(AxisLength(aligned.v) == AxisLength(target.transform.v));
-    assert(AxisLength(aligned.w) == AxisLength(target.transform.w));
+    assert(SameMatrix(aligned, MatrixUtils::Identity()));
+    assert(scene.fixtures.at(target.uuid).parentGroupUuid.empty());
+    assert(!scene.fixtures.at(target.uuid).hasLocalTransform);
+    assert(SameMatrix(scene.fixtures.at(target.uuid).localTransform,
+                      MatrixUtils::Identity()));
   }
 
   assert(scene.fixtures.size() == original.fixtures.size());
@@ -73,7 +85,8 @@ int main() {
 
   {
     tools::ScopedSingleModelCaptureScene missing(
-        cfg, {tools::SceneModelKind::Fixture, "missing"}, true);
+        cfg, {tools::SceneModelKind::Fixture, "missing"},
+        tools::SymbolCaptureTransformPolicy::CanonicalFixtureType);
     assert(scene.fixtures.empty());
     assert(scene.trusses.empty());
     assert(scene.sceneObjects.empty());
@@ -83,5 +96,41 @@ int main() {
   assert(scene.trusses.size() == original.trusses.size());
   assert(scene.sceneObjects.size() == original.sceneObjects.size());
   assert(scene.supports.size() == original.supports.size());
+
+  Fixture firstRepresentative = target;
+  firstRepresentative.uuid = "000-first";
+  Fixture secondRepresentative = target;
+  secondRepresentative.uuid = "zzz-second";
+  secondRepresentative.transform.u = {2.0f, 0.3f, 0.0f};
+  secondRepresentative.transform.v = {0.4f, 0.5f, 0.2f};
+  secondRepresentative.transform.w = {0.1f, 0.0f, 1.4f};
+  secondRepresentative.transform.o = {-900.0f, 700.0f, 120.0f};
+  secondRepresentative.parentGroupUuid = "different-parent";
+  secondRepresentative.localTransform = secondRepresentative.transform;
+  secondRepresentative.hasLocalTransform = true;
+  scene.fixtures = {{firstRepresentative.uuid, firstRepresentative},
+                    {secondRepresentative.uuid, secondRepresentative}};
+  const Fixture firstClone = CaptureFixtureClone(cfg, firstRepresentative.uuid);
+  const Fixture secondClone =
+      CaptureFixtureClone(cfg, secondRepresentative.uuid);
+  assert(SameMatrix(firstClone.transform, secondClone.transform));
+  assert(firstClone.parentGroupUuid == secondClone.parentGroupUuid);
+  assert(firstClone.hasLocalTransform == secondClone.hasLocalTransform);
+  assert(SameMatrix(firstClone.localTransform, secondClone.localTransform));
+
+  MvrScene replacementScene;
+  replacementScene.fixtures.emplace(secondRepresentative.uuid,
+                                    secondRepresentative);
+  MvrScene priorScene;
+  priorScene.fixtures.emplace(firstRepresentative.uuid, firstRepresentative);
+  scene = priorScene;
+  scene = replacementScene;
+  const Fixture afterReplacement =
+      CaptureFixtureClone(cfg, secondRepresentative.uuid);
+  scene = replacementScene;
+  const Fixture freshScene = CaptureFixtureClone(cfg, secondRepresentative.uuid);
+  assert(SameMatrix(afterReplacement.transform, freshScene.transform));
+  assert(afterReplacement.parentGroupUuid == freshScene.parentGroupUuid);
+  assert(afterReplacement.hasLocalTransform == freshScene.hasLocalTransform);
   return 0;
 }

--- a/tests/viewer2d_bounds_fit_test.cpp
+++ b/tests/viewer2d_bounds_fit_test.cpp
@@ -106,5 +106,31 @@ int main() {
   assert(viewer2d::ComputeViewFitForBounds(
       actual, Viewer2DView::Front, 1103, 1200, actualFit));
   assert(actualFit.zoom < fallbackFit.zoom);
+
+  Viewer3DBoundingBox quantumWash;
+  quantumWash.min = {-0.228000f, -0.158000f, -0.503910f};
+  quantumWash.max = {0.228000f, 0.158000f, -0.001200f};
+  viewer2d::ViewFitResult frontFit;
+  assert(viewer2d::ComputeViewFitForBounds(
+      quantumWash, Viewer2DView::Front, 1103, 1200, frontFit));
+  assert(Near(frontFit.zoom, 83.028248f));
+  assert(Near(frontFit.offsetXPixels, 0.0f));
+  assert(Near(frontFit.offsetYPixels, 6.313875f));
+
+  viewer2d::ViewFitResult sideFit;
+  assert(viewer2d::ComputeViewFitForBounds(
+      quantumWash, Viewer2DView::Side, 764, 1200, sideFit));
+  assert(Near(sideFit.zoom, 83.028248f));
+  assert(Near(sideFit.offsetXPixels, 0.0f));
+  assert(Near(sideFit.offsetYPixels, 6.313875f));
+
+  for (Viewer2DView view : {Viewer2DView::Top, Viewer2DView::Bottom}) {
+    viewer2d::ViewFitResult planFit;
+    assert(viewer2d::ComputeViewFitForBounds(quantumWash, view, 1200, 831,
+                                             planFit));
+    assert(Near(planFit.zoom, 91.469455f));
+    assert(Near(planFit.offsetXPixels, 0.0f));
+    assert(Near(planFit.offsetYPixels, 0.0f));
+  }
   return 0;
 }

--- a/tests/viewer2d_bounds_fit_test.cpp
+++ b/tests/viewer2d_bounds_fit_test.cpp
@@ -1,0 +1,110 @@
+#include "iselectioncontext.h"
+#include "viewer2dviewfit.h"
+
+#include <cassert>
+#include <cmath>
+
+namespace {
+
+class SelectionContextStub final : public ISelectionContext {
+public:
+  std::unordered_map<std::string, BoundingBox> fixtureBounds;
+
+  void ApplyHighlightUuid(const std::string &) override {}
+  void ReplaceSelectedUuids(const std::vector<std::string> &) override {}
+  bool IsCameraMoving() const override { return false; }
+  const BoundingBox *FindFixtureBounds(const std::string &) const override {
+    return nullptr;
+  }
+  const BoundingBox *FindTrussBounds(const std::string &) const override {
+    return nullptr;
+  }
+  const BoundingBox *FindObjectBounds(const std::string &) const override {
+    return nullptr;
+  }
+  const VisibleSet &GetVisibleSet(
+      const ViewFrustumSnapshot &, const std::unordered_set<std::string> &,
+      bool, float) const override {
+    return visible;
+  }
+  const std::string &GetHighlightUuid() const override { return text; }
+  const std::unordered_set<std::string> &GetSelectedUuids() const override {
+    return selected;
+  }
+  const std::unordered_map<std::string, BoundingBox> &
+  GetFixtureBoundsMap() const override {
+    return fixtureBounds;
+  }
+  const std::unordered_map<std::string, BoundingBox> &
+  GetTrussBoundsMap() const override {
+    return emptyBounds;
+  }
+  const std::unordered_map<std::string, BoundingBox> &
+  GetObjectBoundsMap() const override {
+    return emptyBounds;
+  }
+  NVGcontext *GetNanoVGContext() const override { return nullptr; }
+  int GetLabelFont() const override { return -1; }
+  int GetLabelBoldFont() const override { return -1; }
+  bool IsDarkMode() const override { return false; }
+  ICanvas2D *GetCaptureCanvas() const override { return nullptr; }
+  void RecordText(float, float, const std::string &,
+                  const CanvasTextStyle &) const override {}
+  PickReadResult ReadPickUuidAtDetailed(
+      int, int, int, int, const std::unordered_set<std::string> &,
+      std::string &) override {
+    return PickReadResult::Unavailable;
+  }
+  bool ReadPickUuidAt(int, int, int, int,
+                      const std::unordered_set<std::string> &,
+                      std::string &) override {
+    return false;
+  }
+
+private:
+  VisibleSet visible;
+  std::string text;
+  std::unordered_set<std::string> selected;
+  std::unordered_map<std::string, BoundingBox> emptyBounds;
+};
+
+// Reports whether two computed fit values agree within float precision.
+bool Near(float left, float right) { return std::fabs(left - right) < 0.0001f; }
+
+} // namespace
+
+// Verifies fallback diagnosis and explicit-bounds fit parity for every view.
+int main() {
+  Viewer3DBoundingBox fallback;
+  fallback.min = {-0.1f, -0.1f, -0.1f};
+  fallback.max = {0.1f, 0.1f, 0.1f};
+  viewer2d::ViewFitResult fallbackFit;
+  assert(viewer2d::ComputeViewFitForBounds(
+      fallback, Viewer2DView::Front, 1103, 1200, fallbackFit));
+  assert(Near(fallbackFit.zoom, 153.460876f));
+  assert(Near(fallbackFit.offsetXPixels, 0.0f));
+  assert(Near(fallbackFit.offsetYPixels, 0.0f));
+
+  Viewer3DBoundingBox actual;
+  actual.min = {-0.45f, -0.32f, -0.58f};
+  actual.max = {0.45f, 0.32f, 0.58f};
+  SelectionContextStub selection;
+  selection.fixtureBounds["fixture"] = actual;
+  for (Viewer2DView view : {Viewer2DView::Top, Viewer2DView::Bottom,
+                            Viewer2DView::Front, Viewer2DView::Side}) {
+    viewer2d::ViewFitResult explicitFit;
+    viewer2d::ViewFitResult selectionFit;
+    assert(viewer2d::ComputeViewFitForBounds(actual, view, 1103, 1200,
+                                             explicitFit));
+    assert(viewer2d::ComputeViewFit(selection, view, 1103, 1200,
+                                    selectionFit));
+    assert(Near(explicitFit.zoom, selectionFit.zoom));
+    assert(Near(explicitFit.offsetXPixels, selectionFit.offsetXPixels));
+    assert(Near(explicitFit.offsetYPixels, selectionFit.offsetYPixels));
+  }
+  viewer2d::ViewFitResult actualFit;
+  assert(viewer2d::ComputeViewFitForBounds(
+      actual, Viewer2DView::Front, 1103, 1200, actualFit));
+  assert(actualFit.zoom < fallbackFit.zoom);
+  return 0;
+}

--- a/viewer2d/viewer2dstate.cpp
+++ b/viewer2d/viewer2dstate.cpp
@@ -316,10 +316,10 @@ void ScopedViewer2DState::Restore() {
     return;
 
   Viewer2DPanel *targetPanel =
-      restorePanel_ ? restorePanel_.get() : Viewer2DPanel::Instance();
+      restorePanel_ ? restorePanel_.get() : applyPanel_.get();
   Viewer2DRenderPanel *targetRenderPanel =
       restoreRenderPanel_ ? restoreRenderPanel_.get()
-                          : Viewer2DRenderPanel::Instance();
+                          : applyRenderPanel_.get();
 
   ApplyState(targetPanel, targetRenderPanel, *cfg_, previousState_,
              persistCameraToConfig_, true);

--- a/viewer2d/viewer2dviewfit.cpp
+++ b/viewer2d/viewer2dviewfit.cpp
@@ -49,6 +49,28 @@ void ExpandProjectedBounds(const ISelectionContext::BoundingBox &box,
   maxB = std::max(maxB, axisBMax);
 }
 
+// Computes fit state from already-projected axis bounds.
+bool ComputeProjectedViewFit(float minA, float maxA, float minB, float maxB,
+                             int viewportWidth, int viewportHeight,
+                             viewer2d::ViewFitResult &result) {
+  if (viewportWidth <= 0 || viewportHeight <= 0 || minA > maxA || minB > maxB)
+    return false;
+  const float centerA = (minA + maxA) * 0.5f;
+  const float centerB = (minB + maxB) * 0.5f;
+  const float spanA = std::max(maxA - minA, 0.25f);
+  const float spanB = std::max(maxB - minB, 0.25f);
+  const float requiredHalfA = spanA * 0.5f * kFitPaddingScale;
+  const float requiredHalfB = spanB * 0.5f * kFitPaddingScale;
+  const float zoomForWidth = static_cast<float>(viewportWidth) /
+                             (2.0f * kPixelsPerMeter * requiredHalfA);
+  const float zoomForHeight = static_cast<float>(viewportHeight) /
+                              (2.0f * kPixelsPerMeter * requiredHalfB);
+  result.zoom = std::max(kMinZoom, std::min(zoomForWidth, zoomForHeight));
+  result.offsetXPixels = -centerA * kPixelsPerMeter;
+  result.offsetYPixels = -centerB * kPixelsPerMeter;
+  return true;
+}
+
 } // namespace
 
 namespace viewer2d {
@@ -97,26 +119,21 @@ bool ComputeViewFit(const ISelectionContext &selectionContext, Viewer2DView view
     accumulateAll(selectionContext.GetObjectBoundsMap());
   }
 
-  if (minA > maxA || minB > maxB)
-    return false;
+  return ComputeProjectedViewFit(minA, maxA, minB, maxB, viewportWidth,
+                                 viewportHeight, result);
+}
 
-  const float centerA = (minA + maxA) * 0.5f;
-  const float centerB = (minB + maxB) * 0.5f;
-  const float spanA = std::max(maxA - minA, 0.25f);
-  const float spanB = std::max(maxB - minB, 0.25f);
-
-  const float requiredHalfA = spanA * 0.5f * kFitPaddingScale;
-  const float requiredHalfB = spanB * 0.5f * kFitPaddingScale;
-
-  const float zoomForWidth =
-      static_cast<float>(viewportWidth) / (2.0f * kPixelsPerMeter * requiredHalfA);
-  const float zoomForHeight = static_cast<float>(viewportHeight) /
-                              (2.0f * kPixelsPerMeter * requiredHalfB);
-
-  result.zoom = std::max(kMinZoom, std::min(zoomForWidth, zoomForHeight));
-  result.offsetXPixels = -centerA * kPixelsPerMeter;
-  result.offsetYPixels = -centerB * kPixelsPerMeter;
-  return true;
+// Computes viewer fit directly from one authoritative world-space bound.
+bool ComputeViewFitForBounds(const Viewer3DBoundingBox &bounds,
+                             Viewer2DView view, int viewportWidth,
+                             int viewportHeight, ViewFitResult &result) {
+  float minA = std::numeric_limits<float>::max();
+  float maxA = std::numeric_limits<float>::lowest();
+  float minB = std::numeric_limits<float>::max();
+  float maxB = std::numeric_limits<float>::lowest();
+  ExpandProjectedBounds(bounds, view, minA, maxA, minB, maxB);
+  return ComputeProjectedViewFit(minA, maxA, minB, maxB, viewportWidth,
+                                 viewportHeight, result);
 }
 
 } // namespace viewer2d

--- a/viewer2d/viewer2dviewfit.h
+++ b/viewer2d/viewer2dviewfit.h
@@ -16,4 +16,8 @@ bool ComputeViewFit(const ISelectionContext &selectionContext, Viewer2DView view
                     int viewportWidth, int viewportHeight,
                     ViewFitResult &result);
 
+bool ComputeViewFitForBounds(const Viewer3DBoundingBox &bounds,
+                             Viewer2DView view, int viewportWidth,
+                             int viewportHeight, ViewFitResult &result);
+
 } // namespace viewer2d

--- a/viewer3d/culling/bounds_cache_system.cpp
+++ b/viewer3d/culling/bounds_cache_system.cpp
@@ -5,6 +5,8 @@
 #endif
 
 #include "bounds_cache_system.h"
+
+#include "gdtf_object_bounds.h"
 #include "primitive_bounds_utils.h"
 
 #include "configmanager.h"
@@ -141,26 +143,8 @@ void BoundsCacheSystem::RebuildIfDirty(
       auto bit = context.modelBounds.find(resourceKey);
       if (bit == context.modelBounds.end()) {
         Viewer3DBoundingBox local;
-        local.min = {FLT_MAX, FLT_MAX, FLT_MAX};
-        local.max = {-FLT_MAX, -FLT_MAX, -FLT_MAX};
-        bool localFound = false;
-        for (const auto &obj : itg->second) {
-          for (size_t vi = 0; vi + 2 < obj.mesh.vertices.size(); vi += 3) {
-            std::array<float, 3> p = {
-                obj.mesh.vertices[vi] * RENDER_SCALE,
-                obj.mesh.vertices[vi + 1] * RENDER_SCALE,
-                obj.mesh.vertices[vi + 2] * RENDER_SCALE};
-            p = TransformPoint(obj.transform, p);
-            local.min[0] = std::min(local.min[0], p[0]);
-            local.min[1] = std::min(local.min[1], p[1]);
-            local.min[2] = std::min(local.min[2], p[2]);
-            local.max[0] = std::max(local.max[0], p[0]);
-            local.max[1] = std::max(local.max[1], p[1]);
-            local.max[2] = std::max(local.max[2], p[2]);
-            localFound = true;
-          }
-        }
-        if (localFound)
+        if (viewer3d::culling::ComputeGdtfObjectBoundsMeters(itg->second,
+                                                             local))
           bit = context.modelBounds.emplace(resourceKey, local).first;
       }
       if (bit != context.modelBounds.end()) {

--- a/viewer3d/culling/bounds_cache_system.cpp
+++ b/viewer3d/culling/bounds_cache_system.cpp
@@ -13,28 +13,13 @@
 #include "logger.h"
 #include "truss_defaults.h"
 #include "matrixutils.h"
+#include "resource_reference_cache_key.h"
 
 #include <algorithm>
 #include <array>
 #include <cfloat>
-#include <filesystem>
-
-namespace fs = std::filesystem;
 
 namespace {
-
-// Normalizes a model reference path for cache lookups.
-static std::string NormalizePath(const std::string &p) {
-  std::string out = p;
-  char sep = static_cast<char>(fs::path::preferred_separator);
-  std::replace(out.begin(), out.end(), '\\', sep);
-  return out;
-}
-
-// Resolves a resource reference to the cache key used by synchronization state.
-static std::string ResolveCacheKey(const std::string &pathRef) {
-  return NormalizePath(pathRef);
-}
 
 // Reports whether a layer is visible using the cached hidden-layer set.
 static bool IsLayerVisibleCached(const std::unordered_set<std::string> &hidden,
@@ -138,14 +123,20 @@ void BoundsCacheSystem::RebuildIfDirty(
     bb.max = {-FLT_MAX, -FLT_MAX, -FLT_MAX};
 
     std::string gdtfPath;
+    const std::string referenceKey =
+        viewer3d::resources::BuildResourceReferenceCacheKey(f.gdtfSpec);
     auto gdtfPathIt =
-        context.resourceSyncState.resolvedGdtfSpecs.find(ResolveCacheKey(f.gdtfSpec));
+        context.resourceSyncState.resolvedGdtfSpecs.find(referenceKey);
+    const bool resolvedEntryHit =
+        gdtfPathIt != context.resourceSyncState.resolvedGdtfSpecs.end();
     if (gdtfPathIt != context.resourceSyncState.resolvedGdtfSpecs.end() &&
         gdtfPathIt->second.attempted) {
       gdtfPath = gdtfPathIt->second.resolvedPath;
     }
     const std::string resourceKey = BuildGdtfResourceKey(gdtfPath, f.gdtfMode);
     auto itg = context.resourceSyncState.loadedGdtf.find(resourceKey);
+    const bool loadedGdtfHit =
+        itg != context.resourceSyncState.loadedGdtf.end();
     if (itg != context.resourceSyncState.loadedGdtf.end()) {
       auto bit = context.modelBounds.find(resourceKey);
       if (bit == context.modelBounds.end()) {
@@ -200,6 +191,21 @@ void BoundsCacheSystem::RebuildIfDirty(
       }
     }
 
+#ifndef NDEBUG
+    Logger::Instance().Log(
+        Logger::Level::Debug,
+        "fixture_bounds fixture_uuid=" + uuid + " gdtf_spec=\"" +
+            f.gdtfSpec + "\" reference_key=\"" + referenceKey +
+            "\" resolved_entry_hit=" + (resolvedEntryHit ? "1" : "0") +
+            " resolved_path=\"" + gdtfPath + "\" mode=\"" + f.gdtfMode +
+            "\" loaded_gdtf_hit=" + (loadedGdtfHit ? "1" : "0") +
+            " source=" + (found ? "gdtf" : "fallback") + " min=" +
+            std::to_string(bb.min[0]) + ',' + std::to_string(bb.min[1]) + ',' +
+            std::to_string(bb.min[2]) + " max=" +
+            std::to_string(bb.max[0]) + ',' + std::to_string(bb.max[1]) + ',' +
+            std::to_string(bb.max[2]));
+#endif
+
     context.fixtureBounds[uuid] = bb;
   }
 
@@ -220,7 +226,8 @@ void BoundsCacheSystem::RebuildIfDirty(
     if (!t.symbolFile.empty()) {
       std::string path;
       auto pathIt =
-          context.resourceSyncState.resolvedModelRefs.find(ResolveCacheKey(t.symbolFile));
+          context.resourceSyncState.resolvedModelRefs.find(
+              viewer3d::resources::BuildResourceReferenceCacheKey(t.symbolFile));
       if (pathIt != context.resourceSyncState.resolvedModelRefs.end() &&
           pathIt->second.attempted) {
         path = pathIt->second.resolvedPath;
@@ -317,7 +324,9 @@ void BoundsCacheSystem::RebuildIfDirty(
 
         std::string path;
         auto modelIt =
-            context.resourceSyncState.resolvedModelRefs.find(ResolveCacheKey(geo.modelFile));
+            context.resourceSyncState.resolvedModelRefs.find(
+                viewer3d::resources::BuildResourceReferenceCacheKey(
+                    geo.modelFile));
         if (modelIt != context.resourceSyncState.resolvedModelRefs.end() &&
             modelIt->second.attempted) {
           path = modelIt->second.resolvedPath;
@@ -366,7 +375,8 @@ void BoundsCacheSystem::RebuildIfDirty(
     } else if (!obj.modelFile.empty()) {
       std::string path;
       auto modelIt =
-          context.resourceSyncState.resolvedModelRefs.find(ResolveCacheKey(obj.modelFile));
+          context.resourceSyncState.resolvedModelRefs.find(
+              viewer3d::resources::BuildResourceReferenceCacheKey(obj.modelFile));
       if (modelIt != context.resourceSyncState.resolvedModelRefs.end() &&
           modelIt->second.attempted) {
         path = modelIt->second.resolvedPath;

--- a/viewer3d/culling/gdtf_object_bounds.h
+++ b/viewer3d/culling/gdtf_object_bounds.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "gdtf_geometry_types.h"
+#include "viewer3d_types.h"
+
+#include <algorithm>
+#include <array>
+#include <cfloat>
+#include <vector>
+
+namespace viewer3d::culling {
+
+// Computes GDTF object bounds in the renderer's metre-based world domain.
+inline bool ComputeGdtfObjectBoundsMeters(
+    const std::vector<GdtfObject> &objects, Viewer3DBoundingBox &outBounds) {
+  Viewer3DBoundingBox bounds;
+  bounds.min = {FLT_MAX, FLT_MAX, FLT_MAX};
+  bounds.max = {-FLT_MAX, -FLT_MAX, -FLT_MAX};
+  bool found = false;
+
+  for (const auto &object : objects) {
+    for (size_t vi = 0; vi + 2 < object.mesh.vertices.size(); vi += 3) {
+      const std::array<float, 3> local = {
+          object.mesh.vertices[vi] * RENDER_SCALE,
+          object.mesh.vertices[vi + 1] * RENDER_SCALE,
+          object.mesh.vertices[vi + 2] * RENDER_SCALE};
+      const std::array<float, 3> point = {
+          object.transform.u[0] * local[0] +
+              object.transform.v[0] * local[1] +
+              object.transform.w[0] * local[2] + object.transform.o[0],
+          object.transform.u[1] * local[0] +
+              object.transform.v[1] * local[1] +
+              object.transform.w[1] * local[2] + object.transform.o[1],
+          object.transform.u[2] * local[0] +
+              object.transform.v[2] * local[1] +
+              object.transform.w[2] * local[2] + object.transform.o[2]};
+      for (size_t axis = 0; axis < 3; ++axis) {
+        bounds.min[axis] = std::min(bounds.min[axis], point[axis]);
+        bounds.max[axis] = std::max(bounds.max[axis], point[axis]);
+      }
+      found = true;
+    }
+  }
+
+  if (found)
+    outBounds = bounds;
+  return found;
+}
+
+} // namespace viewer3d::culling

--- a/viewer3d/culling/visibilitysystem.cpp
+++ b/viewer3d/culling/visibilitysystem.cpp
@@ -20,6 +20,7 @@
 #include "configmanager.h"
 #include "matrixutils.h"
 #include "resource_sync_system.h"
+#include "resource_reference_cache_key.h"
 #include "scenedatamanager.h"
 
 #include <algorithm>
@@ -41,18 +42,6 @@ std::unordered_set<std::string> SnapshotHiddenLayers(const ConfigManager &cfg) {
   return cfg.GetHiddenLayers();
 }
 
-
-// Normalizes path separators for stable resource cache lookups.
-static std::string NormalizePath(const std::string &pathRef) {
-  std::string out = pathRef;
-  std::replace(out.begin(), out.end(), '\\', '/');
-  return out;
-}
-
-// Resolves the normalized cache key used by model and fixture resource maps.
-static std::string ResolveCacheKey(const std::string &pathRef) {
-  return NormalizePath(pathRef);
-}
 
 // Transforms a local point into world space using the supplied matrix.
 static std::array<float, 3> TransformPoint(const Matrix &m,
@@ -222,7 +211,8 @@ bool VisibilitySystem::EnsureBoundsComputed(
 
     std::string gdtfPath;
     auto gdtfIt = m_controller.GetResourceSyncState().resolvedGdtfSpecs.find(
-        ResolveCacheKey(fit->second.gdtfSpec));
+        viewer3d::resources::BuildResourceReferenceCacheKey(
+            fit->second.gdtfSpec));
     if (gdtfIt != m_controller.GetResourceSyncState().resolvedGdtfSpecs.end() &&
         gdtfIt->second.attempted)
       gdtfPath = gdtfIt->second.resolvedPath;
@@ -305,7 +295,8 @@ bool VisibilitySystem::EnsureBoundsComputed(
     if (!tit->second.symbolFile.empty()) {
       std::string path;
       auto modelIt = m_controller.GetResourceSyncState().resolvedModelRefs.find(
-          ResolveCacheKey(tit->second.symbolFile));
+          viewer3d::resources::BuildResourceReferenceCacheKey(
+              tit->second.symbolFile));
       if (modelIt != m_controller.GetResourceSyncState().resolvedModelRefs.end() &&
           modelIt->second.attempted)
         path = modelIt->second.resolvedPath;
@@ -402,7 +393,7 @@ bool VisibilitySystem::EnsureBoundsComputed(
 
       std::string path;
       auto modelIt = m_controller.GetResourceSyncState().resolvedModelRefs.find(
-          ResolveCacheKey(geo.modelFile));
+          viewer3d::resources::BuildResourceReferenceCacheKey(geo.modelFile));
       if (modelIt != m_controller.GetResourceSyncState().resolvedModelRefs.end() &&
           modelIt->second.attempted)
         path = modelIt->second.resolvedPath;
@@ -448,7 +439,9 @@ bool VisibilitySystem::EnsureBoundsComputed(
   } else if (!oit->second.modelFile.empty()) {
     std::string path;
     auto modelIt =
-        m_controller.GetResourceSyncState().resolvedModelRefs.find(ResolveCacheKey(oit->second.modelFile));
+        m_controller.GetResourceSyncState().resolvedModelRefs.find(
+            viewer3d::resources::BuildResourceReferenceCacheKey(
+                oit->second.modelFile));
     if (modelIt != m_controller.GetResourceSyncState().resolvedModelRefs.end() &&
         modelIt->second.attempted)
       path = modelIt->second.resolvedPath;

--- a/viewer3d/gdtfloader.cpp
+++ b/viewer3d/gdtfloader.cpp
@@ -26,6 +26,7 @@
 #include "runtime_storage.h"
 #include "meshprimitives.h"
 #include "consolepanel.h"
+#include "logger.h"
 
 #include <cctype>
 #include <cerrno>
@@ -57,6 +58,7 @@ class wxZipStreamLink;
 #include <memory>
 #include <cfloat>
 #include <cstdint>
+#include <cstring>
 #include <sstream>
 #include <iomanip>
 #include <mutex>
@@ -202,12 +204,15 @@ struct GdtfCacheEntry
     std::vector<std::string> modes;
     std::unordered_map<std::string, std::vector<GdtfChannelInfo>> modeChannels;
     std::unordered_map<std::string, int> modeChannelCounts;
-    std::unordered_map<std::string, Mesh> meshCache;
+    std::unordered_map<std::string, Mesh> rawFileMeshCache;
+    std::unordered_map<std::string, Mesh> dimensionedFileMeshCache;
+    std::unordered_map<std::string, Mesh> primitiveMeshCache;
     std::unordered_map<std::string, GdtfGeometryTree> geometryTreeCache;
     std::unordered_map<std::string, std::vector<GdtfObject>> flatObjectCache;
     std::string fixtureName;
     std::string fixtureManufacturer;
     std::string fixtureTypeId;
+    std::string sourceArchiveFilename;
     bool propertiesParsed = false;
     float weightKg = 0.0f;
     float powerW = 0.0f;
@@ -303,6 +308,80 @@ static void ApplyModelDimensions(Mesh& mesh, const GdtfModelInfo& modelInfo)
             mesh.vertices[vi + 2] *= sz;
         }
     }
+}
+
+// Serializes a parsed model dimension using its exact floating-point bits.
+static std::string FloatIdentity(float value)
+{
+    std::uint32_t bits = 0;
+    static_assert(sizeof(bits) == sizeof(value));
+    std::memcpy(&bits, &value, sizeof(bits));
+    std::ostringstream output;
+    output << std::hex << std::setw(8) << std::setfill('0') << bits;
+    return output.str();
+}
+
+// Builds the complete identity of a dimension-scaled file-backed model mesh.
+static std::string BuildFileModelMeshCacheKey(const std::string& path,
+                                              const GdtfModelInfo& modelInfo)
+{
+    return path + "|dimensions=" + FloatIdentity(modelInfo.length) + ',' +
+           FloatIdentity(modelInfo.width) + ',' + FloatIdentity(modelInfo.height);
+}
+
+// Formats mesh bounds for concise debug cache diagnostics.
+static std::string FormatMeshBounds(const Mesh& mesh)
+{
+    if (mesh.vertices.size() < 3)
+        return "empty";
+    float minX = mesh.vertices[0], maxX = mesh.vertices[0];
+    float minY = mesh.vertices[1], maxY = mesh.vertices[1];
+    float minZ = mesh.vertices[2], maxZ = mesh.vertices[2];
+    for (size_t index = 3; index + 2 < mesh.vertices.size(); index += 3) {
+        minX = std::min(minX, mesh.vertices[index]);
+        maxX = std::max(maxX, mesh.vertices[index]);
+        minY = std::min(minY, mesh.vertices[index + 1]);
+        maxY = std::max(maxY, mesh.vertices[index + 1]);
+        minZ = std::min(minZ, mesh.vertices[index + 2]);
+        maxZ = std::max(maxZ, mesh.vertices[index + 2]);
+    }
+    std::ostringstream output;
+    output << (maxX - minX) << 'x' << (maxY - minY) << 'x' << (maxZ - minZ);
+    return output.str();
+}
+
+// Records one file-backed model cache decision in debug diagnostics.
+static void LogFileModelCacheLookup(const std::string& archiveFilename,
+                                    const std::string& modeName,
+                                    const GdtfModelInfo& modelInfo,
+                                    const std::string& path,
+                                    const std::string& cacheKey,
+                                    bool cacheHit,
+                                    const Mesh& mesh)
+{
+#ifndef NDEBUG
+    Logger::Instance().Log(
+        Logger::Level::Debug,
+        "GDTF model mesh cache archive=" + archiveFilename + " mode=" +
+            (modeName.empty() ? "<default>" : modeName) + " model=" +
+            modelInfo.name + " resource=" + PathUtils::PathToUtf8(
+                PathUtils::PathFromUtf8(path).filename()) + " declared_m=" +
+            std::to_string(modelInfo.length) + ',' +
+            std::to_string(modelInfo.width) + ',' +
+            std::to_string(modelInfo.height) + " dimension_bits=" +
+            FloatIdentity(modelInfo.length) + ',' + FloatIdentity(modelInfo.width) +
+            ',' + FloatIdentity(modelInfo.height) + " result=" +
+            (cacheHit ? "hit" : "miss") + " key=" + cacheKey + " bounds=" +
+            FormatMeshBounds(mesh));
+#else
+    (void)archiveFilename;
+    (void)modeName;
+    (void)modelInfo;
+    (void)path;
+    (void)cacheKey;
+    (void)cacheHit;
+    (void)mesh;
+#endif
 }
 
 
@@ -1304,6 +1383,7 @@ static GdtfCacheEntry* GetCachedGdtf(const std::string& gdtfPath,
 
     GdtfCacheEntry entry;
     entry.timestamp = timestamp;
+    entry.sourceArchiveFilename = PathUtils::PathToUtf8(absPath.filename());
     TempExtraction extraction(PathUtils::PathToUtf8(absPath));
     if (!extraction.IsValid()) {
         g_failedGdtfCache[stableKey] = timestamp;
@@ -1357,16 +1437,21 @@ static GdtfCacheEntry* GetCachedGdtf(const std::string& gdtfPath,
     return res.second ? &res.first->second : nullptr;
 }
 
+// Parses one geometry subtree while reusing semantically isolated model meshes.
 static void ParseGeometry(tinyxml2::XMLElement* node,
                           const Matrix& parent,
                           const std::unordered_map<std::string, GdtfModelInfo>& models,
                           const std::string& baseDir,
                           const std::unordered_map<std::string, tinyxml2::XMLElement*>& geomMap,
-                          std::unordered_map<std::string, Mesh>& meshCache,
+                          std::unordered_map<std::string, Mesh>& rawFileMeshCache,
+                          std::unordered_map<std::string, Mesh>& dimensionedFileMeshCache,
+                          std::unordered_map<std::string, Mesh>& primitiveMeshCache,
                           GdtfGeometryTree& outTree,
                           std::unordered_set<std::string>* missingModels,
                           std::unordered_set<std::string>* failedModelLoads,
                           int parentNodeIndex,
+                          const std::string& archiveFilename,
+                          const std::string& modeName,
                           const char* overrideModel = nullptr,
                           bool parentIsLens = false)
 {
@@ -1407,9 +1492,12 @@ static void ParseGeometry(tinyxml2::XMLElement* node,
             auto it = geomMap.find(refName);
             if (it != geomMap.end()) {
                 const char* m = node->Attribute("Model");
-                ParseGeometry(it->second, transform, models, baseDir, geomMap, meshCache,
+                ParseGeometry(it->second, transform, models, baseDir, geomMap,
+                              rawFileMeshCache, dimensionedFileMeshCache,
+                              primitiveMeshCache,
                               outTree, missingModels, failedModelLoads, parentNodeIndex,
-                              m ? m : overrideModel, parentIsLens);
+                              archiveFilename, modeName, m ? m : overrideModel,
+                              parentIsLens);
             }
         }
         return;
@@ -1444,17 +1532,20 @@ static void ParseGeometry(tinyxml2::XMLElement* node,
             if (!modelInfo.file.empty()) {
                 std::string path = FindModelFile(baseDir, modelInfo.file);
                 if (!path.empty()) {
-                    auto mit = meshCache.find(path);
-                    if (mit == meshCache.end()) {
+                    std::string modelMeshKey = BuildFileModelMeshCacheKey(path, modelInfo);
+                    auto mit = dimensionedFileMeshCache.find(modelMeshKey);
+                    bool dimensionedCacheHit = mit != dimensionedFileMeshCache.end();
+                    if (!dimensionedCacheHit) {
                         bool alreadyFailed = failedModelLoads && failedModelLoads->find(path) != failedModelLoads->end();
                         if (!alreadyFailed) {
-                            bool loaded = false;
+                            auto rawIt = rawFileMeshCache.find(path);
+                            bool loaded = rawIt != rawFileMeshCache.end();
                             bool tried3ds = false;
                             bool triedGlb = false;
                             const fs::path loadedPath = PathUtils::PathFromUtf8(path);
                             std::string fallbackGlbPath;
 
-                            if (HasExtension(loadedPath, ".3ds")) {
+                            if (!loaded && HasExtension(loadedPath, ".3ds")) {
                                 tried3ds = true;
                                 std::string loadError3ds;
                                 loaded = Load3DS(path, mesh, false, &loadError3ds);
@@ -1468,15 +1559,25 @@ static void ParseGeometry(tinyxml2::XMLElement* node,
                                             path = fallbackGlbPath;
                                     }
                                 }
-                            } else if (HasExtension(loadedPath, ".glb")) {
+                            } else if (!loaded && HasExtension(loadedPath, ".glb")) {
                                 triedGlb = true;
                                 std::string loadErrorGlb;
                                 loaded = LoadGLB(path, mesh, &loadErrorGlb);
                             }
 
                             if (loaded) {
-                                ApplyModelDimensions(mesh, modelInfo);
-                                mit = meshCache.emplace(path, std::move(mesh)).first;
+                                if (rawIt == rawFileMeshCache.end())
+                                    rawIt = rawFileMeshCache.emplace(path, std::move(mesh)).first;
+                                modelMeshKey = BuildFileModelMeshCacheKey(path, modelInfo);
+                                mit = dimensionedFileMeshCache.find(modelMeshKey);
+                                dimensionedCacheHit =
+                                    mit != dimensionedFileMeshCache.end();
+                                if (mit == dimensionedFileMeshCache.end()) {
+                                    Mesh dimensionedMesh = rawIt->second;
+                                    ApplyModelDimensions(dimensionedMesh, modelInfo);
+                                    mit = dimensionedFileMeshCache.emplace(
+                                        modelMeshKey, std::move(dimensionedMesh)).first;
+                                }
                             } else {
                                 bool shouldLog = true;
                                 if (failedModelLoads)
@@ -1497,9 +1598,12 @@ static void ParseGeometry(tinyxml2::XMLElement* node,
                             }
                         }
                     }
-                    if (mit != meshCache.end()) {
+                    if (mit != dimensionedFileMeshCache.end()) {
                         mesh = mit->second;
                         haveMesh = true;
+                        LogFileModelCacheLookup(archiveFilename, modeName, modelInfo,
+                                                path, modelMeshKey,
+                                                dimensionedCacheHit, mesh);
                     }
                 } else if (ConsolePanel::Instance()) {
                     std::string key = baseDir + "|" + modelInfo.file;
@@ -1514,7 +1618,7 @@ static void ParseGeometry(tinyxml2::XMLElement* node,
             }
 
             if (!haveMesh && IsPrimitiveTypeDefined(modelInfo.primitiveType)) {
-                if (GetCachedPrimitiveMesh(modelInfo, meshCache, mesh))
+                if (GetCachedPrimitiveMesh(modelInfo, primitiveMeshCache, mesh))
                     haveMesh = true;
             }
 
@@ -1542,9 +1646,11 @@ static void ParseGeometry(tinyxml2::XMLElement* node,
     for (tinyxml2::XMLElement* child = node->FirstChildElement(); child; child = child->NextSiblingElement()) {
         std::string n = child->Name();
         if (kGeometryNodeTypes.find(n) != kGeometryNodeTypes.end() || n.rfind("Filter",0)==0) {
-            ParseGeometry(child, transform, models, baseDir, geomMap, meshCache, outTree,
-                          missingModels, failedModelLoads, currentNodeIndex, nullptr,
-                          isLensGeometry);
+            ParseGeometry(child, transform, models, baseDir, geomMap,
+                          rawFileMeshCache, dimensionedFileMeshCache,
+                          primitiveMeshCache, outTree, missingModels,
+                          failedModelLoads, currentNodeIndex, archiveFilename,
+                          modeName, nullptr, isLensGeometry);
         }
     }
 }
@@ -1705,8 +1811,10 @@ static bool BuildGdtfGeometryTreeFromCache(GdtfCacheEntry& entry,
         const auto roots = ResolveGeometryRoots(entry.fixtureType, geoms, geomMap, modeName);
         for (tinyxml2::XMLElement* g : roots) {
             ParseGeometry(g, MatrixUtils::Identity(), models, entry.extractedDir, geomMap,
-                          entry.meshCache, built, &entry.missingModelsLogged,
-                          &entry.failedModelLoads, -1);
+                          entry.rawFileMeshCache, entry.dimensionedFileMeshCache,
+                          entry.primitiveMeshCache, built,
+                          &entry.missingModelsLogged, &entry.failedModelLoads, -1,
+                          entry.sourceArchiveFilename, modeName);
         }
     }
 

--- a/viewer3d/render/opaque_pass_utils.cpp
+++ b/viewer3d/render/opaque_pass_utils.cpp
@@ -1,4 +1,5 @@
 #include "opaque_pass_utils.h"
+#include "resource_reference_cache_key.h"
 
 #include <algorithm>
 #include <cmath>
@@ -25,7 +26,7 @@ std::string NormalizeModelKey(const std::string &p) {
 
 // Resolves a path reference into the stable cache-key form.
 std::string ResolveCacheKey(const std::string &pathRef) {
-  return NormalizeModelKey(pathRef);
+  return viewer3d::resources::BuildResourceReferenceCacheKey(pathRef);
 }
 
 // Computes 2D command bounds including render-safe stroke padding.

--- a/viewer3d/resources/mesh_processing.cpp
+++ b/viewer3d/resources/mesh_processing.cpp
@@ -1,5 +1,6 @@
 #include "mesh_processing.h"
 #include "filesystem_path_utils.h"
+#include "physical_asset_revision.h"
 
 #include <algorithm>
 #include <cstdint>
@@ -17,13 +18,14 @@ namespace {
 
 constexpr uint32_t kMeshCacheMagic = 0x4843534Du; // MSCH
 constexpr uint32_t kGdtfCacheMagic = 0x48434747u; // GGCH
-constexpr uint32_t kCacheVersion = 3u;
+constexpr uint32_t kCacheVersion = 4u;
 constexpr float kOverdrawThreshold = 1.05f;
 
 struct CacheHeader {
   uint32_t magic = 0;
   uint32_t version = 0;
   int64_t sourceTimestampNs = 0;
+  uint64_t sourceSize = 0;
 };
 
 template <typename T>
@@ -88,15 +90,6 @@ std::string BuildGdtfCachePath(const std::string &sourcePath,
   return sourcePath + "." + std::to_string(HashCacheToken(modeName)) + ".cache";
 }
 
-int64_t GetSourceTimestampNs(const std::string &sourcePath) {
-  std::error_code ec;
-  const fs::file_time_type writeTime = fs::last_write_time(PathUtils::PathFromUtf8(sourcePath), ec);
-  if (ec)
-    return -1;
-  return std::chrono::duration_cast<std::chrono::nanoseconds>(writeTime.time_since_epoch())
-      .count();
-}
-
 bool WriteMesh(std::ofstream &out, const Mesh &mesh) {
   if (!WriteVector(out, mesh.vertices) || !WriteVector(out, mesh.indices) ||
       !WriteVector(out, mesh.normals) || !WriteVector(out, mesh.texcoords) ||
@@ -130,12 +123,15 @@ bool ReadMesh(std::ifstream &in, Mesh &mesh) {
   return true;
 }
 
+// Validates that a disk cache belongs to the current physical source revision.
 bool ValidateHeader(const CacheHeader &header, uint32_t expectedMagic,
                     const std::string &sourcePath) {
   if (header.magic != expectedMagic || header.version != kCacheVersion)
     return false;
-  const int64_t sourceTimestampNs = GetSourceTimestampNs(sourcePath);
-  return sourceTimestampNs >= 0 && sourceTimestampNs == header.sourceTimestampNs;
+  const PhysicalAssetRevision revision = ReadPhysicalAssetRevision(sourcePath);
+  return revision.metadataAvailable &&
+         revision.modificationTimeNs == header.sourceTimestampNs &&
+         revision.fileSize == header.sourceSize;
 }
 
 void OptimizeIndices(Mesh &mesh) {
@@ -180,9 +176,10 @@ bool TryLoadMeshCache(const std::string &sourcePath, Mesh &outMesh) {
   return ReadMesh(in, outMesh);
 }
 
+// Saves a model mesh with the bounded source revision used for validation.
 bool TrySaveMeshCache(const std::string &sourcePath, const Mesh &mesh) {
-  const int64_t sourceTimestampNs = GetSourceTimestampNs(sourcePath);
-  if (sourceTimestampNs < 0)
+  const PhysicalAssetRevision revision = ReadPhysicalAssetRevision(sourcePath);
+  if (!revision.metadataAvailable)
     return false;
 
   std::ofstream out(BuildCachePath(sourcePath), std::ios::binary | std::ios::trunc);
@@ -192,7 +189,8 @@ bool TrySaveMeshCache(const std::string &sourcePath, const Mesh &mesh) {
   CacheHeader header;
   header.magic = kMeshCacheMagic;
   header.version = kCacheVersion;
-  header.sourceTimestampNs = sourceTimestampNs;
+  header.sourceTimestampNs = revision.modificationTimeNs;
+  header.sourceSize = revision.fileSize;
   return WriteRaw(out, header) && WriteMesh(out, mesh);
 }
 
@@ -229,8 +227,8 @@ bool TryLoadGdtfCache(const std::string &gdtfPath,
 bool TrySaveGdtfCache(const std::string &gdtfPath,
                       const std::string &modeName,
                       const std::vector<GdtfObject> &objects) {
-  const int64_t sourceTimestampNs = GetSourceTimestampNs(gdtfPath);
-  if (sourceTimestampNs < 0)
+  const PhysicalAssetRevision revision = ReadPhysicalAssetRevision(gdtfPath);
+  if (!revision.metadataAvailable)
     return false;
 
   std::ofstream out(BuildGdtfCachePath(gdtfPath, modeName),
@@ -241,7 +239,8 @@ bool TrySaveGdtfCache(const std::string &gdtfPath,
   CacheHeader header;
   header.magic = kGdtfCacheMagic;
   header.version = kCacheVersion;
-  header.sourceTimestampNs = sourceTimestampNs;
+  header.sourceTimestampNs = revision.modificationTimeNs;
+  header.sourceSize = revision.fileSize;
   if (!WriteRaw(out, header))
     return false;
 

--- a/viewer3d/resources/physical_asset_revision.h
+++ b/viewer3d/resources/physical_asset_revision.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "filesystem_path_utils.h"
+
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
+#include <string>
+
+namespace viewer3d::resources {
+
+struct PhysicalAssetRevision {
+  std::string physicalPathIdentity;
+  std::uintmax_t fileSize = 0;
+  std::int64_t modificationTimeNs = 0;
+  bool metadataAvailable = false;
+
+  bool operator==(const PhysicalAssetRevision &) const = default;
+};
+
+// Reads the cheap physical identity used by runtime and disk asset caches.
+inline PhysicalAssetRevision ReadPhysicalAssetRevision(const std::string &path) {
+  PhysicalAssetRevision revision;
+  revision.physicalPathIdentity = PathUtils::BuildFilesystemIdentityKey(path);
+  std::error_code sizeError;
+  revision.fileSize =
+      std::filesystem::file_size(PathUtils::PathFromUtf8(path), sizeError);
+  std::error_code timeError;
+  const auto writeTime = std::filesystem::last_write_time(
+      PathUtils::PathFromUtf8(path), timeError);
+  if (!timeError) {
+    revision.modificationTimeNs =
+        std::chrono::duration_cast<std::chrono::nanoseconds>(
+            writeTime.time_since_epoch())
+            .count();
+  }
+  revision.metadataAvailable = !sizeError && !timeError;
+  return revision;
+}
+
+} // namespace viewer3d::resources

--- a/viewer3d/resources/resource_reference_cache_key.h
+++ b/viewer3d/resources/resource_reference_cache_key.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <algorithm>
+#include <cctype>
+#include <filesystem>
+#include <string>
+
+namespace viewer3d::resources {
+
+// Builds a platform-neutral key for an unresolved scene resource reference.
+inline std::string
+BuildResourceReferenceCacheKey(const std::string &reference) {
+  std::string normalized = reference;
+  const auto isWhitespace = [](unsigned char value) {
+    return std::isspace(value) != 0;
+  };
+  normalized.erase(normalized.begin(),
+                   std::find_if_not(normalized.begin(), normalized.end(),
+                                    isWhitespace));
+  normalized.erase(
+      std::find_if_not(normalized.rbegin(), normalized.rend(), isWhitespace)
+          .base(),
+      normalized.end());
+  if (normalized.size() >= 2 && normalized.front() == '"' &&
+      normalized.back() == '"') {
+    normalized = normalized.substr(1, normalized.size() - 2);
+  }
+  std::replace(normalized.begin(), normalized.end(), '\\', '/');
+  if (normalized.empty())
+    return {};
+  return std::filesystem::path(normalized).lexically_normal().generic_string();
+}
+
+} // namespace viewer3d::resources

--- a/viewer3d/resources/resource_sync_system.cpp
+++ b/viewer3d/resources/resource_sync_system.cpp
@@ -7,6 +7,7 @@
 #include "loader3ds.h"
 #include "loaderglb.h"
 #include "loader_obj.h"
+#include "logger.h"
 #include "matrixutils.h"
 #include "projectutils.h"
 
@@ -14,6 +15,9 @@
 #include <array>
 #include <chrono>
 #include <exception>
+#include <cstdint>
+#include <cstring>
+#include <sstream>
 #include <system_error>
 #include <cctype>
 #include <cmath>
@@ -25,6 +29,32 @@ namespace fs = std::filesystem;
 
 namespace {
 using RetryClock = std::chrono::steady_clock;
+
+// Builds a stable summary of GDTF object transforms and mesh sizes.
+std::string BuildGdtfObjectSignature(const std::vector<GdtfObject> &objects) {
+  std::uint64_t hash = 1469598103934665603ULL;
+  size_t vertices = 0;
+  size_t indices = 0;
+  for (const GdtfObject &object : objects) {
+    vertices += object.mesh.vertices.size();
+    indices += object.mesh.indices.size();
+    const auto hashAxis = [&hash](const std::array<float, 3> &axis) {
+      for (float value : axis) {
+        std::uint32_t bits = 0;
+        std::memcpy(&bits, &value, sizeof(bits));
+        hash = (hash ^ bits) * 1099511628211ULL;
+      }
+    };
+    hashAxis(object.transform.u);
+    hashAxis(object.transform.v);
+    hashAxis(object.transform.w);
+    hashAxis(object.transform.o);
+  }
+  std::ostringstream output;
+  output << "objects=" << objects.size() << " vertices=" << vertices
+         << " indices=" << indices << " transform_hash=" << std::hex << hash;
+  return output.str();
+}
 
 // Returns the current monotonic time used for retry backoff.
 RetryClock::time_point CurrentRetryTime() { return RetryClock::now(); }
@@ -953,9 +983,11 @@ ResourceSyncResult ResourceSyncSystem::Sync(
     if (state.loadedGdtf.find(resourceKey) == state.loadedGdtf.end()) {
       std::vector<GdtfObject> objs;
       std::string gdtfError;
+      bool loadedFromDiskCache = false;
       try {
         if (meshProcessingOptions.enableDiskCache &&
             viewer3d::resources::TryLoadGdtfCache(gdtfPath, f.gdtfMode, objs)) {
+          loadedFromDiskCache = true;
         } else if (LoadGdtf(gdtfPath, objs, f.gdtfMode, &gdtfError)) {
           if (meshProcessingOptions.enableMeshOptimization)
             viewer3d::resources::OptimizeGdtfObjectsForRuntime(objs);
@@ -969,6 +1001,17 @@ ResourceSyncResult ResourceSyncSystem::Sync(
       }
 
       if (!objs.empty()) {
+#ifndef NDEBUG
+        Logger::Instance().Log(
+            Logger::Level::Debug,
+            "GDTF runtime resource path=" + gdtfPath + " mode=\"" +
+                f.gdtfMode + "\" source=" +
+                (loadedFromDiskCache ? "disk_cache" : "fresh_parse") +
+                " revision_size=" + std::to_string(currentRevision.fileSize) +
+                " revision_mtime=" +
+                std::to_string(currentRevision.modificationTimeNs) + ' ' +
+                BuildGdtfObjectSignature(objs));
+#endif
         SetupGdtfMeshBuffers(objs, callbacks);
         state.loadedGdtf[resourceKey] = std::move(objs);
         state.loadedGdtfRevisions[resourceKey] = currentRevision;

--- a/viewer3d/resources/resource_sync_system.cpp
+++ b/viewer3d/resources/resource_sync_system.cpp
@@ -571,32 +571,49 @@ void EnsureModelLoaded(const std::string &path, ResourceSyncState &state,
                        const ResourceSyncCallbacks &callbacks,
                        const viewer3d::resources::MeshProcessingOptions &meshProcessingOptions,
                        bool &assetsChanged) {
-  if (path.empty() || state.loadedMeshes.find(path) != state.loadedMeshes.end())
+  if (path.empty())
     return;
 
+  const auto currentRevision =
+      viewer3d::resources::ReadPhysicalAssetRevision(path);
+  auto loaded = state.loadedMeshes.find(path);
+  auto loadedRevision = state.loadedMeshRevisions.find(path);
+  if (loaded != state.loadedMeshes.end() &&
+      loadedRevision != state.loadedMeshRevisions.end() &&
+      currentRevision.metadataAvailable &&
+      loadedRevision->second == currentRevision)
+    return;
+  if (loaded != state.loadedMeshes.end()) {
+    if (callbacks.releaseMeshBuffers)
+      callbacks.releaseMeshBuffers(loaded->second);
+    state.loadedMeshes.erase(loaded);
+    state.loadedMeshRevisions.erase(path);
+    assetsChanged = true;
+  }
+
   Mesh mesh;
-  bool loaded = false;
+  bool loadedFromSource = false;
 
   if (meshProcessingOptions.enableDiskCache &&
       viewer3d::resources::TryLoadMeshCache(path, mesh)) {
-    loaded = true;
+    loadedFromSource = true;
   }
 
   std::string ext = fs::path(path).extension().string();
   std::transform(ext.begin(), ext.end(), ext.begin(),
                  [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
-  if (!loaded) {
+  if (!loadedFromSource) {
     std::string loadException;
     try {
       if (ext == ".3ds")
-        loaded = Load3DS(path, mesh,
+        loadedFromSource = Load3DS(path, mesh,
                          meshProcessingOptions.applyThreeDsObjectTransforms);
       else if (ext == ".glb")
-        loaded = LoadGLB(path, mesh);
+        loadedFromSource = LoadGLB(path, mesh);
       else if (ext == ".obj") {
         std::string objError;
-        loaded = LoadOBJ(path, mesh, &objError);
-        if (!loaded && callbacks.appendConsoleMessage)
+        loadedFromSource = LoadOBJ(path, mesh, &objError);
+        if (!loadedFromSource && callbacks.appendConsoleMessage)
           callbacks.appendConsoleMessage("OBJ load failed for " + path + ": " + objError);
       }
     } catch (const std::exception &ex) {
@@ -608,17 +625,18 @@ void EnsureModelLoaded(const std::string &path, ResourceSyncState &state,
     if (!loadException.empty() && callbacks.appendConsoleMessage)
       callbacks.appendConsoleMessage("Model load exception for " + path + ": " + loadException);
 
-    if (loaded && meshProcessingOptions.enableMeshOptimization)
+    if (loadedFromSource && meshProcessingOptions.enableMeshOptimization)
       viewer3d::resources::OptimizeMeshForRuntime(mesh);
 
-    if (loaded && meshProcessingOptions.enableDiskCache)
+    if (loadedFromSource && meshProcessingOptions.enableDiskCache)
       viewer3d::resources::TrySaveMeshCache(path, mesh);
   }
 
-  if (loaded) {
+  if (loadedFromSource) {
     if (callbacks.setupMeshBuffers)
       callbacks.setupMeshBuffers(mesh);
     state.loadedMeshes[path] = std::move(mesh);
+    state.loadedMeshRevisions[path] = currentRevision;
     assetsChanged = true;
   } else if (callbacks.appendConsoleMessage) {
     callbacks.appendConsoleMessage("Failed to load model: " + path);
@@ -679,8 +697,11 @@ ResourceSyncResult ResourceSyncSystem::Sync(
         callbacks.releaseMeshBuffers(mesh);
     }
     state.loadedMeshes.clear();
+    state.loadedMeshRevisions.clear();
     ReleaseGdtfMeshBuffers(state, callbacks);
     state.loadedGdtf.clear();
+    state.loadedGdtfRevisions.clear();
+    state.attemptedGdtfRevisions.clear();
     state.loadedGdtfGeometryTrees.clear();
     state.fixtureNodeRegistry.clear();
     state.fixtureAnchorRegistry.clear();
@@ -894,6 +915,27 @@ ResourceSyncResult ResourceSyncSystem::Sync(
     }
 
     const std::string resourceKey = BuildGdtfResourceKey(gdtfPath, f.gdtfMode);
+    const auto currentRevision =
+        viewer3d::resources::ReadPhysicalAssetRevision(gdtfPath);
+    auto attemptedRevision = state.attemptedGdtfRevisions.find(resourceKey);
+    if (attemptedRevision != state.attemptedGdtfRevisions.end() &&
+        attemptedRevision->second != currentRevision) {
+      state.failedGdtfReasons.erase(resourceKey);
+      state.failedGdtfAttemptCounts.erase(resourceKey);
+      state.reportedGdtfFailureCounts.erase(resourceKey);
+      state.reportedGdtfFailureReasons.erase(resourceKey);
+    }
+    auto loadedRevision = state.loadedGdtfRevisions.find(resourceKey);
+    const bool revisionMatches =
+        currentRevision.metadataAvailable &&
+        loadedRevision != state.loadedGdtfRevisions.end() &&
+        loadedRevision->second == currentRevision;
+    if (state.loadedGdtf.find(resourceKey) != state.loadedGdtf.end() &&
+        !revisionMatches) {
+      ResourceSyncSystem::InvalidatePhysicalAsset(
+          gdtfPath, f.gdtfMode, state, callbacks);
+      result.assetsChanged = true;
+    }
     auto failedIt = state.failedGdtfReasons.find(resourceKey);
     if (failedIt != state.failedGdtfReasons.end()) {
       const size_t attempts = state.failedGdtfAttemptCounts[resourceKey];
@@ -929,6 +971,8 @@ ResourceSyncResult ResourceSyncSystem::Sync(
       if (!objs.empty()) {
         SetupGdtfMeshBuffers(objs, callbacks);
         state.loadedGdtf[resourceKey] = std::move(objs);
+        state.loadedGdtfRevisions[resourceKey] = currentRevision;
+        state.attemptedGdtfRevisions[resourceKey] = currentRevision;
         state.failedGdtfAttemptCounts.erase(resourceKey);
 
         GdtfGeometryTree geometryTree;
@@ -946,6 +990,7 @@ ResourceSyncResult ResourceSyncSystem::Sync(
       } else {
         std::string reason = gdtfError.empty() ? "Failed to load GDTF" : gdtfError;
         state.failedGdtfReasons[resourceKey] = reason;
+        state.attemptedGdtfRevisions[resourceKey] = currentRevision;
         ++state.failedGdtfAttemptCounts[resourceKey];
         ++gdtfErrorCounts[resourceKey];
         gdtfErrorReasons[resourceKey] = reason;
@@ -1067,4 +1112,87 @@ ResourceSyncResult ResourceSyncSystem::Sync(
   }
 
   return result;
+}
+
+// Invalidates cached runtime data for one physical asset and optional GDTF mode.
+bool ResourceSyncSystem::InvalidatePhysicalAsset(
+    const std::string &physicalPath,
+    const std::optional<std::string> &exactMode, ResourceSyncState &state,
+    const ResourceSyncCallbacks &callbacks) {
+  bool invalidated = false;
+  const auto requestedRevision =
+      viewer3d::resources::ReadPhysicalAssetRevision(physicalPath);
+  auto meshIt = state.loadedMeshes.find(physicalPath);
+  if (meshIt == state.loadedMeshes.end()) {
+    for (auto candidate = state.loadedMeshRevisions.begin();
+         candidate != state.loadedMeshRevisions.end(); ++candidate) {
+      if (candidate->second.physicalPathIdentity ==
+          requestedRevision.physicalPathIdentity) {
+        meshIt = state.loadedMeshes.find(candidate->first);
+        break;
+      }
+    }
+  }
+  if (meshIt != state.loadedMeshes.end()) {
+    const std::string loadedPath = meshIt->first;
+    if (callbacks.releaseMeshBuffers)
+      callbacks.releaseMeshBuffers(meshIt->second);
+    state.loadedMeshes.erase(meshIt);
+    state.loadedMeshRevisions.erase(loadedPath);
+    invalidated = true;
+  }
+
+  for (auto it = state.loadedGdtf.begin(); it != state.loadedGdtf.end();) {
+    const auto revisionIt = state.loadedGdtfRevisions.find(it->first);
+    const bool pathMatches =
+        (revisionIt != state.loadedGdtfRevisions.end() &&
+         revisionIt->second.physicalPathIdentity ==
+             requestedRevision.physicalPathIdentity) ||
+        it->first.starts_with(physicalPath + "\nmode=");
+    const bool modeMatches =
+        !exactMode || it->first.ends_with("\nmode=" + *exactMode);
+    if (!pathMatches || !modeMatches) {
+      ++it;
+      continue;
+    }
+    if (callbacks.releaseMeshBuffers) {
+      for (auto &object : it->second)
+        callbacks.releaseMeshBuffers(object.mesh);
+    }
+    const std::string resourceKey = it->first;
+    it = state.loadedGdtf.erase(it);
+    state.loadedGdtfRevisions.erase(resourceKey);
+    state.attemptedGdtfRevisions.erase(resourceKey);
+    state.loadedGdtfGeometryTrees.erase(resourceKey);
+    state.geometryTreeVersionByResolvedGdtfPath.erase(resourceKey);
+    state.failedGdtfReasons.erase(resourceKey);
+    state.failedGdtfAttemptCounts.erase(resourceKey);
+    state.reportedGdtfFailureCounts.erase(resourceKey);
+    state.reportedGdtfFailureReasons.erase(resourceKey);
+    invalidated = true;
+  }
+  for (auto it = state.attemptedGdtfRevisions.begin();
+       it != state.attemptedGdtfRevisions.end();) {
+    const bool pathMatches =
+        it->second.physicalPathIdentity == requestedRevision.physicalPathIdentity;
+    const bool modeMatches =
+        !exactMode || it->first.ends_with("\nmode=" + *exactMode);
+    if (!pathMatches || !modeMatches) {
+      ++it;
+      continue;
+    }
+    const std::string resourceKey = it->first;
+    it = state.attemptedGdtfRevisions.erase(it);
+    state.failedGdtfReasons.erase(resourceKey);
+    state.failedGdtfAttemptCounts.erase(resourceKey);
+    state.reportedGdtfFailureCounts.erase(resourceKey);
+    state.reportedGdtfFailureReasons.erase(resourceKey);
+    invalidated = true;
+  }
+  if (invalidated) {
+    state.fixtureNodeRegistry.clear();
+    state.fixtureAnchorRegistry.clear();
+    state.fixtureRegistrySignatureByUuid.clear();
+  }
+  return invalidated;
 }

--- a/viewer3d/resources/resource_sync_system.cpp
+++ b/viewer3d/resources/resource_sync_system.cpp
@@ -3,6 +3,7 @@
 #include "gdtfloader.h"
 #include "mesh_processing.h"
 #include "resource_path_search.h"
+#include "resource_reference_cache_key.h"
 
 #include "loader3ds.h"
 #include "loaderglb.h"
@@ -433,20 +434,6 @@ std::string NormalizePath(const std::string &p) {
   return out;
 }
 
-// Normalizes a model path for cache-key comparisons.
-std::string NormalizeModelKey(const std::string &p) {
-  if (p.empty())
-    return {};
-  fs::path path(p);
-  path = path.lexically_normal();
-  return NormalizePath(path.string());
-}
-
-// Builds the stable cache key for a resource path reference.
-std::string ResolveCacheKey(const std::string &pathRef) {
-  return NormalizeModelKey(TrimPathRef(pathRef));
-}
-
 // Resolves a GDTF resource specification against scene and library paths.
 std::string ResolveGdtfPath(
     const std::string &base, const std::string &spec,
@@ -800,7 +787,8 @@ ResourceSyncResult ResourceSyncSystem::Sync(
     const std::string cleanSpec = TrimPathRef(spec);
     if (cleanSpec.empty())
       return;
-    const std::string key = ResolveCacheKey(cleanSpec);
+    const std::string key =
+        viewer3d::resources::BuildResourceReferenceCacheKey(cleanSpec);
     auto [it, inserted] =
         state.resolvedGdtfSpecs.try_emplace(key, ResourceSyncState::PathResolutionEntry{});
     if (!inserted && HasValidResolvedPath(it->second, callbacks))
@@ -838,7 +826,8 @@ ResourceSyncResult ResourceSyncSystem::Sync(
     const std::string cleanModelRef = TrimPathRef(modelRef);
     if (cleanModelRef.empty())
       return;
-    const std::string key = ResolveCacheKey(cleanModelRef);
+    const std::string key =
+        viewer3d::resources::BuildResourceReferenceCacheKey(cleanModelRef);
     auto [it, inserted] =
         state.resolvedModelRefs.try_emplace(key, ResourceSyncState::PathResolutionEntry{});
     if (!inserted && HasValidResolvedPath(it->second, callbacks))
@@ -890,7 +879,8 @@ ResourceSyncResult ResourceSyncSystem::Sync(
 
   for (const auto *entry : visibleTrusses) {
     const auto &t = entry->second;
-    auto pathIt = state.resolvedModelRefs.find(ResolveCacheKey(t.symbolFile));
+    auto pathIt = state.resolvedModelRefs.find(
+        viewer3d::resources::BuildResourceReferenceCacheKey(t.symbolFile));
     const std::string path =
         (pathIt != state.resolvedModelRefs.end() && pathIt->second.attempted)
             ? pathIt->second.resolvedPath
@@ -902,7 +892,8 @@ ResourceSyncResult ResourceSyncSystem::Sync(
     const auto &obj = entry->second;
     if (!obj.geometries.empty()) {
       for (const auto &geo : obj.geometries) {
-        auto pathIt = state.resolvedModelRefs.find(ResolveCacheKey(geo.modelFile));
+        auto pathIt = state.resolvedModelRefs.find(
+            viewer3d::resources::BuildResourceReferenceCacheKey(geo.modelFile));
         const std::string path =
             (pathIt != state.resolvedModelRefs.end() && pathIt->second.attempted)
                 ? pathIt->second.resolvedPath
@@ -912,7 +903,8 @@ ResourceSyncResult ResourceSyncSystem::Sync(
       continue;
     }
 
-    auto pathIt = state.resolvedModelRefs.find(ResolveCacheKey(obj.modelFile));
+    auto pathIt = state.resolvedModelRefs.find(
+        viewer3d::resources::BuildResourceReferenceCacheKey(obj.modelFile));
     const std::string path =
         (pathIt != state.resolvedModelRefs.end() && pathIt->second.attempted)
             ? pathIt->second.resolvedPath
@@ -930,7 +922,8 @@ ResourceSyncResult ResourceSyncSystem::Sync(
     if (f.gdtfSpec.empty())
       continue;
 
-    auto gdtfPathIt = state.resolvedGdtfSpecs.find(ResolveCacheKey(f.gdtfSpec));
+    auto gdtfPathIt = state.resolvedGdtfSpecs.find(
+        viewer3d::resources::BuildResourceReferenceCacheKey(f.gdtfSpec));
     const std::string gdtfPath =
         (gdtfPathIt != state.resolvedGdtfSpecs.end() && gdtfPathIt->second.attempted)
             ? gdtfPathIt->second.resolvedPath
@@ -1068,7 +1061,8 @@ ResourceSyncResult ResourceSyncSystem::Sync(
       continue;
     }
 
-    auto gdtfPathIt = state.resolvedGdtfSpecs.find(ResolveCacheKey(fixture.gdtfSpec));
+    auto gdtfPathIt = state.resolvedGdtfSpecs.find(
+        viewer3d::resources::BuildResourceReferenceCacheKey(fixture.gdtfSpec));
     if (gdtfPathIt == state.resolvedGdtfSpecs.end() || !gdtfPathIt->second.attempted ||
         gdtfPathIt->second.resolvedPath.empty()) {
       state.fixtureNodeRegistry.erase(uuid);

--- a/viewer3d/resources/resource_sync_system.h
+++ b/viewer3d/resources/resource_sync_system.h
@@ -6,6 +6,7 @@
 #include "fixture.h"
 #include "sceneobject.h"
 #include "truss.h"
+#include "physical_asset_revision.h"
 
 #include <functional>
 #include <optional>
@@ -40,7 +41,13 @@ struct ResourceSyncState {
   };
 
   std::unordered_map<std::string, Mesh> loadedMeshes;
+  std::unordered_map<std::string, viewer3d::resources::PhysicalAssetRevision>
+      loadedMeshRevisions;
   std::unordered_map<std::string, std::vector<GdtfObject>> loadedGdtf;
+  std::unordered_map<std::string, viewer3d::resources::PhysicalAssetRevision>
+      loadedGdtfRevisions;
+  std::unordered_map<std::string, viewer3d::resources::PhysicalAssetRevision>
+      attemptedGdtfRevisions;
   std::unordered_map<std::string, GdtfGeometryTree> loadedGdtfGeometryTrees;
   std::unordered_map<std::string, std::string> failedGdtfReasons;
   std::unordered_map<std::string, size_t> failedGdtfAttemptCounts;
@@ -86,4 +93,8 @@ public:
        const std::vector<const std::pair<const std::string, SceneObject> *> &visibleObjects,
        const std::vector<const std::pair<const std::string, Fixture> *> &visibleFixtures,
        ResourceSyncState &state, const ResourceSyncCallbacks &callbacks);
+
+  static bool InvalidatePhysicalAsset(
+      const std::string &physicalPath, const std::optional<std::string> &exactMode,
+      ResourceSyncState &state, const ResourceSyncCallbacks &callbacks);
 };


### PR DESCRIPTION
### Motivation

- The renderer and resource-sync caches were keyed only by resolved physical path and mode, allowing a same-path GDTF or model replacement to leave stale GPU geometry and mesh buffers in-use and produce mixed-revision symbols. 
- Offscreen Viewer2D state restoration could fall back to the global singleton instead of restoring the original apply-target, which breaks offscreen-only captures and leaks UI state. 
- A capture can become invalid if its authoritative GDTF source changes during the four-view capture, so capture must verify the source revision before accepting renders.

### Description

- Added a lightweight physical-asset revision type and reader `PhysicalAssetRevision` / `ReadPhysicalAssetRevision` to capture filesystem identity, file size and modification time, and used it as the bounded revision for runtime caches (`viewer3d/resources/physical_asset_revision.h`).
- Made `ResourceSyncState` revision-aware by storing `loadedMeshRevisions`, `loadedGdtfRevisions`, and `attemptedGdtfRevisions` and updated `ResourceSyncSystem::Sync` to compare current revisions before reusing cached `loadedGdtf`/`loadedMeshes` and to call a new `InvalidatePhysicalAsset` when mismatches are detected (`viewer3d/resources/resource_sync_system.{h,cpp}`).
- Implemented `ResourceSyncSystem::InvalidatePhysicalAsset` to release GPU buffers (via callbacks), erase stale `loadedGdtf`/`loadedMeshes` entries and associated geometry trees, versions, fixture node/anchor registries and failure state, and to leave the system ready to reload the current revision (`viewer3d/resources/resource_sync_system.cpp`).
- Hardened on-disk mesh/GDTF caches by bumping the cache format version and validating both source `fileSize` and `modificationTime` before accepting a cache (`viewer3d/resources/mesh_processing.cpp`); treated uncertain metadata as a cache miss.
- Fixed `ScopedViewer2DState::Restore()` so that absent explicit restore targets it restores the original `applyPanel_`/`applyRenderPanel_` (instead of `Instance()` singletons) to preserve offscreen capture isolation (`viewer2d/viewer2dstate.cpp`).
- Added a post-capture revision gate in `FixtureSymbolPreparationService` to abort a capture if the authoritative `GdtfFileRevision` changed during capture, and updated small tests and diagnostic checks and release notes accordingly (`gui/services/fixture_symbol_preparation_service.cpp`, `tests/*`, `docs/release-notes-draft.md`).

### Testing

- Ran the repository policy and ownership checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both passed. 
- Ran the focused fixture-capture architecture checks `tests/check_fixture_symbol_capture_isolation.sh` and `tests/check_viewer2d_state_ownership_boundary.sh`, both passed and confirm the new revision and restore-contract checks are present. 
- Performed `git diff --check` and `git status` to ensure a clean working tree after the change. 
- Attempted CMake configure with `cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON`, which failed to complete because the container lacks the `wxWidgets` development libraries (configuration failed, not a code failure in these changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8c28ceb4648324937adcd455bf46f0)