### PR TITLE
Keep fallback fixture type colors consistent

### DIFF
--- a/core/fixture_visual_color.cpp
+++ b/core/fixture_visual_color.cpp
@@ -2,6 +2,20 @@
 
 #include <cctype>
 
+// Builds the stable fixture-type key used when assigning shared automatic colors.
+std::string BuildFixtureVisualColorGroupKey(const Fixture &fixture) {
+  if (!fixture.gdtfSpec.empty())
+    return "gdtf\n" + fixture.gdtfSpec + "\n" + fixture.gdtfMode;
+
+  std::string normalizedType;
+  normalizedType.reserve(fixture.typeName.size());
+  for (const unsigned char value : fixture.typeName) {
+    if (!std::isspace(value))
+      normalizedType.push_back(static_cast<char>(std::tolower(value)));
+  }
+  return "type\n" + normalizedType + "\n" + fixture.gdtfMode;
+}
+
 // Normalizes a hexadecimal RGB color to canonical uppercase #RRGGBB form.
 std::optional<std::string> NormalizeFixtureVisualColor(std::string_view raw) {
   size_t first = 0;

--- a/core/fixture_visual_color.h
+++ b/core/fixture_visual_color.h
@@ -35,6 +35,9 @@ struct FixtureVisualColorAggregate {
   FixtureVisualColorSource source = FixtureVisualColorSource::Unresolved;
 };
 
+// Builds the stable fixture-type key used when assigning shared automatic colors.
+std::string BuildFixtureVisualColorGroupKey(const Fixture &fixture);
+
 // Normalizes a hexadecimal RGB color to canonical uppercase #RRGGBB form.
 std::optional<std::string> NormalizeFixtureVisualColor(std::string_view raw);
 

--- a/docs/developer/text_to_scene_rules.md
+++ b/docs/developer/text_to_scene_rules.md
@@ -541,7 +541,9 @@ After a successful **Tools → Create from text** import:
 
 - The same **Auto color** routine used after MVR import is executed.
 - Fixture/layer colors are normalized immediately, including fallback random
-  colors for fixture groups with no dictionary color.
+  colors for fixture groups with no dictionary color. Fixtures without a GDTF
+  library match are grouped by their normalized parsed type name, so repeated
+  instances of the same missing fixture type receive the same color.
 - This runs before the final scene refresh, so users see the colored result as
   soon as text import completes.
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -39,6 +39,9 @@ Changes since **v1.5.0**.
 
 ## Fixes
 
+- Fixtures of the same type now receive one consistent type color when
+  text-to-scene generation cannot find their definition in the GDTF library.
+
 - Create from text now recognizes common Spanish and English front, middle,
   rear, side, floor, and screen headings without mistaking words inside
   equipment descriptions for section headers. Effects and lighting-control

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -63,6 +63,7 @@
 #include "diagnostics/DiagnosticReport.h"
 #include "dictionaryeditdialog.h"
 #include "fixture.h"
+#include "fixture_visual_color.h"
 #include "fixturetablepanel.h"
 #include "gdtf_catalog_service.h"
 #include "gdtfdictionary.h"
@@ -870,10 +871,6 @@ void MainWindow::OnAutoColor(wxCommandEvent &WXUNUSED(event)) {
   std::set<std::string> selectedFixtureSet(selectedFixtureIds.begin(),
                                            selectedFixtureIds.end());
 
-  auto buildFixtureGroupKey = [](const auto &fixture) {
-    return fixture.gdtfSpec + "\n" + fixture.gdtfMode;
-  };
-
   std::map<std::string, std::string> fixtureGroupColors;
   for (auto &[uuid, f] : scene.fixtures) {
     if (hasFixtureSelection &&
@@ -881,11 +878,7 @@ void MainWindow::OnAutoColor(wxCommandEvent &WXUNUSED(event)) {
       continue;
 
     if (hasFixtureSelection) {
-      if (f.gdtfSpec.empty()) {
-        f.visualColorHex = randHex();
-        continue;
-      }
-      const std::string groupKey = buildFixtureGroupKey(f);
+      const std::string groupKey = BuildFixtureVisualColorGroupKey(f);
       auto existing = fixtureGroupColors.find(groupKey);
       if (existing == fixtureGroupColors.end()) {
         const auto dictColor = GdtfDictionary::GetDefaultVisualColorForFixture(
@@ -899,21 +892,17 @@ void MainWindow::OnAutoColor(wxCommandEvent &WXUNUSED(event)) {
       continue;
     }
 
-    if (!f.gdtfSpec.empty()) {
-      auto it = fixtureGroupColors.find(buildFixtureGroupKey(f));
-      if (it == fixtureGroupColors.end()) {
-        const std::string c =
-            (f.visualColorHex.empty() || isWhiteColor(f.visualColorHex))
-                ? randHex()
-                : f.visualColorHex;
-        fixtureGroupColors[buildFixtureGroupKey(f)] = c;
-        f.visualColorHex = c;
-      } else {
-        f.visualColorHex = it->second;
-      }
-    } else if (hasFixtureSelection || f.visualColorHex.empty() ||
-               isWhiteColor(f.visualColorHex)) {
-      f.visualColorHex = randHex();
+    const std::string groupKey = BuildFixtureVisualColorGroupKey(f);
+    auto it = fixtureGroupColors.find(groupKey);
+    if (it == fixtureGroupColors.end()) {
+      const std::string c =
+          (f.visualColorHex.empty() || isWhiteColor(f.visualColorHex))
+              ? randHex()
+              : f.visualColorHex;
+      fixtureGroupColors[groupKey] = c;
+      f.visualColorHex = c;
+    } else {
+      f.visualColorHex = it->second;
     }
   }
 

--- a/tests/fixture_visual_color_test.cpp
+++ b/tests/fixture_visual_color_test.cpp
@@ -78,9 +78,27 @@ static void TestAggregation() {
   assert(!aggregate.mixed && !aggregate.colorHex);
 }
 
+// Verifies that missing-library fixtures are grouped by normalized type name.
+static void TestFixtureTypeGrouping() {
+  Fixture missingFirst;
+  missingFirst.typeName = "GLP JDC1";
+  Fixture missingSecond;
+  missingSecond.typeName = "glp  jdc1";
+  assert(BuildFixtureVisualColorGroupKey(missingFirst) ==
+         BuildFixtureVisualColorGroupKey(missingSecond));
+
+  Fixture knownFixture = missingFirst;
+  knownFixture.gdtfSpec = "GLP@JDC1.gdtf";
+  Fixture knownAlias = knownFixture;
+  knownAlias.typeName = "An alias";
+  assert(BuildFixtureVisualColorGroupKey(knownFixture) ==
+         BuildFixtureVisualColorGroupKey(knownAlias));
+}
+
 // Runs the fixture visual-color domain regression checks.
 int main() {
   TestResolution();
   TestAggregation();
+  TestFixtureTypeGrouping();
   return 0;
 }


### PR DESCRIPTION
### Motivation

- When creating scenes from text, fixtures missing from the GDTF library were assigned dummy fallbacks but received inconsistent automatic type colors, causing identical missing types (e.g., GLP JDC1) to get different colors.

### Description

- Added `BuildFixtureVisualColorGroupKey(const Fixture& fixture)` in `core/fixture_visual_color.{h,cpp}` to produce a stable grouping key that prefers `gdtfSpec+mode` for known fixtures and a normalized, whitespace-insensitive `typeName+mode` key for missing-library fixtures.
- Updated the Auto Color flow in `gui/mainwindow_menu.cpp` to use `BuildFixtureVisualColorGroupKey(...)` so all instances of the same missing fixture type receive a single consistent automatic color and known fixtures remain grouped by their GDTF spec/mode.
- Added a regression test `TestFixtureTypeGrouping` in `tests/fixture_visual_color_test.cpp` to assert case- and whitespace-insensitive grouping for missing-library fixtures and preserved grouping for known GDTF-backed fixtures.
- Documented the behavior in `docs/developer/text_to_scene_rules.md` and added a short entry to `docs/release-notes-draft.md` describing the fix.

### Testing

- Ran `./tests/check_perastage_tree_modules.sh` and it passed.
- Ran `./tests/check_no_configmanager_get_in_gui.sh` and it passed.
- Compiled and ran the unit check with `g++ -std=c++20 -Icore -Imodels tests/fixture_visual_color_test.cpp core/fixture_visual_color.cpp -o /tmp/fixture_visual_color_test && /tmp/fixture_visual_color_test` and the test binary completed successfully.
- Verified `git diff --check` reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8cbe406a708324b376558a3e17057b)