### PR TITLE
Suggest current project name when exporting MVR

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -4,6 +4,10 @@ Changes since **v1.5.0**.
 
 ## Highlights
 
+- Export MVR now suggests the current project name as the destination file
+  name, matching the Save Project workflow while still allowing it to be
+  changed before export.
+
 - Textures, images, and external binary buffers used by 3DS and glTF geometry
   now survive MVR export and re-import, while dependencies of deleted models
   continue to be removed and filename collisions fail safely instead of

--- a/docs/user/opening-mvr-files.md
+++ b/docs/user/opening-mvr-files.md
@@ -68,7 +68,8 @@ Perastage fixture categories are also stored in root-level `UserData/Data` with 
 When your changes are ready for exchange:
 
 1. Open **File → Export MVR...**.
-2. Choose destination and file name.
+2. Choose the destination. The file name initially matches the current project
+   name when one is available.
 3. Export the updated scene.
 
 ## Practical tip

--- a/gui/mainwindow_io.cpp
+++ b/gui/mainwindow_io.cpp
@@ -78,6 +78,16 @@ std::string Utf8StringFromPath(const std::filesystem::path &path) {
   return std::string(utf8.begin(), utf8.end());
 }
 
+// Returns the current project name suitable for a suggested output file name.
+wxString SuggestedProjectFileBaseName(const std::string &projectPath,
+                                      const wxString &projectDisplayName) {
+  if (!projectPath.empty())
+    return wxFileName(wxString::FromUTF8(projectPath)).GetName();
+  if (!projectDisplayName.IsEmpty() && projectDisplayName != "Untitled")
+    return projectDisplayName;
+  return {};
+}
+
 // Copies a generated fixture GDTF into the project MVR root and returns its
 // archive-relative file name.
 bool CopyFixtureGdtfIntoProject(const std::filesystem::path &sourcePath,
@@ -365,16 +375,11 @@ void MainWindow::OnSaveAs(wxCommandEvent &event) {
     projDir =
         wxString::FromUTF8(ProjectUtils::GetWritableLibraryPath("projects"));
 
-  wxString suggestedProjectName;
-  if (!currentProjectPath.empty()) {
-    suggestedProjectName =
-        wxFileName(wxString::FromUTF8(currentProjectPath)).GetName();
-  } else if (!currentProjectDisplayName.IsEmpty() &&
-             currentProjectDisplayName != "Untitled") {
-    suggestedProjectName = currentProjectDisplayName;
-  }
+  const wxString suggestedProjectName = SuggestedProjectFileBaseName(
+      currentProjectPath, currentProjectDisplayName);
   const wxString suggestedFileName =
-      suggestedProjectName.IsEmpty() ? wxString() : suggestedProjectName + projectExtension;
+      suggestedProjectName.IsEmpty() ? wxString()
+                                     : suggestedProjectName + projectExtension;
 
   wxFileDialog dlg(this, "Save Project", projDir, suggestedFileName, filter,
                    wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
@@ -558,8 +563,13 @@ void MainWindow::OnExportMVR(wxCommandEvent &event) {
   diagnostics::DiagnosticLogger::Info("MVR export requested.");
   wxString miscDir =
       wxString::FromUTF8(ProjectUtils::GetWritableLibraryPath("misc"));
-  wxFileDialog saveFileDialog(this, "Export MVR file", miscDir, "",
-                              "MVR files (*.mvr)|*.mvr",
+  const wxString suggestedProjectName = SuggestedProjectFileBaseName(
+      currentProjectPath, currentProjectDisplayName);
+  const wxString suggestedFileName = suggestedProjectName.IsEmpty()
+                                         ? wxString()
+                                         : suggestedProjectName + ".mvr";
+  wxFileDialog saveFileDialog(this, "Export MVR file", miscDir,
+                              suggestedFileName, "MVR files (*.mvr)|*.mvr",
                               wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
 
   if (saveFileDialog.ShowModal() == wxID_CANCEL)


### PR DESCRIPTION
### Motivation
- Make the MVR export dialog pre-fill the destination file name with the current project name to match the existing Save Project workflow and reduce repetitive typing.
- Keep the existing behavior for unnamed projects ("Untitled") and allow the suggested name to be changed before export.

### Description
- Add a small helper `SuggestedProjectFileBaseName` in `gui/mainwindow_io.cpp` to derive a suggested base name from `currentProjectPath` or `currentProjectDisplayName`.\
- Use the helper to pre-fill the `Save Project` and `Export MVR` dialogs, and append the `.mvr` extension for MVR exports.\
- Add an English one-line comment above the new helper function as required for C++ files.\
- Update user docs `docs/user/opening-mvr-files.md` and the release notes `docs/release-notes-draft.md` to document the new behavior.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which succeeded.\
- Ran `tests/check_no_configmanager_get_in_gui.sh` which succeeded.\
- Ran `git diff --check` which reported no issues.\
- Attempted `cmake --preset wsl-x64-debug` for a full configure but it could not complete in this environment due to missing wxWidgets development files (environment limitation, not a code failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8d933d738883248ce282989e5f4d7c)