### PR TITLE
Refactor MVR export diagnostics into structured model and GUI presenter

### DIFF
--- a/core/configmanager.cpp
+++ b/core/configmanager.cpp
@@ -558,11 +558,6 @@ bool ConfigManager::SaveProject(const std::string &path) {
         const bool exported =
             exporter.ExportToBuffer(sceneBytes, CanonicalMvrExportOptions());
         const auto sceneExportEnd = std::chrono::steady_clock::now();
-        for (const std::string &warning : exporter.GetExportWarnings()) {
-          Logger::Instance().Log(Logger::Level::Warn,
-                                 "Project save MVR export warning: " +
-                                     warning);
-        }
         Logger::Instance().Log(
             Logger::Level::Info,
             "Project save scene serialization duration_ms=" +

--- a/core/mvr_identity_recovery.cpp
+++ b/core/mvr_identity_recovery.cpp
@@ -65,9 +65,11 @@ void AddDiagnostic(RecoveryResult &result, const std::string &kind,
                    const std::string &name, const std::string &context,
                    const std::string &identitySource,
                    const std::string &original, const std::string &replacement,
-                   RecoveryReason reason) {
+                   RecoveryReason reason, bool generatedNewIdentity = false,
+                   bool conflictingValidIdentities = false) {
   result.diagnostics.push_back(
-      {kind, name, context, identitySource, original, replacement, reason});
+      {kind, name, context, identitySource, original, replacement, reason,
+       generatedNewIdentity, conflictingValidIdentities});
 }
 
 // Derives a collision-free deterministic replacement within one identity scope.
@@ -136,32 +138,38 @@ void DiagnoseIdentityInputs(RecoveryResult &result, const std::string &kind,
                             const std::string &replacement) {
   const std::string canonicalKey = CanonicalizeUuid(key);
   const std::string canonicalField = CanonicalizeUuid(field);
+  const bool generatedNewIdentity = canonicalKey.empty() && canonicalField.empty();
+  const bool conflictingValidIdentities = !canonicalKey.empty() &&
+                                          !canonicalField.empty() &&
+                                          canonicalKey != canonicalField;
   if (key.empty())
     AddDiagnostic(result, kind, name, context, "map-key", key, replacement,
-                  RecoveryReason::Missing);
+                  RecoveryReason::Missing, generatedNewIdentity);
   else if (canonicalKey.empty())
     AddDiagnostic(result, kind, name, context, "map-key", key, replacement,
-                  RecoveryReason::Malformed);
+                  RecoveryReason::Malformed, generatedNewIdentity);
   else if (canonicalKey != key)
     AddDiagnostic(result, kind, name, context, "map-key", key, replacement,
-                  RecoveryReason::Canonicalized);
+                  RecoveryReason::Canonicalized, generatedNewIdentity);
 
   if (field.empty())
     AddDiagnostic(result, kind, name, context, "object-field", field,
-                  replacement, RecoveryReason::Missing);
+                  replacement, RecoveryReason::Missing, generatedNewIdentity);
   else if (canonicalField.empty())
     AddDiagnostic(result, kind, name, context, "object-field", field,
-                  replacement, RecoveryReason::Malformed);
+                  replacement, RecoveryReason::Malformed, generatedNewIdentity);
   else if (canonicalField != field)
     AddDiagnostic(result, kind, name, context, "object-field", field,
-                  replacement, RecoveryReason::Canonicalized);
+                  replacement, RecoveryReason::Canonicalized,
+                  generatedNewIdentity);
 
   if (!key.empty() && !field.empty() &&
       (canonicalKey.empty() || canonicalField.empty() ||
        canonicalKey != canonicalField)) {
     AddDiagnostic(result, kind, name, context, "map-key/object-field",
                   key + " | " + field, replacement,
-                  RecoveryReason::KeyFieldMismatch);
+                  RecoveryReason::KeyFieldMismatch, generatedNewIdentity,
+                  conflictingValidIdentities);
   }
 }
 

--- a/core/mvr_identity_recovery.h
+++ b/core/mvr_identity_recovery.h
@@ -26,6 +26,8 @@ struct RecoveryDiagnostic {
   std::string originalIdentity;
   std::string replacementIdentity;
   RecoveryReason reason = RecoveryReason::Missing;
+  bool generatedNewIdentity = false;
+  bool conflictingValidIdentities = false;
 };
 
 struct RecoveryResult {

--- a/docs/developer/technical-notes/mvr_exporter.md
+++ b/docs/developer/technical-notes/mvr_exporter.md
@@ -24,6 +24,15 @@ an unavailable requested compatibility representation are user-visible
 archive I/O, and hierarchy recursion failures are user-visible `Error` records
 and make the operation fail.
 
+Identity storage mismatches are evaluated using both sources. A malformed or
+missing field remains log-only when the other source preserves the effective
+identity; two different valid identities produce one `IdentityConflict`, while
+two unusable sources produce one `IdentityGenerated`. Unresolved non-empty
+Position references produce `ReferenceCleared` because the reference is omitted.
+Failure to create a required physical-property GDTF patch or mandatory
+SceneObject placeholder geometry is fatal rather than silently exporting stale
+properties or deleting the object.
+
 The stable code policy is:
 
 | Codes | Severity | Normal UI |

--- a/docs/developer/technical-notes/mvr_exporter.md
+++ b/docs/developer/technical-notes/mvr_exporter.md
@@ -1,6 +1,43 @@
-# MVR exporter warning behavior
+# MVR exporter diagnostic behavior
 
-Perastage MVR export now distinguishes between fatal validation errors and non-fatal resource warnings.
+MVR export reports `MvrExportDiagnostic` records rather than treating log text as
+presentation data. Each record has a stable code, `Info`/`Warning`/`Error`
+severity, semantic impact, explicit user-visibility policy, optional object and
+resource context, and a technical detail for logging. The model is independent
+of wxWidgets.
+
+## Classification policy
+
+The exporter classifies the effect of recovery, not just its original reason.
+Canonical UUID spelling changes, inferred layers, safely recovered duplicate
+identity fields, transform recalculation that preserves world transforms,
+legacy Position remapping, normal pruning, successful GDTF canonicalization,
+and requested Symbol/Symdef preservation or flattening are `Info` and log-only.
+In particular, uppercase, braced, or otherwise noncanonical spelling represents
+the same UUID and is not a user warning.
+
+Meaningful identity replacement, cleared references, duplicate numeric fixture
+IDs, fallback or missing GDTFs, omitted resources or textures, placeholder or
+empty geometry, rejected foreign metadata, omitted invalid DMX addresses, and
+an unavailable requested compatibility representation are user-visible
+`Warning` records. Structural validation, transform integrity, canonicalization,
+archive I/O, and hierarchy recursion failures are user-visible `Error` records
+and make the operation fail.
+
+The stable code policy is:
+
+| Codes | Severity | Normal UI |
+|---|---|---|
+| `IdentityCanonicalized`, `LayerInferred`, `TransformRepaired`, `InternalRecovery` | Info | Hidden |
+| `IdentityGenerated`, `IdentityReassigned`, `IdentityConflict`, `ReferenceCleared`, `SymbolIdentityReplaced`, `FixtureIdReassigned` | Warning | Shown |
+| `GdtfFallbackUsed`, `GdtfMissing`, `TrussGdtfMissing`, `GdtfPatchFailed` | Warning | Shown |
+| `TextureMissing`, `ResourceMissing`, `ResourceDuplicate`, `SupportGeometryMissing`, `PlaceholderGeometryUsed` | Warning | Shown |
+| `CompatibilityRepresentationUnavailable`, `ForeignMetadataDiscarded`, `DmxAddressOmitted` | Warning | Shown |
+| `TransformInvalid`, `StructuralValidationFailed`, `CanonicalizationFailed`, `ArchiveIoFailed`, `HierarchyRecursion` | Error | Shown; export fails |
+
+`GetExportDiagnostics()` is the authoritative API. `GetExportWarnings()` is a
+temporary compatibility view built from non-Info structured records; callers
+must not infer policy by parsing its English text.
 
 ## Non-fatal warnings
 
@@ -9,15 +46,24 @@ When `GeneralSceneDescription.xml` references a `fileName`/`GDTFSpec` entry that
 - Missing file warning: `Referenced file '<name>' is missing from the archive and will be omitted.`
 - Duplicate file warning: `Referenced file '<name>' appears multiple times; duplicates will be ignored.`
 
-Warnings are available through `MvrExporter::GetExportWarnings()` after `ExportToFile(...)`/`ExportToBuffer(...)`.
+Diagnostics are available through `MvrExporter::GetExportDiagnostics()` after
+`ExportToFile(...)`/`ExportToBuffer(...)`.
 
 ## Fatal errors
 
-Structural MVR compliance errors still fail export (for example missing `GeneralSceneDescription`, invalid version, or invalid required IDs).
+Structural MVR compliance errors still fail export (for example missing
+`GeneralSceneDescription`, invalid version, or invalid required IDs). Every
+export-abort path retains a structured Error for the caller.
 
 ## UI behavior
 
-GUI code should show export warnings only after any busy overlay is destroyed, so dialogs remain visible to the user.
+Standalone GUI export shows exactly one result dialog. Warning summaries are
+aggregated by semantic code, while a bounded, resizable details control lists
+affected objects and resources. Log-only diagnostics never enter this summary.
+The persistent diagnostic log remains the owner of full technical context.
+Project persistence, canonical snapshots, and MVR-xchange remain non-modal and
+may inspect structured records according to their own policy; they do not log a
+second copy of exporter-owned diagnostics.
 ## MVR node validity notes
 
 Support is a standard MVR scene node and is preserved as `<Support>` during import/export; if geometry is missing, Perastage writes an empty `<Geometries/>` plus required `ChainLength` so the logical Support remains schema-valid without inventing model geometry. Generic `<SceneObject>` nodes require a `<Geometries>` child, so Perastage writes a small 10 cm placeholder cube when no source geometry is available instead of writing invalid XML. Truss children are emitted in XSD `xs:sequence` order, with `Matrix` before `Geometries`, fixture identifiers after geometry-related content, and `CustomIdType` before `CustomId`.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -8,6 +8,9 @@ Changes since **v1.5.0**.
   technical diagnostics, while harmless UUID normalization stays in the log and
   export failures provide a focused, expandable result. The collapsed result
   remains compact and uses reliably rendered summary markers on every platform.
+  Missing fixture profiles, unresolved positions, and failures to preserve
+  edited profile properties or required object geometry are now reported
+  explicitly instead of being silently omitted.
 
 - Project reopening is faster for typical projects by loading packaged scene
   and configuration data directly, while retaining a safe large-project

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -4,6 +4,10 @@ Changes since **v1.5.0**.
 
 ## Highlights
 
+- MVR export now presents concise, grouped fidelity warnings instead of raw
+  technical diagnostics, while harmless UUID normalization stays in the log and
+  export failures provide a focused, expandable result.
+
 - Project reopening is faster for typical projects by loading packaged scene
   and configuration data directly, while retaining a safe large-project
   fallback and all existing MVR resource compatibility.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -6,7 +6,8 @@ Changes since **v1.5.0**.
 
 - MVR export now presents concise, grouped fidelity warnings instead of raw
   technical diagnostics, while harmless UUID normalization stays in the log and
-  export failures provide a focused, expandable result.
+  export failures provide a focused, expandable result. The collapsed result
+  remains compact and uses reliably rendered summary markers on every platform.
 
 - Project reopening is faster for typical projects by loading packaged scene
   and configuration data directly, while retaining a safe large-project

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -10,7 +10,9 @@ Changes since **v1.5.0**.
   remains compact and uses reliably rendered summary markers on every platform.
   Missing fixture profiles, unresolved positions, and failures to preserve
   edited profile properties or required object geometry are now reported
-  explicitly instead of being silently omitted.
+  explicitly instead of being silently omitted, with Linux export regression
+  coverage preserving the existing fixture-address and legacy truss migration
+  contracts.
 
 - Project reopening is faster for typical projects by loading packaged scene
   and configuration data directly, while retaining a safe large-project

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -95,6 +95,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow/controllers/mainwindow_io_controller.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow/controllers/mainwindow_view_controller.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_io.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/mvr_export_result_dialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_layout.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_cli_shortcut_router.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_cli_shortcuts.cpp

--- a/gui/mainwindow_io.cpp
+++ b/gui/mainwindow_io.cpp
@@ -56,6 +56,7 @@
 #include "hoisttablepanel.h"
 #include "layoutviewerpanel.h"
 #include "mvrexporter.h"
+#include "mvr_export_result_dialog.h"
 #include "mvrimporter.h"
 #include "mvr_preferences.h"
 #include "projectutils.h"
@@ -581,24 +582,14 @@ void MainWindow::OnExportMVR(wxCommandEvent &event) {
     diagnostics::DiagnosticLogger::Error(
         "MVR export failed: " +
         diagnostics::DiagnosticLogger::FileNameOnly(path.ToStdString()));
-    wxMessageBox("Failed to export MVR file.", "Error", wxICON_ERROR);
+    ShowMvrExportResult(this, false, exporter.GetExportDiagnostics());
     if (consolePanel)
       consolePanel->AppendMessage("[ERROR] Failed to export " + path);
   } else {
     diagnostics::DiagnosticLogger::Info(
         "MVR export completed: " +
         diagnostics::DiagnosticLogger::FileNameOnly(path.ToStdString()));
-    const auto &warnings = exporter.GetExportWarnings();
-    if (!warnings.empty()) {
-      wxString warningText;
-      for (const auto &warning : warnings) {
-        warningText += wxString::FromUTF8(warning);
-        warningText += "\n";
-      }
-      wxMessageBox(warningText, "Export Warnings", wxOK | wxICON_WARNING, this);
-    }
-    wxMessageBox("MVR file exported successfully.", "Success",
-                 wxICON_INFORMATION);
+    ShowMvrExportResult(this, true, exporter.GetExportDiagnostics());
     if (consolePanel)
       consolePanel->AppendMessage("[INFO] Exported " + path);
   }

--- a/gui/mvr_export_result_dialog.cpp
+++ b/gui/mvr_export_result_dialog.cpp
@@ -27,16 +27,31 @@ wxSize ClampToDisplay(wxWindow *parent, wxSize requested) {
   return requested;
 }
 
+// Maps related diagnostic codes onto one user-facing summary category.
+MvrExportDiagnosticCode PresentationCode(MvrExportDiagnosticCode code) {
+  switch (code) {
+  case MvrExportDiagnosticCode::IdentityGenerated:
+  case MvrExportDiagnosticCode::IdentityReassigned:
+  case MvrExportDiagnosticCode::IdentityConflict:
+  case MvrExportDiagnosticCode::SymbolIdentityReplaced:
+    return MvrExportDiagnosticCode::IdentityGenerated;
+  case MvrExportDiagnosticCode::GdtfMissing:
+  case MvrExportDiagnosticCode::TrussGdtfMissing:
+  case MvrExportDiagnosticCode::GdtfPatchFailed:
+    return MvrExportDiagnosticCode::GdtfMissing;
+  default:
+    return code;
+  }
+}
+
 // Returns concise user-facing copy for a diagnostic category.
 wxString SummaryFor(MvrExportDiagnosticCode code, size_t count) {
   const wxString amount = wxString::FromUTF8(std::to_string(count));
   switch (code) {
   case MvrExportDiagnosticCode::GdtfFallbackUsed: return amount + " fixtures used a fallback GDTF.";
   case MvrExportDiagnosticCode::DmxAddressOmitted: return amount + " DMX addresses were omitted.";
-  case MvrExportDiagnosticCode::IdentityGenerated:
-  case MvrExportDiagnosticCode::IdentityReassigned:
-  case MvrExportDiagnosticCode::IdentityConflict:
-  case MvrExportDiagnosticCode::SymbolIdentityReplaced: return amount + " object identities were repaired.";
+  case MvrExportDiagnosticCode::IdentityGenerated: return amount + " object identities were repaired.";
+  case MvrExportDiagnosticCode::ReferenceCleared: return amount + " unresolved references were omitted.";
   case MvrExportDiagnosticCode::ForeignMetadataDiscarded: return amount + " third-party metadata blocks could not be preserved.";
   case MvrExportDiagnosticCode::TextureMissing: return amount + " model texture dependencies were omitted.";
   case MvrExportDiagnosticCode::ResourceMissing:
@@ -45,9 +60,8 @@ wxString SummaryFor(MvrExportDiagnosticCode code, size_t count) {
   case MvrExportDiagnosticCode::SupportGeometryMissing: return amount + " objects used adjusted geometry.";
   case MvrExportDiagnosticCode::FixtureIdReassigned: return amount + " fixture numeric identifiers were reassigned.";
   case MvrExportDiagnosticCode::CompatibilityRepresentationUnavailable: return amount + " trusses could not use the requested compatibility representation.";
-  case MvrExportDiagnosticCode::TrussGdtfMissing:
   case MvrExportDiagnosticCode::GdtfMissing:
-  case MvrExportDiagnosticCode::GdtfPatchFailed: return amount + " GDTF resources could not be preserved as requested.";
+    return amount + " GDTF resources could not be preserved as requested.";
   default: return amount + " export issues require attention.";
   }
 }
@@ -124,7 +138,7 @@ void ShowMvrExportResult(wxWindow *parent, bool exported,
   for (const auto &diagnostic : diagnostics) {
     if (!diagnostic.userVisible)
       continue;
-    ++counts[diagnostic.code];
+    ++counts[PresentationCode(diagnostic.code)];
     if (!diagnostic.objectName.empty())
       details += wxString::FromUTF8(diagnostic.objectType + " " + diagnostic.objectName + ": ");
     details += wxString::FromUTF8(diagnostic.technicalDetail) + "\n\n";

--- a/gui/mvr_export_result_dialog.cpp
+++ b/gui/mvr_export_result_dialog.cpp
@@ -1,0 +1,110 @@
+#include "mvr_export_result_dialog.h"
+
+#include <map>
+
+#include <wx/button.h>
+#include <wx/dialog.h>
+#include <wx/sizer.h>
+#include <wx/stattext.h>
+#include <wx/textctrl.h>
+
+namespace {
+
+// Returns concise user-facing copy for a diagnostic category.
+wxString SummaryFor(MvrExportDiagnosticCode code, size_t count) {
+  const wxString amount = wxString::FromUTF8(std::to_string(count));
+  switch (code) {
+  case MvrExportDiagnosticCode::GdtfFallbackUsed: return amount + " fixtures used a fallback GDTF.";
+  case MvrExportDiagnosticCode::DmxAddressOmitted: return amount + " DMX addresses were omitted.";
+  case MvrExportDiagnosticCode::IdentityGenerated:
+  case MvrExportDiagnosticCode::IdentityReassigned:
+  case MvrExportDiagnosticCode::IdentityConflict:
+  case MvrExportDiagnosticCode::SymbolIdentityReplaced: return amount + " object identities were repaired.";
+  case MvrExportDiagnosticCode::ForeignMetadataDiscarded: return amount + " third-party metadata blocks could not be preserved.";
+  case MvrExportDiagnosticCode::TextureMissing: return amount + " model texture dependencies were omitted.";
+  case MvrExportDiagnosticCode::ResourceMissing:
+  case MvrExportDiagnosticCode::ResourceDuplicate: return amount + " archive resources could not be preserved.";
+  case MvrExportDiagnosticCode::PlaceholderGeometryUsed:
+  case MvrExportDiagnosticCode::SupportGeometryMissing: return amount + " objects used adjusted geometry.";
+  case MvrExportDiagnosticCode::FixtureIdReassigned: return amount + " fixture numeric identifiers were reassigned.";
+  case MvrExportDiagnosticCode::CompatibilityRepresentationUnavailable: return amount + " trusses could not use the requested compatibility representation.";
+  case MvrExportDiagnosticCode::TrussGdtfMissing:
+  case MvrExportDiagnosticCode::GdtfMissing:
+  case MvrExportDiagnosticCode::GdtfPatchFailed: return amount + " GDTF resources could not be preserved as requested.";
+  default: return amount + " export issues require attention.";
+  }
+}
+
+// Builds a safely bounded result dialog with an optional details pane.
+void ShowDialog(wxWindow *parent, const wxString &title,
+                const wxString &primary, const wxString &summary,
+                const wxString &details) {
+  wxDialog dialog(parent, wxID_ANY, title, wxDefaultPosition, wxSize(720, 500),
+                  wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER);
+  auto *layout = new wxBoxSizer(wxVERTICAL);
+  auto *primaryText = new wxStaticText(&dialog, wxID_ANY, primary);
+  primaryText->Wrap(660);
+  layout->Add(primaryText, 0, wxALL | wxEXPAND, 14);
+  if (!summary.empty()) {
+    auto *summaryText = new wxStaticText(&dialog, wxID_ANY, summary);
+    summaryText->Wrap(660);
+    layout->Add(summaryText, 0, wxLEFT | wxRIGHT | wxBOTTOM | wxEXPAND, 14);
+  }
+  wxTextCtrl *detailText = nullptr;
+  if (!details.empty()) {
+    detailText = new wxTextCtrl(&dialog, wxID_ANY, details, wxDefaultPosition,
+                                wxSize(-1, 240), wxTE_MULTILINE | wxTE_READONLY |
+                                                    wxTE_RICH2 | wxHSCROLL);
+    detailText->Hide();
+    layout->Add(detailText, 1, wxLEFT | wxRIGHT | wxBOTTOM | wxEXPAND, 14);
+  }
+  auto *buttons = new wxBoxSizer(wxHORIZONTAL);
+  if (detailText) {
+    auto *detailsButton = new wxButton(&dialog, wxID_ANY, "Show details...");
+    detailsButton->Bind(wxEVT_BUTTON, [&, detailText, detailsButton](wxCommandEvent &) {
+      const bool show = !detailText->IsShown();
+      detailText->Show(show);
+      detailsButton->SetLabel(show ? "Hide details" : "Show details...");
+      dialog.Layout();
+    });
+    buttons->Add(detailsButton, 0, wxRIGHT, 8);
+  }
+  buttons->Add(new wxButton(&dialog, wxID_OK, "OK"));
+  layout->Add(buttons, 0, wxALIGN_RIGHT | wxALL, 14);
+  dialog.SetSizer(layout);
+  dialog.SetMinSize(wxSize(560, 260));
+  dialog.CentreOnParent();
+  dialog.ShowModal();
+}
+
+} // namespace
+
+// Presents success, aggregated warnings, or a concise failure without raw logs.
+void ShowMvrExportResult(wxWindow *parent, bool exported,
+                         const std::vector<MvrExportDiagnostic> &diagnostics) {
+  std::map<MvrExportDiagnosticCode, size_t> counts;
+  wxString details;
+  for (const auto &diagnostic : diagnostics) {
+    if (!diagnostic.userVisible)
+      continue;
+    ++counts[diagnostic.code];
+    if (!diagnostic.objectName.empty())
+      details += wxString::FromUTF8(diagnostic.objectType + " " + diagnostic.objectName + ": ");
+    details += wxString::FromUTF8(diagnostic.technicalDetail) + "\n\n";
+  }
+  wxString summary;
+  for (const auto &[code, count] : counts)
+    summary += "• " + SummaryFor(code, count) + "\n";
+
+  if (!exported) {
+    ShowDialog(parent, "MVR export failed",
+               "The MVR file could not be created because export validation or file writing failed.",
+               {}, details);
+  } else if (!counts.empty()) {
+    ShowDialog(parent, "MVR exported with warnings",
+               "The MVR file was exported successfully, but some data had to be adjusted or could not be preserved.",
+               summary, details);
+  } else {
+    ShowDialog(parent, "Success", "MVR file exported successfully.", {}, {});
+  }
+}

--- a/gui/mvr_export_result_dialog.cpp
+++ b/gui/mvr_export_result_dialog.cpp
@@ -1,14 +1,31 @@
 #include "mvr_export_result_dialog.h"
 
+#include <algorithm>
 #include <map>
 
 #include <wx/button.h>
+#include <wx/display.h>
 #include <wx/dialog.h>
 #include <wx/sizer.h>
 #include <wx/stattext.h>
 #include <wx/textctrl.h>
 
 namespace {
+
+constexpr int kCollapsedMinimumWidth = 620;
+constexpr int kExpandedPreferredWidth = 720;
+constexpr int kExpandedPreferredHeight = 500;
+
+// Clamps a dialog size to the client area of the display containing its parent.
+wxSize ClampToDisplay(wxWindow *parent, wxSize requested) {
+  const int displayIndex = parent ? wxDisplay::GetFromWindow(parent) : wxNOT_FOUND;
+  const wxRect clientArea = displayIndex == wxNOT_FOUND
+                                ? wxGetClientDisplayRect()
+                                : wxDisplay(displayIndex).GetClientArea();
+  requested.SetWidth(std::min(requested.GetWidth(), clientArea.GetWidth()));
+  requested.SetHeight(std::min(requested.GetHeight(), clientArea.GetHeight()));
+  return requested;
+}
 
 // Returns concise user-facing copy for a diagnostic category.
 wxString SummaryFor(MvrExportDiagnosticCode code, size_t count) {
@@ -39,7 +56,7 @@ wxString SummaryFor(MvrExportDiagnosticCode code, size_t count) {
 void ShowDialog(wxWindow *parent, const wxString &title,
                 const wxString &primary, const wxString &summary,
                 const wxString &details) {
-  wxDialog dialog(parent, wxID_ANY, title, wxDefaultPosition, wxSize(720, 500),
+  wxDialog dialog(parent, wxID_ANY, title, wxDefaultPosition, wxDefaultSize,
                   wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER);
   auto *layout = new wxBoxSizer(wxVERTICAL);
   auto *primaryText = new wxStaticText(&dialog, wxID_ANY, primary);
@@ -59,20 +76,40 @@ void ShowDialog(wxWindow *parent, const wxString &title,
     layout->Add(detailText, 1, wxLEFT | wxRIGHT | wxBOTTOM | wxEXPAND, 14);
   }
   auto *buttons = new wxBoxSizer(wxHORIZONTAL);
+  wxButton *detailsButton = nullptr;
   if (detailText) {
-    auto *detailsButton = new wxButton(&dialog, wxID_ANY, "Show details...");
-    detailsButton->Bind(wxEVT_BUTTON, [&, detailText, detailsButton](wxCommandEvent &) {
-      const bool show = !detailText->IsShown();
-      detailText->Show(show);
-      detailsButton->SetLabel(show ? "Hide details" : "Show details...");
-      dialog.Layout();
-    });
+    detailsButton = new wxButton(&dialog, wxID_ANY, "Show details...");
     buttons->Add(detailsButton, 0, wxRIGHT, 8);
   }
   buttons->Add(new wxButton(&dialog, wxID_OK, "OK"));
   layout->Add(buttons, 0, wxALIGN_RIGHT | wxALL, 14);
-  dialog.SetSizer(layout);
-  dialog.SetMinSize(wxSize(560, 260));
+  dialog.SetSizerAndFit(layout);
+  wxSize collapsedSize = dialog.GetSize();
+  collapsedSize.SetWidth(std::max(collapsedSize.GetWidth(),
+                                  kCollapsedMinimumWidth));
+  collapsedSize = ClampToDisplay(parent, collapsedSize);
+  dialog.SetSize(collapsedSize);
+  dialog.SetMinSize(collapsedSize);
+  if (detailsButton) {
+    detailsButton->Bind(
+        wxEVT_BUTTON,
+        [&, detailText, detailsButton, collapsedSize](wxCommandEvent &) {
+          const bool show = !detailText->IsShown();
+          detailText->Show(show);
+          detailsButton->SetLabel(show ? "Hide details" : "Show details...");
+          if (show) {
+            dialog.SetMinSize(collapsedSize);
+            dialog.SetSize(ClampToDisplay(
+                parent, wxSize(std::max(collapsedSize.GetWidth(),
+                                        kExpandedPreferredWidth),
+                               std::max(collapsedSize.GetHeight() + 280,
+                                        kExpandedPreferredHeight))));
+          } else {
+            dialog.SetSize(collapsedSize);
+          }
+          dialog.Layout();
+        });
+  }
   dialog.CentreOnParent();
   dialog.ShowModal();
 }
@@ -94,7 +131,7 @@ void ShowMvrExportResult(wxWindow *parent, bool exported,
   }
   wxString summary;
   for (const auto &[code, count] : counts)
-    summary += "• " + SummaryFor(code, count) + "\n";
+    summary += "- " + SummaryFor(code, count) + "\n";
 
   if (!exported) {
     ShowDialog(parent, "MVR export failed",

--- a/gui/mvr_export_result_dialog.h
+++ b/gui/mvr_export_result_dialog.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "mvr_export_diagnostic.h"
+
+#include <vector>
+
+class wxWindow;
+
+// Presents one bounded, aggregated result for an interactive MVR export.
+void ShowMvrExportResult(wxWindow *parent, bool exported,
+                         const std::vector<MvrExportDiagnostic> &diagnostics);

--- a/mvr/mvr_export_diagnostic.h
+++ b/mvr/mvr_export_diagnostic.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <string>
+
+// Stable machine-readable classifications emitted by MVR export.
+enum class MvrExportDiagnosticCode {
+  IdentityCanonicalized,
+  IdentityGenerated,
+  IdentityReassigned,
+  IdentityConflict,
+  ReferenceCleared,
+  LayerInferred,
+  TransformRepaired,
+  TransformInvalid,
+  SymbolIdentityReplaced,
+  FixtureIdReassigned,
+  GdtfFallbackUsed,
+  GdtfMissing,
+  TrussGdtfMissing,
+  GdtfPatchFailed,
+  TextureMissing,
+  ResourceMissing,
+  ResourceDuplicate,
+  SupportGeometryMissing,
+  PlaceholderGeometryUsed,
+  CompatibilityRepresentationUnavailable,
+  ForeignMetadataDiscarded,
+  DmxAddressOmitted,
+  StructuralValidationFailed,
+  CanonicalizationFailed,
+  ArchiveIoFailed,
+  HierarchyRecursion,
+  InternalRecovery
+};
+
+enum class MvrExportDiagnosticSeverity { Info, Warning, Error };
+enum class MvrExportDiagnosticImpact { None, IdentityChanged, DataOmitted,
+                                       DataSubstituted, RequestNotHonored,
+                                       ExportFailed };
+
+// Carries exporter diagnostics without dependencies on a presentation toolkit.
+struct MvrExportDiagnostic {
+  MvrExportDiagnosticCode code = MvrExportDiagnosticCode::InternalRecovery;
+  MvrExportDiagnosticSeverity severity = MvrExportDiagnosticSeverity::Info;
+  MvrExportDiagnosticImpact impact = MvrExportDiagnosticImpact::None;
+  bool userVisible = false;
+  std::string objectType;
+  std::string objectName;
+  std::string objectIdentity;
+  std::string resourceName;
+  std::string technicalDetail;
+};

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -524,7 +524,7 @@ static std::string ToLowerAscii(std::string value) {
 }
 
 static void LogLegacyPositionUuidWarning(const std::string &message) {
-  Logger::Instance().Log(Logger::Level::Warn, message);
+  Logger::Instance().Log(Logger::Level::Info, message);
 }
 
 static std::string
@@ -2400,30 +2400,28 @@ bool MvrExporter::SerializeSnapshotToFile(const MvrScene &sourceScene,
   MvrScene scene = sourceScene;
   const auto identityRecovery =
       mvridentity::RecoverSceneIdentities(scene, "editable-scene");
+  std::unordered_set<std::string> emittedIdentityRecoveryWarnings;
   for (const auto &diagnostic : identityRecovery.diagnostics) {
     const std::string message =
         mvridentity::FormatRecoveryDiagnostic(diagnostic);
-    const bool hasUnusableCounterpart = std::any_of(
-        identityRecovery.diagnostics.begin(), identityRecovery.diagnostics.end(),
-        [&](const mvridentity::RecoveryDiagnostic &other) {
-          return &other != &diagnostic &&
-                 other.objectKind == diagnostic.objectKind &&
-                 other.objectName == diagnostic.objectName &&
-                 other.replacementIdentity == diagnostic.replacementIdentity &&
-                 other.identitySource != diagnostic.identitySource &&
-                 (other.reason == mvridentity::RecoveryReason::Missing ||
-                  other.reason == mvridentity::RecoveryReason::Malformed);
-        });
-    const bool visible = diagnostic.reason == mvridentity::RecoveryReason::Duplicate ||
-        diagnostic.reason == mvridentity::RecoveryReason::KeyFieldMismatch ||
+    const bool validIdentityConflict = diagnostic.conflictingValidIdentities;
+    const bool needsGeneratedIdentity = diagnostic.generatedNewIdentity;
+    const bool visibleCandidate =
+        diagnostic.reason == mvridentity::RecoveryReason::Duplicate ||
+        validIdentityConflict ||
         diagnostic.reason == mvridentity::RecoveryReason::AmbiguousReference ||
         diagnostic.reason == mvridentity::RecoveryReason::UnresolvedReference ||
-        ((diagnostic.reason == mvridentity::RecoveryReason::Missing ||
-          diagnostic.reason == mvridentity::RecoveryReason::Malformed) &&
-         hasUnusableCounterpart);
+        needsGeneratedIdentity;
+    const std::string recoveryEventKey = diagnostic.objectKind + "|" +
+                                         diagnostic.objectName + "|" +
+                                         diagnostic.replacementIdentity;
+    const bool visible = visibleCandidate &&
+                         emittedIdentityRecoveryWarnings
+                             .insert(recoveryEventKey)
+                             .second;
     AddDiagnostic({visible ? (diagnostic.reason == mvridentity::RecoveryReason::Duplicate
                                   ? MvrExportDiagnosticCode::IdentityReassigned
-                                  : diagnostic.reason == mvridentity::RecoveryReason::KeyFieldMismatch
+                                  : validIdentityConflict
                                         ? MvrExportDiagnosticCode::IdentityConflict
                                         : diagnostic.reason == mvridentity::RecoveryReason::AmbiguousReference ||
                                                   diagnostic.reason == mvridentity::RecoveryReason::UnresolvedReference
@@ -3057,6 +3055,25 @@ bool MvrExporter::SerializeSnapshotToFile(const MvrScene &sourceScene,
   const auto assignedUnitNumbers =
       BuildFixtureUnitNumbersForExport(scene.fixtures);
 
+  auto resolveObjectPosition = [&](const std::string &objectType,
+                                   const std::string &objectName,
+                                   const std::string &objectUuid,
+                                   const std::string &positionId,
+                                   const std::string &positionName) {
+    const std::string resolved =
+        resolvePositionReference(positionId, positionName);
+    if (resolved.empty() && !TrimAscii(positionId).empty()) {
+      AddDiagnostic({MvrExportDiagnosticCode::ReferenceCleared,
+                     MvrExportDiagnosticSeverity::Warning,
+                     MvrExportDiagnosticImpact::DataOmitted, true, objectType,
+                     objectName, objectUuid, {},
+                     "MVR export omitted an unresolved Position reference for " +
+                         objectType + " '" + objectName + "' (uuid=" +
+                         objectUuid + ")."});
+    }
+    return resolved;
+  };
+
   tinyxml2::XMLDocument doc;
   doc.InsertEndChild(
       doc.NewDeclaration("xml version=\"1.0\" encoding=\"UTF-8\""));
@@ -3359,14 +3376,17 @@ bool MvrExporter::SerializeSnapshotToFile(const MvrScene &sourceScene,
     if (fixtureSourceGdtf.empty() && !f.originalMvrGdtfSpec.empty()) {
       fixtureSourceGdtf = f.originalMvrGdtfSpec;
       ++preservedOriginalFixtureGdtfRecoveries;
-      Logger::Instance().Log(
-          Logger::Level::Warn,
-          wxString::Format(
+      AddDiagnostic({MvrExportDiagnosticCode::InternalRecovery,
+                     MvrExportDiagnosticSeverity::Info,
+                     MvrExportDiagnosticImpact::None, false, "Fixture",
+                     fixtureExportName, f.uuid,
+                     SanitizeArchiveFileName(fixtureSourceGdtf, "fixture.gdtf"),
+                     wxString::Format(
               "Fixture '%s' (uuid=%s) had an empty current GDTF. Recovering "
               "preserved original MVR GDTFSpec '%s' for export.",
               fixtureExportName.c_str(), f.uuid.c_str(),
               fixtureSourceGdtf.c_str())
-              .ToStdString());
+                         .ToStdString()});
     }
     bool usedDummyFallbackForFixture = false;
     if (fixtureSourceGdtf.empty()) {
@@ -3379,14 +3399,24 @@ bool MvrExporter::SerializeSnapshotToFile(const MvrScene &sourceScene,
         msg << "Fixture '" << fixtureExportName << "' (uuid=" << f.uuid
             << ") has no GDTF and fallback '" << fallbackHint
             << "' is not available.";
-        Logger::Instance().Log(Logger::Level::Warn, msg.str());
+        AddDiagnostic({MvrExportDiagnosticCode::GdtfMissing,
+                       MvrExportDiagnosticSeverity::Warning,
+                       MvrExportDiagnosticImpact::DataOmitted, true, "Fixture",
+                       fixtureExportName, f.uuid,
+                       SanitizeArchiveFileName(fallbackHint, "fixture.gdtf"),
+                       msg.str()});
       } else {
         std::ostringstream msg;
         msg << "Fixture '" << fixtureExportName << "' (uuid=" << f.uuid
             << ") has no GDTF. Using fallback '"
             << fs::path(fixtureSourceGdtf).filename().string()
             << "' for MVR export.";
-        Logger::Instance().Log(Logger::Level::Info, msg.str());
+        AddDiagnostic({MvrExportDiagnosticCode::GdtfFallbackUsed,
+                       MvrExportDiagnosticSeverity::Warning,
+                       MvrExportDiagnosticImpact::DataSubstituted, true,
+                       "Fixture", fixtureExportName, f.uuid,
+                       fs::path(fixtureSourceGdtf).filename().generic_string(),
+                       msg.str()});
         usedDummyFallbackForFixture = true;
         if (dummyFallbackFixtureExamples.size() < 5)
           dummyFallbackFixtureExamples.push_back(fixtureExportName +
@@ -3401,18 +3431,37 @@ bool MvrExporter::SerializeSnapshotToFile(const MvrScene &sourceScene,
       } else if (!usedDummyFallbackForFixture) {
         const std::string fallbackGdtf = ResolveFallbackFixtureGdtfPath();
         if (!fallbackGdtf.empty()) {
-          Logger::Instance().Log(
-              Logger::Level::Warn,
-              "Fixture '" + fixtureExportName + "' (uuid=" + f.uuid +
-                  ") references missing GDTF '" + fixtureSourceGdtf +
+          AddDiagnostic({MvrExportDiagnosticCode::GdtfFallbackUsed,
+                         MvrExportDiagnosticSeverity::Warning,
+                         MvrExportDiagnosticImpact::DataSubstituted, true,
+                         "Fixture", fixtureExportName, f.uuid,
+                         SanitizeArchiveFileName(fixtureSourceGdtf,
+                                                 "fixture.gdtf"),
+                         "Fixture '" + fixtureExportName + "' (uuid=" + f.uuid +
+                  ") references missing GDTF '" +
+                  SanitizeArchiveFileName(fixtureSourceGdtf, "fixture.gdtf") +
                   "'. Using fallback '" +
                   fs::path(fallbackGdtf).filename().generic_string() +
-                  "' for MVR export.");
+                  "' for MVR export."});
           fixtureSourceGdtf = fallbackGdtf;
           usedDummyFallbackForFixture = true;
           if (dummyFallbackFixtureExamples.size() < 5)
             dummyFallbackFixtureExamples.push_back(fixtureExportName +
                                                    " (uuid=" + f.uuid + ")");
+        }
+        else {
+          AddDiagnostic({MvrExportDiagnosticCode::GdtfMissing,
+                         MvrExportDiagnosticSeverity::Warning,
+                         MvrExportDiagnosticImpact::DataOmitted, true,
+                         "Fixture", fixtureExportName, f.uuid,
+                         SanitizeArchiveFileName(fixtureSourceGdtf,
+                                                 "fixture.gdtf"),
+                         "Fixture '" + fixtureExportName + "' (uuid=" + f.uuid +
+                             ") references missing GDTF '" +
+                             SanitizeArchiveFileName(fixtureSourceGdtf,
+                                                     "fixture.gdtf") +
+                             "' and no fallback is available."});
+          fixtureSourceGdtf.clear();
         }
       }
     }
@@ -3473,7 +3522,9 @@ bool MvrExporter::SerializeSnapshotToFile(const MvrScene &sourceScene,
     if (!fixtureGdtfArchivePath.empty())
       addStr("GDTFMode", f.gdtfMode.empty() ? "Default" : f.gdtfMode);
     if (!f.position.empty() || !f.positionName.empty())
-      addStr("Position", resolvePositionReference(f.position, f.positionName));
+      addStr("Position", resolveObjectPosition("Fixture", fixtureExportName,
+                                                f.uuid, f.position,
+                                                f.positionName));
     addStr("FixtureID", fixtureExportId.text);
     addInt("FixtureIDNumeric", fixtureExportId.numeric);
     auto unitIt = assignedUnitNumbers.find(f.uuid);
@@ -3511,6 +3562,7 @@ bool MvrExporter::SerializeSnapshotToFile(const MvrScene &sourceScene,
     parent->InsertEndChild(fe);
   };
 
+  bool fatalTrussGdtfGenerationFailure = false;
   auto exportTruss = [&](tinyxml2::XMLElement *parent, const Truss &t) {
     const Truss effectiveTruss =
         BuildEffectiveTrussTypeMetadata(t, trussTypeMetadataBySourceKey);
@@ -3574,11 +3626,30 @@ bool MvrExporter::SerializeSnapshotToFile(const MvrScene &sourceScene,
                                 ? trussWorkspace.Path() / ((t.uuid.empty() ? std::string("truss") : t.uuid) + ".gdtf")
                                 : fs::path{};
         std::string conversionError;
-        if (!tempPath.empty() &&
-            BuildTrussGdtfFromInstance(effectiveTruss, tempPath, &conversionError)) {
+        if (!tempPath.empty() && BuildTrussGdtfFromInstance(
+                                     effectiveTruss, tempPath,
+                                     &conversionError)) {
           trussSourceGdtf = tempPath.string();
           exportGeneratedFiles.push_back(tempPath);
           exportWorkspaceLeases.push_back(trussWorkspace.TransferToSceneLease());
+        } else {
+          const bool required = !importedFromMvrGeometry ||
+                                trussGeometryAuthority ==
+                                    TrussGeometryAuthority::Gdtf;
+          AddDiagnostic({MvrExportDiagnosticCode::TrussGdtfMissing,
+                         required ? MvrExportDiagnosticSeverity::Error
+                                  : MvrExportDiagnosticSeverity::Warning,
+                         required ? MvrExportDiagnosticImpact::ExportFailed
+                                  : MvrExportDiagnosticImpact::DataOmitted,
+                         true, "Truss", t.name, exportedTrussUuid,
+                         BuildTrussGdtfArchiveName(effectiveTruss),
+                         "MVR export could not generate the requested Truss "
+                         "GDTF for '" + t.name + "' (uuid=" +
+                             exportedTrussUuid + "): " +
+                             (conversionError.empty()
+                                  ? "the conversion did not produce an archive"
+                                  : conversionError)});
+          fatalTrussGdtfGenerationFailure |= required;
         }
       }
 
@@ -3616,7 +3687,8 @@ bool MvrExporter::SerializeSnapshotToFile(const MvrScene &sourceScene,
 
     {
       const std::string positionRef =
-          resolvePositionReference(t.position, t.positionName);
+          resolveObjectPosition("Truss", t.name, t.uuid, t.position,
+                                t.positionName);
       if (!positionRef.empty()) {
         tinyxml2::XMLElement *e = doc.NewElement("Position");
         e->SetText(positionRef.c_str());
@@ -3810,7 +3882,8 @@ bool MvrExporter::SerializeSnapshotToFile(const MvrScene &sourceScene,
     se->InsertEndChild(mat);
 
     const std::string supportPositionRef =
-        resolvePositionReference(s.position, s.positionName);
+        resolveObjectPosition("Support", s.name, s.uuid, s.position,
+                              s.positionName);
     if (!supportPositionRef.empty()) {
       tinyxml2::XMLElement *position = doc.NewElement("Position");
       position->SetText(supportPositionRef.c_str());
@@ -3914,8 +3987,9 @@ bool MvrExporter::SerializeSnapshotToFile(const MvrScene &sourceScene,
   };
   std::vector<PrimitiveGeometryMapEntry> primitiveGeometryMapEntries;
 
+  bool sceneObjectExportFailed = false;
   auto exportSceneObject = [&](tinyxml2::XMLElement *parent,
-                               const SceneObject &obj) {
+                               const SceneObject &obj) -> bool {
     struct CylinderTokenParams {
       float topRadiusMm = 0.5f;
       float bottomRadiusMm = 0.5f;
@@ -4114,8 +4188,16 @@ bool MvrExporter::SerializeSnapshotToFile(const MvrScene &sourceScene,
 
     if (!oe->FirstChildElement("Geometries") &&
         !appendPlaceholderCubeGeometry(oe, obj.uuid, "SceneObject")) {
+      AddDiagnostic({MvrExportDiagnosticCode::PlaceholderGeometryUsed,
+                     MvrExportDiagnosticSeverity::Error,
+                     MvrExportDiagnosticImpact::ExportFailed, true,
+                     "SceneObject", obj.name, obj.uuid, {},
+                     "MVR export could not generate mandatory replacement "
+                     "geometry for SceneObject '" + obj.name + "' (uuid=" +
+                         obj.uuid + ")."});
       doc.DeleteNode(oe);
-      return;
+      sceneObjectExportFailed = true;
+      return false;
     }
 
     auto sceneObjectIdIt = assignedIds.find(obj.uuid);
@@ -4138,6 +4220,7 @@ bool MvrExporter::SerializeSnapshotToFile(const MvrScene &sourceScene,
     appendSceneObjectText("FixtureIDNumeric", std::to_string(sceneObjectNumericId));
 
     parent->InsertEndChild(oe);
+    return true;
   };
 
   std::unordered_set<std::string> exportedGroupUuids;
@@ -4171,7 +4254,8 @@ bool MvrExporter::SerializeSnapshotToFile(const MvrScene &sourceScene,
       } else if (childRef.type == MvrNodeType::SceneObject) {
         auto it = scene.sceneObjects.find(childRef.uuid);
         if (it != scene.sceneObjects.end())
-          exportSceneObject(childList, it->second);
+          if (!exportSceneObject(childList, it->second))
+            sceneObjectExportFailed = true;
       } else if (childRef.type == MvrNodeType::Fixture) {
         auto it = scene.fixtures.find(childRef.uuid);
         if (it != scene.fixtures.end())
@@ -4250,7 +4334,8 @@ bool MvrExporter::SerializeSnapshotToFile(const MvrScene &sourceScene,
     for (const auto &[uid, obj] : scene.sceneObjects) {
       if (obj.layer != layer.name || !obj.parentGroupUuid.empty())
         continue;
-      exportSceneObject(childList, obj);
+      if (!exportSceneObject(childList, obj))
+        sceneObjectExportFailed = true;
     }
 
     layerElem->InsertEndChild(childList);
@@ -4284,9 +4369,11 @@ bool MvrExporter::SerializeSnapshotToFile(const MvrScene &sourceScene,
   for (const auto &[uid, obj] : scene.sceneObjects) {
     if ((obj.layer == DEFAULT_LAYER_NAME || obj.layer.empty()) &&
         obj.parentGroupUuid.empty())
-      exportSceneObject(rootChildList, obj);
+      if (!exportSceneObject(rootChildList, obj))
+        sceneObjectExportFailed = true;
   }
-  if (hierarchyRecursionDetected) {
+  if (hierarchyRecursionDetected || sceneObjectExportFailed ||
+      fatalTrussGdtfGenerationFailure) {
     zip.Close();
     return false;
   }
@@ -4421,6 +4508,17 @@ bool MvrExporter::SerializeSnapshotToFile(const MvrScene &sourceScene,
       if (!tmp.empty()) {
         entry.sourcePath = fs::path(tmp);
         exportGeneratedFiles.push_back(entry.sourcePath);
+      } else {
+        AddDiagnostic({MvrExportDiagnosticCode::GdtfPatchFailed,
+                       MvrExportDiagnosticSeverity::Error,
+                       MvrExportDiagnosticImpact::ExportFailed, true, {}, {}, {},
+                       SanitizeArchiveFileName(entry.archivePath,
+                                               "fixture.gdtf"),
+                       "MVR export could not create the patched GDTF '" +
+                           SanitizeArchiveFileName(entry.archivePath,
+                                                   "fixture.gdtf") + "'."});
+        zip.Close();
+        return false;
       }
     }
     if (ToLowerAscii(fs::path(entry.archivePath).extension().string()) == ".gdtf") {
@@ -4621,9 +4719,6 @@ bool MvrExporter::SerializeSnapshotToBuffer(
   wxFileName tempFile(wxString::FromUTF8(tempPath));
   const bool exported = SerializeSnapshotToFile(scene, tempPath, options);
   if (!exported) {
-    Logger::Instance().Log(Logger::Level::Error,
-                           "MVR export-to-buffer failed while writing " +
-                               tempPath);
     wxRemoveFile(tempFile.GetFullPath());
     return false;
   }
@@ -4632,18 +4727,23 @@ bool MvrExporter::SerializeSnapshotToBuffer(
                             ? fs::file_size(tempPath, sizeEc)
                             : 0;
   if (sizeEc || tempSize == 0) {
-    Logger::Instance().Log(
-        Logger::Level::Error,
-        "MVR export-to-buffer produced an empty or unreadable file '" +
-            tempPath + "' size=" + std::to_string(tempSize));
+    AddDiagnostic({MvrExportDiagnosticCode::ArchiveIoFailed,
+                   MvrExportDiagnosticSeverity::Error,
+                   MvrExportDiagnosticImpact::ExportFailed, true, {}, {}, {},
+                   "export-buffer.mvr",
+                   "MVR export-to-buffer produced an empty or unreadable file '" +
+                       tempPath + "' size=" + std::to_string(tempSize)});
     wxRemoveFile(tempFile.GetFullPath());
     return false;
   }
 
   std::ifstream input(tempPath, std::ios::binary);
   if (!input.is_open()) {
-    Logger::Instance().Log(Logger::Level::Error,
-                           "MVR export-to-buffer could not open " + tempPath);
+    AddDiagnostic({MvrExportDiagnosticCode::ArchiveIoFailed,
+                   MvrExportDiagnosticSeverity::Error,
+                   MvrExportDiagnosticImpact::ExportFailed, true, {}, {}, {},
+                   "export-buffer.mvr",
+                   "MVR export-to-buffer could not open " + tempPath});
     wxRemoveFile(tempFile.GetFullPath());
     return false;
   }
@@ -4654,9 +4754,11 @@ bool MvrExporter::SerializeSnapshotToBuffer(
   if (size <= 0) {
     input.close();
     wxRemoveFile(tempFile.GetFullPath());
-    Logger::Instance().Log(Logger::Level::Error,
-                           "MVR export-to-buffer read zero bytes from " +
-                               tempPath);
+    AddDiagnostic({MvrExportDiagnosticCode::ArchiveIoFailed,
+                   MvrExportDiagnosticSeverity::Error,
+                   MvrExportDiagnosticImpact::ExportFailed, true, {}, {}, {},
+                   "export-buffer.mvr",
+                   "MVR export-to-buffer read zero bytes from " + tempPath});
     return false;
   }
   outBytes.resize(static_cast<size_t>(size));
@@ -4666,9 +4768,12 @@ bool MvrExporter::SerializeSnapshotToBuffer(
   input.close();
   wxRemoveFile(tempFile.GetFullPath());
   if (!readOk || outBytes.empty()) {
-    Logger::Instance().Log(Logger::Level::Error,
-                           "MVR export-to-buffer failed to read payload from " +
-                               tempPath);
+    AddDiagnostic({MvrExportDiagnosticCode::ArchiveIoFailed,
+                   MvrExportDiagnosticSeverity::Error,
+                   MvrExportDiagnosticImpact::ExportFailed, true, {}, {}, {},
+                   "export-buffer.mvr",
+                   "MVR export-to-buffer failed to read payload from " +
+                       tempPath});
     return false;
   }
   return true;

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -3633,9 +3633,8 @@ bool MvrExporter::SerializeSnapshotToFile(const MvrScene &sourceScene,
           exportGeneratedFiles.push_back(tempPath);
           exportWorkspaceLeases.push_back(trussWorkspace.TransferToSceneLease());
         } else {
-          const bool required = !importedFromMvrGeometry ||
-                                trussGeometryAuthority ==
-                                    TrussGeometryAuthority::Gdtf;
+          const bool required = trussGeometryAuthority ==
+                                TrussGeometryAuthority::Gdtf;
           AddDiagnostic({MvrExportDiagnosticCode::TrussGdtfMissing,
                          required ? MvrExportDiagnosticSeverity::Error
                                   : MvrExportDiagnosticSeverity::Warning,

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -980,7 +980,7 @@ static std::string ResolveExportSymbolUuid(
     const std::string &candidateUuid, const std::string &containerUuid,
     const std::string &symdefUuid, const std::string &deterministicSeed,
     std::unordered_set<std::string> &usedSymbolUuids,
-    std::vector<std::string> *exportWarnings, const std::string &context) {
+    bool *replacedMeaningfulUuid, const std::string &context) {
   const std::string canonicalCandidate = CanonicalizeUuid(candidateUuid);
   const std::string canonicalContainer = CanonicalizeUuid(containerUuid);
   const std::string canonicalSymdef = CanonicalizeUuid(symdefUuid);
@@ -996,11 +996,8 @@ static std::string ResolveExportSymbolUuid(
     return canonicalCandidate;
   }
 
-  if (!TrimAscii(candidateUuid).empty() && exportWarnings) {
-    exportWarnings->push_back(
-        "MVR export replaced invalid or conflicting Symbol uuid '" +
-                              TrimAscii(candidateUuid) + "' for " + context + ".");
-  }
+  if (replacedMeaningfulUuid)
+    *replacedMeaningfulUuid = !TrimAscii(candidateUuid).empty();
 
   for (int suffix = 0;; ++suffix) {
     const std::string seed = deterministicSeed + "#" + std::to_string(suffix);
@@ -2398,27 +2395,65 @@ bool MvrExporter::ExportToFile(const std::string &filePath,
 bool MvrExporter::SerializeSnapshotToFile(const MvrScene &sourceScene,
                                           const std::string &filePath,
                                           const MvrExportOptions &options) {
-  m_exportWarnings.clear();
+  m_exportDiagnostics.clear();
+  m_exportWarningAdapter.clear();
   MvrScene scene = sourceScene;
   const auto identityRecovery =
       mvridentity::RecoverSceneIdentities(scene, "editable-scene");
   for (const auto &diagnostic : identityRecovery.diagnostics) {
     const std::string message =
         mvridentity::FormatRecoveryDiagnostic(diagnostic);
-    m_exportWarnings.push_back(message);
-    Logger::Instance().Log(Logger::Level::Warn, message);
+    const bool hasUnusableCounterpart = std::any_of(
+        identityRecovery.diagnostics.begin(), identityRecovery.diagnostics.end(),
+        [&](const mvridentity::RecoveryDiagnostic &other) {
+          return &other != &diagnostic &&
+                 other.objectKind == diagnostic.objectKind &&
+                 other.objectName == diagnostic.objectName &&
+                 other.replacementIdentity == diagnostic.replacementIdentity &&
+                 other.identitySource != diagnostic.identitySource &&
+                 (other.reason == mvridentity::RecoveryReason::Missing ||
+                  other.reason == mvridentity::RecoveryReason::Malformed);
+        });
+    const bool visible = diagnostic.reason == mvridentity::RecoveryReason::Duplicate ||
+        diagnostic.reason == mvridentity::RecoveryReason::KeyFieldMismatch ||
+        diagnostic.reason == mvridentity::RecoveryReason::AmbiguousReference ||
+        diagnostic.reason == mvridentity::RecoveryReason::UnresolvedReference ||
+        ((diagnostic.reason == mvridentity::RecoveryReason::Missing ||
+          diagnostic.reason == mvridentity::RecoveryReason::Malformed) &&
+         hasUnusableCounterpart);
+    AddDiagnostic({visible ? (diagnostic.reason == mvridentity::RecoveryReason::Duplicate
+                                  ? MvrExportDiagnosticCode::IdentityReassigned
+                                  : diagnostic.reason == mvridentity::RecoveryReason::KeyFieldMismatch
+                                        ? MvrExportDiagnosticCode::IdentityConflict
+                                        : diagnostic.reason == mvridentity::RecoveryReason::AmbiguousReference ||
+                                                  diagnostic.reason == mvridentity::RecoveryReason::UnresolvedReference
+                                              ? MvrExportDiagnosticCode::ReferenceCleared
+                                              : MvrExportDiagnosticCode::IdentityGenerated)
+                           : diagnostic.reason == mvridentity::RecoveryReason::InferredLayer
+                                 ? MvrExportDiagnosticCode::LayerInferred
+                                 : diagnostic.reason == mvridentity::RecoveryReason::Canonicalized
+                                       ? MvrExportDiagnosticCode::IdentityCanonicalized
+                                       : MvrExportDiagnosticCode::InternalRecovery,
+                   visible ? MvrExportDiagnosticSeverity::Warning
+                           : MvrExportDiagnosticSeverity::Info,
+                   visible ? MvrExportDiagnosticImpact::IdentityChanged
+                           : MvrExportDiagnosticImpact::None,
+                   visible, diagnostic.objectKind, diagnostic.objectName,
+                   diagnostic.replacementIdentity, {}, message});
   }
   const auto transformIntegrity =
       scene_transform_integrity::ValidateAndRepair(scene);
   for (const auto &diagnostic : transformIntegrity.diagnostics) {
     const std::string message =
         scene_transform_integrity::FormatDiagnostic(diagnostic);
-    m_exportWarnings.push_back(message);
-    Logger::Instance().Log(
-        diagnostic.severity == scene_transform_integrity::Severity::Fatal
-            ? Logger::Level::Error
-            : Logger::Level::Warn,
-        message);
+    const bool fatal = diagnostic.severity == scene_transform_integrity::Severity::Fatal;
+    AddDiagnostic({fatal ? MvrExportDiagnosticCode::TransformInvalid
+                         : MvrExportDiagnosticCode::TransformRepaired,
+                   fatal ? MvrExportDiagnosticSeverity::Error
+                         : MvrExportDiagnosticSeverity::Info,
+                   fatal ? MvrExportDiagnosticImpact::ExportFailed
+                         : MvrExportDiagnosticImpact::None,
+                   fatal, {}, {}, diagnostic.uuid, {}, message});
   }
   if (!transformIntegrity.success)
     return false;
@@ -2573,8 +2608,10 @@ bool MvrExporter::SerializeSnapshotToFile(const MvrScene &sourceScene,
     if (!sourcePath.empty())
       message << " source='" << sourcePath << "'";
     message << ": " << reason;
-    m_exportWarnings.push_back(message.str());
-    Logger::Instance().Log(Logger::Level::Error, message.str());
+    AddDiagnostic({MvrExportDiagnosticCode::ArchiveIoFailed,
+                   MvrExportDiagnosticSeverity::Error,
+                   MvrExportDiagnosticImpact::ExportFailed, true, {}, {}, {},
+                   fs::path(entryName).filename().generic_string(), message.str()});
     return false;
   };
   if (!output.IsOk())
@@ -2691,6 +2728,13 @@ bool MvrExporter::SerializeSnapshotToFile(const MvrScene &sourceScene,
     if (allowReuseBySource)
       sourceToArchivePath[sourceIdentityKey] = archivePath;
     resourceEntries.push_back({fs::path(normalizedSource), archivePath});
+    if (!fs::exists(fs::path(normalizedSource)))
+      AddDiagnostic({MvrExportDiagnosticCode::ResourceMissing,
+                     MvrExportDiagnosticSeverity::Warning,
+                     MvrExportDiagnosticImpact::DataOmitted, true, {}, {}, {},
+                     fs::path(preferredArchivePath).filename().generic_string(),
+                     "Referenced MVR resource could not be found and will be omitted: " +
+                         fs::path(preferredArchivePath).filename().generic_string()});
     return archivePath;
   };
 
@@ -2706,19 +2750,25 @@ bool MvrExporter::SerializeSnapshotToFile(const MvrScene &sourceScene,
     if (resolvedGdtfPath.empty() && allowFallback) {
       resolvedGdtfPath = ResolveFallbackFixtureGdtfPath();
       if (!resolvedGdtfPath.empty()) {
-        Logger::Instance().Log(
-            Logger::Level::Warn,
-            "MVR export could not resolve fixture GDTF '" + rawGdtfPath +
-                "'. Using fallback '" +
-                fs::path(resolvedGdtfPath).filename().generic_string() + "'.");
+        AddDiagnostic({MvrExportDiagnosticCode::GdtfFallbackUsed,
+                       MvrExportDiagnosticSeverity::Warning,
+                       MvrExportDiagnosticImpact::DataSubstituted, true,
+                       "Fixture", {}, objectUuid,
+                       fs::path(rawGdtfPath).filename().generic_string(),
+                       "MVR export could not resolve fixture GDTF '" + rawGdtfPath +
+                           "'. Using fallback '" +
+                           fs::path(resolvedGdtfPath).filename().generic_string() + "'."});
       }
     }
     if (resolvedGdtfPath.empty() && !allowFallback) {
       const std::string message =
           "MVR export omitted missing explicit auxiliary Truss GDTF '" +
           rawGdtfPath + "'; no fallback was substituted.";
-      m_exportWarnings.push_back(message);
-      Logger::Instance().Log(Logger::Level::Warn, message);
+      AddDiagnostic({MvrExportDiagnosticCode::TrussGdtfMissing,
+                     MvrExportDiagnosticSeverity::Warning,
+                     MvrExportDiagnosticImpact::DataOmitted, true, "Truss", {},
+                     objectUuid, fs::path(rawGdtfPath).filename().generic_string(),
+                     message});
       return {};
     }
     const std::string gdtfSourceForExport =
@@ -2753,8 +2803,15 @@ bool MvrExporter::SerializeSnapshotToFile(const MvrScene &sourceScene,
           Collect3dsTextureReferences(modelPath);
       for (const std::string &textureRef : textureRefs) {
         fs::path texturePath;
-        if (!ResolveTextureDependencyPath(modelPath, textureRef, texturePath))
+        if (!ResolveTextureDependencyPath(modelPath, textureRef, texturePath)) {
+          AddDiagnostic({MvrExportDiagnosticCode::TextureMissing,
+                         MvrExportDiagnosticSeverity::Warning,
+                         MvrExportDiagnosticImpact::DataOmitted, true, "Model", {}, {},
+                         fs::path(textureRef).filename().generic_string(),
+                         "A referenced 3DS texture could not be found and was omitted: " +
+                             fs::path(textureRef).filename().generic_string()});
           continue;
+        }
 
         std::string preferredTextureName = SanitizeArchiveFileName(
             textureRef, texturePath.filename().generic_string());
@@ -2774,8 +2831,15 @@ bool MvrExporter::SerializeSnapshotToFile(const MvrScene &sourceScene,
           continue;
         const fs::path candidate =
             modelDir / PathUtils::PathFromUtf8(trimmedRef);
-        if (!fs::exists(candidate))
+        if (!fs::exists(candidate)) {
+          AddDiagnostic({MvrExportDiagnosticCode::TextureMissing,
+                         MvrExportDiagnosticSeverity::Warning,
+                         MvrExportDiagnosticImpact::DataOmitted, true, "Model", {}, {},
+                         fs::path(trimmedRef).filename().generic_string(),
+                         "A referenced glTF texture could not be found and was omitted: " +
+                             fs::path(trimmedRef).filename().generic_string()});
           continue;
+        }
 
         std::string preferredTextureName = SanitizeArchiveFileName(
             trimmedRef, candidate.filename().generic_string());
@@ -2928,8 +2992,10 @@ bool MvrExporter::SerializeSnapshotToFile(const MvrScene &sourceScene,
           "MVR export reassigned duplicate FixtureIDNumeric " +
           std::to_string(originalId) + " for fixture '" + fixtureName +
           "' to the next available value " + std::to_string(repairedId) + ".";
-      m_exportWarnings.push_back(message);
-      Logger::Instance().Log(Logger::Level::Warn, message);
+      AddDiagnostic({MvrExportDiagnosticCode::FixtureIdReassigned,
+                     MvrExportDiagnosticSeverity::Warning,
+                     MvrExportDiagnosticImpact::IdentityChanged, true, "Fixture",
+                     fixtureName, fixture.uuid, {}, message});
     };
 
     std::unordered_map<std::string, std::pair<std::string, int>> result;
@@ -3021,10 +3087,11 @@ bool MvrExporter::SerializeSnapshotToFile(const MvrScene &sourceScene,
     g3d->InsertEndChild(geoMatrix);
     geos->InsertEndChild(g3d);
     owner->InsertEndChild(geos);
-    Logger::Instance().Log(
-        Logger::Level::Warn,
-                           std::string("MVR export added placeholder cube geometry for ") +
-                               nodeName + " uuid=" + objectUuid);
+    AddDiagnostic({MvrExportDiagnosticCode::PlaceholderGeometryUsed,
+                   MvrExportDiagnosticSeverity::Warning,
+                   MvrExportDiagnosticImpact::DataSubstituted, true, nodeName, {},
+                   objectUuid, {}, "MVR export substituted placeholder geometry for " +
+                                       std::string(nodeName) + "."});
     return true;
   };
 
@@ -3043,8 +3110,10 @@ bool MvrExporter::SerializeSnapshotToFile(const MvrScene &sourceScene,
     const std::string warning =
         "Ignored opaque MVR UserData provider block '" + block.provider +
         "': " + reason;
-    m_exportWarnings.push_back(warning);
-    Logger::Instance().Log(Logger::Level::Warn, warning);
+    AddDiagnostic({MvrExportDiagnosticCode::ForeignMetadataDiscarded,
+                   MvrExportDiagnosticSeverity::Warning,
+                   MvrExportDiagnosticImpact::DataOmitted, true, "UserData", {},
+                   {}, block.provider, warning});
   };
   for (const MvrOpaqueUserDataBlock &block : scene.opaqueUserDataBlocks) {
     if (ToLowerAscii(TrimAscii(block.provider)) == "perastage") {
@@ -3423,14 +3492,16 @@ bool MvrExporter::SerializeSnapshotToFile(const MvrScene &sourceScene,
         addresses->InsertEndChild(addr);
         fe->InsertEndChild(addresses);
       } else {
-        Logger::Instance().Log(
-            Logger::Level::Warn,
-            wxString::Format("Skipping invalid DMX patch for fixture '%s' "
+        AddDiagnostic({MvrExportDiagnosticCode::DmxAddressOmitted,
+                       MvrExportDiagnosticSeverity::Warning,
+                       MvrExportDiagnosticImpact::DataOmitted, true, "Fixture",
+                       f.instanceName, f.uuid, {},
+                       wxString::Format("Skipping invalid DMX patch for fixture '%s' "
                              "(uuid=%s): '%s' (expected Universe.Address with "
                              "universe >= 1 and address in [1,512])",
                              f.instanceName.c_str(), f.uuid.c_str(),
                              trimmedAddress.c_str())
-                .ToStdString());
+                           .ToStdString()});
       }
     }
 
@@ -3609,19 +3680,29 @@ bool MvrExporter::SerializeSnapshotToFile(const MvrScene &sourceScene,
                                  t.uuid.c_str(), t.sourceSymdefUuid.c_str())
                     .ToStdString());
           } else {
-            m_exportWarnings.push_back(
-                "MVR export could not resolve truss Symdef '" +
-                t.sourceSymdefUuid +
-                "' for direct Geometry3D export; preserving Symbol/Symdef "
-                "representation.");
+            AddDiagnostic({MvrExportDiagnosticCode::CompatibilityRepresentationUnavailable,
+                           MvrExportDiagnosticSeverity::Warning,
+                           MvrExportDiagnosticImpact::RequestNotHonored, true,
+                           "Truss", t.name, t.uuid, {},
+                           "MVR export could not resolve the requested direct "
+                           "geometry representation for truss '" + t.name +
+                               "'; Symbol/Symdef was preserved."});
             tinyxml2::XMLElement *sym = doc.NewElement("Symbol");
             const std::string symbolMatrixText =
                 MatrixUtils::FormatMatrix(t.sourceSymbolMatrix);
+            bool replacedSymbolUuid = false;
             const std::string symbolUuid = ResolveExportSymbolUuid(
                 t.sourceSymbolUuid, t.uuid, t.sourceSymdefUuid,
                 "mvr:symbol:truss:" + t.uuid + ":" + t.sourceSymdefUuid + ":" +
                     symbolMatrixText + ":0",
-                usedSymbolUuids, &m_exportWarnings, "Truss uuid " + t.uuid);
+                usedSymbolUuids, &replacedSymbolUuid, "Truss uuid " + t.uuid);
+            if (replacedSymbolUuid)
+              AddDiagnostic({MvrExportDiagnosticCode::SymbolIdentityReplaced,
+                             MvrExportDiagnosticSeverity::Warning,
+                             MvrExportDiagnosticImpact::IdentityChanged, true,
+                             "Truss Symbol", t.name, t.uuid, {},
+                             "An invalid or conflicting Symbol UUID was replaced for truss '" +
+                                 t.name + "'."});
             sym->SetAttribute("uuid", symbolUuid.c_str());
             sym->SetAttribute("symdef", t.sourceSymdefUuid.c_str());
             tinyxml2::XMLElement *symMat = doc.NewElement("Matrix");
@@ -3634,11 +3715,19 @@ bool MvrExporter::SerializeSnapshotToFile(const MvrScene &sourceScene,
           tinyxml2::XMLElement *sym = doc.NewElement("Symbol");
           const std::string symbolMatrixText =
               MatrixUtils::FormatMatrix(t.sourceSymbolMatrix);
+          bool replacedSymbolUuid = false;
           const std::string symbolUuid = ResolveExportSymbolUuid(
               t.sourceSymbolUuid, t.uuid, t.sourceSymdefUuid,
               "mvr:symbol:truss:" + t.uuid + ":" + t.sourceSymdefUuid + ":" +
                   symbolMatrixText + ":0",
-              usedSymbolUuids, &m_exportWarnings, "Truss uuid " + t.uuid);
+              usedSymbolUuids, &replacedSymbolUuid, "Truss uuid " + t.uuid);
+          if (replacedSymbolUuid)
+            AddDiagnostic({MvrExportDiagnosticCode::SymbolIdentityReplaced,
+                           MvrExportDiagnosticSeverity::Warning,
+                           MvrExportDiagnosticImpact::IdentityChanged, true,
+                           "Truss Symbol", t.name, t.uuid, {},
+                           "An invalid or conflicting Symbol UUID was replaced for truss '" +
+                               t.name + "'."});
           sym->SetAttribute("uuid", symbolUuid.c_str());
           sym->SetAttribute("symdef", t.sourceSymdefUuid.c_str());
           tinyxml2::XMLElement *symMat = doc.NewElement("Matrix");
@@ -3766,10 +3855,12 @@ bool MvrExporter::SerializeSnapshotToFile(const MvrScene &sourceScene,
     } else {
       tinyxml2::XMLElement *emptyGeometries = doc.NewElement("Geometries");
       se->InsertEndChild(emptyGeometries);
-      Logger::Instance().Log(
-          Logger::Level::Warn,
-                             "MVR export kept Support uuid=" + s.uuid +
-                                 " with empty Geometries because no source geometry is available");
+      AddDiagnostic({MvrExportDiagnosticCode::SupportGeometryMissing,
+                     MvrExportDiagnosticSeverity::Warning,
+                     MvrExportDiagnosticImpact::DataOmitted, true, "Support",
+                     s.name, s.uuid, {},
+                     "MVR export kept Support uuid=" + s.uuid +
+                         " with empty Geometries because no source geometry is available"});
     }
 
     const std::string supportFunction =
@@ -4050,13 +4141,17 @@ bool MvrExporter::SerializeSnapshotToFile(const MvrScene &sourceScene,
   };
 
   std::unordered_set<std::string> exportedGroupUuids;
+  bool hierarchyRecursionDetected = false;
   auto exportGroupObject = [&](auto &&self, tinyxml2::XMLElement *parent,
                                const GroupObject &group) -> void {
     if (!exportedGroupUuids.insert(group.uuid).second) {
-      Logger::Instance().Log(
-          Logger::Level::Error,
-          "MVR export stopped recursive GroupObject revisit for uuid=" +
-              group.uuid);
+      hierarchyRecursionDetected = true;
+      AddDiagnostic({MvrExportDiagnosticCode::HierarchyRecursion,
+                     MvrExportDiagnosticSeverity::Error,
+                     MvrExportDiagnosticImpact::ExportFailed, true,
+                     "GroupObject", group.name, group.uuid, {},
+                     "MVR export stopped recursive GroupObject revisit for uuid=" +
+                         group.uuid});
       return;
     }
     tinyxml2::XMLElement *go = doc.NewElement("GroupObject");
@@ -4191,6 +4286,10 @@ bool MvrExporter::SerializeSnapshotToFile(const MvrScene &sourceScene,
         obj.parentGroupUuid.empty())
       exportSceneObject(rootChildList, obj);
   }
+  if (hierarchyRecursionDetected) {
+    zip.Close();
+    return false;
+  }
   if (rootChildList->FirstChild()) {
     tinyxml2::XMLElement *defaultLayerElem = doc.NewElement("Layer");
     if (!defaultLayerUuid.empty()) {
@@ -4297,9 +4396,12 @@ bool MvrExporter::SerializeSnapshotToFile(const MvrScene &sourceScene,
     if (normalizedPath.empty())
       continue;
     if (!seenArchivePaths.insert(normalizedPath).second) {
-      m_exportWarnings.push_back(
-          "Referenced file '" + normalizedPath +
-                                 "' appears multiple times; duplicates will be ignored.");
+      AddDiagnostic({MvrExportDiagnosticCode::ResourceDuplicate,
+                     MvrExportDiagnosticSeverity::Warning,
+                     MvrExportDiagnosticImpact::DataOmitted, true, {}, {}, {},
+                     fs::path(normalizedPath).filename().generic_string(),
+                     "Referenced file '" + normalizedPath +
+                         "' appears multiple times; duplicates will be ignored."});
       continue;
     }
     deduplicatedResources.push_back(entry);
@@ -4335,7 +4437,11 @@ bool MvrExporter::SerializeSnapshotToFile(const MvrScene &sourceScene,
                                                 canonicalOptions);
       if (!canonicalResult.success) {
         for (const std::string &error : canonicalResult.errors)
-          m_exportWarnings.push_back("GDTF canonicalization failed: " + error);
+          AddDiagnostic({MvrExportDiagnosticCode::CanonicalizationFailed,
+                         MvrExportDiagnosticSeverity::Error,
+                         MvrExportDiagnosticImpact::ExportFailed, true, {}, {}, {},
+                         fs::path(entry.archivePath).filename().generic_string(),
+                         "GDTF canonicalization failed: " + error});
         zip.Close();
         return failExport("CanonicalizeGdtf", entry.archivePath,
                           entry.sourcePath.string(),
@@ -4357,11 +4463,21 @@ bool MvrExporter::SerializeSnapshotToFile(const MvrScene &sourceScene,
                           : layerValidation.message);
   }
 
+  std::vector<std::string> validationWarnings;
   if (!ValidateMvr16Export(doc, gdtfArchiveByObjectUuid, plannedArchiveEntries,
-                           &m_exportWarnings)) {
+                           &validationWarnings)) {
+    AddDiagnostic({MvrExportDiagnosticCode::StructuralValidationFailed,
+                   MvrExportDiagnosticSeverity::Error,
+                   MvrExportDiagnosticImpact::ExportFailed, true, {}, {}, {}, {},
+                   "MVR 1.6 structural validation failed."});
     zip.Close();
     return false;
   }
+  for (const std::string &warning : validationWarnings)
+    AddDiagnostic({MvrExportDiagnosticCode::ResourceMissing,
+                   MvrExportDiagnosticSeverity::Warning,
+                   MvrExportDiagnosticImpact::DataOmitted, true, {}, {}, {}, {},
+                   warning});
 
   // Serialize XML
   tinyxml2::XMLPrinter printer;
@@ -4490,9 +4606,16 @@ bool MvrExporter::SerializeSnapshotToBuffer(
     const MvrScene &scene, std::vector<uint8_t> &outBytes,
     const MvrExportOptions &options) {
   outBytes.clear();
+  m_exportDiagnostics.clear();
+  m_exportWarningAdapter.clear();
   runtime_storage::TemporaryWorkspace bufferWorkspace("mvr-export-buffer");
-  if (!bufferWorkspace.IsValid())
+  if (!bufferWorkspace.IsValid()) {
+    AddDiagnostic({MvrExportDiagnosticCode::ArchiveIoFailed,
+                   MvrExportDiagnosticSeverity::Error,
+                   MvrExportDiagnosticImpact::ExportFailed, true, {}, {}, {}, {},
+                   "MVR export could not create its temporary archive workspace."});
     return false;
+  }
   const std::string tempPath =
       (bufferWorkspace.Path() / "export-buffer.mvr").string();
   wxFileName tempFile(wxString::FromUTF8(tempPath));
@@ -4551,7 +4674,40 @@ bool MvrExporter::SerializeSnapshotToBuffer(
   return true;
 }
 
-// Return non-fatal validation and packaging warnings captured during export.
+// Records a diagnostic once and writes its technical form to the persistent log.
+void MvrExporter::AddDiagnostic(MvrExportDiagnostic diagnostic) {
+  const auto duplicate = std::find_if(
+      m_exportDiagnostics.begin(), m_exportDiagnostics.end(),
+      [&](const MvrExportDiagnostic &existing) {
+        return existing.code == diagnostic.code &&
+               existing.objectIdentity == diagnostic.objectIdentity &&
+               existing.resourceName == diagnostic.resourceName &&
+               existing.technicalDetail == diagnostic.technicalDetail;
+      });
+  if (duplicate != m_exportDiagnostics.end())
+    return;
+  const Logger::Level level =
+      diagnostic.severity == MvrExportDiagnosticSeverity::Error
+          ? Logger::Level::Error
+          : diagnostic.severity == MvrExportDiagnosticSeverity::Warning
+                ? Logger::Level::Warn
+                : Logger::Level::Info;
+  Logger::Instance().Log(level, diagnostic.technicalDetail);
+  m_exportDiagnostics.push_back(std::move(diagnostic));
+  m_exportWarningAdapter.clear();
+}
+
+// Returns all semantic diagnostics from the latest operation.
+const std::vector<MvrExportDiagnostic> &MvrExporter::GetExportDiagnostics() const {
+  return m_exportDiagnostics;
+}
+
+// Return a compatibility text view derived from structured diagnostics.
 const std::vector<std::string> &MvrExporter::GetExportWarnings() const {
-  return m_exportWarnings;
+  m_exportWarningAdapter.clear();
+  for (const auto &diagnostic : m_exportDiagnostics) {
+    if (diagnostic.severity != MvrExportDiagnosticSeverity::Info)
+      m_exportWarningAdapter.push_back(diagnostic.technicalDetail);
+  }
+  return m_exportWarningAdapter;
 }

--- a/mvr/mvrexporter.h
+++ b/mvr/mvrexporter.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "mvr_export_options.h"
+#include "mvr_export_diagnostic.h"
 
 #include <cstdint>
 #include <string>
@@ -43,7 +44,9 @@ public:
     // Serialize an isolated canonical scene snapshot without modifying live project state.
     bool ExportCanonicalSnapshotToBuffer(const MvrScene& scene,
                                          std::vector<uint8_t>& outBytes);
-    // Return non-fatal export warnings collected during the most recent export.
+    // Return structured diagnostics collected during the most recent export.
+    const std::vector<MvrExportDiagnostic>& GetExportDiagnostics() const;
+    // Return a legacy text view derived from structured diagnostics.
     const std::vector<std::string>& GetExportWarnings() const;
 
 private:
@@ -55,5 +58,8 @@ private:
     bool SerializeSnapshotToBuffer(const MvrScene& scene,
                                    std::vector<uint8_t>& outBytes,
                                    const MvrExportOptions& options);
-    std::vector<std::string> m_exportWarnings;
+    // Records and logs one structured diagnostic.
+    void AddDiagnostic(MvrExportDiagnostic diagnostic);
+    std::vector<MvrExportDiagnostic> m_exportDiagnostics;
+    mutable std::vector<std::string> m_exportWarningAdapter;
 };

--- a/tests/mvr_exporter_compliance_test.cpp
+++ b/tests/mvr_exporter_compliance_test.cpp
@@ -651,6 +651,7 @@ int main() {
   Fixture noProfileFixture;
   noProfileFixture.uuid = "90000000-0000-4000-8000-000000000001";
   noProfileFixture.instanceName = "No profile fixture";
+  noProfileFixture.address = "24.1";
   scene.fixtures[noProfileFixture.uuid] = noProfileFixture;
 
   Fixture missingProfileFixture;
@@ -659,6 +660,7 @@ int main() {
   missingProfileFixture.gdtfSpec =
       (tempDir / "missing-profile.gdtf").generic_string();
   missingProfileFixture.position = "unresolvable-position";
+  missingProfileFixture.address = "25.1";
   scene.fixtures[missingProfileFixture.uuid] = missingProfileFixture;
 
   MvrExporter exporter;

--- a/tests/mvr_exporter_compliance_test.cpp
+++ b/tests/mvr_exporter_compliance_test.cpp
@@ -651,6 +651,12 @@ int main() {
   MvrExporter exporter;
   fs::path mvrPath = tempDir / "Test1.mvr";
   assert(exporter.ExportToFile(mvrPath.generic_string()));
+  for (const auto &diagnostic : exporter.GetExportDiagnostics()) {
+    if (diagnostic.code == MvrExportDiagnosticCode::IdentityCanonicalized) {
+      assert(diagnostic.severity == MvrExportDiagnosticSeverity::Info);
+      assert(!diagnostic.userVisible);
+    }
+  }
 
   const auto mvrGeometryEntries = ReadArchiveTextEntries(mvrPath);
   std::unordered_set<std::string> entries;

--- a/tests/mvr_exporter_compliance_test.cpp
+++ b/tests/mvr_exporter_compliance_test.cpp
@@ -648,15 +648,50 @@ int main() {
   malformedSceneObject.modelFile = "primitive:cube";
   scene.sceneObjects[malformedSceneObject.uuid] = malformedSceneObject;
 
+  Fixture noProfileFixture;
+  noProfileFixture.uuid = "90000000-0000-4000-8000-000000000001";
+  noProfileFixture.instanceName = "No profile fixture";
+  scene.fixtures[noProfileFixture.uuid] = noProfileFixture;
+
+  Fixture missingProfileFixture;
+  missingProfileFixture.uuid = "90000000-0000-4000-8000-000000000002";
+  missingProfileFixture.instanceName = "Missing profile fixture";
+  missingProfileFixture.gdtfSpec =
+      (tempDir / "missing-profile.gdtf").generic_string();
+  missingProfileFixture.position = "unresolvable-position";
+  scene.fixtures[missingProfileFixture.uuid] = missingProfileFixture;
+
   MvrExporter exporter;
   fs::path mvrPath = tempDir / "Test1.mvr";
   assert(exporter.ExportToFile(mvrPath.generic_string()));
+  size_t generatedMalformedObjectWarnings = 0;
+  size_t fixtureFallbackWarnings = 0;
+  size_t unresolvedPositionWarnings = 0;
   for (const auto &diagnostic : exporter.GetExportDiagnostics()) {
     if (diagnostic.code == MvrExportDiagnosticCode::IdentityCanonicalized) {
       assert(diagnostic.severity == MvrExportDiagnosticSeverity::Info);
       assert(!diagnostic.userVisible);
     }
+    if (diagnostic.code == MvrExportDiagnosticCode::IdentityGenerated &&
+        diagnostic.objectName == "Malformed SceneObject Recovery" &&
+        diagnostic.userVisible) {
+      ++generatedMalformedObjectWarnings;
+    }
+    if (diagnostic.code == MvrExportDiagnosticCode::GdtfFallbackUsed &&
+        (diagnostic.objectName == "No profile fixture" ||
+         diagnostic.objectName == "Missing profile fixture") &&
+        diagnostic.userVisible) {
+      ++fixtureFallbackWarnings;
+    }
+    if (diagnostic.code == MvrExportDiagnosticCode::ReferenceCleared &&
+        diagnostic.objectName == "Missing profile fixture" &&
+        diagnostic.userVisible) {
+      ++unresolvedPositionWarnings;
+    }
   }
+  assert(generatedMalformedObjectWarnings == 1);
+  assert(fixtureFallbackWarnings == 2);
+  assert(unresolvedPositionWarnings == 1);
 
   const auto mvrGeometryEntries = ReadArchiveTextEntries(mvrPath);
   std::unordered_set<std::string> entries;

--- a/tests/mvr_identity_recovery_test.cpp
+++ b/tests/mvr_identity_recovery_test.cpp
@@ -199,6 +199,22 @@ void TestKeyFieldConflictMatrix() {
   assert(HasReason(first, mvridentity::RecoveryReason::Malformed));
   assert(HasReason(first, mvridentity::RecoveryReason::Missing));
   assert(HasReason(first, mvridentity::RecoveryReason::KeyFieldMismatch));
+  size_t validConflicts = 0;
+  size_t generatedIdentities = 0;
+  for (const auto &diagnostic : first.diagnostics) {
+    if (diagnostic.conflictingValidIdentities)
+      ++validConflicts;
+    if (diagnostic.generatedNewIdentity)
+      ++generatedIdentities;
+    if (diagnostic.objectName.empty() &&
+        (diagnostic.originalIdentity == "bad-field" ||
+         diagnostic.originalIdentity.empty())) {
+      assert(!diagnostic.conflictingValidIdentities);
+      assert(!diagnostic.generatedNewIdentity);
+    }
+  }
+  assert(validConflicts == 1);
+  assert(generatedIdentities == 0);
   assert(scene.sceneObjects.contains(kSceneObjectUuid));
   assert(scene.sceneObjects.contains(kSupportUuid));
   assert(scene.sceneObjects.contains(kFixtureUuid));
@@ -207,6 +223,26 @@ void TestKeyFieldConflictMatrix() {
   const auto second =
       mvridentity::RecoverSceneIdentities(scene, "key-field-matrix");
   assert(second.diagnostics.empty());
+}
+
+// Verifies unusable key and field identities mark one deterministic generation event.
+void TestGeneratedIdentityClassification() {
+  MvrScene scene;
+  SceneObject object;
+  object.name = "Generated identity";
+  object.uuid = "malformed-field";
+  scene.sceneObjects["malformed-key"] = object;
+
+  const auto result =
+      mvridentity::RecoverSceneIdentities(scene, "generated-identity");
+  size_t generatedEvents = 0;
+  for (const auto &diagnostic : result.diagnostics) {
+    if (diagnostic.generatedNewIdentity &&
+        diagnostic.reason == mvridentity::RecoveryReason::KeyFieldMismatch)
+      ++generatedEvents;
+  }
+  assert(generatedEvents == 1);
+  AssertCanonicalMap(scene.sceneObjects);
 }
 
 // Verifies layer duplicates recover deterministically and identity survives
@@ -287,6 +323,7 @@ int main() {
   TestSpellingsAndReferences();
   TestDuplicateAndAmbiguousAliases();
   TestKeyFieldConflictMatrix();
+  TestGeneratedIdentityClassification();
   TestLayerIdentityMatrix();
   TestUnresolvedReferenceDiagnostic();
   assert(RecoverDeterministicTrussUuid() == RecoverDeterministicTrussUuid());

--- a/tests/mvr_io_stubs.cpp
+++ b/tests/mvr_io_stubs.cpp
@@ -66,7 +66,11 @@ bool MvrExporter::ExportToBuffer(std::vector<unsigned char> &, const MvrExportOp
 
 // Returns collected export warnings for the stub exporter.
 const std::vector<std::string> &MvrExporter::GetExportWarnings() const {
-  return m_exportWarnings;
+  return m_exportWarningAdapter;
+}
+
+const std::vector<MvrExportDiagnostic> &MvrExporter::GetExportDiagnostics() const {
+  return m_exportDiagnostics;
 }
 
 namespace AppPaths {

--- a/tests/mvr_project_fixture_metadata_contracts_test.cpp
+++ b/tests/mvr_project_fixture_metadata_contracts_test.cpp
@@ -373,11 +373,12 @@ int main() {
   MvrExporter exporter;
   const fs::path standalonePath = workspace.Path() / "standalone.mvr";
   assert(exporter.ExportToFile(standalonePath.string(), MvrExportOptions{}));
-  assert(std::any_of(exporter.GetExportWarnings().begin(),
-                     exporter.GetExportWarnings().end(),
-                     [](const std::string &warning) {
-                       return warning.find("MalformedProvider") !=
-                              std::string::npos;
+  assert(std::any_of(exporter.GetExportDiagnostics().begin(),
+                     exporter.GetExportDiagnostics().end(),
+                     [](const MvrExportDiagnostic &diagnostic) {
+                       return diagnostic.code ==
+                                  MvrExportDiagnosticCode::ForeignMetadataDiscarded &&
+                              diagnostic.userVisible;
                      }));
   const ArchiveSnapshot standalone = ReadMvr(standalonePath);
   const SceneSignature standaloneSignature =

--- a/tests/mvr_truss_roundtrip_structure_test.cpp
+++ b/tests/mvr_truss_roundtrip_structure_test.cpp
@@ -590,11 +590,12 @@ int main() {
   MvrExporter missingAuxiliaryExporter;
   assert(missingAuxiliaryExporter.ExportToFile(
       missingAuxiliaryMvrPath.string()));
-  assert(std::any_of(missingAuxiliaryExporter.GetExportWarnings().begin(),
-                     missingAuxiliaryExporter.GetExportWarnings().end(),
-                     [](const std::string &warning) {
-                       return warning.find("no fallback was substituted") !=
-                              std::string::npos;
+  assert(std::any_of(missingAuxiliaryExporter.GetExportDiagnostics().begin(),
+                     missingAuxiliaryExporter.GetExportDiagnostics().end(),
+                     [](const MvrExportDiagnostic &diagnostic) {
+                       return diagnostic.code ==
+                                  MvrExportDiagnosticCode::TrussGdtfMissing &&
+                              diagnostic.userVisible;
                      }));
   const auto missingAuxiliaryEntries =
       ReadArchiveTextEntries(missingAuxiliaryMvrPath);

--- a/tests/riderimporter_stubs.cpp
+++ b/tests/riderimporter_stubs.cpp
@@ -107,7 +107,11 @@ bool MvrExporter::ExportToBuffer(std::vector<unsigned char> &,
 }
 // Returns collected export warnings for the stub exporter.
 const std::vector<std::string> &MvrExporter::GetExportWarnings() const {
-  return m_exportWarnings;
+  return m_exportWarningAdapter;
+}
+
+const std::vector<MvrExportDiagnostic> &MvrExporter::GetExportDiagnostics() const {
+  return m_exportDiagnostics;
 }
 
 


### PR DESCRIPTION
### Motivation

- The exporter currently emits a flat list of English warning strings (`m_exportWarnings`) which destroys semantic information and forces the GUI to parse machine-oriented text for presentation.
- Harmless internal recoveries (UUID canonicalization, inferred layers, transform repairs) must remain log-only while real fidelity loss, substitutions, and fatal validation failures must be reported as concise user-visible items.
- Presentation must aggregate and bound results so the GUI never shows an unbounded raw `wxMessageBox` of internal diagnostics and background callers remain non-modal.

### Description

- Introduced a GUI-independent diagnostic model `MvrExportDiagnostic` with stable `MvrExportDiagnosticCode`, `MvrExportDiagnosticSeverity` (Info/Warning/Error), impact, object/resource context, technical detail, and `userVisible` flag in `mvr/mvr_export_diagnostic.h`.
- Reworked `MvrExporter` to emit structured diagnostics: added `AddDiagnostic(...)`, `GetExportDiagnostics()` (authoritative), and a compatibility adapter `GetExportWarnings()` that derives legacy text from non-Info diagnostics; replaced many ad-hoc `m_exportWarnings` pushes and duplicated logging with structured calls in `mvr/mvrexporter.cpp` and `mvr/mvrexporter.h`.
- Made exporter the single logging owner: diagnostics are logged once at the exporter level and `core/configmanager.cpp` no longer re-logs exporter warnings during project save.
- Replaced the unbounded warning `wxMessageBox` UI with a single aggregated, bounded presenter `ShowMvrExportResult(...)` implemented in `gui/mvr_export_result_dialog.{h,cpp}` and wired into `gui/mainwindow_io.cpp` so interactive export shows one result dialog with aggregated counts and a resizable details pane.
- Converted a number of previously-silent or duplicate conditions into structured diagnostics (examples: `GdtfFallbackUsed`, `TextureMissing`, `ResourceMissing`, `ResourceDuplicate`, `PlaceholderGeometryUsed`, `SupportGeometryMissing`, `DmxAddressOmitted`, `FixtureIdReassigned`, `TrussGdtfMissing`, `SymbolIdentityReplaced`, `HierarchyRecursion`, `ArchiveIoFailed`, and structural/canonicalization failures) while intentionally keeping harmless canonicalization and inferred-layer cases as `Info`/log-only.
- Updated documentation `docs/developer/technical-notes/mvr_exporter.md` and `docs/release-notes-draft.md` to describe the structured model, classification, aggregation, and UI policy.
- Updated unit-test stubs and assertions to consume the new structured model (modified: `tests/*` files) and preserved `GetExportWarnings()` as a compatibility adapter implemented in test stubs.

Key files changed: `mvr/mvr_export_diagnostic.h`, `mvr/mvrexporter.cpp`, `mvr/mvrexporter.h`, `gui/mvr_export_result_dialog.{h,cpp}`, `gui/mainwindow_io.cpp`, `core/configmanager.cpp`, docs and several tests under `tests/`.

### Testing

- Ran repository checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both passed.
- Ran `git diff --check` and updated release notes; no whitespace/errors reported.
- Performed C++ static/syntax checks by invoking targeted compile-style checks (`g++ -fsyntax-only`) against the modified units (exporter and the new GUI presenter) and those checks passed.
- Updated and compiled tests that reference exporter warnings to assert against structured diagnostics (tests under `tests/` were updated to use `GetExportDiagnostics()`), however a full CMake configure/build+run of the entire test matrix could not be completed in this environment because the container was missing an upstream `meshoptimizer` CMake package; as a result the full test-suite execution was blocked here.

If you want, I can: (1) run the full CMake build/tests in an environment with the `meshoptimizer` package available, (2) further refine the mapping of specific recovery reasons -> diagnostic codes if you prefer different code names, or (3) extract the diagnostic-to-UI mapping into a dedicated presenter interface for easier GUI testing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8d5595d0b4832492ab85c2fe05b861)