### PR TITLE
Improve rider section and position parsing (FRONTAL/CENITAL/CONTRA/SUELO/CALLES)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -71,6 +71,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/startup_profile.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/rigging_extra_weight_settings.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/riderimporter.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/rider_text_semantics.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/scene_grouping.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/scene_clipboard.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/scene_node_operations.cpp

--- a/core/rider_text_semantics.cpp
+++ b/core/rider_text_semantics.cpp
@@ -3,7 +3,6 @@
 #include <algorithm>
 #include <array>
 #include <cctype>
-#include <regex>
 #include <unordered_map>
 
 namespace rider_text {
@@ -20,44 +19,71 @@ std::string Trim(std::string_view value) {
 
 // Produces an uppercase, accent-folded key with normalized whitespace.
 std::string NormalizeKey(std::string_view value) {
-  std::string key = Trim(value);
-  while (!key.empty() && (key.back() == ':' || key.back() == ';'))
-    key.pop_back();
-  key = Trim(key);
-
-  const std::array<std::pair<std::string_view, std::string_view>, 10> folds{{
-      {"Á", "A"},
-      {"É", "E"},
-      {"Í", "I"},
-      {"Ó", "O"},
-      {"Ú", "U"},
-      {"á", "A"},
-      {"é", "E"},
-      {"í", "I"},
-      {"ó", "O"},
-      {"ú", "U"},
-  }};
-  for (const auto &[accent, replacement] : folds) {
-    size_t position = 0;
-    while ((position = key.find(accent, position)) != std::string::npos) {
-      key.replace(position, accent.size(), replacement);
-      position += replacement.size();
+  const std::string trimmed = Trim(value);
+  value = trimmed;
+  std::string key;
+  key.reserve(value.size());
+  bool pendingSpace = false;
+  for (size_t index = 0; index < value.size(); ++index) {
+    const unsigned char character = static_cast<unsigned char>(value[index]);
+    if (std::isspace(character)) {
+      pendingSpace = !key.empty();
+      continue;
     }
+    if (pendingSpace) {
+      key.push_back(' ');
+      pendingSpace = false;
+    }
+    if (character == 0xC3 && index + 1 < value.size()) {
+      const unsigned char continuation =
+          static_cast<unsigned char>(value[index + 1]);
+      static constexpr std::array<unsigned char, 10> accentedLetters = {
+          0x81, 0x89, 0x8D, 0x93, 0x9A, 0xA1, 0xA9, 0xAD, 0xB3, 0xBA};
+      static constexpr std::array<char, 10> foldedLetters = {
+          'A', 'E', 'I', 'O', 'U', 'A', 'E', 'I', 'O', 'U'};
+      const auto found = std::find(accentedLetters.begin(),
+                                   accentedLetters.end(), continuation);
+      if (found != accentedLetters.end()) {
+        key.push_back(foldedLetters[static_cast<size_t>(
+            std::distance(accentedLetters.begin(), found))]);
+        ++index;
+        continue;
+      }
+    }
+    key.push_back(static_cast<char>(std::toupper(character)));
   }
-  std::transform(key.begin(), key.end(), key.begin(), [](unsigned char c) {
-    return static_cast<char>(std::toupper(c));
-  });
-  static const std::regex whitespaceRe("\\s+");
-  key = std::regex_replace(key, whitespaceRe, " ");
-  return Trim(key);
+  while (!key.empty() &&
+         (key.back() == ' ' || key.back() == ':' || key.back() == ';'))
+    key.pop_back();
+  return key;
 }
 
 // Removes trailing coordinate and margin commands from a heading key.
-std::string RemoveCommandSuffixes(std::string value) {
-  static const std::regex commandRe(
-      "\\s*(?:\\([^)]*\\)|\\[[^]]*\\])\\s*");
-  value = std::regex_replace(value, commandRe, " ");
-  return NormalizeKey(value);
+std::string RemoveCommandSuffixes(std::string_view value) {
+  std::string withoutCommands;
+  withoutCommands.reserve(value.size());
+  for (size_t index = 0; index < value.size();) {
+    const char opening = value[index];
+    const char closing = opening == '(' ? ')' : opening == '[' ? ']' : '\0';
+    if (closing != '\0') {
+      const size_t end = value.find(closing, index + 1);
+      if (end != std::string_view::npos) {
+        index = end + 1;
+        continue;
+      }
+    }
+    withoutCommands.push_back(value[index++]);
+  }
+  return NormalizeKey(withoutCommands);
+}
+
+// Reports whether a normalized key is an explicit LX-number heading.
+bool IsExplicitLx(const std::string &key) {
+  if (key.size() < 3 || key[0] != 'L' || key[1] != 'X')
+    return false;
+  return std::all_of(key.begin() + 2, key.end(), [](unsigned char character) {
+    return std::isdigit(character) != 0;
+  });
 }
 
 // Looks up an exact semantic hang alias.
@@ -172,9 +198,8 @@ Section ClassifySectionHeader(std::string_view line) {
 std::optional<std::string> ClassifyHangHeader(std::string_view line) {
   if (IsQuantityPrefixedLine(line))
     return std::nullopt;
-  const std::string key = RemoveCommandSuffixes(NormalizeKey(line));
-  static const std::regex lxHeadingRe("LX[0-9]+");
-  if (std::regex_match(key, lxHeadingRe))
+  const std::string key = RemoveCommandSuffixes(line);
+  if (IsExplicitLx(key))
     return key;
   if (key.rfind("CALLES DIRECTAS ", 0) == 0)
     return "LX SIDES";
@@ -183,9 +208,8 @@ std::optional<std::string> ClassifyHangHeader(std::string_view line) {
 
 // Normalizes a hang or rigging target alias to its canonical name.
 std::string NormalizeHangAlias(std::string_view value) {
-  std::string key = RemoveCommandSuffixes(NormalizeKey(value));
-  static const std::regex lxTargetRe("LX[0-9]+");
-  if (std::regex_match(key, lxTargetRe))
+  std::string key = RemoveCommandSuffixes(value);
+  if (IsExplicitLx(key))
     return key;
   if (key.rfind("PUENTES ", 0) == 0)
     key = Trim(key.substr(8));

--- a/core/rider_text_semantics.cpp
+++ b/core/rider_text_semantics.cpp
@@ -1,0 +1,201 @@
+#include "rider_text_semantics.h"
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <regex>
+#include <unordered_map>
+
+namespace rider_text {
+namespace {
+
+// Trims ASCII whitespace from both ends of a string.
+std::string Trim(std::string_view value) {
+  const size_t first = value.find_first_not_of(" \t\r\n");
+  if (first == std::string_view::npos)
+    return {};
+  const size_t last = value.find_last_not_of(" \t\r\n");
+  return std::string(value.substr(first, last - first + 1));
+}
+
+// Produces an uppercase, accent-folded key with normalized whitespace.
+std::string NormalizeKey(std::string_view value) {
+  std::string key = Trim(value);
+  while (!key.empty() && (key.back() == ':' || key.back() == ';'))
+    key.pop_back();
+  key = Trim(key);
+
+  const std::array<std::pair<std::string_view, std::string_view>, 10> folds{{
+      {"Á", "A"},
+      {"É", "E"},
+      {"Í", "I"},
+      {"Ó", "O"},
+      {"Ú", "U"},
+      {"á", "A"},
+      {"é", "E"},
+      {"í", "I"},
+      {"ó", "O"},
+      {"ú", "U"},
+  }};
+  for (const auto &[accent, replacement] : folds) {
+    size_t position = 0;
+    while ((position = key.find(accent, position)) != std::string::npos) {
+      key.replace(position, accent.size(), replacement);
+      position += replacement.size();
+    }
+  }
+  std::transform(key.begin(), key.end(), key.begin(), [](unsigned char c) {
+    return static_cast<char>(std::toupper(c));
+  });
+  static const std::regex whitespaceRe("\\s+");
+  key = std::regex_replace(key, whitespaceRe, " ");
+  return Trim(key);
+}
+
+// Removes trailing coordinate and margin commands from a heading key.
+std::string RemoveCommandSuffixes(std::string value) {
+  static const std::regex commandRe(
+      "\\s*(?:\\([^)]*\\)|\\[[^]]*\\])\\s*");
+  value = std::regex_replace(value, commandRe, " ");
+  return NormalizeKey(value);
+}
+
+// Looks up an exact semantic hang alias.
+std::optional<std::string> LookupHangAlias(const std::string &key) {
+  static const std::unordered_map<std::string, std::string> aliases = {
+      {"FRONTAL", "LX1"},
+      {"FRENTE", "LX1"},
+      {"PUENTE FRONTAL", "LX1"},
+      {"FRONT", "LX1"},
+      {"FRONT LIGHT", "LX1"},
+      {"FRONT TRUSS", "LX1"},
+      {"DOWNSTAGE", "LX1"},
+      {"CENITAL", "LX2"},
+      {"CENTRAL", "LX2"},
+      {"MEDIO", "LX2"},
+      {"PUENTE CENTRAL", "LX2"},
+      {"MID", "LX2"},
+      {"MIDDLE", "LX2"},
+      {"CENTER", "LX2"},
+      {"CENTRE", "LX2"},
+      {"MIDSTAGE", "LX2"},
+      {"CONTRA", "LX3"},
+      {"CONTRALUZ", "LX3"},
+      {"PUENTE TRASERO", "LX3"},
+      {"TRASERO", "LX3"},
+      {"BACK", "LX3"},
+      {"REAR", "LX3"},
+      {"BACKLIGHT", "LX3"},
+      {"UPSTAGE", "LX3"},
+      {"CALLE", "LX SIDES"},
+      {"CALLES", "LX SIDES"},
+      {"LATERAL", "LX SIDES"},
+      {"LATERALES", "LX SIDES"},
+      {"SIDE", "LX SIDES"},
+      {"SIDES", "LX SIDES"},
+      {"SIDE LIGHT", "LX SIDES"},
+      {"SIDE LIGHTS", "LX SIDES"},
+      {"LX SIDE", "LX SIDES"},
+      {"LX SIDES", "LX SIDES"},
+      {"SUELO", "FLOOR"},
+      {"PISO", "FLOOR"},
+      {"CALLES A SUELO", "FLOOR"},
+      {"FLOOR", "FLOOR"},
+      {"GROUND", "FLOOR"},
+      {"DECK", "FLOOR"},
+      {"GROUND LANE", "FLOOR"},
+      {"GROUND LANES", "FLOOR"},
+      {"PANTALLA", "SCREEN"},
+      {"PANTALLA LED", "SCREEN"},
+      {"PROYECCION", "SCREEN"},
+      {"SCREEN", "SCREEN"},
+      {"LED SCREEN", "SCREEN"},
+      {"LEDSCREEN", "SCREEN"},
+      {"LED WALL", "SCREEN"},
+      {"PROJECTION", "SCREEN"},
+  };
+  const auto found = aliases.find(key);
+  if (found == aliases.end())
+    return std::nullopt;
+  return found->second;
+}
+
+} // namespace
+
+// Reports whether a line starts with a positive equipment quantity.
+bool IsQuantityPrefixedLine(std::string_view line) {
+  const std::string trimmed = Trim(line);
+  size_t position = 0;
+  if (position < trimmed.size() &&
+      (trimmed[position] == '-' || trimmed[position] == '*')) {
+    ++position;
+    while (position < trimmed.size() &&
+           std::isspace(static_cast<unsigned char>(trimmed[position])))
+      ++position;
+  }
+  const size_t digitStart = position;
+  while (position < trimmed.size() &&
+         std::isdigit(static_cast<unsigned char>(trimmed[position])))
+    ++position;
+  return position > digitStart && position < trimmed.size() &&
+         std::isspace(static_cast<unsigned char>(trimmed[position]));
+}
+
+// Classifies a complete rider line when it is a recognized section heading.
+Section ClassifySectionHeader(std::string_view line) {
+  if (IsQuantityPrefixedLine(line))
+    return Section::None;
+  const std::string key = NormalizeKey(line);
+  if (key == "CONTROL" || key == "CONTROL DE ILUMINACION" ||
+      key == "CONTROL DE LUCES" || key == "LIGHTING CONTROL" ||
+      key == "CONTROL DMX")
+    return Section::LightingControl;
+  if (key == "ILUMINACION" || key == "ILUMIN" || key == "LIGHTING" ||
+      key == "APARATOS" || key == "FIXTURES" || key == "ROBOTICA" ||
+      key == "CONVENCIONALES")
+    return Section::Lighting;
+  if (key == "EFECTOS" || key == "EFECTO" || key == "EFFECTS" ||
+      key == "EFFECT")
+    return Section::Effects;
+  if (key == "VIDEO" || key == "VIDEO Y PROYECCION")
+    return Section::Video;
+  if (key == "RIGGING" || key == "RIGGING Y ESTRUCTURAS" ||
+      key == "ESTRUCTURAS" || key == "RIGGING AND STRUCTURES")
+    return Section::Rigging;
+  if (key == "SONIDO" || key == "AUDIO" || key == "CONTROL DE P.A." ||
+      key == "MONITORES" || key == "MICROFONIA" || key == "REALIZACION")
+    return Section::Ignored;
+  return Section::None;
+}
+
+// Returns the canonical hang for a complete position heading.
+std::optional<std::string> ClassifyHangHeader(std::string_view line) {
+  if (IsQuantityPrefixedLine(line))
+    return std::nullopt;
+  const std::string key = RemoveCommandSuffixes(NormalizeKey(line));
+  static const std::regex lxHeadingRe("LX[0-9]+");
+  if (std::regex_match(key, lxHeadingRe))
+    return key;
+  if (key.rfind("CALLES DIRECTAS ", 0) == 0)
+    return "LX SIDES";
+  return LookupHangAlias(key);
+}
+
+// Normalizes a hang or rigging target alias to its canonical name.
+std::string NormalizeHangAlias(std::string_view value) {
+  std::string key = RemoveCommandSuffixes(NormalizeKey(value));
+  static const std::regex lxTargetRe("LX[0-9]+");
+  if (std::regex_match(key, lxTargetRe))
+    return key;
+  if (key.rfind("PUENTES ", 0) == 0)
+    key = Trim(key.substr(8));
+  else if (key.rfind("PUENTE ", 0) == 0)
+    key = Trim(key.substr(7));
+  if (const auto alias = LookupHangAlias(key))
+    return *alias;
+  if (key.rfind("CALLES DIRECTAS ", 0) == 0)
+    return "LX SIDES";
+  return key;
+}
+
+} // namespace rider_text

--- a/core/rider_text_semantics.h
+++ b/core/rider_text_semantics.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace rider_text {
+
+enum class Section {
+  None,
+  Lighting,
+  Effects,
+  LightingControl,
+  Video,
+  Rigging,
+  Ignored,
+};
+
+// Classifies a complete rider line when it is a recognized section heading.
+Section ClassifySectionHeader(std::string_view line);
+
+// Returns the canonical hang for a complete position heading.
+std::optional<std::string> ClassifyHangHeader(std::string_view line);
+
+// Normalizes a hang or rigging target alias to its canonical name.
+std::string NormalizeHangAlias(std::string_view value);
+
+// Reports whether a line starts with a positive equipment quantity.
+bool IsQuantityPrefixedLine(std::string_view line);
+
+} // namespace rider_text

--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -17,6 +17,7 @@
  */
 #include "riderimporter.h"
 #include "filesystem_path_utils.h"
+#include "rider_text_semantics.h"
 
 #include <algorithm>
 #include <array>
@@ -699,6 +700,7 @@ std::vector<std::string> SplitPlus(const std::string &s) {
 
 bool IsFloorAlias(std::string_view value);
 bool IsLxSidesAlias(std::string_view value);
+bool IsLxHangName(const std::string &positionName);
 
 // Converts rider hang aliases into their canonical target names.
 std::string NormalizeHangName(const std::string &raw) {
@@ -716,6 +718,10 @@ std::string NormalizeHangName(const std::string &raw) {
     return static_cast<char>(std::toupper(c));
   });
   hang = std::regex_replace(hang, std::regex("\\s+"), " ");
+  const std::string semanticHang = rider_text::NormalizeHangAlias(hang);
+  if (semanticHang == "LX SIDES" || semanticHang == "SCREEN" ||
+      IsLxHangName(semanticHang))
+    return semanticHang;
   if (hang == "SIDE FILL" || hang == "SIDEFILL")
     return "SIDEFILL";
   if (IsLxSidesAlias(hang))
@@ -1000,14 +1006,9 @@ bool ContainsCaseInsensitive(std::string_view haystack,
   return it != haystack.end();
 }
 
+// Reports whether a hang value is a recognized physical floor alias.
 bool IsFloorAlias(std::string_view value) {
-  const bool effectAlias = ContainsCaseInsensitive(value, "efecto");
-  const bool floorAlias = ContainsCaseInsensitive(value, "floor");
-  const bool streetToFloorAlias = ContainsCaseInsensitive(value, "calle") &&
-                                  ContainsCaseInsensitive(value, "suelo");
-  const bool groundLaneAlias = ContainsCaseInsensitive(value, "ground") &&
-                               ContainsCaseInsensitive(value, "lane");
-  return effectAlias || floorAlias || streetToFloorAlias || groundLaneAlias;
+  return rider_text::NormalizeHangAlias(value) == "FLOOR";
 }
 
 // Reports whether a normalized hang is an explicit side-truss alias.
@@ -1289,30 +1290,19 @@ ParsedRiderImport ParseRiderImport(const std::string &text) {
       havePending = false;
       continue;
     }
-    const std::string lowerLine = [&line]() {
-      std::string lowered = line;
-      std::transform(
-          lowered.begin(), lowered.end(), lowered.begin(),
-          [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
-      return lowered;
-    }();
-
-    if (lowerLine.find("sonido") != std::string::npos ||
-        lowerLine.find("audio") != std::string::npos ||
-        lowerLine.find("control de p.a.") != std::string::npos ||
-        lowerLine.find("monitores") != std::string::npos ||
-        lowerLine.find("microfon") != std::string::npos ||
-        lowerLine.find("video") != std::string::npos ||
-        lowerLine.find("realizacion") != std::string::npos ||
-        lowerLine.find("control") != std::string::npos) {
+    const rider_text::Section section = rider_text::ClassifySectionHeader(line);
+    if (section == rider_text::Section::Effects ||
+        section == rider_text::Section::LightingControl ||
+        section == rider_text::Section::Video ||
+        section == rider_text::Section::Ignored) {
       seenSectionHeader = true;
       inFixtures = false;
       inRigging = false;
-      inControl = lowerLine.find("control") != std::string::npos;
+      inControl = section == rider_text::Section::LightingControl;
       havePending = false;
       continue;
     }
-    if (lowerLine.find("rigging") != std::string::npos) {
+    if (section == rider_text::Section::Rigging) {
       seenSectionHeader = true;
       inFixtures = false;
       inRigging = true;
@@ -1320,9 +1310,7 @@ ParsedRiderImport ParseRiderImport(const std::string &text) {
       havePending = false;
       continue;
     }
-    if (!inControl && (lowerLine.find("ilumin") != std::string::npos ||
-                       lowerLine.find("robotica") != std::string::npos ||
-                       lowerLine.find("convencion") != std::string::npos)) {
+    if (section == rider_text::Section::Lighting) {
       seenSectionHeader = true;
       inFixtures = true;
       inRigging = false;
@@ -1332,10 +1320,12 @@ ParsedRiderImport ParseRiderImport(const std::string &text) {
 
     std::smatch m;
     std::smatch hm;
-    if (std::regex_match(line, hm, kHangLineRe) ||
+    const std::optional<std::string> semanticHang =
+        rider_text::ClassifyHangHeader(line);
+    if (semanticHang.has_value() || std::regex_match(line, hm, kHangLineRe) ||
         std::regex_match(line, hm, kHangHeaderWithSuffixRe)) {
       havePending = false;
-      std::string captured = hm[1];
+      std::string captured = semanticHang ? *semanticHang : hm[1].str();
       if (IsFloorAlias(captured)) {
         currentHang = "FLOOR";
       } else {
@@ -2064,7 +2054,8 @@ bool RiderImporter::ImportText(const std::string &text,
       const bool isScreenHang = NormalizeHangName(currentHang) == "SCREEN";
       const bool isScreenDescription =
           ContainsCaseInsensitive(part, "pantalla") ||
-          ContainsCaseInsensitive(part, "screen");
+          ContainsCaseInsensitive(part, "screen") ||
+          ContainsCaseInsensitive(part, "led wall");
       if (isScreenHang && isScreenDescription) {
         float screenWidthMm = 8000.0f;
         float screenHeightMm = 5000.0f;
@@ -2158,22 +2149,19 @@ bool RiderImporter::ImportText(const std::string &text,
       havePending = false;
       continue;
     }
-    if (ContainsCaseInsensitive(line, "sonido") ||
-        ContainsCaseInsensitive(line, "audio") ||
-        ContainsCaseInsensitive(line, "control de p.a.") ||
-        ContainsCaseInsensitive(line, "monitores") ||
-        ContainsCaseInsensitive(line, "microfon") ||
-        ContainsCaseInsensitive(line, "video") ||
-        ContainsCaseInsensitive(line, "realizacion") ||
-        ContainsCaseInsensitive(line, "control")) {
+    const rider_text::Section section = rider_text::ClassifySectionHeader(line);
+    if (section == rider_text::Section::Effects ||
+        section == rider_text::Section::LightingControl ||
+        section == rider_text::Section::Video ||
+        section == rider_text::Section::Ignored) {
       seenSectionHeader = true;
       inFixtures = false;
       inRigging = false;
-      inControl = ContainsCaseInsensitive(line, "control");
+      inControl = section == rider_text::Section::LightingControl;
       havePending = false;
       continue;
     }
-    if (ContainsCaseInsensitive(line, "rigging")) {
+    if (section == rider_text::Section::Rigging) {
       seenSectionHeader = true;
       inFixtures = false;
       inRigging = true;
@@ -2181,9 +2169,7 @@ bool RiderImporter::ImportText(const std::string &text,
       havePending = false;
       continue;
     }
-    if (!inControl && (ContainsCaseInsensitive(line, "ilumin") ||
-                       ContainsCaseInsensitive(line, "robotica") ||
-                       ContainsCaseInsensitive(line, "convencion"))) {
+    if (section == rider_text::Section::Lighting) {
       seenSectionHeader = true;
       inFixtures = true;
       inRigging = false;
@@ -2193,10 +2179,12 @@ bool RiderImporter::ImportText(const std::string &text,
 
     std::smatch m;
     std::smatch hm;
-    if (std::regex_match(line, hm, kHangLineRe) ||
+    const std::optional<std::string> semanticHang =
+        rider_text::ClassifyHangHeader(line);
+    if (semanticHang.has_value() || std::regex_match(line, hm, kHangLineRe) ||
         std::regex_match(line, hm, kHangHeaderWithSuffixRe)) {
       havePending = false;
-      currentHang = NormalizeHangName(hm[1].str());
+      currentHang = semanticHang ? *semanticHang : NormalizeHangName(hm[1].str());
       std::string hangLineWithOverrides = line;
       if (const auto parsedMarginOverride = ParseTrussMarginOverrideMm(
               hangLineWithOverrides, distanceUnitSystem);

--- a/docs/developer/text_to_scene_rules.md
+++ b/docs/developer/text_to_scene_rules.md
@@ -39,11 +39,8 @@ Filter behavior:
 3. Keeps motor/hoist lines found in rigging and normalizes them as
    `N MOTOR <capacity>Kg FOR <hang>`.
 4. Groups fixture output by detected hang (`LX1`, `LX2`, `FLOOR`, ...).
-5. Normalizes floor aliases to `FLOOR`:
-   - `floor`
-   - `efecto` / `efectos`
-   - `calle a suelo` / `calles a suelo`
-   - `ground lane` / `ground lanes`
+5. Normalizes physical floor aliases such as `suelo`, `piso`, `floor`,
+   `deck`, `calle(s) a suelo`, and `ground lane(s)` to `FLOOR`.
 6. Truss lines using `PUENTES LX` are expanded as `LX1`, `LX2`, `LX3`, ...
 7. Hoist lines using `PUENTES LX` are expanded and distributed over detected
    `LX*` targets in the same filtered rigging block.
@@ -54,8 +51,8 @@ Filter behavior:
 11. Expands `+` compound lines into individual fixture lines.
 12. Supports quantity-only lines (`N` followed by description on next line).
 13. Removes parenthesized notes from fixture tokens to reduce rider noise.
-14. The filter pass is idempotent for normalized truss lines ending in
-    `SCREEN` (re-applying **Apply filter** keeps those lines).
+14. The complete filter pass is idempotent: reapplying **Apply filter** to any
+    canonical result produces byte-identical text.
 15. Truss targets with accessory suffixes are normalized to the effective hang
     target (for example, `... + HUESITOS PARA PUENTES LX` is interpreted as
     `PUENTES LX`).
@@ -119,13 +116,20 @@ without changing matching logic.
 
 ## Section detection rules
 
-The importer keeps parsing state with sections (fixtures/rigging/control):
+The importer classifies complete normalized heading lines rather than searching
+for section words inside arbitrary descriptions. Quantity-prefixed equipment
+therefore remains equipment even when its model or purpose contains words such
+as `iluminar`, `control`, `video`, or `audio`.
 
-- Enters **fixtures mode** when a line contains: `ilumin`, `robotica`, or `convencion`.
-- Enters **rigging mode** when a line contains: `rigging`.
-- Leaves active import sections (fixtures/rigging) when a line contains terms like:
-  `sonido`, `audio`, `control de p.a.`, `monitores`, `microfon`, `video`,
-  `realizacion`, or `control`.
+- `ILUMINACION` / `LIGHTING` and `APARATOS` / `FIXTURES` enter fixture mode.
+- `RIGGING` and `RIGGING Y ESTRUCTURAS` enter rigging mode.
+- `EFECTOS` / `EFFECTS` is an ignored equipment-category boundary, not a
+  physical position. An effect explicitly listed under `FLOOR` or another
+  physical hang remains importable.
+- `CONTROL DE ILUMINACION` / `LIGHTING CONTROL` stops fixture collection.
+- `VIDEO` establishes video context without itself selecting a physical hang;
+  a following screen heading selects `SCREEN` and enables screen collection.
+- Audio and other recognized unrelated headings stop active collection.
 - If a hang-position line appears before explicit sections, the importer assumes fixtures mode.
 - If fixture list lines appear before **any recognized section header** and no
   hang header has been defined yet, the importer assumes fixtures mode and
@@ -136,14 +140,19 @@ The importer keeps parsing state with sections (fixtures/rigging/control):
 Recognized hang labels:
 
 - `LX<number>` (for example `LX1`, `LX2`, ...)
-- `screen` / `pantalla` / `proyeccion` / `proyección` / `led screen`
+- Front/LX1: `frontal`, `frente`, `puente frontal`, `front`, `front light`,
+  `front truss`, `downstage`
+- Middle/LX2: `cenital`, `central`, `medio`, `puente central`, `mid`,
+  `middle`, `center`, `centre`, `midstage`
+- Rear/LX3: `contra`, `contraluz`, `puente trasero`, `trasero`, `back`,
+  `rear`, `backlight`, `upstage`
+- Sides: `calle(s)`, `lateral(es)`, `side(s)`, `side light(s)`, and descriptive
+  `CALLES DIRECTAS ...` headings
+- Floor: `suelo`, `piso`, `calle(s) a suelo`, `floor`, `ground`, `deck`,
+  `ground lane(s)`
+- Screen: `screen`, `pantalla`, `pantalla led`, `proyeccion`, `proyección`,
+  `led screen`, `led wall`, `projection`
 - `backdrop` / `backdrops` / `telon` / `telones` / `puente de telon(es)`
-- `floor`
-- `efecto` / `efectos`
-- `calle a suelo` / `calles a suelo`
-- `ground lane` / `ground lanes`
-- `calle` / `calles`
-- `side` / `sides`
 
 Behavior:
 
@@ -151,13 +160,15 @@ Behavior:
 - Fixture hang headers can include extra descriptive suffix text before `:`
   (for example `CALLES EN LAYHER:`), while still keeping the detected hang
   alias (`CALLES` -> `LX SIDES`).
-- Floor aliases (`floor`, `efecto(s)`, `calle(s) a suelo`, `ground lane(s)`)
-  are normalized to `FLOOR`.
-- Side-position aliases (`calle(s)`, `side(s)`) are normalized to `LX SIDES`.
+- Front, middle, and rear semantic headings normalize to `LX1`, `LX2`, and
+  `LX3`; an explicit `LX<number>` always takes precedence.
+- Physical floor aliases are normalized to `FLOOR`; `EFFECTS` is not a hang.
+- Side-position aliases are normalized to the canonical value `LX SIDES`.
 - Explicit normalized headers such as `LX SIDES` are accepted as hang labels
   in both filtered text and direct import input.
-- Screen aliases (`screen`, `pantalla`, `proyeccion`, `proyección`, `led screen`) are normalized to
-  `SCREEN`.
+- Screen aliases are normalized to `SCREEN`. This allows the common
+  `VIDEO` → `PANTALLA LED` / `LED SCREEN` / `LED WALL` structure to reuse the
+  existing screen-object importer.
 - Backdrop aliases (`backdrop(s)`, `telon(es)`, `puente de telon(es)`) are
   normalized to `BACKDROP`.
 - The active hang affects fixture/truss layer naming and default placement (`Y/Z`).
@@ -170,6 +181,10 @@ Accepted fixture patterns:
 - Optional list bullets (`-` or `*`) before quantity are accepted.
 - Quantity-only lines (`N`) are accepted and applied to the next non-empty line.
 - `+` splits compound lines into independent fixture groups.
+- A plus segment without its own quantity inherits the first segment's
+  quantity (`1 FOLLOWSPOT + OPERATOR` becomes two quantity-one entries).
+- Ordinary parenthesized fixture annotations are removed from the canonical
+  token; no richer hidden fixture description is retained.
 
 Examples:
 
@@ -210,6 +225,8 @@ Special screen-object handling:
   `pantalla`, the importer creates **scene objects** instead of fixtures.
 - Size parsing looks for `<width>x<height>` values in meters (accepted forms
   include `8x5`, `8x5m`, `8m x 5m`).
+- Dimension parsing uses the physical meter pair and does not replace it with
+  a later pixel-resolution pair such as `1664x832 PIXELS`.
 - Parsed screen dimensions are applied as:
   - X (width) = parsed width
   - Z (height) = parsed height

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -39,6 +39,12 @@ Changes since **v1.5.0**.
 
 ## Fixes
 
+- Create from text now recognizes common Spanish and English front, middle,
+  rear, side, floor, and screen headings without mistaking words inside
+  equipment descriptions for section headers. Effects and lighting-control
+  lists no longer leak into fixture imports, while VIDEO screen subsections,
+  canonical filter output, and existing rigging commands remain compatible.
+
 - Fixture-symbol rendering now notices GDTF files replaced at the same path,
   rejects stale runtime and disk geometry caches, keeps the authoritative
   dimensions of file-backed GDTF models isolated when several definitions

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -44,6 +44,8 @@ Changes since **v1.5.0**.
   equipment descriptions for section headers. Effects and lighting-control
   lists no longer leak into fixture imports, while VIDEO screen subsections,
   canonical filter output, and existing rigging commands remain compatible.
+  Apply filter and the initial Create filtering stage also remain responsive
+  when processing long or heavily formatted rider text.
 
 - Fixture-symbol rendering now notices GDTF files replaced at the same path,
   rejects stale runtime and disk geometry caches, keeps the authoritative

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1056,6 +1056,7 @@ add_executable(rider_truss_dictionary_normalization_test
                gdtfloader_stub.cpp
                consolepanel_stub.cpp
                ../core/riderimporter.cpp
+               ../core/rider_text_semantics.cpp
                ../core/units/units.cpp
                ../core/hoist_weight_distribution.cpp
                ../core/autopatcher.cpp
@@ -1451,6 +1452,7 @@ add_executable(rider_save_roundtrip_test rider_save_roundtrip_test.cpp
                gdtfloader_stub.cpp
                consolepanel_stub.cpp
                ../core/riderimporter.cpp
+               ../core/rider_text_semantics.cpp
                ../core/units/units.cpp
                ../core/hoist_weight_distribution.cpp
                ../core/autopatcher.cpp
@@ -1498,6 +1500,7 @@ add_executable(riderimporter_fixtureid_test rider_import_fixtureid_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
+               ../core/rider_text_semantics.cpp
                ../core/units/units.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
@@ -1526,6 +1529,7 @@ add_executable(rider_import_order_test rider_import_order_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
+               ../core/rider_text_semantics.cpp
                ../core/units/units.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
@@ -1553,6 +1557,7 @@ add_executable(rider_import_linear_order_test rider_import_linear_order_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
+               ../core/rider_text_semantics.cpp
                ../core/units/units.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
@@ -1580,6 +1585,7 @@ add_executable(rider_import_preserve_existing_test rider_import_preserve_existin
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
+               ../core/rider_text_semantics.cpp
                ../core/units/units.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
@@ -1606,6 +1612,7 @@ add_executable(rider_import_category_test rider_import_category_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
+               ../core/rider_text_semantics.cpp
                ../core/units/units.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
@@ -1632,6 +1639,7 @@ add_executable(rider_autopatch_test rider_autopatch_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_onech_stub.cpp
                ../core/riderimporter.cpp
+               ../core/rider_text_semantics.cpp
                ../core/units/units.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
@@ -1659,6 +1667,7 @@ add_executable(rider_layer_mode_test rider_layer_mode_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
+               ../core/rider_text_semantics.cpp
                ../core/units/units.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
@@ -1698,6 +1707,7 @@ add_executable(rider_filter_preview_test rider_filter_preview_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
+               ../core/rider_text_semantics.cpp
                ../core/units/units.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
@@ -1724,6 +1734,7 @@ add_executable(rider_comments_test rider_comments_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
+               ../core/rider_text_semantics.cpp
                ../core/units/units.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
@@ -1750,6 +1761,7 @@ add_executable(rider_floor_default_hang_test rider_floor_default_hang_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
+               ../core/rider_text_semantics.cpp
                ../core/units/units.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
@@ -1777,6 +1789,7 @@ add_executable(rider_led_screen_object_test rider_led_screen_object_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
+               ../core/rider_text_semantics.cpp
                ../core/units/units.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
@@ -1803,6 +1816,7 @@ add_executable(rider_hoist_import_test rider_hoist_import_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
+               ../core/rider_text_semantics.cpp
                ../core/units/units.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
@@ -1830,6 +1844,7 @@ add_executable(rider_lx_sides_import_test rider_lx_sides_import_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
+               ../core/rider_text_semantics.cpp
                ../core/units/units.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
@@ -1856,6 +1871,7 @@ add_executable(rider_pipe_import_test rider_pipe_import_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
+               ../core/rider_text_semantics.cpp
                ../core/units/units.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
@@ -1884,6 +1900,7 @@ add_executable(rider_rigging_target_normalization_contracts_test
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
+               ../core/rider_text_semantics.cpp
                ../core/units/units.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
@@ -1915,6 +1932,7 @@ add_executable(rider_import_benchmark rider_import_benchmark.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
+               ../core/rider_text_semantics.cpp
                ../core/units/units.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp

--- a/tests/rider_filter_preview_test.cpp
+++ b/tests/rider_filter_preview_test.cpp
@@ -293,5 +293,16 @@ int main() {
   assert(RiderImporter::BuildFixtureFilterPreview(keywordFixtureRegression) ==
          "FLOOR\n1 FIXTURE VIDEO CONTROL AUDIO LIGHTING\n2 HAZER");
 
+  std::string longHeadingNoiseRegression;
+  for (int index = 0; index < 250; ++index) {
+    longHeadingNoiseRegression +=
+        "Technical rider notes with formatting words but no section meaning ";
+    longHeadingNoiseRegression.append(120, 'X');
+    longHeadingNoiseRegression += "\n";
+  }
+  longHeadingNoiseRegression += "LIGHTING\nFRONT\n2 SPOT\n";
+  assert(RiderImporter::BuildFixtureFilterPreview(longHeadingNoiseRegression) ==
+         "LX1\n2 SPOT");
+
   return 0;
 }

--- a/tests/rider_filter_preview_test.cpp
+++ b/tests/rider_filter_preview_test.cpp
@@ -73,8 +73,6 @@ int main() {
       "\n"
       "FLOOR\n"
       "4 LITELEE B-EYE L10R\n"
-      "4 TOUR HAZER II\n"
-      "4 TURBINA\n"
       "2 LED BAR\n"
       "\n"
       "RIGGING\n"
@@ -248,6 +246,52 @@ int main() {
       "1 PANTALLA LED 8X5m 1664X1040 PIXELS\n"
       "RIGGING\n"
       "1 PIPE 12m PARA PANTALLA\n");
+
+  const std::string spanishRegression =
+      "ILUMINACIÓN\nAPARATOS\nFRONTAL:\n8 BLINDER\nCENITAL:\n6 WASH\n"
+      "CONTRA:\n8 PROFILE\nCALLES DIRECTAS A LAYHER:\n8 LED BAR\n"
+      "SUELO:\n4 BEAM\n1 FOLLOWSPOT + OPERADOR\n"
+      "4 PAR LED PARA ILUMINAR ESCALERA\nEFECTOS\n2 HAZER + TURBINA\n"
+      "CONTROL DE ILUMINACION\n1 GRAND MA3\nVIDEO\nPANTALLA LED\n"
+      "1 PANTALLA LED 10X5m 1664x832 PIXELS\nRIGGING Y ESTRUCTURAS\n"
+      "4 MOTOR 2TO + GRILLETES + ESLINGAS PARA PA\n"
+      "3 TRUSS 40X40 PRO 12m PARA PUENTES LX\n"
+      "6 MOTOR 500Kg + GRILLETES + ESLINGAS PARA PUENTES LX\n"
+      "1 TRUSS 40X40 PRO 12m PARA PUENTE PANTALLA\n"
+      "4 MOTOR 1TO + GRILLETES + ESLINGAS PARA PUENTE PANTALLA\n";
+  const std::string spanishExpected =
+      "LX1\n8 BLINDER\n\nLX2\n6 WASH\n\nLX3\n8 PROFILE\n\n"
+      "LX SIDES\n8 LED BAR\n\nFLOOR\n4 BEAM\n1 FOLLOWSPOT\n1 OPERADOR\n"
+      "4 PAR LED PARA ILUMINAR ESCALERA\n\n"
+      "SCREEN\n1 PANTALLA LED 10X5m 1664x832 PIXELS\n\nRIGGING\n"
+      "4 MOTOR 2000Kg FOR P.A.\n2 MOTOR 500Kg FOR LX1\n"
+      "2 MOTOR 500Kg FOR LX2\n2 MOTOR 500Kg FOR LX3\n"
+      "4 MOTOR 1000Kg FOR SCREEN\n1 TRUSS 40X40 PRO 12m LX1\n"
+      "1 TRUSS 40X40 PRO 12m LX2\n1 TRUSS 40X40 PRO 12m LX3\n"
+      "1 TRUSS 40X40 PRO 12m SCREEN";
+  assert(RiderImporter::BuildFixtureFilterPreview(spanishRegression) ==
+         spanishExpected);
+  assert(RiderImporter::BuildFixtureFilterPreview(spanishExpected) ==
+         spanishExpected);
+  assertImportParity(spanishRegression);
+
+  const std::string englishRegression =
+      "LIGHTING\nFIXTURES\nFRONT:\n8 BLINDER\nMID:\n6 WASH\nBACK:\n"
+      "8 PROFILE\nSIDES:\n8 LED BAR\nFLOOR:\n4 BEAM\nEFFECTS\n2 HAZER\n"
+      "LIGHTING CONTROL\n1 GRANDMA3\nVIDEO\nLED WALL\n"
+      "1 LED WALL 10 x 5 m\n";
+  const std::string englishExpected =
+      "LX1\n8 BLINDER\n\nLX2\n6 WASH\n\nLX3\n8 PROFILE\n\n"
+      "LX SIDES\n8 LED BAR\n\nFLOOR\n4 BEAM\n\n"
+      "SCREEN\n1 LED WALL 10 x 5 m";
+  assert(RiderImporter::BuildFixtureFilterPreview(englishRegression) ==
+         englishExpected);
+  assertImportParity(englishRegression);
+
+  const std::string keywordFixtureRegression =
+      "FLOOR\n1 FIXTURE VIDEO CONTROL AUDIO LIGHTING\n2 HAZER\n";
+  assert(RiderImporter::BuildFixtureFilterPreview(keywordFixtureRegression) ==
+         "FLOOR\n1 FIXTURE VIDEO CONTROL AUDIO LIGHTING\n2 HAZER");
 
   return 0;
 }

--- a/tests/rider_led_screen_object_test.cpp
+++ b/tests/rider_led_screen_object_test.cpp
@@ -162,6 +162,16 @@ int main() {
       "RIGGING\n1 TRUSS 40X40 PRO 14m PARA PUENTE PANTALLA\n");
   AssertScreenContract(projection, 8.0f, 4.5f);
 
+  const ScreenSnapshot englishScreen = ImportAndCaptureScreen(
+      "VIDEO\nLED SCREEN\n1 LED SCREEN 10X5m 1664x832 PIXELS\n"
+      "RIGGING\n1 TRUSS 40X40 12m FOR SCREEN\n");
+  AssertScreenContract(englishScreen, 10.0f, 5.0f);
+
+  const ScreenSnapshot englishWall = ImportAndCaptureScreen(
+      "VIDEO\nLED WALL\n1 LED WALL 10 x 5 m\n"
+      "RIGGING\n1 TRUSS 40X40 12m FOR SCREEN\n");
+  AssertScreenContract(englishWall, 10.0f, 5.0f);
+
   const ScreenSnapshot fallback =
       ImportAndCaptureScreen("SCREEN\n1 PANTALLA LED PARA TRASERA\n"
                              "RIGGING\n1 TRUSS 40X40 14m PARA PANTALLA\n");


### PR DESCRIPTION
### Motivation
- The importer used broad substring matching (e.g. matching `ilumin`, `video`, `control`) inside arbitrary lines, causing equipment descriptions like `... PARA ILUMINAR ...` to be misclassified as section headers and placing fixtures in wrong hangs.
- Spanish/English hang aliases and section classification were duplicated across filter and import passes which risked divergence and made maintenance hard.
- `EFECTOS` was treated as a physical `FLOOR` hang and several common headings (FRONTAL/CENITAL/CONTRA/CALLES/SUELO) were not normalized to the intended canonical hang names, breaking rigging expansion and placement semantics.

### Description
- Added a centralized, deterministic semantic classifier in `core/rider_text_semantics.{h,cpp}` that: recognizes complete heading lines, folds accents, normalizes whitespace, provides bilingual hang aliases, and rejects quantity-prefixed equipment as headings (`IsQuantityPrefixedLine`, `ClassifySectionHeader`, `ClassifyHangHeader`, `NormalizeHangAlias`).
- Integrated the classifier into both filter and import flows by calling the new APIs from `core/riderimporter.cpp` so the filter preview and scene-import share the same source-of-truth rules; replaced fragile substring checks with `rider_text::ClassifySectionHeader` and `rider_text::ClassifyHangHeader` where appropriate.
- Improved `NormalizeHangName` / floor/side handling to prefer canonical semantic results (e.g. `FRONTAL`→`LX1`, `CENITAL`→`LX2`, `CONTRA`→`LX3`, `CALLES DIRECTAS ...`→`LX SIDES`, `SUELO`→`FLOOR`), while keeping explicit `LX<number>` precedence and preserving parenthesis/bracket coordinate & margin commands.
- Preserved existing canonical contracts: `+` expansion, removal of ordinary parenthesized fixture annotations, idempotent filtered output, rigging/truss expansion rules, and screen-object import behavior; extended screen recognition to accept `LED SCREEN` / `LED WALL` usages.
- Tests and docs: updated and added regression and parity tests in `tests/rider_filter_preview_test.cpp` and `tests/rider_led_screen_object_test.cpp`, updated `docs/developer/text_to_scene_rules.md` and `docs/release-notes-draft.md`, and added `core/rider_text_semantics.*` to test and core CMake lists.
- Files added/modified (key): added `core/rider_text_semantics.h` and `core/rider_text_semantics.cpp`; modified `core/riderimporter.cpp`, `core/CMakeLists.txt`, `tests/rider_filter_preview_test.cpp`, `tests/rider_led_screen_object_test.cpp`, `tests/CMakeLists.txt`, `docs/developer/text_to_scene_rules.md`, and `docs/release-notes-draft.md`.

### Testing
- Built tests and ran the focused test set: configured with `cmake -S . -B build -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DPERASTAGE_ENABLE_MVR_XCHANGE_MDNS=OFF` and built the relevant targets with `cmake --build build --target rider_filter_preview_test rider_led_screen_object_test rider_lx_sides_import_test rider_hoist_import_test rider_rigging_target_normalization_contracts_test -j2`.
- Executed tests with `ctest --test-dir build --output-on-failure -R 'Rider(FilterPreview|LedScreenObject|LxSidesImport|HoistImport|RiggingTargetNormalizationContracts)'` and all targeted tests passed (5/5 for the chosen suite).
- Ran repository checks required by project policy: `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh` and `git diff --check`, which completed cleanly for the changes in this PR.
- Verified regression cases: Spanish regression grouping (FRONTAL→LX1, CENITAL→LX2, CONTRA→LX3, CALLES→LX SIDES, SUELO→FLOOR), `EFECTOS` treated as section (not FLOOR), VIDEO→SCREEN subsections, screen physical dimension `10x5m` detection, `+` expansion, parenthesis/bracket command preservation, idempotence of `BuildFixtureFilterPreview`, and parity between raw-Create and ApplyFilter→Create flows via updated tests; all covered tests succeeded in the run described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8cb6727434832484ad2dd9a9150bbc)