### PR TITLE
Improve topology-aware automatic DMX patching

### DIFF
--- a/core/autopatcher.cpp
+++ b/core/autopatcher.cpp
@@ -19,7 +19,12 @@
 #include "gdtfloader.h"
 #include "patchmanager.h"
 #include <algorithm>
+#include <cctype>
+#include <cmath>
 #include <filesystem>
+#include <limits>
+#include <map>
+#include <numeric>
 #include <optional>
 #include <string>
 #include <unordered_set>
@@ -30,10 +35,52 @@ namespace fs = std::filesystem;
 namespace AutoPatcher {
 namespace {
 
+constexpr double kCoordinateNoiseFloor = 0.01;
+constexpr double kComponentGapFactor = 3.0;
+
+enum class Orientation { Transverse, Longitudinal };
+enum class PatchTraversalMode { Serpentine, SameDirection };
+
+struct FixturePatchInfo {
+  std::string uuid;
+  int channels = 0;
+  double x = 0.0;
+  double y = 0.0;
+  std::string type;
+};
+
+struct FixtureTypeGroup {
+  std::string type;
+  std::vector<FixturePatchInfo *> fixtures;
+  int channels = 0;
+};
+
+struct PhysicalPatchComponent {
+  std::vector<FixturePatchInfo *> fixtures;
+  std::vector<FixtureTypeGroup> typeGroups;
+  Orientation orientation = Orientation::Transverse;
+  bool reverseTraversal = false;
+  double centerX = 0.0;
+  double centerY = 0.0;
+  int channels = 0;
+};
+
+struct LogicalPatchPosition {
+  std::string key;
+  std::vector<FixturePatchInfo *> fixtures;
+  std::vector<PhysicalPatchComponent> components;
+  Orientation orientation = Orientation::Transverse;
+  double centerX = 0.0;
+  double centerY = 0.0;
+  int channels = 0;
+};
+
+// Parses a stored universe.channel patch address.
 std::optional<PatchManager::PatchAddress>
 ParsePatchAddress(const std::string &address) {
   const size_t dotPos = address.find('.');
-  if (dotPos == std::string::npos || dotPos == 0 || dotPos + 1 >= address.size())
+  if (dotPos == std::string::npos || dotPos == 0 ||
+      dotPos + 1 >= address.size())
     return std::nullopt;
 
   try {
@@ -47,157 +94,388 @@ ParsePatchAddress(const std::string &address) {
   }
 }
 
+// Resolves a fixture's footprint from its GDTF mode with a safe fallback.
 int ResolveFixtureChannelCount(const MvrScene &scene, const Fixture &fixture) {
   std::string fullPath;
   if (!fixture.gdtfSpec.empty()) {
-    fs::path p = scene.basePath.empty()
-                     ? fs::path(fixture.gdtfSpec)
-                     : fs::path(scene.basePath) / fixture.gdtfSpec;
-    fullPath = p.string();
+    const fs::path path = scene.basePath.empty()
+                              ? fs::path(fixture.gdtfSpec)
+                              : fs::path(scene.basePath) / fixture.gdtfSpec;
+    fullPath = path.string();
   }
-  int channelCount = GetGdtfModeChannelCount(fullPath, fixture.gdtfMode);
+  const int channelCount = GetGdtfModeChannelCount(fullPath, fixture.gdtfMode);
   return channelCount > 0 ? channelCount : 1;
 }
 
-std::optional<PatchManager::PatchAddress>
-FindNextAddressAfterHighestPatchedFixture(const MvrScene &scene,
-                                          const std::unordered_set<std::string> &ignoredUuids) {
-  int highestAbsoluteEnd = 0;
+// Normalizes a display name for deterministic fallback position identity.
+std::string NormalizePositionName(const std::string &name) {
+  std::string normalized;
+  bool pendingSpace = false;
+  for (const unsigned char value : name) {
+    if (std::isspace(value)) {
+      pendingSpace = !normalized.empty();
+      continue;
+    }
+    if (pendingSpace) {
+      normalized.push_back(' ');
+      pendingSpace = false;
+    }
+    normalized.push_back(static_cast<char>(std::toupper(value)));
+  }
+  return normalized;
+}
 
+// Selects the standards-based logical Position identity with safe fallbacks.
+std::string LogicalPositionKey(const Fixture &fixture) {
+  if (!fixture.position.empty())
+    return "uuid:" + fixture.position;
+  const std::string normalizedName =
+      NormalizePositionName(fixture.positionName);
+  if (!normalizedName.empty())
+    return "name:" + normalizedName;
+  // A noise-tolerant Y row preserves the old front-to-back behavior without
+  // pretending that every metadata-free fixture shares one semantic Position.
+  const auto coordinates = fixture.GetPosition();
+  const long long row =
+      std::llround(static_cast<double>(coordinates[1]) / kCoordinateNoiseFloor);
+  return "legacy-row:" + std::to_string(row);
+}
+
+// Calculates planar distance between two patch fixtures.
+double Distance(const FixturePatchInfo &a, const FixturePatchInfo &b) {
+  return std::hypot(a.x - b.x, a.y - b.y);
+}
+
+// Detects disconnected structures by cutting anomalously long MST edges.
+std::vector<std::vector<FixturePatchInfo *>>
+ClusterPhysicalComponents(const std::vector<FixturePatchInfo *> &fixtures) {
+  if (fixtures.size() < 3)
+    return {fixtures};
+
+  struct Edge {
+    size_t a = 0;
+    size_t b = 0;
+    double distance = 0.0;
+  };
+
+  std::vector<double> nearest(fixtures.size(),
+                              std::numeric_limits<double>::max());
+  for (size_t i = 0; i < fixtures.size(); ++i) {
+    for (size_t j = i + 1; j < fixtures.size(); ++j) {
+      const double distance = Distance(*fixtures[i], *fixtures[j]);
+      if (distance > kCoordinateNoiseFloor) {
+        nearest[i] = std::min(nearest[i], distance);
+        nearest[j] = std::min(nearest[j], distance);
+      }
+    }
+  }
+  nearest.erase(std::remove_if(nearest.begin(), nearest.end(),
+                               [](double value) {
+                                 return !std::isfinite(value) ||
+                                        value ==
+                                            std::numeric_limits<double>::max();
+                               }),
+                nearest.end());
+  if (nearest.empty())
+    return {fixtures};
+  std::sort(nearest.begin(), nearest.end());
+  const double localSpacing = nearest[nearest.size() / 2];
+  const double cutThreshold =
+      std::max(kCoordinateNoiseFloor, localSpacing * kComponentGapFactor);
+
+  std::vector<bool> included(fixtures.size(), false);
+  std::vector<Edge> mst;
+  included[0] = true;
+  for (size_t count = 1; count < fixtures.size(); ++count) {
+    Edge best{0, 0, std::numeric_limits<double>::max()};
+    for (size_t i = 0; i < fixtures.size(); ++i) {
+      if (!included[i])
+        continue;
+      for (size_t j = 0; j < fixtures.size(); ++j) {
+        if (included[j])
+          continue;
+        const double distance = Distance(*fixtures[i], *fixtures[j]);
+        if (distance < best.distance ||
+            (std::abs(distance - best.distance) <= kCoordinateNoiseFloor &&
+             fixtures[j]->uuid < fixtures[best.b]->uuid))
+          best = {i, j, distance};
+      }
+    }
+    included[best.b] = true;
+    mst.push_back(best);
+  }
+
+  std::vector<size_t> parent(fixtures.size());
+  std::iota(parent.begin(), parent.end(), 0);
+  const auto findRoot = [&parent](size_t value) {
+    size_t root = value;
+    while (parent[root] != root)
+      root = parent[root];
+    while (parent[value] != value) {
+      const size_t next = parent[value];
+      parent[value] = root;
+      value = next;
+    }
+    return root;
+  };
+  for (const Edge &edge : mst) {
+    if (edge.distance <= cutThreshold) {
+      const size_t a = findRoot(edge.a);
+      const size_t b = findRoot(edge.b);
+      parent[b] = a;
+    }
+  }
+
+  std::map<size_t, std::vector<FixturePatchInfo *>> clusters;
+  for (size_t i = 0; i < fixtures.size(); ++i)
+    clusters[findRoot(i)].push_back(fixtures[i]);
+  std::vector<std::vector<FixturePatchInfo *>> result;
+  for (auto &[root, cluster] : clusters) {
+    (void)root;
+    std::sort(cluster.begin(), cluster.end(),
+              [](const auto *a, const auto *b) { return a->uuid < b->uuid; });
+    result.push_back(std::move(cluster));
+  }
+  return result;
+}
+
+// Classifies a component by its dominant planar range.
+Orientation
+ClassifyOrientation(const std::vector<FixturePatchInfo *> &fixtures) {
+  double minX = fixtures.front()->x;
+  double maxX = minX;
+  double minY = fixtures.front()->y;
+  double maxY = minY;
+  for (const FixturePatchInfo *fixture : fixtures) {
+    minX = std::min(minX, fixture->x);
+    maxX = std::max(maxX, fixture->x);
+    minY = std::min(minY, fixture->y);
+    maxY = std::max(maxY, fixture->y);
+  }
+  return maxY - minY > maxX - minX + kCoordinateNoiseFloor
+             ? Orientation::Longitudinal
+             : Orientation::Transverse;
+}
+
+// Builds stable type groups and orders each group along the component axis.
+void BuildFixtureTypeGroups(PhysicalPatchComponent &component) {
+  std::map<std::string, std::vector<FixturePatchInfo *>> byType;
+  for (FixturePatchInfo *fixture : component.fixtures)
+    byType[fixture->type].push_back(fixture);
+
+  for (auto &[type, fixtures] : byType) {
+    std::sort(
+        fixtures.begin(), fixtures.end(), [&](const auto *a, const auto *b) {
+          const double primaryA =
+              component.orientation == Orientation::Transverse ? a->x : a->y;
+          const double primaryB =
+              component.orientation == Orientation::Transverse ? b->x : b->y;
+          if (std::abs(primaryA - primaryB) > kCoordinateNoiseFloor)
+            return component.reverseTraversal ? primaryA > primaryB
+                                              : primaryA < primaryB;
+          const double secondaryA =
+              component.orientation == Orientation::Transverse ? a->y : a->x;
+          const double secondaryB =
+              component.orientation == Orientation::Transverse ? b->y : b->x;
+          if (std::abs(secondaryA - secondaryB) > kCoordinateNoiseFloor)
+            return secondaryA < secondaryB;
+          return a->uuid < b->uuid;
+        });
+    FixtureTypeGroup group{type, std::move(fixtures), 0};
+    for (const FixturePatchInfo *fixture : group.fixtures)
+      group.channels += fixture->channels;
+    component.typeGroups.push_back(std::move(group));
+  }
+}
+
+// Builds topology and applies the isolated component traversal policy.
+void BuildPhysicalComponents(LogicalPatchPosition &position,
+                             PatchTraversalMode traversalMode) {
+  for (auto &cluster : ClusterPhysicalComponents(position.fixtures)) {
+    PhysicalPatchComponent component;
+    component.fixtures = std::move(cluster);
+    component.orientation = ClassifyOrientation(component.fixtures);
+    for (const FixturePatchInfo *fixture : component.fixtures) {
+      component.centerX += fixture->x;
+      component.centerY += fixture->y;
+      component.channels += fixture->channels;
+    }
+    component.centerX /= component.fixtures.size();
+    component.centerY /= component.fixtures.size();
+    position.components.push_back(std::move(component));
+  }
+
+  const size_t longitudinalCount = std::count_if(
+      position.components.begin(), position.components.end(),
+      [](const auto &c) { return c.orientation == Orientation::Longitudinal; });
+  position.orientation = longitudinalCount * 2 >= position.components.size()
+                             ? Orientation::Longitudinal
+                             : Orientation::Transverse;
+  std::sort(position.components.begin(), position.components.end(),
+            [&](const auto &a, const auto &b) {
+              const double primaryA =
+                  position.orientation == Orientation::Longitudinal ? a.centerX
+                                                                    : a.centerY;
+              const double primaryB =
+                  position.orientation == Orientation::Longitudinal ? b.centerX
+                                                                    : b.centerY;
+              if (std::abs(primaryA - primaryB) > kCoordinateNoiseFloor)
+                return primaryA < primaryB;
+              if (std::abs(a.centerX - b.centerX) > kCoordinateNoiseFloor)
+                return a.centerX < b.centerX;
+              return a.fixtures.front()->uuid < b.fixtures.front()->uuid;
+            });
+  for (size_t i = 0; i < position.components.size(); ++i) {
+    position.components[i].reverseTraversal =
+        traversalMode == PatchTraversalMode::Serpentine && i % 2 == 1;
+    BuildFixtureTypeGroups(position.components[i]);
+  }
+}
+
+// Collects fixtures and groups them by standard Position identity.
+std::vector<LogicalPatchPosition>
+BuildLogicalPatchPositions(MvrScene &scene,
+                           std::vector<FixturePatchInfo> &fixtureStorage) {
+  std::vector<std::string> uuids;
+  uuids.reserve(scene.fixtures.size());
+  for (const auto &[uuid, fixture] : scene.fixtures) {
+    (void)fixture;
+    uuids.push_back(uuid);
+  }
+  std::sort(uuids.begin(), uuids.end());
+
+  std::map<std::string, std::vector<FixturePatchInfo *>> grouped;
+  for (const std::string &uuid : uuids) {
+    const Fixture &fixture = scene.fixtures.at(uuid);
+    const int channels = ResolveFixtureChannelCount(scene, fixture);
+    const auto coordinates = fixture.GetPosition();
+    fixtureStorage.push_back(
+        {uuid, channels, coordinates[0], coordinates[1], fixture.typeName});
+    grouped[LogicalPositionKey(fixture)].push_back(&fixtureStorage.back());
+  }
+
+  std::vector<LogicalPatchPosition> positions;
+  for (auto &[key, fixtures] : grouped) {
+    LogicalPatchPosition position;
+    position.key = key;
+    position.fixtures = std::move(fixtures);
+    for (const FixturePatchInfo *fixture : position.fixtures) {
+      position.centerX += fixture->x;
+      position.centerY += fixture->y;
+      position.channels += fixture->channels;
+    }
+    position.centerX /= position.fixtures.size();
+    position.centerY /= position.fixtures.size();
+    BuildPhysicalComponents(position, PatchTraversalMode::Serpentine);
+    positions.push_back(std::move(position));
+  }
+
+  std::sort(positions.begin(), positions.end(),
+            [](const auto &a, const auto &b) {
+              if (a.orientation != b.orientation)
+                return a.orientation == Orientation::Transverse;
+              if (std::abs(a.centerY - b.centerY) > kCoordinateNoiseFloor)
+                return a.centerY < b.centerY;
+              if (std::abs(a.centerX - b.centerX) > kCoordinateNoiseFloor)
+                return a.centerX < b.centerX;
+              return a.key < b.key;
+            });
+  return positions;
+}
+
+// Advances to a fresh universe when a protected block cannot fit completely.
+void ProtectBlock(int blockChannels, int &universe, int &channel) {
+  if (blockChannels <= 512 && channel + blockChannels - 1 > 512) {
+    ++universe;
+    channel = 1;
+  }
+}
+
+// Assigns one fixture without allowing it to cross a universe boundary.
+void AssignFixture(MvrScene &scene, const FixturePatchInfo &fixture,
+                   int &universe, int &channel) {
+  if (channel + fixture.channels - 1 > 512) {
+    ++universe;
+    channel = 1;
+  }
+  scene.fixtures.at(fixture.uuid).address =
+      std::to_string(universe) + "." + std::to_string(channel);
+  channel += fixture.channels;
+  if (channel > 512) {
+    ++universe;
+    channel = 1;
+  }
+}
+
+// Packs logical positions with position, component, and type protection levels.
+void PackLogicalPositions(MvrScene &scene,
+                          const std::vector<LogicalPatchPosition> &positions,
+                          int startUniverse, int startChannel) {
+  int universe = std::max(1, startUniverse);
+  int channel = std::clamp(startChannel, 1, 512);
+  for (const LogicalPatchPosition &position : positions) {
+    ProtectBlock(position.channels, universe, channel);
+    for (const PhysicalPatchComponent &component : position.components) {
+      if (position.channels > 512)
+        ProtectBlock(component.channels, universe, channel);
+      for (const FixtureTypeGroup &group : component.typeGroups) {
+        if (component.channels > 512)
+          ProtectBlock(group.channels, universe, channel);
+        for (const FixturePatchInfo *fixture : group.fixtures)
+          AssignFixture(scene, *fixture, universe, channel);
+      }
+    }
+  }
+}
+
+// Finds the first address after every fixture not included in a selection.
+std::optional<PatchManager::PatchAddress>
+FindNextAddressAfterHighestPatchedFixture(
+    const MvrScene &scene,
+    const std::unordered_set<std::string> &ignoredUuids) {
+  int highestAbsoluteEnd = 0;
   for (const auto &[uuid, fixture] : scene.fixtures) {
     if (ignoredUuids.contains(uuid))
       continue;
-    const std::optional<PatchManager::PatchAddress> startAddress =
-        ParsePatchAddress(fixture.address);
+    const auto startAddress = ParsePatchAddress(fixture.address);
     if (!startAddress)
       continue;
-
-    const int channelCount = ResolveFixtureChannelCount(scene, fixture);
-    const int absoluteStart = (startAddress->universe - 1) * 512 + startAddress->channel;
-    const int absoluteEnd = absoluteStart + channelCount - 1;
-    highestAbsoluteEnd = std::max(highestAbsoluteEnd, absoluteEnd);
+    const int absoluteStart =
+        (startAddress->universe - 1) * 512 + startAddress->channel;
+    highestAbsoluteEnd = std::max(
+        highestAbsoluteEnd,
+        absoluteStart + ResolveFixtureChannelCount(scene, fixture) - 1);
   }
-
   if (highestAbsoluteEnd <= 0)
     return PatchManager::PatchAddress{1, 1};
-
   const int nextAbsolute = highestAbsoluteEnd + 1;
-  const int universe = ((nextAbsolute - 1) / 512) + 1;
-  const int channel = ((nextAbsolute - 1) % 512) + 1;
-  return PatchManager::PatchAddress{universe, channel};
+  return PatchManager::PatchAddress{((nextAbsolute - 1) / 512) + 1,
+                                    ((nextAbsolute - 1) % 512) + 1};
 }
+
 } // namespace
 
+// Automatically patches fixtures using logical and physical rig topology.
 void AutoPatch(MvrScene &scene, int startUniverse, int startChannel) {
-  struct FixtureInfo {
-    std::string uuid;
-    int channels;
-    float x;
-    float y;
-    std::string type;
-    std::string hang;
-  };
-
-  std::vector<FixtureInfo> fixtures;
-  fixtures.reserve(scene.fixtures.size());
-
-  for (auto &pair : scene.fixtures) {
-    auto &f = pair.second;
-    std::string fullPath;
-    if (!f.gdtfSpec.empty()) {
-      fs::path p = scene.basePath.empty()
-                       ? fs::path(f.gdtfSpec)
-                       : fs::path(scene.basePath) / f.gdtfSpec;
-      fullPath = p.string();
-    }
-    int chCount = GetGdtfModeChannelCount(fullPath, f.gdtfMode);
-    if (chCount <= 0)
-      continue; // skip fixtures without a valid channel count
-    auto pos = f.GetPosition();
-    fixtures.push_back(
-        {pair.first, chCount, pos[0], pos[1], f.typeName, f.positionName});
-  }
-
-  std::sort(fixtures.begin(), fixtures.end(),
-            [](const FixtureInfo &a, const FixtureInfo &b) {
-              if (a.y == b.y) {
-                if (a.hang == b.hang) {
-                  if (a.type == b.type)
-                    return a.x < b.x;
-                  return a.type < b.type;
-                }
-                return a.hang < b.hang;
-              }
-              return a.y < b.y;
-            });
-
-  struct Group {
-    std::vector<size_t> indices;
-    int total = 0;
-  };
-
-  std::vector<Group> groups;
-  // Reserve upfront to avoid repeated reallocations when processing large
-  // rigs where fixtures.size() can be in the hundreds.
-  groups.reserve(fixtures.size());
-  for (size_t i = 0; i < fixtures.size(); ++i) {
-    const auto &f = fixtures[i];
-    if (groups.empty()) {
-      groups.push_back({{i}, f.channels});
-      continue;
-    }
-
-    const auto &last = fixtures[groups.back().indices.front()];
-    if (last.hang == f.hang && last.type == f.type) {
-      groups.back().indices.push_back(i);
-      groups.back().total += f.channels;
-    } else {
-      groups.push_back({{i}, f.channels});
-    }
-  }
-
-  int uni = startUniverse < 1 ? 1 : startUniverse;
-  int ch = startChannel < 1 ? 1 : startChannel;
-
-  for (const auto &g : groups) {
-    if (g.total <= 512 && ch + g.total - 1 > 512) {
-      ++uni;
-      ch = 1;
-    }
-
-    for (size_t idx : g.indices) {
-      const auto &f = fixtures[idx];
-      if (ch + f.channels - 1 > 512) {
-        ++uni;
-        ch = 1;
-      }
-
-      scene.fixtures[f.uuid].address =
-          std::to_string(uni) + "." + std::to_string(ch);
-
-      ch += f.channels;
-      if (ch > 512) {
-        ++uni;
-        ch = 1;
-      }
-    }
-  }
+  std::vector<FixturePatchInfo> fixtureStorage;
+  fixtureStorage.reserve(scene.fixtures.size());
+  const std::vector<LogicalPatchPosition> positions =
+      BuildLogicalPatchPositions(scene, fixtureStorage);
+  PackLogicalPositions(scene, positions, startUniverse, startChannel);
 }
 
+// Re-patches selected fixtures in their exact user-provided order.
 void AutoPatchSelection(MvrScene &scene,
                         const std::vector<std::string> &selectionOrder) {
   if (selectionOrder.empty())
     return;
-
   std::unordered_set<std::string> uniqueSelection(selectionOrder.begin(),
                                                   selectionOrder.end());
-
-  for (const auto &uuid : uniqueSelection) {
+  for (const std::string &uuid : uniqueSelection) {
     auto fixtureIt = scene.fixtures.find(uuid);
     if (fixtureIt != scene.fixtures.end())
       fixtureIt->second.address.clear();
   }
-
   const auto nextStart =
       FindNextAddressAfterHighestPatchedFixture(scene, uniqueSelection);
   if (!nextStart)
@@ -205,33 +483,25 @@ void AutoPatchSelection(MvrScene &scene,
 
   std::vector<int> channelCounts;
   std::vector<std::string> orderedFixtureUuids;
-  channelCounts.reserve(selectionOrder.size());
-  orderedFixtureUuids.reserve(selectionOrder.size());
-
   std::unordered_set<std::string> seen;
-  for (const auto &uuid : selectionOrder) {
+  for (const std::string &uuid : selectionOrder) {
     if (!seen.insert(uuid).second)
       continue;
-
     const auto fixtureIt = scene.fixtures.find(uuid);
     if (fixtureIt == scene.fixtures.end())
       continue;
-
     orderedFixtureUuids.push_back(uuid);
-    channelCounts.push_back(ResolveFixtureChannelCount(scene, fixtureIt->second));
+    channelCounts.push_back(
+        ResolveFixtureChannelCount(scene, fixtureIt->second));
   }
-
-  if (orderedFixtureUuids.empty())
-    return;
-
   const std::vector<PatchManager::PatchAddress> addresses =
       PatchManager::SequentialPatch(channelCounts, nextStart->universe,
                                     nextStart->channel);
-
-  for (size_t i = 0; i < orderedFixtureUuids.size() && i < addresses.size(); ++i) {
-    const auto &patch = addresses[i];
+  for (size_t i = 0; i < orderedFixtureUuids.size() && i < addresses.size();
+       ++i) {
     scene.fixtures[orderedFixtureUuids[i]].address =
-        std::to_string(patch.universe) + "." + std::to_string(patch.channel);
+        std::to_string(addresses[i].universe) + "." +
+        std::to_string(addresses[i].channel);
   }
 }
 

--- a/core/autopatcher.h
+++ b/core/autopatcher.h
@@ -22,12 +22,10 @@
 #include <vector>
 
 namespace AutoPatcher {
-// Automatically assign DMX addresses to fixtures in the scene.
-// Fixtures are grouped by hang position and type to keep identical fixtures
-// together. Groups are patched sequentially starting at the given universe and
-// channel, advancing to a new universe when a whole group would otherwise be
-// split. The order is front-to-back (Y axis), then by hang position, then by
-// type, and finally left-to-right (X axis).
+// Automatically assign DMX addresses by Position, physical component, and type.
+// Transverse Positions run front-to-back before longitudinal Positions, while
+// disconnected parallel components use a deterministic serpentine traversal.
+// Positions and components that fit one universe are kept intact when possible.
 void AutoPatch(MvrScene &scene, int startUniverse = 1, int startChannel = 1);
 
 // Re-patch only the selected fixtures in the exact order provided by

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -4,6 +4,11 @@ Changes since **v1.5.0**.
 
 ## Highlights
 
+- Automatic DMX patching now keeps logical lighting Positions and their
+  physically separate bridge components together whenever universe capacity
+  allows, including deterministic serpentine patching for parallel side
+  structures without relying on position names.
+
 - Export MVR now suggests the current project name as the destination file
   name, matching the Save Project workflow while still allowing it to be
   changed before export.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -914,6 +914,13 @@ target_include_directories(autopatcher_universe_wrap_test PRIVATE ../core ../mod
 add_test(NAME AutoPatchUniverseWrap COMMAND autopatcher_universe_wrap_test)
 set_library_env(AutoPatchUniverseWrap)
 
+add_executable(autopatcher_topology_test autopatcher_topology_test.cpp
+               ../core/autopatcher.cpp
+               ../core/patchmanager.cpp)
+target_include_directories(autopatcher_topology_test PRIVATE ../core ../models ../viewer3d)
+add_test(NAME AutoPatchTopology COMMAND autopatcher_topology_test)
+set_library_env(AutoPatchTopology)
+
 add_executable(save_load_roundtrip_test save_load_roundtrip_test.cpp
                support/gdtf_test_fixture_builder.cpp
                build_info_stub.cpp

--- a/tests/autopatcher_topology_test.cpp
+++ b/tests/autopatcher_topology_test.cpp
@@ -1,0 +1,234 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "autopatcher.h"
+#include "fixture.h"
+#include "mvrscene.h"
+#include <algorithm>
+#include <cassert>
+#include <map>
+#include <string>
+#include <vector>
+
+// Supplies deterministic fixture footprints without requiring GDTF archives.
+int GetGdtfModeChannelCount(const std::string &, const std::string &mode) {
+  return mode.empty() ? 1 : std::stoi(mode);
+}
+
+namespace {
+
+// Adds a compact test fixture with explicit topology and channel metadata.
+void AddFixture(MvrScene &scene, const std::string &uuid,
+                const std::string &positionUuid,
+                const std::string &positionName, const std::string &type,
+                float x, float y, int channels) {
+  Fixture fixture;
+  fixture.uuid = uuid;
+  fixture.position = positionUuid;
+  fixture.positionName = positionName;
+  fixture.typeName = type;
+  fixture.gdtfMode = std::to_string(channels);
+  fixture.transform.o[0] = x;
+  fixture.transform.o[1] = y;
+  scene.fixtures[uuid] = fixture;
+}
+
+// Parses an address into universe and channel values for assertions.
+std::pair<int, int> Address(const Fixture &fixture) {
+  const size_t separator = fixture.address.find('.');
+  assert(separator != std::string::npos);
+  return {std::stoi(fixture.address.substr(0, separator)),
+          std::stoi(fixture.address.substr(separator + 1))};
+}
+
+// Captures all addresses by UUID independently of unordered insertion order.
+std::map<std::string, std::string> Addresses(const MvrScene &scene) {
+  std::map<std::string, std::string> result;
+  for (const auto &[uuid, fixture] : scene.fixtures)
+    result[uuid] = fixture.address;
+  return result;
+}
+
+// Creates the representative pair of longitudinal side components.
+void AddSides(MvrScene &scene, int channels = 10, float noise = 0.0f,
+              bool reverseInsertion = false) {
+  struct Entry {
+    std::string uuid;
+    float x;
+    float y;
+  };
+  std::vector<Entry> entries = {
+      {"left-front", -6500.0f, 0.0f},   {"left-mid", -6500.0f, 1000.0f},
+      {"left-back", -6500.0f, 2000.0f}, {"right-front", 6500.0f, 0.0f},
+      {"right-mid", 6500.0f, 1000.0f},  {"right-back", 6500.0f, 2000.0f}};
+  if (reverseInsertion)
+    std::reverse(entries.begin(), entries.end());
+  for (size_t i = 0; i < entries.size(); ++i) {
+    const float coordinateNoise = i % 2 == 0 ? noise : -noise;
+    AddFixture(scene, entries[i].uuid, "side-position", "Arbitrary sides",
+               "Wash", entries[i].x + coordinateNoise,
+               entries[i].y + coordinateNoise, channels);
+  }
+}
+
+// Verifies horizontal type grouping and left-to-right traversal.
+void TestHorizontalTypeGrouping() {
+  MvrScene scene;
+  AddFixture(scene, "spot-left", "horizontal", "Bridge", "Spot", -2, 0, 1);
+  AddFixture(scene, "wash-left", "horizontal", "Bridge", "Wash", -1, 0, 1);
+  AddFixture(scene, "spot-right", "horizontal", "Bridge", "Spot", 2, 0, 1);
+  AddFixture(scene, "wash-right", "horizontal", "Bridge", "Wash", 1, 0, 1);
+  AutoPatcher::AutoPatch(scene);
+  assert(scene.fixtures.at("spot-left").address == "1.1");
+  assert(scene.fixtures.at("spot-right").address == "1.2");
+  assert(scene.fixtures.at("wash-left").address == "1.3");
+  assert(scene.fixtures.at("wash-right").address == "1.4");
+}
+
+// Verifies component detection, coherence, and serpentine traversal.
+void TestLongitudinalComponentsAndDeterminism() {
+  MvrScene scene;
+  AddSides(scene);
+  AutoPatcher::AutoPatch(scene);
+  assert(scene.fixtures.at("left-front").address == "1.1");
+  assert(scene.fixtures.at("left-mid").address == "1.11");
+  assert(scene.fixtures.at("left-back").address == "1.21");
+  assert(scene.fixtures.at("right-back").address == "1.31");
+  assert(scene.fixtures.at("right-mid").address == "1.41");
+  assert(scene.fixtures.at("right-front").address == "1.51");
+  const auto firstPatch = Addresses(scene);
+  AutoPatcher::AutoPatch(scene);
+  assert(Addresses(scene) == firstPatch);
+
+  MvrScene reverseScene;
+  AddSides(reverseScene, 10, 0.0f, true);
+  AutoPatcher::AutoPatch(reverseScene);
+  assert(Addresses(reverseScene) == firstPatch);
+}
+
+// Verifies transverse Positions finish before a spanning longitudinal Position.
+void TestLxPositionsBeforeSides() {
+  MvrScene scene;
+  for (int row = 0; row < 3; ++row) {
+    AddFixture(scene, "lx-" + std::to_string(row),
+               "lx-position-" + std::to_string(row), "Row", "Spot", 0,
+               static_cast<float>(row * 1000), 400);
+  }
+  AddSides(scene, 60);
+  AutoPatcher::AutoPatch(scene);
+  assert(Address(scene.fixtures.at("lx-0")).first == 1);
+  assert(Address(scene.fixtures.at("lx-1")).first == 2);
+  assert(Address(scene.fixtures.at("lx-2")).first == 3);
+  for (const std::string uuid : {"left-front", "left-mid", "left-back",
+                                 "right-front", "right-mid", "right-back"})
+    assert(Address(scene.fixtures.at(uuid)).first == 4);
+}
+
+// Verifies protection of a complete Position that fits one universe.
+void TestCompletePositionProtection() {
+  MvrScene scene;
+  AddFixture(scene, "a", "position", "Position", "Spot", 0, 0, 90);
+  AddFixture(scene, "b", "position", "Position", "Spot", 1, 0, 90);
+  AutoPatcher::AutoPatch(scene, 1, 400);
+  assert(scene.fixtures.at("a").address == "2.1");
+  assert(scene.fixtures.at("b").address == "2.91");
+}
+
+// Verifies component protection when a Position exceeds one universe.
+void TestLargePositionComponentProtection() {
+  MvrScene scene;
+  for (int side = 0; side < 2; ++side) {
+    for (int row = 0; row < 2; ++row)
+      AddFixture(
+          scene,
+          "component-" + std::to_string(side) + "-" + std::to_string(row),
+          "large-position", "Large", "Wash", side == 0 ? -6000.0f : 6000.0f,
+          static_cast<float>(row * 1000), 170);
+  }
+  AutoPatcher::AutoPatch(scene);
+  assert(Address(scene.fixtures.at("component-0-0")).first == 1);
+  assert(Address(scene.fixtures.at("component-0-1")).first == 1);
+  assert(Address(scene.fixtures.at("component-1-0")).first == 2);
+  assert(Address(scene.fixtures.at("component-1-1")).first == 2);
+}
+
+// Verifies unavoidable component splitting preserves fixture boundaries.
+void TestUnavoidableSplit() {
+  MvrScene scene;
+  for (int i = 0; i < 6; ++i)
+    AddFixture(scene, "large-" + std::to_string(i), "one-component", "Long",
+               "Spot", 0, static_cast<float>(i * 1000), 100);
+  AutoPatcher::AutoPatch(scene);
+  for (const auto &[uuid, fixture] : scene.fixtures) {
+    (void)uuid;
+    const auto [universe, channel] = Address(fixture);
+    assert(universe >= 1);
+    assert(channel >= 1 && channel + 99 <= 512);
+  }
+  assert(Address(scene.fixtures.at("large-5")).first == 2);
+}
+
+// Verifies tiny imported coordinate noise does not alter topology or order.
+void TestCoordinateNoise() {
+  MvrScene clean;
+  MvrScene noisy;
+  AddSides(clean);
+  AddSides(noisy, 10, 0.0002f);
+  AutoPatcher::AutoPatch(clean);
+  AutoPatcher::AutoPatch(noisy);
+  assert(Addresses(clean) == Addresses(noisy));
+}
+
+// Verifies UUID identity takes precedence and normalized names remain safe.
+void TestPositionIdentity() {
+  MvrScene uuidScene;
+  AddFixture(uuidScene, "uuid-a", "a-position", "Same", "Spot", 10, 0, 200);
+  AddFixture(uuidScene, "uuid-b", "b-position", "Same", "Spot", -10, 0, 200);
+  AutoPatcher::AutoPatch(uuidScene, 1, 200);
+  assert(Address(uuidScene.fixtures.at("uuid-b")).first == 1);
+  assert(Address(uuidScene.fixtures.at("uuid-a")).first == 2);
+
+  MvrScene fallbackScene;
+  AddFixture(fallbackScene, "name-right", "", " bridge  one ", "Spot", 10, 0,
+             1);
+  AddFixture(fallbackScene, "name-left", "", "BRIDGE ONE", "Spot", -10, 0, 1);
+  AutoPatcher::AutoPatch(fallbackScene);
+  assert(fallbackScene.fixtures.at("name-left").address == "1.1");
+  assert(fallbackScene.fixtures.at("name-right").address == "1.2");
+
+  MvrScene metadataFreeScene;
+  AddFixture(metadataFreeScene, "free-right", "", "", "Spot", 10, 0, 1);
+  AddFixture(metadataFreeScene, "free-left", "", "", "Spot", -10, 0, 1);
+  AutoPatcher::AutoPatch(metadataFreeScene);
+  assert(metadataFreeScene.fixtures.at("free-left").address == "1.1");
+  assert(metadataFreeScene.fixtures.at("free-right").address == "1.2");
+}
+
+} // namespace
+
+// Runs topology-aware global patching regression coverage.
+int main() {
+  TestHorizontalTypeGrouping();
+  TestLongitudinalComponentsAndDeterminism();
+  TestLxPositionsBeforeSides();
+  TestCompletePositionProtection();
+  TestLargePositionComponentProtection();
+  TestUnavoidableSplit();
+  TestCoordinateNoise();
+  TestPositionIdentity();
+  return 0;
+}


### PR DESCRIPTION
### Motivation

- The previous global `AutoPatch()` was driven primarily by exact Y sorting which interleaved fixtures from distinct physical structures that shared a logical MVR Position, causing unnecessary universe fragmentation for coherent bridges (e.g. paired side bridges).
- The intent is to make autopatching respect logical Positions and detect independent physical components so physical bridges remain coherent blocks while preserving existing selection semantics and type-grouping behaviour.

### Description

- Replaced the monolithic Y-first sorter with a modular topology pipeline implemented as pure helpers: `FixturePatchInfo`, `LogicalPatchPosition`, `PhysicalPatchComponent`, `FixtureTypeGroup`, clustering, orientation classification, type grouping, and packing helpers; these are contained in `core/autopatcher.cpp` and declared in `core/autopatcher.h`.
- Logical grouping now prefers `fixture.position` (UUID), falls back to a normalized `positionName`, and uses a conservative noise-tolerant Y-row fallback for metadata-free fixtures to preserve legacy behaviour.
- Independent physical components are detected using an adaptive nearest-neighbour scale and a minimum-spanning-tree gap cut (with a small coordinate-noise floor) so parallel side bridges are clustered into separate components deterministically.
- Component orientation is chosen by dominant X/Y range and type groups are ordered along the traversal axis; traversal direction alternates per component (serpentine) by default and uses stable tie-breakers (UUID) for determinism.
- Packing enforces hierarchical protected blocks: protect whole Position when it fits a universe, otherwise protect per-component blocks when possible, and protect type-groups for oversized components; no individual fixture is ever split across a universe boundary.
- Kept `AutoPatchSelection()` behaviour unchanged (exact selection order and “start after highest remaining patched fixture” semantics) and reused safe helpers for address calculation.
- Added tests and docs: new `tests/autopatcher_topology_test.cpp` exercising horizontal grouping, two-component longitudinal sides, LX rows + sides, complete-position protection, component protection, unavoidable splits, coordinate-noise stability, deterministic insertion, and Position identity; registered as `AutoPatchTopology` in `tests/CMakeLists.txt`; updated `docs/release-notes-draft.md` with the user-visible improvement.

Files changed:
- Modified: `core/autopatcher.cpp`, `core/autopatcher.h`
- Added: `tests/autopatcher_topology_test.cpp`
- Updated: `tests/CMakeLists.txt`, `docs/release-notes-draft.md`

### Testing

- Built and ran the autopatcher unit suites directly (compiled with system headers): `autopatcher_topology_test`, `autopatcher_test`, `autopatcher_grouping_test`, and `autopatcher_universe_wrap_test`; all executed successfully and assertions passed.
- Ran repository quality checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`; both returned OK in this environment.
- Ran `git diff --check` and compilation with `-Wall -Wextra -Wpedantic` for direct tests; no blocking issues were found (only a minor test warning fixed).
- CMake configuration for the full project could not complete in this environment because the system lacks the wxWidgets development libraries, so wxWidgets-dependent Rider import and some Rider-executable tests were not built here; the autopatcher core tests executed and passed locally in this environment.

Remaining limitations (intentional conservative fallbacks):
- Clustering is conservative when no clear distance gap exists and will not aggressively split irregularly connected fixtures.
- Orientation uses dominant axis range rather than a full PCA rotation; highly diagonal/irregular structures will fall back to the dominant world axis.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8d95f7c538832491d142f2668ee52f)