### PR TITLE
Preserve transitive 3D model dependencies during MVR export (3DS/glTF textures & buffers)

### DIFF
--- a/docs/developer/technical-notes/mvr_exporter.md
+++ b/docs/developer/technical-notes/mvr_exporter.md
@@ -58,6 +58,24 @@ When `GeneralSceneDescription.xml` references a `fileName`/`GDTFSpec` entry that
 Diagnostics are available through `MvrExporter::GetExportDiagnostics()` after
 `ExportToFile(...)`/`ExportToBuffer(...)`.
 
+## Live resource dependency pruning
+
+Resource pruning follows the complete live dependency graph. File-bearing XML
+elements such as `Geometry3D` and `GDTFSpec` are direct MVR references. A live
+3DS, glTF, or GLB model may in turn reference root-level external resources,
+including bitmap images and glTF binary buffers; those model-internal files are
+transitive dependencies and remain in the archive even though the scene XML
+does not name them directly. Resources outside both sets are stale and are
+pruned, so deleting a model also removes dependencies used only by that model.
+
+Dependency discovery uses the resolved model source selected for export,
+including a model recovered from packaged scene resources. External dependency
+filenames remain identical to the model URI or bitmap filename. A
+case-insensitive archive-name collision between different source files fails
+export rather than silently renaming one side and breaking the model reference.
+Embedded `data:` URIs and remote HTTP(S) URIs do not require or trigger archive
+resource collection.
+
 ## Fatal errors
 
 Structural MVR compliance errors still fail export (for example missing

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -4,6 +4,11 @@ Changes since **v1.5.0**.
 
 ## Highlights
 
+- Textures, images, and external binary buffers used by 3DS and glTF geometry
+  now survive MVR export and re-import, while dependencies of deleted models
+  continue to be removed and filename collisions fail safely instead of
+  producing broken model references.
+
 - MVR export now presents concise, grouped fidelity warnings instead of raw
   technical diagnostics, while harmless UUID normalization stays in the log and
   export failures provide a focused, expandable result. The collapsed result

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -330,6 +330,7 @@ static std::unordered_map<std::string, int> BuildFixtureUnitNumbersForExport(
   return result;
 }
 
+// Reads a 3DS chunk header from the current stream position.
 static bool Read3dsChunkHeader(std::ifstream &file, ThreeDsChunkHeader &chunk) {
   if (!file.read(reinterpret_cast<char *>(&chunk.id), sizeof(chunk.id)))
     return false;
@@ -338,6 +339,7 @@ static bool Read3dsChunkHeader(std::ifstream &file, ThreeDsChunkHeader &chunk) {
   return true;
 }
 
+// Reads a null-terminated 3DS string without crossing its containing chunk.
 static std::string Read3dsCString(std::ifstream &file, std::streampos endPos) {
   std::string output;
   char ch = 0;
@@ -349,6 +351,7 @@ static std::string Read3dsCString(std::ifstream &file, std::streampos endPos) {
   return output;
 }
 
+// Collects bitmap filenames referenced by standard 3DS material map chunks.
 static std::vector<std::string>
 Collect3dsTextureReferences(const fs::path &modelPath) {
   std::vector<std::string> references;
@@ -419,16 +422,36 @@ Collect3dsTextureReferences(const fs::path &modelPath) {
   return references;
 }
 
+// Collects local external URIs from a glTF JSON document or GLB JSON chunk.
 static std::vector<std::string>
-CollectGltfTextureReferences(const fs::path &modelPath) {
+CollectGltfExternalReferences(const fs::path &modelPath) {
   std::vector<std::string> references;
-  std::ifstream file(modelPath);
+  std::ifstream file(modelPath, std::ios::binary);
   if (!file.is_open())
     return references;
 
   std::ostringstream content;
   content << file.rdbuf();
-  const std::string jsonText = content.str();
+  std::string jsonText = content.str();
+  if (ToLowerAscii(modelPath.extension().string()) == ".glb") {
+    constexpr uint32_t kGlbMagic = 0x46546C67;
+    constexpr uint32_t kJsonChunkType = 0x4E4F534A;
+    if (jsonText.size() < 20)
+      return references;
+    auto readUint32 = [&](size_t offset) {
+      const auto *bytes =
+          reinterpret_cast<const unsigned char *>(jsonText.data());
+      return static_cast<uint32_t>(bytes[offset]) |
+             (static_cast<uint32_t>(bytes[offset + 1]) << 8) |
+             (static_cast<uint32_t>(bytes[offset + 2]) << 16) |
+             (static_cast<uint32_t>(bytes[offset + 3]) << 24);
+    };
+    const uint32_t chunkLength = readUint32(12);
+    if (readUint32(0) != kGlbMagic || readUint32(16) != kJsonChunkType ||
+        chunkLength > jsonText.size() - 20)
+      return references;
+    jsonText = jsonText.substr(20, chunkLength);
+  }
   if (jsonText.empty())
     return references;
 
@@ -440,8 +463,10 @@ CollectGltfTextureReferences(const fs::path &modelPath) {
     if (uri.empty())
       continue;
 
-    // Ignore embedded data URIs. We only need to collect external files.
-    if (uri.rfind("data:", 0) == 0)
+    const std::string lowerUri = ToLowerAscii(TrimAscii(uri));
+    // Embedded and remote resources do not correspond to archive entries.
+    if (lowerUri.rfind("data:", 0) == 0 || lowerUri.rfind("http://", 0) == 0 ||
+        lowerUri.rfind("https://", 0) == 0)
       continue;
 
     if (seenRefs.insert(ToLowerAscii(uri)).second)
@@ -451,10 +476,11 @@ CollectGltfTextureReferences(const fs::path &modelPath) {
   return references;
 }
 
-static bool ResolveTextureDependencyPath(const fs::path &modelPath,
-                                         const std::string &textureRef,
-                                         fs::path &resolvedPath) {
-  const std::string normalizedRef = TrimAscii(textureRef);
+// Resolves a model-internal local URI relative to the exported model source.
+static bool ResolveModelDependencyPath(const fs::path &modelPath,
+                                       const std::string &dependencyRef,
+                                       fs::path &resolvedPath) {
+  const std::string normalizedRef = TrimAscii(dependencyRef);
   if (normalizedRef.empty())
     return false;
 
@@ -2625,6 +2651,9 @@ bool MvrExporter::SerializeSnapshotToFile(const MvrScene &sourceScene,
   std::unordered_map<std::string, std::string> trussArchiveByTypeKey;
   std::unordered_map<std::string, std::string> primitiveSourceByToken;
   std::unordered_set<std::string> reservedArchivePaths;
+  std::unordered_map<std::string, std::unordered_set<std::string>>
+      modelDependenciesByArchivePath;
+  bool modelDependencyRegistrationFailed = false;
   auto primitiveWorkspace = CreateExportWorkspace("mvr-export-primitives");
   const std::string primitiveTempDir = primitiveWorkspace.IsValid()
                                            ? primitiveWorkspace.Path().string()
@@ -2789,70 +2818,107 @@ bool MvrExporter::SerializeSnapshotToFile(const MvrScene &sourceScene,
     return archivePath;
   };
 
-  auto registerModelTextureDependencies = [&](const std::string
-                                                  &rawModelSource) {
-    if (rawModelSource.empty())
+  auto registerModelDependencies = [&](const std::string &resolvedModelSource,
+                                       const std::string &modelArchivePath) {
+    if (resolvedModelSource.empty() || modelArchivePath.empty())
       return;
-    const std::string normalizedModelPath = normalizeSourcePath(rawModelSource);
-    const fs::path modelPath(normalizedModelPath);
+    const fs::path modelPath = PathUtils::PathFromUtf8(resolvedModelSource);
     std::string ext = ToLowerAscii(modelPath.extension().string());
+    std::vector<std::string> dependencyRefs;
     if (ext == ".3ds") {
-      const std::vector<std::string> textureRefs =
-          Collect3dsTextureReferences(modelPath);
-      for (const std::string &textureRef : textureRefs) {
-        fs::path texturePath;
-        if (!ResolveTextureDependencyPath(modelPath, textureRef, texturePath)) {
-          AddDiagnostic({MvrExportDiagnosticCode::TextureMissing,
-                         MvrExportDiagnosticSeverity::Warning,
-                         MvrExportDiagnosticImpact::DataOmitted, true, "Model", {}, {},
-                         fs::path(textureRef).filename().generic_string(),
-                         "A referenced 3DS texture could not be found and was omitted: " +
-                             fs::path(textureRef).filename().generic_string()});
-          continue;
-        }
-
-        std::string preferredTextureName = SanitizeArchiveFileName(
-            textureRef, texturePath.filename().generic_string());
-        registerResource(texturePath.generic_string(), preferredTextureName);
-      }
-      return;
+      dependencyRefs = Collect3dsTextureReferences(modelPath);
+    } else if (ext == ".gltf" || ext == ".glb") {
+      dependencyRefs = CollectGltfExternalReferences(modelPath);
     }
 
-    if (ext == ".gltf" || ext == ".glb") {
-      const std::vector<std::string> textureRefs =
-          CollectGltfTextureReferences(modelPath);
-      const fs::path modelDir =
-          modelPath.has_parent_path() ? modelPath.parent_path() : fs::path();
-      for (const std::string &textureRef : textureRefs) {
-        const std::string trimmedRef = TrimAscii(textureRef);
-        if (trimmedRef.empty())
-          continue;
-        const fs::path candidate =
-            modelDir / PathUtils::PathFromUtf8(trimmedRef);
-        if (!fs::exists(candidate)) {
-          AddDiagnostic({MvrExportDiagnosticCode::TextureMissing,
+    for (const std::string &dependencyRef : dependencyRefs) {
+      fs::path dependencyPath;
+      if (!ResolveModelDependencyPath(modelPath, dependencyRef,
+                                      dependencyPath)) {
+        AddDiagnostic(
+            {MvrExportDiagnosticCode::TextureMissing,
                          MvrExportDiagnosticSeverity::Warning,
-                         MvrExportDiagnosticImpact::DataOmitted, true, "Model", {}, {},
-                         fs::path(trimmedRef).filename().generic_string(),
-                         "A referenced glTF texture could not be found and was omitted: " +
-                             fs::path(trimmedRef).filename().generic_string()});
+             MvrExportDiagnosticImpact::DataOmitted,
+             true,
+             "Model",
+             {},
+             {},
+             fs::path(dependencyRef).filename().generic_string(),
+             "A required external model dependency could not be found: " +
+                 fs::path(dependencyRef).filename().generic_string()});
           continue;
         }
 
-        std::string preferredTextureName = SanitizeArchiveFileName(
-            trimmedRef, candidate.filename().generic_string());
-        registerResource(candidate.generic_string(), preferredTextureName);
+      std::string normalizedRef = TrimAscii(dependencyRef);
+      std::replace(normalizedRef.begin(), normalizedRef.end(), '\\', '/');
+      const std::string dependencyArchivePath =
+          fs::path(normalizedRef).filename().generic_string();
+      const std::string safeArchivePath = SanitizeArchiveFileName(
+          dependencyArchivePath, dependencyPath.filename().generic_string());
+      if (safeArchivePath != dependencyArchivePath) {
+        modelDependencyRegistrationFailed = true;
+        AddDiagnostic(
+            {MvrExportDiagnosticCode::StructuralValidationFailed,
+             MvrExportDiagnosticSeverity::Error,
+             MvrExportDiagnosticImpact::ExportFailed,
+             true,
+             "Model",
+             {},
+             {},
+             dependencyArchivePath,
+             "MVR export cannot preserve external model dependency URI '" +
+                 dependencyRef + "' as a root archive filename."});
+        continue;
+    }
+
+      const std::string dependencyIdentity =
+          buildSourceIdentityKey(dependencyPath.generic_string());
+      auto collision =
+          std::find_if(resourceEntries.begin(), resourceEntries.end(),
+                       [&](const ResourceEntry &entry) {
+                         return ToLowerAscii(entry.archivePath) ==
+                                ToLowerAscii(dependencyArchivePath);
+                       });
+      if (collision != resourceEntries.end()) {
+        if (buildSourceIdentityKey(collision->sourcePath.generic_string()) !=
+            dependencyIdentity) {
+          modelDependencyRegistrationFailed = true;
+          AddDiagnostic(
+              {MvrExportDiagnosticCode::StructuralValidationFailed,
+               MvrExportDiagnosticSeverity::Error,
+               MvrExportDiagnosticImpact::ExportFailed,
+               true,
+               "Model",
+               {},
+               {},
+               dependencyArchivePath,
+               "MVR export found conflicting resources for required model "
+               "dependency '" +
+                   dependencyArchivePath + "'."});
+          continue;
+        }
+      } else {
+        reservedArchivePaths.insert(dependencyArchivePath);
+        sourceToArchivePath.try_emplace(dependencyIdentity,
+                                        dependencyArchivePath);
+        resourceEntries.push_back({dependencyPath, dependencyArchivePath});
       }
+      modelDependenciesByArchivePath[modelArchivePath].insert(
+          dependencyArchivePath);
     }
   };
 
   auto registerModelResource =
       [&](const std::string &rawModelSource,
                                    const std::string &fallbackArchiveName) -> std::string {
+    const std::string resolvedModelSource =
+        resolveExistingResourceSourcePath(rawModelSource);
+    const std::string sourceForExport =
+        resolvedModelSource.empty() ? rawModelSource : resolvedModelSource;
     std::string archivePath = registerResource(
-        rawModelSource,
+        sourceForExport,
         SanitizeArchiveFileName(rawModelSource, fallbackArchiveName));
-    registerModelTextureDependencies(rawModelSource);
+    registerModelDependencies(resolvedModelSource, archivePath);
     return archivePath;
   };
 
@@ -4437,8 +4503,16 @@ bool MvrExporter::SerializeSnapshotToFile(const MvrScene &sourceScene,
 
   // Prunes non-referenced resources so deleted scene elements do not keep stale
   // payload files.
-  const std::unordered_set<std::string> referencedArchivePaths =
+  std::unordered_set<std::string> referencedArchivePaths =
       CollectReferencedArchivePaths(doc);
+  for (const auto &[modelArchivePath, dependencies] :
+       modelDependenciesByArchivePath) {
+    if (!referencedArchivePaths.contains(
+            NormalizeArchiveEntryPath(modelArchivePath)))
+      continue;
+    for (const std::string &dependency : dependencies)
+      referencedArchivePaths.insert(NormalizeArchiveEntryPath(dependency));
+  }
   std::ostringstream fixtureGdtfExportDiagnostics;
   fixtureGdtfExportDiagnostics
       << "MVR export fixture GDTF diagnostics: real="
@@ -4493,6 +4567,11 @@ bool MvrExporter::SerializeSnapshotToFile(const MvrScene &sourceScene,
     deduplicatedResources.push_back(entry);
   }
   resourceEntries = std::move(deduplicatedResources);
+
+  if (modelDependencyRegistrationFailed) {
+    zip.Close();
+    return false;
+  }
 
   std::unordered_map<std::string, int> plannedArchiveEntries;
   plannedArchiveEntries["GeneralSceneDescription.xml"] = 1;
@@ -4549,6 +4628,21 @@ bool MvrExporter::SerializeSnapshotToFile(const MvrScene &sourceScene,
       exportWorkspaceLeases.push_back(canonicalWorkspace.TransferToSceneLease());
     }
     ++plannedArchiveEntries[entry.archivePath];
+  }
+
+  for (const auto &[modelArchivePath, dependencies] :
+       modelDependenciesByArchivePath) {
+    if (!referencedArchivePaths.contains(
+            NormalizeArchiveEntryPath(modelArchivePath)))
+      continue;
+    for (const std::string &dependency : dependencies) {
+      if (plannedArchiveEntries[dependency] != 1) {
+        zip.Close();
+        return failExport(
+            "ValidateModelDependency", dependency, modelArchivePath,
+            "required external dependency is absent from the archive plan");
+      }
+    }
   }
 
   const auto layerValidation = layerdomain::ValidateSceneLayers(scene);

--- a/tests/mvr_exporter_compliance_test.cpp
+++ b/tests/mvr_exporter_compliance_test.cpp
@@ -87,6 +87,24 @@ static std::string BuildTrussGeometry3ds() {
   return {reinterpret_cast<const char *>(archive.data()), archive.size()};
 }
 
+// Builds a minimal 3DS document containing a standard diffuse bitmap map.
+static std::string BuildTexturedGeometry3ds(const std::string &textureName) {
+  std::vector<std::uint8_t> textureNamePayload(textureName.begin(),
+                                               textureName.end());
+  textureNamePayload.push_back(0);
+  std::vector<std::uint8_t> textureMap;
+  Append3dsChunk(textureMap, 0xA300, textureNamePayload);
+  std::vector<std::uint8_t> material;
+  Append3dsChunk(material, 0xA200, textureMap);
+  std::vector<std::uint8_t> editor;
+  Append3dsChunk(editor, 0xAFFF, material);
+  std::vector<std::uint8_t> root;
+  Append3dsChunk(root, 0x3D3D, editor);
+  std::vector<std::uint8_t> archive;
+  Append3dsChunk(archive, 0x4D4D, root);
+  return {reinterpret_cast<const char *>(archive.data()), archive.size()};
+}
+
 static std::string ReadCurrentZipEntry(wxZipInputStream &zip) {
   std::string content;
   char buffer[4096];
@@ -1578,6 +1596,68 @@ int main() {
   assert(importedScene.positions.count(legacyFixture.position) == 1);
   assert(legacyFixture.visualColorHex.empty());
   assert(!legacyFixture.mvrFixtureColorHex.empty());
+
+  cfg.Reset();
+  MvrScene &dependencyScene = cfg.GetScene();
+  dependencyScene.basePath = (tempDir / "dependency_scene").generic_string();
+  fs::create_directories(dependencyScene.basePath);
+  const fs::path dependencyDir(dependencyScene.basePath);
+  std::ofstream(dependencyDir / "textured.3ds", std::ios::binary)
+      << BuildTexturedGeometry3ds("shared.png");
+  std::ofstream(dependencyDir / "shared.png", std::ios::binary) << "PNG";
+  std::ofstream(dependencyDir / "mesh.bin", std::ios::binary) << "BIN";
+  std::ofstream(dependencyDir / "scene.gltf")
+      << R"({"asset":{"version":"2.0"},"buffers":[{"uri":"mesh.bin","byteLength":3}],"images":[{"uri":"shared.png"}]})";
+  std::ofstream(dependencyDir / "stale.png", std::ios::binary) << "STALE";
+  std::ofstream(dependencyDir / "stale.gltf")
+      << R"({"asset":{"version":"2.0"},"images":[{"uri":"stale.png"}]})";
+
+  SceneObject texturedObject;
+  texturedObject.uuid = "10000000-0000-4000-8000-000000000001";
+  texturedObject.name = "Textured 3DS";
+  texturedObject.modelFile = (dependencyDir / "textured.3ds").generic_string();
+  dependencyScene.sceneObjects[texturedObject.uuid] = texturedObject;
+  SceneObject gltfObject;
+  gltfObject.uuid = "10000000-0000-4000-8000-000000000002";
+  gltfObject.name = "External glTF";
+  gltfObject.modelFile = (dependencyDir / "scene.gltf").generic_string();
+  dependencyScene.sceneObjects[gltfObject.uuid] = gltfObject;
+
+  const fs::path dependencyMvrPath = tempDir / "model_dependencies.mvr";
+  assert(MvrExporter().ExportToFile(dependencyMvrPath.generic_string()));
+  const auto dependencyEntries = ReadArchiveTextEntries(dependencyMvrPath);
+  assert(dependencyEntries.count("textured.3ds") == 1);
+  assert(dependencyEntries.count("scene.gltf") == 1);
+  assert(dependencyEntries.count("mesh.bin") == 1);
+  assert(dependencyEntries.count("shared.png") == 1);
+  assert(dependencyEntries.count("stale.gltf") == 0);
+  assert(dependencyEntries.count("stale.png") == 0);
+  assert(dependencyEntries.at("scene.gltf").find("mesh.bin") !=
+         std::string::npos);
+  assert(dependencyEntries.at("scene.gltf").find("shared.png") !=
+         std::string::npos);
+
+  const fs::path collisionDir = tempDir / "dependency_collision";
+  fs::create_directories(collisionDir);
+  std::ofstream(collisionDir / "shared.png", std::ios::binary) << "OTHER";
+  std::ofstream(collisionDir / "collision.gltf")
+      << R"({"asset":{"version":"2.0"},"images":[{"uri":"shared.png"}]})";
+  SceneObject collisionObject;
+  collisionObject.uuid = "10000000-0000-4000-8000-000000000003";
+  collisionObject.name = "Conflicting dependency";
+  collisionObject.modelFile =
+      (collisionDir / "collision.gltf").generic_string();
+  dependencyScene.sceneObjects[collisionObject.uuid] = collisionObject;
+  MvrExporter collisionExporter;
+  assert(!collisionExporter.ExportToFile(
+      (tempDir / "model_dependency_collision.mvr").generic_string()));
+  assert(std::any_of(collisionExporter.GetExportDiagnostics().begin(),
+                     collisionExporter.GetExportDiagnostics().end(),
+                     [](const MvrExportDiagnostic &diagnostic) {
+                       return diagnostic.severity ==
+                                  MvrExportDiagnosticSeverity::Error &&
+                              diagnostic.resourceName == "shared.png";
+                     }));
 
   fs::remove_all(tempDir);
   return 0;


### PR DESCRIPTION
### Motivation
- Fix a regression where external files referenced only from inside imported 3D models (3DS textures, glTF images/buffers) were pruned from MVR exports because pruning used only XML `fileName` references. 
- Ensure exported MVR archives include the complete dependency closure for live `Geometry3D` entries while still pruning genuinely stale resources. 
- Keep archive filenames compatible with URIs encoded inside models and avoid silently renaming dependencies which would break model references.

### Description
- Generalized dependency discovery by adding `CollectGltfExternalReferences(...)` (handles `.gltf` and `.glb` JSON chunk extraction) and renaming/rescoping the model dependency resolver to `ResolveModelDependencyPath(...)`. 
- Centralized dependency registration into `registerModelDependencies(...)` and tracked transitive dependencies in `modelDependenciesByArchivePath` so model dependencies are associated with the model's archive path. 
- Expanded the live-resource set used for pruning to the union of `CollectReferencedArchivePaths(doc)` plus the validated transitive dependencies of referenced `Geometry3D` models, and updated the prune pass to preserve that closure. 
- Added deterministic collision detection that rejects exports when two different source files would produce the same case-insensitive archive filename for a required model dependency instead of silently renaming and breaking references. 
- Added pre-write archive-plan validation to ensure each required model dependency is present exactly once in the planned archive before writing ZIP entries. 
- Added focused regression tests in `tests/mvr_exporter_compliance_test.cpp` covering 3DS texture retention, glTF external buffer/image retention, shared dependency behavior, stale resource pruning, and filename-collision failure behavior, and updated exporter docs and release notes to explain pruning semantics.

### Testing
- Ran `git diff --check` and `clang-format` checks with no code-style errors reported. 
- Ran repository quality scripts `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both of which passed. 
- Attempted to configure/build the `mvr_exporter_compliance_test` locally via CMake, but CMake configuration did not complete in this environment due to missing system `wxWidgets` development libraries so the compiled regression test binary was not executed here; the new tests have been added and will run in CI where dependencies are available. 
- The change set includes the new regression tests and documentation updates and is ready for CI verification where the compliance test target will be built and its assertions exercised.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8d82e460308324a0de7908e5325d12)