### PR TITLE
GDTF: prompt for credentials before loading uncached catalog and avoid opening empty Search dialog

### DIFF
--- a/core/gdtf_share_workflow.h
+++ b/core/gdtf_share_workflow.h
@@ -27,6 +27,14 @@ enum class CredentialPromptReason {
   ExpiredSession
 };
 
+enum class CatalogAccessAction {
+  OpenCachedCatalog,
+  OpenOnlineCatalog,
+  RequestCredentials,
+  ReportCatalogFailure,
+  Cancel
+};
+
 struct WorkflowState {
   CatalogSource catalogSource = CatalogSource::None;
   CredentialAvailability credentialAvailability = CredentialAvailability::None;
@@ -64,6 +72,26 @@ inline CredentialPromptReason PromptReasonForAuthenticationResult(
 // Returns true when the prompt reason requires user credentials.
 inline bool ShouldPromptForCredentials(CredentialPromptReason reason) {
   return reason != CredentialPromptReason::None;
+}
+
+// Chooses the next user-visible step without coupling catalog state to GUI code.
+inline CatalogAccessAction DetermineCatalogAccessAction(
+    bool hasUsableCache, CredentialAvailability credentials,
+    const std::optional<GdtfShareResult> &authenticationResult,
+    bool onlineCatalogAvailable, bool authenticationCancelled = false) {
+  if (onlineCatalogAvailable)
+    return CatalogAccessAction::OpenOnlineCatalog;
+  if (hasUsableCache)
+    return CatalogAccessAction::OpenCachedCatalog;
+  if (authenticationCancelled)
+    return CatalogAccessAction::Cancel;
+  if (credentials != CredentialAvailability::Complete ||
+      (authenticationResult &&
+       authenticationResult->category ==
+           GdtfShareResultCategory::AuthenticationRejected)) {
+    return CatalogAccessAction::RequestCredentials;
+  }
+  return CatalogAccessAction::ReportCatalogFailure;
 }
 
 // Converts catalog source state to stable diagnostic text.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -28,6 +28,14 @@ Changes since **v1.5.0**.
 - Deferred fixture-symbol preparation now reuses unchanged GDTF inspection
   results instead of repeatedly scanning the same profile.
 
+## Fixes
+
+- Download GDTF now requests sign-in before loading an uncached catalog and no
+  longer opens an unusable empty search window when credentials are missing,
+  rejected, or the online catalog cannot be loaded. Cached catalogs remain
+  available for offline browsing, and cancelling sign-in ends the operation
+  cleanly.
+
 - Saved Layouts now retain bounded 2D-view and legend previews even when their
   vector replay data is too large to cache, reducing repeated rendering work
   when reopening unchanged projects.

--- a/docs/user/gdtf-download.md
+++ b/docs/user/gdtf-download.md
@@ -5,7 +5,7 @@ Perastage can download fixture profiles from GDTF Share.
 ## Before you start
 
 - You need an active GDTF Share account.
-- Internet access is required for login and downloads.
+- Internet access is required to load the online catalog and download files.
 
 ## Download workflow
 
@@ -13,6 +13,10 @@ Perastage can download fixture profiles from GDTF Share.
 2. Sign in when prompted.
 3. Search for the fixture profile you need.
 4. Download and store it in your local user library.
+
+If no catalog is available locally, Perastage asks you to sign in before it
+loads the online catalog. Cancelling that sign-in simply cancels the Download
+GDTF operation; it does not open an empty search window or report an error.
 
 ## Related tools
 
@@ -29,6 +33,6 @@ When available, Perastage stores the GDTF Share password in the operating system
 
 Official Perastage builds include wxSecretStore support. On Linux, password persistence also requires an active Freedesktop Secret Service provider such as GNOME Keyring or KWallet. On systems where the operating-system credential store is unavailable at runtime, or on intentionally minimal developer builds without secure-store support, Perastage can still validate credentials for the current operation, but it does not persist the password. Perastage shows a warning in this state, may keep the username as a non-secret hint, and will ask for the password again in a later session.
 
-The GDTF search dialog identifies whether it is showing the online catalog or a cached catalog. A cached catalog can be browsed without a current authenticated session, but Perastage will ask you to sign in when you download. If the online catalog was loaded successfully in the same workflow, the authenticated session is reused for the download without asking again.
+The GDTF search dialog identifies whether it is showing the online catalog or a cached catalog. A cached catalog can be browsed offline and without a current authenticated session, but Perastage will ask you to sign in when you download. Loading the online catalog and downloading require a GDTF Share account and an Internet connection. If the online catalog was loaded successfully in the same workflow, the authenticated session is reused for the download without asking again.
 
 Downloads are written to temporary sibling files first and are published only after the response is successful and ZIP-compatible. If a download, cancellation, or local publication step fails, an existing destination GDTF file is preserved.

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -534,11 +534,16 @@ void MainWindow::OnDownloadGdtf(wxCommandEvent &WXUNUSED(event)) {
     }
 
     if (!catalogResult.snapshot) {
-      const std::string detail = gdtfWorkflowState.lastCatalogResult
-          ? gdtfWorkflowState.lastCatalogResult->message
-          : (gdtfWorkflowState.lastAuthenticationResult
-                 ? gdtfWorkflowState.lastAuthenticationResult->message
-                 : catalogResult.failureMessage);
+      std::string detail = catalogResult.failureMessage;
+      const std::optional<GdtfShareResult> &shareResult =
+          gdtfWorkflowState.lastCatalogResult
+              ? gdtfWorkflowState.lastCatalogResult
+              : gdtfWorkflowState.lastAuthenticationResult;
+      if (shareResult) {
+        detail = "result=" + GdtfShareResultCategoryName(shareResult->category) +
+                 " http=" + std::to_string(shareResult->httpStatus) +
+                 " transport=" + std::to_string(shareResult->transportCode);
+      }
       diagnostics::DiagnosticLogger::Error(
           "GDTF online catalog resolution failed; search dialog not opened: " +
           detail);

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -426,7 +426,7 @@ void MainWindow::OnDownloadGdtf(wxCommandEvent &WXUNUSED(event)) {
   GdtfShareResult initialLoginResult;
   GdtfShareResult initialCatalogResult;
   bool initialLoginAttempted = false;
-  const GdtfCatalogRefreshResult catalogResult =
+  GdtfCatalogRefreshResult catalogResult =
       catalogService.RefreshCatalogIfStale(
           [&](std::string &onlineListData) {
             if (!activeCredentials || activeCredentials->username.empty() ||
@@ -452,6 +452,102 @@ void MainWindow::OnDownloadGdtf(wxCommandEvent &WXUNUSED(event)) {
 
   refreshOverlay.reset();
   refreshDisabler.reset();
+
+  bool catalogAuthenticationCancelled = false;
+  if (!catalogResult.snapshot) {
+    auto requestCatalogCredentials = [&]() -> bool {
+      while (true) {
+        const std::string initialUser =
+            activeCredentials
+                ? activeCredentials->username
+                : loadedCredentials.usernameHint.value_or(std::string());
+        GdtfLoginDialog loginDlg(this, initialUser, std::string());
+        if (loginDlg.ShowModal() != wxID_OK) {
+          catalogAuthenticationCancelled = true;
+          diagnostics::DiagnosticLogger::Info(
+              "GDTF catalog authentication cancelled; search dialog not opened.");
+          return false;
+        }
+
+        CredentialStore::Credentials enteredCredentials;
+        enteredCredentials.username = WxToUtf8(
+            wxString::FromUTF8(loginDlg.GetUsername()).Trim(true).Trim(false));
+        enteredCredentials.password = loginDlg.GetPassword();
+        if (enteredCredentials.username.empty() ||
+            enteredCredentials.password.empty()) {
+          wxMessageBox(_("Please provide username and password."),
+                       _("Login Error"), wxOK | wxICON_ERROR, this);
+          continue;
+        }
+        activeCredentials = std::move(enteredCredentials);
+        loadedCredentials.usernameHint = activeCredentials->username;
+        return true;
+      }
+    };
+
+    gdtf_share_workflow::CatalogAccessAction accessAction =
+        gdtf_share_workflow::DetermineCatalogAccessAction(
+            false, gdtfWorkflowState.credentialAvailability,
+            gdtfWorkflowState.lastAuthenticationResult, false);
+    while (accessAction ==
+           gdtf_share_workflow::CatalogAccessAction::RequestCredentials) {
+      diagnostics::DiagnosticLogger::Info(
+          "GDTF catalog login requested because no cache is available.");
+      activeCredentials.reset();
+      if (!requestCatalogCredentials())
+        return;
+
+      initialLoginAttempted = true;
+      gdtfClient.ResetSession();
+      initialLoginResult = gdtfClient.Login(activeCredentials->username,
+                                            activeCredentials->password);
+      gdtfWorkflowState.lastAuthenticationResult = initialLoginResult;
+      gdtfWorkflowState.credentialAvailability =
+          gdtf_share_workflow::CredentialAvailability::Complete;
+      if (initialLoginResult.Succeeded()) {
+        gdtfWorkflowState.sessionAuthenticated = true;
+        gdtfWorkflowState.authenticatedUsername = activeCredentials->username;
+        const CredentialStore::Result persistResult =
+            PersistGdtfCredentialsForGui(*activeCredentials, configManager);
+        if (!persistResult.Succeeded()) {
+          diagnostics::DiagnosticLogger::Warning(
+              std::string("GDTF credentials authenticated but persistence failed: status=") +
+              CredentialStore::StatusName(persistResult.status));
+          wxMessageBox(
+              _("GDTF Share credentials were authenticated for this operation, but the password could not be saved securely. You may need to enter it again after restart."),
+              _("GDTF Share credentials"), wxOK | wxICON_WARNING, this);
+        }
+        catalogResult = catalogService.RefreshCatalogIfStale(
+            [&](std::string &onlineListData) {
+              initialCatalogResult = gdtfClient.GetCatalog();
+              gdtfWorkflowState.lastCatalogResult = initialCatalogResult;
+              onlineListData = initialCatalogResult.payload;
+              return initialCatalogResult.Succeeded() &&
+                     !onlineListData.empty();
+            },
+            nowUtc, 0);
+      }
+      accessAction = gdtf_share_workflow::DetermineCatalogAccessAction(
+          false, gdtfWorkflowState.credentialAvailability,
+          gdtfWorkflowState.lastAuthenticationResult,
+          catalogResult.snapshot.has_value(), catalogAuthenticationCancelled);
+    }
+
+    if (!catalogResult.snapshot) {
+      const std::string detail = gdtfWorkflowState.lastCatalogResult
+          ? gdtfWorkflowState.lastCatalogResult->message
+          : (gdtfWorkflowState.lastAuthenticationResult
+                 ? gdtfWorkflowState.lastAuthenticationResult->message
+                 : catalogResult.failureMessage);
+      diagnostics::DiagnosticLogger::Error(
+          "GDTF online catalog resolution failed; search dialog not opened: " +
+          detail);
+      wxMessageBox(
+          _("The GDTF catalog could not be loaded. Check your Internet connection and GDTF Share credentials."),
+          _("GDTF catalog unavailable"), wxOK | wxICON_ERROR, this);
+      return;
+    }
+  }
 
   const auto catalogResolveElapsedMs =
       std::chrono::duration_cast<std::chrono::milliseconds>(

--- a/tests/gdtf_share_security_test.cpp
+++ b/tests/gdtf_share_security_test.cpp
@@ -276,6 +276,31 @@ void TestWorkflowPromptDecisions() {
            CredentialPromptReason::RejectedCredentials);
     assert(PromptReasonForAuthenticationResult(true, transport, true) ==
            CredentialPromptReason::ExpiredSession);
+
+    assert(DetermineCatalogAccessAction(false, CredentialAvailability::None,
+                                        std::nullopt, false) ==
+           CatalogAccessAction::RequestCredentials);
+    assert(DetermineCatalogAccessAction(true, CredentialAvailability::None,
+                                        std::nullopt, false) ==
+           CatalogAccessAction::OpenCachedCatalog);
+    assert(DetermineCatalogAccessAction(false, CredentialAvailability::Complete,
+                                        rejected, false) ==
+           CatalogAccessAction::RequestCredentials);
+    assert(DetermineCatalogAccessAction(true, CredentialAvailability::Complete,
+                                        rejected, false) ==
+           CatalogAccessAction::OpenCachedCatalog);
+    assert(DetermineCatalogAccessAction(false, CredentialAvailability::Complete,
+                                        std::nullopt, true) ==
+           CatalogAccessAction::OpenOnlineCatalog);
+    assert(DetermineCatalogAccessAction(false, CredentialAvailability::Complete,
+                                        transport, false) ==
+           CatalogAccessAction::ReportCatalogFailure);
+    assert(DetermineCatalogAccessAction(false, CredentialAvailability::None,
+                                        std::nullopt, false, true) ==
+           CatalogAccessAction::Cancel);
+    assert(DetermineCatalogAccessAction(true, CredentialAvailability::Complete,
+                                        transport, false) ==
+           CatalogAccessAction::OpenCachedCatalog);
 }
 
 // Verifies credential storage orchestration and metadata omit passwords.


### PR DESCRIPTION
### Motivation

- Fix a broken workflow where selecting `Tools → Download GDTF` with no cached catalog and missing/invalid credentials could open an unusable empty `GdtfSearchDialog` instead of requesting sign-in.
- Ensure the UX follows the documented flow: request credentials when no cache is present, then load and cache the online catalog and open the dialog only on success.

### Description

- Add a small GUI-independent decision model `CatalogAccessAction` and `DetermineCatalogAccessAction` in `core/gdtf_share_workflow.h` to decide whether to open cached/online catalog, prompt for credentials, report failure, or cancel.
- Update `MainWindow::OnDownloadGdtf` in `gui/mainwindow_menu.cpp` to: prompt the existing `GdtfLoginDialog` when no usable cache exists, retry on rejected credentials, avoid opening `GdtfSearchDialog` when catalog resolution fails or authentication is cancelled, log structured diagnostics, and reuse the authenticated `GdtfShareClient` session for subsequent download attempts.
- Preserve cached-catalog browsing without forcing authentication and preserve secure-persistence semantics, including showing a friendly warning when secure-store persistence fails (without logging secrets). Also preserve username-hint behavior when available.
- Add deterministic unit assertions in `tests/gdtf_share_security_test.cpp` to cover catalog-access decision outcomes (request credentials, open cached, report failure, cancel, open online) and extend test coverage for the workflow decisions.
- Update user documentation `docs/user/gdtf-download.md` and `docs/release-notes-draft.md` to describe the pre-catalog sign-in, clean cancellation, and offline cached-browsing behavior.

### Testing

- Added assertions in `tests/gdtf_share_security_test.cpp` covering `DetermineCatalogAccessAction(...)` and existing credential/workflow decisions; a local syntax-only compile of the test file succeeded (`g++ -std=c++20 -fsyntax-only tests/gdtf_share_security_test.cpp` with appropriate include paths).
- Ran repository checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`; both returned OK locally.
- Ran `git diff --check` and repository style checks prior to committing; no blocking diffs prevented the commit.
- Full CMake configuration/build and running of the test suite could not be completed in this environment because the system wxWidgets development libraries/headers are not available, so integration builds and linked test execution were not run here (CMake configuration failed due to missing `wxWidgets`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8d8e662afc832489df7758bb7b522f)