### PR TITLE
Add non-destructive rider fixture analysis and dictionary-first resolution service

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -29,6 +29,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtf/gdtf_mode_channel_browser.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtf_catalog_service.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtf_download_workflow.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gdtf_download_filename.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtf_canonicalizer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtf_mutation_audit.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtf/editor/gdtf_document.cpp

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -71,6 +71,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/startup_profile.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/rigging_extra_weight_settings.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/riderimporter.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/rider_fixture_resolution.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/rider_text_semantics.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/scene_grouping.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/scene_clipboard.cpp

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -28,6 +28,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtf/gdtf_dmx_inspector.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtf/gdtf_mode_channel_browser.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtf_catalog_service.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gdtf_download_workflow.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtf_canonicalizer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtf_mutation_audit.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtf/editor/gdtf_document.cpp

--- a/core/gdtf_catalog_service.cpp
+++ b/core/gdtf_catalog_service.cpp
@@ -1,6 +1,7 @@
 #include "gdtf_catalog_service.h"
 #include "apppaths.h"
 #include "logger.h"
+#include "../mvr/gdtf_catalog_parser.h"
 
 #include <chrono>
 #include <filesystem>
@@ -72,7 +73,9 @@ std::optional<long long> ComputeAgeSeconds(const std::string &updatedAt,
   return static_cast<long long>(ageMillis.GetValue() / 1000);
 }
 
-std::optional<GdtfCatalogSnapshot> LoadCacheSnapshot() {
+// Loads the last validated catalog snapshot and optionally returns parsed data.
+std::optional<GdtfCatalogSnapshot> LoadCacheSnapshot(
+    mvr::gdtf_catalog_parser::GdtfCatalogParseResult *parsedOut = nullptr) {
   const fs::path cachePath = GetCatalogCachePath();
   if (!fs::exists(cachePath))
     return std::nullopt;
@@ -106,6 +109,19 @@ std::optional<GdtfCatalogSnapshot> LoadCacheSnapshot() {
 
   if (snapshot.listData.empty())
     return std::nullopt;
+
+  const auto parsed = mvr::gdtf_catalog_parser::ParseCatalog(snapshot.listData);
+  if (!parsed.IsUsable()) {
+    Logger::Instance().Log(
+        Logger::Level::Warn,
+        "Ignoring unusable GDTF catalog cache: bytes=" +
+            std::to_string(parsed.payloadBytes) + " fingerprint=" +
+            parsed.payloadFingerprint + " usable_entries=" +
+            std::to_string(parsed.usableEntryCount));
+    return std::nullopt;
+  }
+  if (parsedOut)
+    *parsedOut = parsed;
 
   return snapshot;
 }
@@ -190,11 +206,24 @@ std::optional<GdtfCatalogSnapshot> GdtfCatalogService::GetCatalogSnapshot() cons
   return LoadCacheSnapshot();
 }
 
+// Loads and validates one reusable parsed catalog snapshot.
+std::optional<GdtfParsedCatalogSnapshot>
+GdtfCatalogService::GetParsedCatalogSnapshot() const {
+  mvr::gdtf_catalog_parser::GdtfCatalogParseResult parsed;
+  const auto snapshot = LoadCacheSnapshot(&parsed);
+  if (!snapshot)
+    return std::nullopt;
+  return GdtfParsedCatalogSnapshot{*snapshot, std::move(parsed)};
+}
+
 GdtfCatalogRefreshResult GdtfCatalogService::RefreshCatalogIfStale(
     const RefreshCatalogFn &refreshCatalogFn, const std::string &nowUtcIso,
     long long refreshThresholdSeconds) const {
   GdtfCatalogRefreshResult result;
-  result.snapshot = LoadCacheSnapshot();
+  mvr::gdtf_catalog_parser::GdtfCatalogParseResult cachedParsed;
+  result.snapshot = LoadCacheSnapshot(&cachedParsed);
+  if (result.snapshot)
+    result.parsedCatalog = std::move(cachedParsed);
   result.metrics.cacheHit = result.snapshot.has_value();
   result.metrics.cacheMiss = !result.metrics.cacheHit;
   result.source = result.snapshot ? GdtfCatalogResultSource::Cache
@@ -222,6 +251,21 @@ GdtfCatalogRefreshResult GdtfCatalogService::RefreshCatalogIfStale(
     result.failureMessage = "Online catalog refresh failed";
     return result;
   }
+
+  const auto parsedRefresh =
+      mvr::gdtf_catalog_parser::ParseCatalog(refreshedListData);
+  if (!parsedRefresh.IsUsable()) {
+    result.staleFallback = result.snapshot.has_value();
+    result.failureMessage = "Online catalog refresh returned no usable entries";
+    Logger::Instance().Log(
+        Logger::Level::Warn,
+        "Rejected unusable GDTF catalog refresh: bytes=" +
+            std::to_string(parsedRefresh.payloadBytes) + " fingerprint=" +
+            parsedRefresh.payloadFingerprint + " usable_entries=" +
+            std::to_string(parsedRefresh.usableEntryCount));
+    return result;
+  }
+  result.parsedCatalog = parsedRefresh;
 
   GdtfCatalogSnapshot refreshedSnapshot;
   refreshedSnapshot.listData = refreshedListData;

--- a/core/gdtf_catalog_service.h
+++ b/core/gdtf_catalog_service.h
@@ -3,6 +3,7 @@
 #include <functional>
 #include <optional>
 #include <string>
+#include "../mvr/gdtf_catalog_parser.h"
 
 struct GdtfCatalogSnapshot {
   std::string listData;
@@ -30,6 +31,12 @@ struct GdtfCatalogRefreshResult {
   GdtfCatalogResultSource source = GdtfCatalogResultSource::None;
   bool staleFallback = false;
   std::string failureMessage;
+  std::optional<mvr::gdtf_catalog_parser::GdtfCatalogParseResult> parsedCatalog;
+};
+
+struct GdtfParsedCatalogSnapshot {
+  GdtfCatalogSnapshot snapshot;
+  mvr::gdtf_catalog_parser::GdtfCatalogParseResult parsed;
 };
 
 class GdtfCatalogService {
@@ -37,6 +44,7 @@ public:
   using RefreshCatalogFn = std::function<bool(std::string &listData)>;
 
   std::optional<GdtfCatalogSnapshot> GetCatalogSnapshot() const;
+  std::optional<GdtfParsedCatalogSnapshot> GetParsedCatalogSnapshot() const;
 
   GdtfCatalogRefreshResult
   RefreshCatalogIfStale(const RefreshCatalogFn &refreshCatalogFn,

--- a/core/gdtf_download_filename.cpp
+++ b/core/gdtf_download_filename.cpp
@@ -1,0 +1,98 @@
+#include "gdtf_download_filename.h"
+
+#include <algorithm>
+#include <cctype>
+#include <iterator>
+
+namespace gdtf_download_filename {
+namespace {
+
+// Replaces characters forbidden or unsafe in portable local filenames.
+std::string SanitizeComponent(const std::string &value) {
+  std::string result;
+  result.reserve(value.size());
+  bool previousSpace = false;
+  for (const char character : value) {
+    const unsigned char byte = static_cast<unsigned char>(character);
+    const bool forbidden = byte < 32 || character == '<' || character == '>' ||
+                           character == ':' || character == '"' ||
+                           character == '/' || character == '\\' ||
+                           character == '|' || character == '?' ||
+                           character == '*';
+    const char output = forbidden ? '_' : character;
+    const bool isSpace = std::isspace(static_cast<unsigned char>(output)) != 0;
+    if (isSpace && previousSpace)
+      continue;
+    result.push_back(isSpace ? ' ' : output);
+    previousSpace = isSpace;
+  }
+  while (!result.empty() &&
+         (result.front() == ' ' || result.front() == '.'))
+    result.erase(result.begin());
+  while (!result.empty() &&
+         (result.back() == ' ' || result.back() == '.'))
+    result.pop_back();
+  return result;
+}
+
+// Protects Windows device names while remaining harmless on other platforms.
+std::string ProtectReservedStem(std::string stem) {
+  std::string upper = stem;
+  std::transform(upper.begin(), upper.end(), upper.begin(), [](char character) {
+    return static_cast<char>(
+        std::toupper(static_cast<unsigned char>(character)));
+  });
+  static const std::string reserved[] = {
+      "CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4",
+      "COM5", "COM6", "COM7", "COM8", "COM9", "LPT1", "LPT2", "LPT3",
+      "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"};
+  if (std::find(std::begin(reserved), std::end(reserved), upper) !=
+      std::end(reserved))
+    stem.insert(stem.begin(), '_');
+  return stem;
+}
+
+// Returns a portable revision suffix used only when the readable name collides.
+std::string RevisionSuffix(const std::string &revisionId) {
+  std::string suffix;
+  for (const char character : revisionId) {
+    const unsigned char byte = static_cast<unsigned char>(character);
+    if (std::isalnum(byte) || character == '-' || character == '_')
+      suffix.push_back(character);
+  }
+  return suffix.empty() ? "revision" : suffix;
+}
+
+} // namespace
+
+// Builds a portable human-readable filename from authoritative catalog identity.
+std::string BuildReadableFileName(const std::string &manufacturer,
+                                  const std::string &fixtureName) {
+  const std::string safeManufacturer = SanitizeComponent(manufacturer);
+  const std::string safeFixture = SanitizeComponent(fixtureName);
+  std::string stem;
+  if (!safeManufacturer.empty() && !safeFixture.empty())
+    stem = safeManufacturer + " " + safeFixture;
+  else if (!safeFixture.empty())
+    stem = safeFixture;
+  else if (!safeManufacturer.empty())
+    stem = safeManufacturer;
+  else
+    stem = "GDTF Share fixture";
+  return ProtectReservedStem(stem) + ".gdtf";
+}
+
+// Chooses the readable name first and adds a stable revision only on collision.
+std::filesystem::path ChooseDestination(
+    const std::filesystem::path &directory, const std::string &manufacturer,
+    const std::string &fixtureName, const std::string &revisionId) {
+  const std::filesystem::path readable =
+      directory / BuildReadableFileName(manufacturer, fixtureName);
+  std::error_code error;
+  if (!std::filesystem::exists(readable, error))
+    return readable;
+  const std::string stem = readable.stem().string();
+  return directory / (stem + " - " + RevisionSuffix(revisionId) + ".gdtf");
+}
+
+} // namespace gdtf_download_filename

--- a/core/gdtf_download_filename.h
+++ b/core/gdtf_download_filename.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+
+namespace gdtf_download_filename {
+
+// Builds a portable human-readable filename from authoritative catalog identity.
+std::string BuildReadableFileName(const std::string &manufacturer,
+                                  const std::string &fixtureName);
+
+// Chooses a deterministic collision-safe destination while preserving readable identity.
+std::filesystem::path ChooseDestination(
+    const std::filesystem::path &directory, const std::string &manufacturer,
+    const std::string &fixtureName, const std::string &revisionId);
+
+} // namespace gdtf_download_filename

--- a/core/gdtf_download_workflow.cpp
+++ b/core/gdtf_download_workflow.cpp
@@ -1,0 +1,22 @@
+#include "gdtf_download_workflow.h"
+
+namespace gdtf_download_workflow {
+
+// Downloads a revision and retries once after an expired authenticated session.
+GdtfShareResult DownloadWithExpiredSessionRetry(
+    GdtfShareClient &client, const std::string &revisionId,
+    const std::string &destination, const Reauthenticate &reauthenticate,
+    std::function<void(const GdtfDownloadProgress &)> progressCallback,
+    std::function<bool()> shouldCancelCallback) {
+  GdtfShareResult result = client.DownloadRevision(
+      revisionId, destination, progressCallback, shouldCancelCallback);
+  if (result.category != GdtfShareResultCategory::AuthenticationRejected ||
+      !reauthenticate || !reauthenticate()) {
+    return result;
+  }
+  return client.DownloadRevision(revisionId, destination,
+                                 std::move(progressCallback),
+                                 std::move(shouldCancelCallback));
+}
+
+} // namespace gdtf_download_workflow

--- a/core/gdtf_download_workflow.h
+++ b/core/gdtf_download_workflow.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "gdtfnet.h"
+
+#include <functional>
+#include <string>
+
+namespace gdtf_download_workflow {
+
+using Reauthenticate = std::function<bool()>;
+
+GdtfShareResult DownloadWithExpiredSessionRetry(
+    GdtfShareClient &client, const std::string &revisionId,
+    const std::string &destination, const Reauthenticate &reauthenticate,
+    std::function<void(const GdtfDownloadProgress &)> progressCallback = {},
+    std::function<bool()> shouldCancelCallback = {});
+
+} // namespace gdtf_download_workflow

--- a/core/gdtfdictionary.cpp
+++ b/core/gdtfdictionary.cpp
@@ -245,7 +245,8 @@ bool IsDummy1ChFallbackPath(const std::string &gdtfPath) {
          normalizedFileName == "genericgeneric1chperastage.gdtf";
 }
 
-std::string NormalizeTypeKey(const std::string &type) {
+// Normalizes fixture aliases for dictionary-equivalent lookup.
+std::string NormalizeTypeKeyImpl(const std::string &type) {
   std::string normalized;
   normalized.reserve(type.size());
   for (unsigned char ch : type) {
@@ -360,12 +361,12 @@ BuildPerastageCanonicalGdtfFileName(const std::filesystem::path &sourcePath) {
 std::optional<std::string>
 FindEquivalentTypeKey(const std::unordered_map<std::string, Entry> &dict,
                       const std::string &rawType) {
-  const std::string normalizedTarget = NormalizeTypeKey(rawType);
+  const std::string normalizedTarget = NormalizeTypeKeyImpl(rawType);
   if (normalizedTarget.empty())
     return std::nullopt;
 
   for (const auto &[existingType, _] : dict) {
-    if (NormalizeTypeKey(existingType) == normalizedTarget)
+    if (NormalizeTypeKeyImpl(existingType) == normalizedTarget)
       return existingType;
   }
   return std::nullopt;
@@ -375,7 +376,7 @@ bool ApplyCategoryUpdateForFile(std::unordered_map<std::string, Entry> &dict,
                                 const std::string &type,
                                 const std::string &gdtfPath,
                                 const std::string &category) {
-  const std::string normalizedType = NormalizeTypeKey(type);
+  const std::string normalizedType = NormalizeTypeKeyImpl(type);
   if (normalizedType.empty())
     return false;
 
@@ -678,6 +679,11 @@ MergeDictionaryEntries(std::unordered_map<std::string, Entry> &current,
 }
 
 } // namespace
+
+// Normalizes fixture aliases for dictionary-equivalent lookup.
+std::string NormalizeTypeKey(const std::string &type) {
+  return NormalizeTypeKeyImpl(type);
+}
 
 
 // Validates that a fixtures dictionary file can be loaded without changing configuration.
@@ -994,7 +1000,7 @@ bool Save(const std::unordered_map<std::string, Entry> &dict,
 std::optional<Entry>
 FindInLoadedDictionary(const std::unordered_map<std::string, Entry> &dict,
     const std::string &type, bool validateExistingPath) {
-  const std::string normalizedType = NormalizeTypeKey(type);
+  const std::string normalizedType = NormalizeTypeKeyImpl(type);
   if (normalizedType.empty())
     return std::nullopt;
   auto keyOpt = FindEquivalentTypeKey(dict, normalizedType);
@@ -1011,7 +1017,7 @@ FindInLoadedDictionary(const std::unordered_map<std::string, Entry> &dict,
 
 std::optional<Entry> Get(const std::string &type) {
   std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
-  const std::string normalizedType = NormalizeTypeKey(type);
+  const std::string normalizedType = NormalizeTypeKeyImpl(type);
   if (normalizedType.empty())
     return std::nullopt;
   auto dictOpt = Load();
@@ -1037,7 +1043,7 @@ GetDefaultVisualColorForFixture(const std::string &type,
     return std::nullopt;
   const auto &dict = *dictOpt;
 
-  const std::string normalizedType = NormalizeTypeKey(type);
+  const std::string normalizedType = NormalizeTypeKeyImpl(type);
   if (!normalizedType.empty()) {
     if (auto keyOpt = FindEquivalentTypeKey(dict, normalizedType)) {
       auto byType = dict.find(*keyOpt);
@@ -1064,7 +1070,7 @@ GetDefaultVisualColorForFixture(const std::string &type,
 // Updates one dictionary entry without performing any fixture file copies.
 void UpdateDictionaryEntry(const std::string &type, const Entry &entry) {
   std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
-  const std::string normalizedType = NormalizeTypeKey(type);
+  const std::string normalizedType = NormalizeTypeKeyImpl(type);
   if (normalizedType.empty())
     return;
 
@@ -1104,7 +1110,7 @@ std::optional<Entry> CreateOrUpdatePerastageLibraryDerivative(
     const std::string &type, const std::string &gdtfPath,
     const std::string &mode, const std::string &category) {
   std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
-  const std::string normalizedType = NormalizeTypeKey(type);
+  const std::string normalizedType = NormalizeTypeKeyImpl(type);
   if (normalizedType.empty() || gdtfPath.empty())
     return std::nullopt;
   if (IsDummy1ChFallbackType(normalizedType) ||
@@ -1203,7 +1209,7 @@ void UpdateVisualColorForFile(const std::string &type,
                               const std::string &mode,
                               const std::string &color) {
   std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
-  const std::string normalizedType = NormalizeTypeKey(type);
+  const std::string normalizedType = NormalizeTypeKeyImpl(type);
   if (normalizedType.empty())
     return;
   auto dictOpt = Load();

--- a/core/gdtfdictionary.cpp
+++ b/core/gdtfdictionary.cpp
@@ -1138,6 +1138,69 @@ std::optional<Entry> CreateOrUpdatePerastageLibraryDerivative(
   return e;
 }
 
+// Registers an external source GDTF in dictionary-owned storage without derivative publication.
+ExternalMappingResult CreateOrUpdateExternalLibraryMapping(
+    const std::string &type, const std::string &gdtfPath,
+    const std::string &mode) {
+  std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
+  ExternalMappingResult result;
+  const std::string normalizedType = NormalizeTypeKey(type);
+  if (normalizedType.empty() || gdtfPath.empty()) {
+    result.failureStage = "validate-input";
+    result.error = "Fixture alias or source path is empty.";
+    return result;
+  }
+  const fs::path source = PathUtils::PathFromUtf8(gdtfPath);
+  if (!fs::is_regular_file(source)) {
+    result.failureStage = "validate-source";
+    result.error = "External GDTF source file does not exist.";
+    return result;
+  }
+  const fs::path dictionaryFile = GetConfiguredUserDictFile();
+  if (dictionaryFile.empty()) {
+    result.failureStage = "resolve-dictionary";
+    result.error = "The active fixture dictionary path is unavailable.";
+    return result;
+  }
+  const auto copy = ActiveDictionaryStorage::CopyAssetIntoDictionaryStorage(
+      {ActiveDictionaryStorage::DictionaryKind::Fixtures, dictionaryFile,
+       GetUserDictFile(), source, source.filename(),
+       FileImportUtils::ConflictPolicy::Overwrite});
+  if (!copy.success) {
+    result.failureStage = "copy-external-source";
+    result.error = "The external GDTF could not be copied into dictionary storage.";
+    return result;
+  }
+  auto dictionary = Load();
+  if (!dictionary) {
+    result.failureStage = "load-dictionary";
+    result.error = "The active fixture dictionary could not be loaded.";
+    return result;
+  }
+  Entry entry;
+  if (auto existing = FindInLoadedDictionary(*dictionary, type, false))
+    entry = *existing;
+  entry.path = copy.finalPath.string();
+  entry.mode = mode;
+  entry.importedAt = FileImportUtils::NowUtcIso8601();
+  entry.sha256 = copy.finalSha256;
+  std::string key = type;
+  if (auto existingKey = FindEquivalentTypeKey(*dictionary, normalizedType))
+    key = *existingKey;
+  (*dictionary)[key] = entry;
+  std::string saveError;
+  if (!Save(*dictionary, &saveError)) {
+    result.failureStage = "save-dictionary";
+    result.error = saveError.empty() ? "The fixture dictionary could not be saved."
+                                     : saveError;
+    return result;
+  }
+  result.success = true;
+  result.entry = entry;
+  result.storedFileName = copy.finalPath.filename().string();
+  return result;
+}
+
 // Registers an explicit user-library fixture import using deterministic
 // @Perastage derivative rules.
 void Update(const std::string &type, const std::string &gdtfPath,

--- a/core/gdtfdictionary.cpp
+++ b/core/gdtfdictionary.cpp
@@ -245,18 +245,6 @@ bool IsDummy1ChFallbackPath(const std::string &gdtfPath) {
          normalizedFileName == "genericgeneric1chperastage.gdtf";
 }
 
-// Normalizes fixture aliases for dictionary-equivalent lookup.
-std::string NormalizeTypeKeyImpl(const std::string &type) {
-  std::string normalized;
-  normalized.reserve(type.size());
-  for (unsigned char ch : type) {
-    if (std::isspace(ch) != 0)
-      continue;
-    normalized.push_back(static_cast<char>(std::toupper(ch)));
-  }
-  return normalized;
-}
-
 // Returns true when the filename optional-comment segment marks a
 // Perastage-authored GDTF.
 bool IsPerastageNamedGdtfFilePath(const std::filesystem::path &path) {
@@ -361,12 +349,12 @@ BuildPerastageCanonicalGdtfFileName(const std::filesystem::path &sourcePath) {
 std::optional<std::string>
 FindEquivalentTypeKey(const std::unordered_map<std::string, Entry> &dict,
                       const std::string &rawType) {
-  const std::string normalizedTarget = NormalizeTypeKeyImpl(rawType);
+  const std::string normalizedTarget = NormalizeTypeKey(rawType);
   if (normalizedTarget.empty())
     return std::nullopt;
 
   for (const auto &[existingType, _] : dict) {
-    if (NormalizeTypeKeyImpl(existingType) == normalizedTarget)
+    if (NormalizeTypeKey(existingType) == normalizedTarget)
       return existingType;
   }
   return std::nullopt;
@@ -376,7 +364,7 @@ bool ApplyCategoryUpdateForFile(std::unordered_map<std::string, Entry> &dict,
                                 const std::string &type,
                                 const std::string &gdtfPath,
                                 const std::string &category) {
-  const std::string normalizedType = NormalizeTypeKeyImpl(type);
+  const std::string normalizedType = NormalizeTypeKey(type);
   if (normalizedType.empty())
     return false;
 
@@ -679,12 +667,6 @@ MergeDictionaryEntries(std::unordered_map<std::string, Entry> &current,
 }
 
 } // namespace
-
-// Normalizes fixture aliases for dictionary-equivalent lookup.
-std::string NormalizeTypeKey(const std::string &type) {
-  return NormalizeTypeKeyImpl(type);
-}
-
 
 // Validates that a fixtures dictionary file can be loaded without changing configuration.
 bool ValidateDictionaryFile(const std::string &path, std::string *errorOut) {
@@ -1000,7 +982,7 @@ bool Save(const std::unordered_map<std::string, Entry> &dict,
 std::optional<Entry>
 FindInLoadedDictionary(const std::unordered_map<std::string, Entry> &dict,
     const std::string &type, bool validateExistingPath) {
-  const std::string normalizedType = NormalizeTypeKeyImpl(type);
+  const std::string normalizedType = NormalizeTypeKey(type);
   if (normalizedType.empty())
     return std::nullopt;
   auto keyOpt = FindEquivalentTypeKey(dict, normalizedType);
@@ -1017,7 +999,7 @@ FindInLoadedDictionary(const std::unordered_map<std::string, Entry> &dict,
 
 std::optional<Entry> Get(const std::string &type) {
   std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
-  const std::string normalizedType = NormalizeTypeKeyImpl(type);
+  const std::string normalizedType = NormalizeTypeKey(type);
   if (normalizedType.empty())
     return std::nullopt;
   auto dictOpt = Load();
@@ -1043,7 +1025,7 @@ GetDefaultVisualColorForFixture(const std::string &type,
     return std::nullopt;
   const auto &dict = *dictOpt;
 
-  const std::string normalizedType = NormalizeTypeKeyImpl(type);
+  const std::string normalizedType = NormalizeTypeKey(type);
   if (!normalizedType.empty()) {
     if (auto keyOpt = FindEquivalentTypeKey(dict, normalizedType)) {
       auto byType = dict.find(*keyOpt);
@@ -1070,7 +1052,7 @@ GetDefaultVisualColorForFixture(const std::string &type,
 // Updates one dictionary entry without performing any fixture file copies.
 void UpdateDictionaryEntry(const std::string &type, const Entry &entry) {
   std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
-  const std::string normalizedType = NormalizeTypeKeyImpl(type);
+  const std::string normalizedType = NormalizeTypeKey(type);
   if (normalizedType.empty())
     return;
 
@@ -1110,7 +1092,7 @@ std::optional<Entry> CreateOrUpdatePerastageLibraryDerivative(
     const std::string &type, const std::string &gdtfPath,
     const std::string &mode, const std::string &category) {
   std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
-  const std::string normalizedType = NormalizeTypeKeyImpl(type);
+  const std::string normalizedType = NormalizeTypeKey(type);
   if (normalizedType.empty() || gdtfPath.empty())
     return std::nullopt;
   if (IsDummy1ChFallbackType(normalizedType) ||
@@ -1209,7 +1191,7 @@ void UpdateVisualColorForFile(const std::string &type,
                               const std::string &mode,
                               const std::string &color) {
   std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
-  const std::string normalizedType = NormalizeTypeKeyImpl(type);
+  const std::string normalizedType = NormalizeTypeKey(type);
   if (normalizedType.empty())
     return;
   auto dictOpt = Load();

--- a/core/gdtfdictionary.h
+++ b/core/gdtfdictionary.h
@@ -19,6 +19,7 @@
 
 #include "dictionary_import.h"
 
+#include <cctype>
 #include <cstddef>
 #include <optional>
 #include <string>
@@ -77,7 +78,17 @@ namespace GdtfDictionary {
     // Missing referenced files return std::nullopt without mutating the dictionary.
     std::optional<Entry> Get(const std::string& type);
     // Normalizes a fixture alias with the same rules used by dictionary lookup.
-    std::string NormalizeTypeKey(const std::string& type);
+    inline std::string NormalizeTypeKey(const std::string& type) {
+        std::string normalized;
+        normalized.reserve(type.size());
+        for (unsigned char character : type) {
+            if (std::isspace(character) != 0)
+                continue;
+            normalized.push_back(
+                static_cast<char>(std::toupper(character)));
+        }
+        return normalized;
+    }
     // Looks up a type in an already loaded dictionary without reloading from disk.
     std::optional<Entry> FindInLoadedDictionary(
         const std::unordered_map<std::string, Entry>& dict,

--- a/core/gdtfdictionary.h
+++ b/core/gdtfdictionary.h
@@ -76,6 +76,8 @@ namespace GdtfDictionary {
     // Returns the stored entry for a given type when the referenced file exists.
     // Missing referenced files return std::nullopt without mutating the dictionary.
     std::optional<Entry> Get(const std::string& type);
+    // Normalizes a fixture alias with the same rules used by dictionary lookup.
+    std::string NormalizeTypeKey(const std::string& type);
     // Looks up a type in an already loaded dictionary without reloading from disk.
     std::optional<Entry> FindInLoadedDictionary(
         const std::unordered_map<std::string, Entry>& dict,

--- a/core/gdtfdictionary.h
+++ b/core/gdtfdictionary.h
@@ -114,6 +114,17 @@ namespace GdtfDictionary {
     std::optional<Entry> CreateOrUpdatePerastageLibraryDerivative(
         const std::string& type, const std::string& gdtfPath,
         const std::string& mode = {}, const std::string& category = {});
+    struct ExternalMappingResult {
+        bool success = false;
+        Entry entry;
+        std::string failureStage;
+        std::string error;
+        std::string storedFileName;
+    };
+    // Registers a validated external GDTF without claiming Perastage derivative ownership.
+    ExternalMappingResult CreateOrUpdateExternalLibraryMapping(
+        const std::string& type, const std::string& gdtfPath,
+        const std::string& mode = {});
     // Updates dictionary metadata without copying fixture files into the library.
     void UpdateDictionaryEntry(const std::string& type, const Entry& entry);
     void UpdateCategory(const std::string& type, const std::string& category);

--- a/core/rider_fixture_resolution.cpp
+++ b/core/rider_fixture_resolution.cpp
@@ -49,13 +49,14 @@ Analysis Service::Analyze(
     item.request = request;
     item.dictionaryEntry =
         GdtfDictionary::FindInLoadedDictionary(dictionary, request.typeName);
-    if (item.dictionaryEntry) {
+    if (item.dictionaryEntry && !item.dictionaryEntry->path.empty()) {
       item.state = State::Dictionary;
       item.selectedMode = item.dictionaryEntry->mode;
       item.details = "Active fixture dictionary";
       result.items.push_back(std::move(item));
       continue;
     }
+    item.dictionaryEntry.reset();
 
     GdtfDownloadRequest matchRequest;
     matchRequest.authoritativeFixtureNames.push_back(request.typeName);

--- a/core/rider_fixture_resolution.cpp
+++ b/core/rider_fixture_resolution.cpp
@@ -82,6 +82,36 @@ bool Service::IsValidProgressTransition(const Progress &previous,
   return static_cast<int>(next.stage) >= static_cast<int>(previous.stage);
 }
 
+// Counts final row provenance without including discarded catalog candidates.
+Summary Service::Summarize(const Analysis &analysis) {
+  Summary summary;
+  for (const Item &item : analysis.items) {
+    if (!item.create || item.origin == ResolutionOrigin::Skipped) {
+      ++summary.skipped;
+      continue;
+    }
+    ++summary.created;
+    switch (item.origin) {
+    case ResolutionOrigin::Dictionary:
+    case ResolutionOrigin::DictionaryModified:
+      ++summary.dictionary;
+      break;
+    case ResolutionOrigin::AutomaticMatch:
+      ++summary.automaticMatches;
+      break;
+    case ResolutionOrigin::UserSelection:
+      ++summary.userSelections;
+      break;
+    case ResolutionOrigin::GenericFallback:
+      ++summary.genericFallbacks;
+      break;
+    case ResolutionOrigin::Skipped:
+      break;
+    }
+  }
+  return summary;
+}
+
 // Re-resolves an item through dictionary lookup and the shared MVR matcher.
 void Service::ResolveItem(
     Item &item,

--- a/core/rider_fixture_resolution.cpp
+++ b/core/rider_fixture_resolution.cpp
@@ -1,0 +1,120 @@
+#include "rider_fixture_resolution.h"
+
+#include <algorithm>
+
+namespace rider_fixture_resolution {
+namespace {
+
+using namespace mvr::gdtf_catalog_matcher;
+
+// Finds a catalog row by the stable revision selected by the shared matcher.
+const GdtfCatalogEntry *FindRevision(const std::vector<GdtfCatalogEntry> &catalog,
+                                    const std::string &rid) {
+  const auto found = std::find_if(catalog.begin(), catalog.end(),
+                                  [&](const GdtfCatalogEntry &entry) {
+                                    return entry.rid == rid;
+                                  });
+  return found == catalog.end() ? nullptr : &*found;
+}
+
+} // namespace
+
+// Reports whether a selected catalog profile still has an ambiguous mode.
+bool Item::RequiresModeSelection() const {
+  return selectedEntry && selectedEntry->modes.size() > 1 && selectedMode.empty();
+}
+
+// Reports whether the row can safely continue to the import stage.
+bool Item::IsReady() const {
+  return state == State::Dictionary || state == State::Generic ||
+         (selectedEntry.has_value() && !RequiresModeSelection());
+}
+
+// Reports whether any alias needs explicit user resolution.
+bool Analysis::RequiresPreflight() const {
+  return std::any_of(items.begin(), items.end(), [](const Item &item) {
+    return item.state != State::Dictionary;
+  });
+}
+
+// Resolves fixture aliases without mutating the dictionary or scene.
+Analysis Service::Analyze(
+    const std::vector<RiderImporter::FixtureTypeRequest> &requests,
+    const std::unordered_map<std::string, GdtfDictionary::Entry> &dictionary,
+    const std::vector<GdtfCatalogEntry> &catalog) {
+  Analysis result;
+  result.items.reserve(requests.size());
+  for (const auto &request : requests) {
+    Item item;
+    item.request = request;
+    item.dictionaryEntry =
+        GdtfDictionary::FindInLoadedDictionary(dictionary, request.typeName);
+    if (item.dictionaryEntry) {
+      item.state = State::Dictionary;
+      item.selectedMode = item.dictionaryEntry->mode;
+      item.details = "Active fixture dictionary";
+      result.items.push_back(std::move(item));
+      continue;
+    }
+
+    GdtfDownloadRequest matchRequest;
+    matchRequest.authoritativeFixtureNames.push_back(request.typeName);
+    const GdtfDownloadMatch match = SelectBestDownloadMatch(matchRequest, catalog);
+    const GdtfCatalogEntry *entry = match.found
+                                        ? FindRevision(catalog, match.rid)
+                                        : nullptr;
+    if (!entry) {
+      item.state = State::Unresolved;
+      item.details = "No reliable catalog candidate";
+      result.items.push_back(std::move(item));
+      continue;
+    }
+
+    item.suggestedEntry = *entry;
+    const FixtureNameMatchTier tier =
+        ComputeFixtureNameMatchTier(entry->fixtureName, request.typeName);
+    const NumericTokenCompatibility numeric = ComputeNumericTokenCompatibility(
+        BuildCanonicalFixtureModel(entry->fixtureName, entry->manufacturer),
+        BuildCanonicalFixtureModel(request.typeName));
+    if (numeric == NumericTokenCompatibility::Different) {
+      item.state = State::Unresolved;
+      item.details = "Conflicting numeric model identity";
+    } else if (tier == FixtureNameMatchTier::ExactNormalized) {
+      item.state = State::Suggested;
+      item.details = "Exact normalized model match";
+    } else {
+      item.state = State::Review;
+      item.details = "Plausible catalog match requires review";
+    }
+    result.items.push_back(std::move(item));
+  }
+  return result;
+}
+
+// Applies a user-confirmed catalog selection and auto-selects only one mode.
+void Service::SelectCatalogEntry(Item &item, const GdtfCatalogEntry &entry) {
+  item.selectedEntry = entry;
+  item.selectedMode = entry.modes.size() == 1 ? entry.modes.front().name : "";
+}
+
+// Marks an alias for the established generic fallback without dictionary state.
+void Service::SelectGeneric(Item &item) {
+  item.state = State::Generic;
+  item.selectedEntry.reset();
+  item.selectedMode.clear();
+  item.details = "Generic fallback selected for this import";
+}
+
+// Converts resolution state to stable diagnostic text.
+const char *StateName(State state) {
+  switch (state) {
+  case State::Dictionary: return "Dictionary";
+  case State::Suggested: return "Suggested";
+  case State::Review: return "Review";
+  case State::Unresolved: return "Unresolved";
+  case State::Generic: return "Generic";
+  }
+  return "Unresolved";
+}
+
+} // namespace rider_fixture_resolution

--- a/core/rider_fixture_resolution.cpp
+++ b/core/rider_fixture_resolution.cpp
@@ -67,7 +67,7 @@ Analysis Service::Analyze(
   return result;
 }
 
-// Validates monotonic matching progress independently from any GUI control.
+// Validates catalog acquisition and monotonic matching stage transitions.
 bool Service::IsValidProgressTransition(const Progress &previous,
                                         const Progress &next) {
   if (next.total > 0 && next.current > next.total)
@@ -79,7 +79,31 @@ bool Service::IsValidProgressTransition(const Progress &previous,
       next.stage == ProgressStage::MatchingFixtures)
     return next.total == previous.total && next.current >= previous.current &&
            next.automaticMatches >= previous.automaticMatches;
-  return static_cast<int>(next.stage) >= static_cast<int>(previous.stage);
+  if (next.stage == ProgressStage::Unavailable)
+    return true;
+  switch (previous.stage) {
+  case ProgressStage::LoadingCatalog:
+    return next.stage == ProgressStage::ParsingCatalog ||
+           next.stage == ProgressStage::WaitingForCredentials;
+  case ProgressStage::WaitingForCredentials:
+    return next.stage == ProgressStage::Authenticating;
+  case ProgressStage::Authenticating:
+    return next.stage == ProgressStage::DownloadingCatalog ||
+           next.stage == ProgressStage::WaitingForCredentials;
+  case ProgressStage::DownloadingCatalog:
+    return next.stage == ProgressStage::ParsingCatalog;
+  case ProgressStage::ParsingCatalog:
+    return next.stage == ProgressStage::WaitingForCredentials ||
+           next.stage == ProgressStage::Authenticating ||
+           next.stage == ProgressStage::MatchingFixtures ||
+           next.stage == ProgressStage::Complete;
+  case ProgressStage::MatchingFixtures:
+    return next.stage == ProgressStage::Complete;
+  case ProgressStage::Complete:
+  case ProgressStage::Unavailable:
+    return false;
+  }
+  return false;
 }
 
 // Counts final row provenance without including discarded catalog candidates.

--- a/core/rider_fixture_resolution.cpp
+++ b/core/rider_fixture_resolution.cpp
@@ -21,7 +21,7 @@ const GdtfCatalogEntry *FindRevision(const std::vector<GdtfCatalogEntry> &catalo
 
 // Reports whether a selected catalog profile still has an ambiguous mode.
 bool Item::RequiresModeSelection() const {
-  return selectedEntry && selectedEntry->modes.size() > 1 && selectedMode.empty();
+  return selectedEntry && selectedMode.empty();
 }
 
 // Reports whether the row can safely continue to the import stage.
@@ -66,7 +66,7 @@ Analysis Service::Analyze(
                                         : nullptr;
     if (!entry) {
       item.state = State::Unresolved;
-      item.details = "No reliable catalog candidate";
+      item.details = "No reliable catalog match; generic will be used unless changed";
       result.items.push_back(std::move(item));
       continue;
     }
@@ -79,13 +79,13 @@ Analysis Service::Analyze(
         BuildCanonicalFixtureModel(request.typeName));
     if (numeric == NumericTokenCompatibility::Different) {
       item.state = State::Unresolved;
-      item.details = "Conflicting numeric model identity";
+      item.details = "Conflicting numeric model identity; generic will be used unless changed";
     } else if (tier == FixtureNameMatchTier::ExactNormalized) {
       item.state = State::Suggested;
-      item.details = "Exact normalized model match";
+      item.details = "Exact normalized model match; generic remains the default";
     } else {
       item.state = State::Review;
-      item.details = "Plausible catalog match requires review";
+      item.details = "Plausible match requires review; generic remains the default";
     }
     result.items.push_back(std::move(item));
   }
@@ -104,6 +104,31 @@ void Service::SelectGeneric(Item &item) {
   item.selectedEntry.reset();
   item.selectedMode.clear();
   item.details = "Generic fallback selected for this import";
+}
+
+// Converts every incomplete non-dictionary row to Generic before import.
+void Service::FinalizeDefaults(Analysis &analysis) {
+  for (Item &item : analysis.items) {
+    if (item.state == State::Dictionary)
+      continue;
+    if (!item.selectedEntry || item.RequiresModeSelection())
+      SelectGeneric(item);
+  }
+}
+
+// Merges background catalog results only into untouched unresolved rows.
+void Service::MergeCatalogSuggestions(Analysis &current,
+                                      const Analysis &matched) {
+  const size_t count = std::min(current.items.size(), matched.items.size());
+  for (size_t index = 0; index < count; ++index) {
+    Item &target = current.items[index];
+    if (target.state == State::Dictionary || target.state == State::Generic ||
+        target.selectedEntry)
+      continue;
+    target.state = matched.items[index].state;
+    target.suggestedEntry = matched.items[index].suggestedEntry;
+    target.details = matched.items[index].details;
+  }
 }
 
 // Converts resolution state to stable diagnostic text.

--- a/core/rider_fixture_resolution.cpp
+++ b/core/rider_fixture_resolution.cpp
@@ -132,6 +132,12 @@ void Service::SelectGeneric(Item &item) {
   item.details = "Generic fallback selected for this import";
 }
 
+// Records a recoverable resolution failure in the final GUI-independent plan.
+void Service::FallbackAfterFailure(Item &item, const std::string &reason) {
+  SelectGeneric(item);
+  item.details = reason + " - using generic fallback";
+}
+
 // Converts every incomplete non-dictionary row to Generic before import.
 void Service::FinalizeDefaults(Analysis &analysis) {
   for (Item &item : analysis.items) {

--- a/core/rider_fixture_resolution.cpp
+++ b/core/rider_fixture_resolution.cpp
@@ -136,6 +136,30 @@ Summary Service::Summarize(const Analysis &analysis) {
   return summary;
 }
 
+// Selects unresolved rows without reprocessing dictionary or explicit choices.
+std::vector<CatalogMatchTarget>
+Service::BuildCatalogMatchTargets(const Analysis &analysis) {
+  std::vector<CatalogMatchTarget> targets;
+  targets.reserve(analysis.items.size());
+  for (size_t index = 0; index < analysis.items.size(); ++index) {
+    const Item &item = analysis.items[index];
+    if (!item.create || item.selectedEntry || item.state == State::Dictionary ||
+        item.state == State::Generic ||
+        item.origin == ResolutionOrigin::Dictionary ||
+        item.origin == ResolutionOrigin::DictionaryModified ||
+        item.origin == ResolutionOrigin::AutomaticMatch ||
+        item.origin == ResolutionOrigin::UserSelection ||
+        item.origin == ResolutionOrigin::Skipped)
+      continue;
+    auto request = item.request;
+    request.typeName = item.effectiveFixtureType;
+    request.normalizedTypeName =
+        GdtfDictionary::NormalizeTypeKey(item.effectiveFixtureType);
+    targets.push_back({index, std::move(request)});
+  }
+  return targets;
+}
+
 // Re-resolves an item through dictionary lookup and the shared MVR matcher.
 void Service::ResolveItem(
     Item &item,

--- a/core/rider_fixture_resolution.cpp
+++ b/core/rider_fixture_resolution.cpp
@@ -41,18 +41,45 @@ bool Analysis::RequiresPreflight() const {
 Analysis Service::Analyze(
     const std::vector<RiderImporter::FixtureTypeRequest> &requests,
     const std::unordered_map<std::string, GdtfDictionary::Entry> &dictionary,
-    const std::vector<GdtfCatalogEntry> &catalog) {
+    const std::vector<GdtfCatalogEntry> &catalog,
+    ProgressCallback progress) {
   Analysis result;
   result.items.reserve(requests.size());
+  size_t automaticMatches = 0;
+  size_t processed = 0;
   for (const auto &request : requests) {
     Item item;
     item.request = request;
     item.originalFixtureType = request.typeName;
     item.effectiveFixtureType = request.typeName;
     ResolveItem(item, dictionary, catalog);
+    if (item.origin == ResolutionOrigin::AutomaticMatch)
+      ++automaticMatches;
     result.items.push_back(std::move(item));
+    ++processed;
+    if (progress)
+      progress({ProgressStage::MatchingFixtures, processed, requests.size(),
+                automaticMatches});
   }
+  if (progress)
+    progress({ProgressStage::Complete, requests.size(), requests.size(),
+              automaticMatches});
   return result;
+}
+
+// Validates monotonic matching progress independently from any GUI control.
+bool Service::IsValidProgressTransition(const Progress &previous,
+                                        const Progress &next) {
+  if (next.total > 0 && next.current > next.total)
+    return false;
+  if (previous.stage == ProgressStage::Complete ||
+      previous.stage == ProgressStage::Unavailable)
+    return false;
+  if (previous.stage == ProgressStage::MatchingFixtures &&
+      next.stage == ProgressStage::MatchingFixtures)
+    return next.total == previous.total && next.current >= previous.current &&
+           next.automaticMatches >= previous.automaticMatches;
+  return static_cast<int>(next.stage) >= static_cast<int>(previous.stage);
 }
 
 // Re-resolves an item through dictionary lookup and the shared MVR matcher.
@@ -152,19 +179,22 @@ void Service::FinalizeDefaults(Analysis &analysis) {
 void Service::MergeCatalogSuggestions(Analysis &current,
                                       const Analysis &matched) {
   const size_t count = std::min(current.items.size(), matched.items.size());
-  for (size_t index = 0; index < count; ++index) {
-    Item &target = current.items[index];
-    if (!target.create || target.state == State::Dictionary ||
-        target.state == State::Generic ||
-        target.selectedEntry)
-      continue;
-    target.state = matched.items[index].state;
-    target.suggestedEntry = matched.items[index].suggestedEntry;
-    target.selectedEntry = matched.items[index].selectedEntry;
-    target.selectedMode = matched.items[index].selectedMode;
-    target.origin = matched.items[index].origin;
-    target.details = matched.items[index].details;
-  }
+  for (size_t index = 0; index < count; ++index)
+    MergeCatalogSuggestion(current.items[index], matched.items[index]);
+}
+
+// Merges one automatic result only when its fixture identity is still current.
+void Service::MergeCatalogSuggestion(Item &target, const Item &matched) {
+  if (target.effectiveFixtureType != matched.effectiveFixtureType ||
+      !target.create || target.state == State::Dictionary ||
+      target.state == State::Generic || target.selectedEntry)
+    return;
+  target.state = matched.state;
+  target.suggestedEntry = matched.suggestedEntry;
+  target.selectedEntry = matched.selectedEntry;
+  target.selectedMode = matched.selectedMode;
+  target.origin = matched.origin;
+  target.details = matched.details;
 }
 
 // Converts resolution state to stable diagnostic text.
@@ -190,6 +220,19 @@ const char *OriginName(ResolutionOrigin origin) {
   case ResolutionOrigin::Skipped: return "Skipped";
   }
   return "Generic fallback";
+}
+
+// Maps resolution provenance to the shared semantic status presentation.
+StatusSemantic StatusSemanticForOrigin(ResolutionOrigin origin) {
+  switch (origin) {
+  case ResolutionOrigin::Dictionary: return StatusSemantic::Neutral;
+  case ResolutionOrigin::DictionaryModified: return StatusSemantic::Modified;
+  case ResolutionOrigin::AutomaticMatch: return StatusSemantic::Success;
+  case ResolutionOrigin::UserSelection: return StatusSemantic::Information;
+  case ResolutionOrigin::GenericFallback: return StatusSemantic::Warning;
+  case ResolutionOrigin::Skipped: return StatusSemantic::Muted;
+  }
+  return StatusSemantic::Warning;
 }
 
 } // namespace rider_fixture_resolution

--- a/core/rider_fixture_resolution.cpp
+++ b/core/rider_fixture_resolution.cpp
@@ -47,60 +47,86 @@ Analysis Service::Analyze(
   for (const auto &request : requests) {
     Item item;
     item.request = request;
-    item.dictionaryEntry =
-        GdtfDictionary::FindInLoadedDictionary(dictionary, request.typeName);
+    item.originalFixtureType = request.typeName;
+    item.effectiveFixtureType = request.typeName;
+    ResolveItem(item, dictionary, catalog);
+    result.items.push_back(std::move(item));
+  }
+  return result;
+}
+
+// Re-resolves an item through dictionary lookup and the shared MVR matcher.
+void Service::ResolveItem(
+    Item &item,
+    const std::unordered_map<std::string, GdtfDictionary::Entry> &dictionary,
+    const std::vector<GdtfCatalogEntry> &catalog) {
+    item.dictionaryEntry = GdtfDictionary::FindInLoadedDictionary(
+        dictionary, item.effectiveFixtureType);
+    item.suggestedEntry.reset();
+    item.selectedEntry.reset();
+    item.selectedMode.clear();
     if (item.dictionaryEntry && !item.dictionaryEntry->path.empty()) {
       item.state = State::Dictionary;
+      item.origin = ResolutionOrigin::Dictionary;
       item.selectedMode = item.dictionaryEntry->mode;
+      item.originalDictionaryMode = item.dictionaryEntry->mode;
       item.details = "Active fixture dictionary";
-      result.items.push_back(std::move(item));
-      continue;
+      return;
     }
     item.dictionaryEntry.reset();
+    item.originalDictionaryMode.clear();
 
     GdtfDownloadRequest matchRequest;
-    matchRequest.authoritativeFixtureNames.push_back(request.typeName);
+    matchRequest.authoritativeFixtureNames.push_back(item.effectiveFixtureType);
+    matchRequest.displayTypeKey = item.effectiveFixtureType;
     const GdtfDownloadMatch match = SelectBestDownloadMatch(matchRequest, catalog);
     const GdtfCatalogEntry *entry = match.found
                                         ? FindRevision(catalog, match.rid)
                                         : nullptr;
     if (!entry) {
       item.state = State::Unresolved;
+      item.origin = ResolutionOrigin::GenericFallback;
       item.details = "No reliable catalog match; generic will be used unless changed";
-      result.items.push_back(std::move(item));
-      continue;
+      return;
     }
 
     item.suggestedEntry = *entry;
-    const FixtureNameMatchTier tier =
-        ComputeFixtureNameMatchTier(entry->fixtureName, request.typeName);
     const NumericTokenCompatibility numeric = ComputeNumericTokenCompatibility(
         BuildCanonicalFixtureModel(entry->fixtureName, entry->manufacturer),
-        BuildCanonicalFixtureModel(request.typeName));
+        BuildCanonicalFixtureModel(item.effectiveFixtureType));
     if (numeric == NumericTokenCompatibility::Different) {
       item.state = State::Unresolved;
+      item.origin = ResolutionOrigin::GenericFallback;
       item.details = "Conflicting numeric model identity; generic will be used unless changed";
-    } else if (tier == FixtureNameMatchTier::ExactNormalized) {
-      item.state = State::Suggested;
-      item.details = "Exact normalized model match; generic remains the default";
     } else {
-      item.state = State::Review;
-      item.details = "Plausible match requires review; generic remains the default";
+      item.state = State::Suggested;
+      SelectCatalogEntry(item, *entry, ResolutionOrigin::AutomaticMatch);
+      item.details = "Selected by the shared GDTF catalog matcher";
     }
-    result.items.push_back(std::move(item));
-  }
-  return result;
 }
 
 // Applies a user-confirmed catalog selection and auto-selects only one mode.
-void Service::SelectCatalogEntry(Item &item, const GdtfCatalogEntry &entry) {
+void Service::SelectCatalogEntry(Item &item, const GdtfCatalogEntry &entry,
+                                 ResolutionOrigin origin) {
   item.selectedEntry = entry;
   item.selectedMode = entry.modes.size() == 1 ? entry.modes.front().name : "";
+  item.origin = origin;
+}
+
+// Marks a row as created or skipped without losing its original identity.
+void Service::SetCreate(Item &item, bool create) {
+  item.create = create;
+  if (!create)
+    item.origin = ResolutionOrigin::Skipped;
+  else
+    item.origin = item.dictionaryEntry ? ResolutionOrigin::Dictionary
+                                       : ResolutionOrigin::GenericFallback;
 }
 
 // Marks an alias for the established generic fallback without dictionary state.
 void Service::SelectGeneric(Item &item) {
   item.state = State::Generic;
+  item.origin = ResolutionOrigin::GenericFallback;
   item.selectedEntry.reset();
   item.selectedMode.clear();
   item.details = "Generic fallback selected for this import";
@@ -109,7 +135,7 @@ void Service::SelectGeneric(Item &item) {
 // Converts every incomplete non-dictionary row to Generic before import.
 void Service::FinalizeDefaults(Analysis &analysis) {
   for (Item &item : analysis.items) {
-    if (item.state == State::Dictionary)
+    if (!item.create || item.state == State::Dictionary)
       continue;
     if (!item.selectedEntry || item.RequiresModeSelection())
       SelectGeneric(item);
@@ -122,11 +148,15 @@ void Service::MergeCatalogSuggestions(Analysis &current,
   const size_t count = std::min(current.items.size(), matched.items.size());
   for (size_t index = 0; index < count; ++index) {
     Item &target = current.items[index];
-    if (target.state == State::Dictionary || target.state == State::Generic ||
+    if (!target.create || target.state == State::Dictionary ||
+        target.state == State::Generic ||
         target.selectedEntry)
       continue;
     target.state = matched.items[index].state;
     target.suggestedEntry = matched.items[index].suggestedEntry;
+    target.selectedEntry = matched.items[index].selectedEntry;
+    target.selectedMode = matched.items[index].selectedMode;
+    target.origin = matched.items[index].origin;
     target.details = matched.items[index].details;
   }
 }
@@ -141,6 +171,19 @@ const char *StateName(State state) {
   case State::Generic: return "Generic";
   }
   return "Unresolved";
+}
+
+// Converts explicit resolution provenance to stable diagnostic text.
+const char *OriginName(ResolutionOrigin origin) {
+  switch (origin) {
+  case ResolutionOrigin::Dictionary: return "Dictionary";
+  case ResolutionOrigin::DictionaryModified: return "Dictionary modified";
+  case ResolutionOrigin::AutomaticMatch: return "Automatic match";
+  case ResolutionOrigin::UserSelection: return "User assigned";
+  case ResolutionOrigin::GenericFallback: return "Generic fallback";
+  case ResolutionOrigin::Skipped: return "Skipped";
+  }
+  return "Generic fallback";
 }
 
 } // namespace rider_fixture_resolution

--- a/core/rider_fixture_resolution.h
+++ b/core/rider_fixture_resolution.h
@@ -11,14 +11,27 @@
 namespace rider_fixture_resolution {
 
 enum class State { Dictionary, Suggested, Review, Unresolved, Generic };
+enum class ResolutionOrigin {
+  Dictionary,
+  DictionaryModified,
+  AutomaticMatch,
+  UserSelection,
+  GenericFallback,
+  Skipped
+};
 
 struct Item {
   RiderImporter::FixtureTypeRequest request;
+  std::string originalFixtureType;
+  std::string effectiveFixtureType;
+  bool create = true;
   State state = State::Unresolved;
+  ResolutionOrigin origin = ResolutionOrigin::GenericFallback;
   std::optional<GdtfDictionary::Entry> dictionaryEntry;
   std::optional<mvr::gdtf_catalog_matcher::GdtfCatalogEntry> suggestedEntry;
   std::optional<mvr::gdtf_catalog_matcher::GdtfCatalogEntry> selectedEntry;
   std::string selectedMode;
+  std::string originalDictionaryMode;
   std::string details;
 
   bool RequiresModeSelection() const;
@@ -41,7 +54,17 @@ public:
   // Selects a real catalog entry while preserving multi-mode ambiguity.
   static void SelectCatalogEntry(
       Item &item,
-      const mvr::gdtf_catalog_matcher::GdtfCatalogEntry &entry);
+      const mvr::gdtf_catalog_matcher::GdtfCatalogEntry &entry,
+      ResolutionOrigin origin = ResolutionOrigin::UserSelection);
+
+  // Re-resolves one edited row using dictionary first and the shared MVR matcher.
+  static void ResolveItem(
+      Item &item,
+      const std::unordered_map<std::string, GdtfDictionary::Entry> &dictionary,
+      const std::vector<mvr::gdtf_catalog_matcher::GdtfCatalogEntry> &catalog);
+
+  // Updates whether the original parsed fixture request should be created.
+  static void SetCreate(Item &item, bool create);
 
   // Selects the existing generic import fallback without persisting a mapping.
   static void SelectGeneric(Item &item);
@@ -55,5 +78,6 @@ public:
 };
 
 const char *StateName(State state);
+const char *OriginName(ResolutionOrigin origin);
 
 } // namespace rider_fixture_resolution

--- a/core/rider_fixture_resolution.h
+++ b/core/rider_fixture_resolution.h
@@ -69,6 +69,9 @@ public:
   // Selects the existing generic import fallback without persisting a mapping.
   static void SelectGeneric(Item &item);
 
+  // Records a recoverable enhancement failure and selects Generic for the row.
+  static void FallbackAfterFailure(Item &item, const std::string &reason);
+
   // Converts incomplete real selections to the non-blocking generic fallback.
   static void FinalizeDefaults(Analysis &analysis);
 

--- a/core/rider_fixture_resolution.h
+++ b/core/rider_fixture_resolution.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "gdtfdictionary.h"
+#include "riderimporter.h"
+#include "../mvr/gdtf_catalog_matcher.h"
+
+#include <optional>
+#include <unordered_map>
+#include <vector>
+
+namespace rider_fixture_resolution {
+
+enum class State { Dictionary, Suggested, Review, Unresolved, Generic };
+
+struct Item {
+  RiderImporter::FixtureTypeRequest request;
+  State state = State::Unresolved;
+  std::optional<GdtfDictionary::Entry> dictionaryEntry;
+  std::optional<mvr::gdtf_catalog_matcher::GdtfCatalogEntry> suggestedEntry;
+  std::optional<mvr::gdtf_catalog_matcher::GdtfCatalogEntry> selectedEntry;
+  std::string selectedMode;
+  std::string details;
+
+  bool RequiresModeSelection() const;
+  bool IsReady() const;
+};
+
+struct Analysis {
+  std::vector<Item> items;
+  bool RequiresPreflight() const;
+};
+
+class Service {
+public:
+  // Resolves dictionary entries first and matches each remaining alias once.
+  static Analysis Analyze(
+      const std::vector<RiderImporter::FixtureTypeRequest> &requests,
+      const std::unordered_map<std::string, GdtfDictionary::Entry> &dictionary,
+      const std::vector<mvr::gdtf_catalog_matcher::GdtfCatalogEntry> &catalog);
+
+  // Selects a real catalog entry while preserving multi-mode ambiguity.
+  static void SelectCatalogEntry(
+      Item &item,
+      const mvr::gdtf_catalog_matcher::GdtfCatalogEntry &entry);
+
+  // Selects the existing generic import fallback without persisting a mapping.
+  static void SelectGeneric(Item &item);
+};
+
+const char *StateName(State state);
+
+} // namespace rider_fixture_resolution

--- a/core/rider_fixture_resolution.h
+++ b/core/rider_fixture_resolution.h
@@ -45,6 +45,13 @@ public:
 
   // Selects the existing generic import fallback without persisting a mapping.
   static void SelectGeneric(Item &item);
+
+  // Converts incomplete real selections to the non-blocking generic fallback.
+  static void FinalizeDefaults(Analysis &analysis);
+
+  // Merges catalog results without replacing explicit user decisions.
+  static void MergeCatalogSuggestions(Analysis &current,
+                                      const Analysis &matched);
 };
 
 const char *StateName(State state);

--- a/core/rider_fixture_resolution.h
+++ b/core/rider_fixture_resolution.h
@@ -78,6 +78,11 @@ struct Summary {
   size_t skipped = 0;
 };
 
+struct CatalogMatchTarget {
+  size_t analysisIndex = 0;
+  RiderImporter::FixtureTypeRequest request;
+};
+
 class Service {
 public:
   // Resolves dictionary entries first and matches each remaining alias once.
@@ -93,6 +98,10 @@ public:
 
   // Counts the resolutions that the current import plan will actually use.
   static Summary Summarize(const Analysis &analysis);
+
+  // Selects only unresolved untouched rows that can benefit from catalog matching.
+  static std::vector<CatalogMatchTarget>
+  BuildCatalogMatchTargets(const Analysis &analysis);
 
   // Selects a real catalog entry while preserving multi-mode ambiguity.
   static void SelectCatalogEntry(

--- a/core/rider_fixture_resolution.h
+++ b/core/rider_fixture_resolution.h
@@ -66,6 +66,15 @@ struct Analysis {
   bool RequiresPreflight() const;
 };
 
+struct Summary {
+  size_t created = 0;
+  size_t dictionary = 0;
+  size_t automaticMatches = 0;
+  size_t userSelections = 0;
+  size_t genericFallbacks = 0;
+  size_t skipped = 0;
+};
+
 class Service {
 public:
   // Resolves dictionary entries first and matches each remaining alias once.
@@ -78,6 +87,9 @@ public:
   // Reports whether a progress transition is internally consistent.
   static bool IsValidProgressTransition(const Progress &previous,
                                         const Progress &next);
+
+  // Counts the resolutions that the current import plan will actually use.
+  static Summary Summarize(const Analysis &analysis);
 
   // Selects a real catalog entry while preserving multi-mode ambiguity.
   static void SelectCatalogEntry(

--- a/core/rider_fixture_resolution.h
+++ b/core/rider_fixture_resolution.h
@@ -5,6 +5,7 @@
 #include "../mvr/gdtf_catalog_matcher.h"
 
 #include <optional>
+#include <functional>
 #include <unordered_map>
 #include <vector>
 
@@ -19,6 +20,28 @@ enum class ResolutionOrigin {
   GenericFallback,
   Skipped
 };
+enum class ProgressStage {
+  LoadingCatalog,
+  ParsingCatalog,
+  MatchingFixtures,
+  Complete,
+  Unavailable
+};
+enum class StatusSemantic {
+  Neutral,
+  Modified,
+  Success,
+  Information,
+  Warning,
+  Muted
+};
+struct Progress {
+  ProgressStage stage = ProgressStage::LoadingCatalog;
+  size_t current = 0;
+  size_t total = 0;
+  size_t automaticMatches = 0;
+};
+using ProgressCallback = std::function<void(const Progress &)>;
 
 struct Item {
   RiderImporter::FixtureTypeRequest request;
@@ -49,7 +72,12 @@ public:
   static Analysis Analyze(
       const std::vector<RiderImporter::FixtureTypeRequest> &requests,
       const std::unordered_map<std::string, GdtfDictionary::Entry> &dictionary,
-      const std::vector<mvr::gdtf_catalog_matcher::GdtfCatalogEntry> &catalog);
+      const std::vector<mvr::gdtf_catalog_matcher::GdtfCatalogEntry> &catalog,
+      ProgressCallback progress = {});
+
+  // Reports whether a progress transition is internally consistent.
+  static bool IsValidProgressTransition(const Progress &previous,
+                                        const Progress &next);
 
   // Selects a real catalog entry while preserving multi-mode ambiguity.
   static void SelectCatalogEntry(
@@ -78,9 +106,12 @@ public:
   // Merges catalog results without replacing explicit user decisions.
   static void MergeCatalogSuggestions(Analysis &current,
                                       const Analysis &matched);
+  // Merges one worker result without replacing a newer explicit decision.
+  static void MergeCatalogSuggestion(Item &current, const Item &matched);
 };
 
 const char *StateName(State state);
 const char *OriginName(ResolutionOrigin origin);
+StatusSemantic StatusSemanticForOrigin(ResolutionOrigin origin);
 
 } // namespace rider_fixture_resolution

--- a/core/rider_fixture_resolution.h
+++ b/core/rider_fixture_resolution.h
@@ -22,6 +22,9 @@ enum class ResolutionOrigin {
 };
 enum class ProgressStage {
   LoadingCatalog,
+  WaitingForCredentials,
+  Authenticating,
+  DownloadingCatalog,
   ParsingCatalog,
   MatchingFixtures,
   Complete,

--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -1679,6 +1679,48 @@ std::string RiderImporter::BuildFixtureFilterPreview(const std::string &text) {
   return BuildFilteredPreviewText(ParseRiderImport(text));
 }
 
+// Aggregates fixture aliases from the same parser output used by scene import.
+std::vector<RiderImporter::FixtureTypeRequest>
+RiderImporter::AnalyzeFixtureTypes(const std::string &text,
+                                   bool textAlreadyFiltered) {
+  const ParsedRiderImport parsed = ParseRiderImport(text);
+  std::vector<FixtureTypeRequest> requests;
+  std::unordered_map<std::string, size_t> indices;
+  for (const std::string &encoded : parsed.fixtureRequests) {
+    const size_t newline = encoded.find('\n');
+    if (newline == std::string::npos)
+      continue;
+    const std::string position = Trim(encoded.substr(0, newline));
+    const std::string fixtureLine = encoded.substr(newline + 1);
+    std::smatch match;
+    if (!std::regex_match(fixtureLine, match, kFixtureLineRe))
+      continue;
+    int quantity = 0;
+    if (!TryParseInt(match[1].str(), quantity) || quantity <= 0)
+      continue;
+    const std::string displayName = Trim(match[2].str());
+    const std::string normalized = GdtfDictionary::NormalizeTypeKey(displayName);
+    if (normalized.empty())
+      continue;
+    auto [it, inserted] = indices.emplace(normalized, requests.size());
+    if (inserted) {
+      FixtureTypeRequest request;
+      request.typeName = displayName;
+      request.normalizedTypeName = normalized;
+      requests.push_back(std::move(request));
+    }
+    FixtureTypeRequest &request = requests[it->second];
+    request.quantity += quantity;
+    if (!position.empty() &&
+        std::find(request.positions.begin(), request.positions.end(), position) ==
+            request.positions.end()) {
+      request.positions.push_back(position);
+    }
+  }
+  (void)textAlreadyFiltered;
+  return requests;
+}
+
 struct ImportedGdtfMetadata {
   std::string parsedFixtureName;
   bool hasProperties = false;

--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -1851,7 +1851,8 @@ void ApplyImportedGdtfMetadata(Fixture &fixture,
 // Imports rider text into the current scene.
 bool RiderImporter::ImportText(const std::string &text,
                                ProgressCallback progressCallback,
-                               bool skipFixtureFilterPreview) {
+                               bool skipFixtureFilterPreview,
+                               const ImportPlan *importPlan) {
   if (text.empty())
     return false;
   RiderImportTimingStats timing;
@@ -2151,6 +2152,21 @@ bool RiderImporter::ImportText(const std::string &text,
           screenObjectRequests.push_back(std::move(request));
         }
         return;
+      }
+      const std::string originalNormalized =
+          GdtfDictionary::NormalizeTypeKey(part);
+      if (importPlan) {
+        const auto selection = std::find_if(
+            importPlan->fixtureSelections.begin(),
+            importPlan->fixtureSelections.end(), [&](const auto &candidate) {
+              return candidate.originalNormalizedTypeName == originalNormalized;
+            });
+        if (selection != importPlan->fixtureSelections.end()) {
+          if (!selection->create)
+            return;
+          if (!selection->effectiveTypeName.empty())
+            part = selection->effectiveTypeName;
+        }
       }
       int &counter = nameCounters[part];
       for (int i = 0; i < quantity; ++i) {

--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -1681,8 +1681,7 @@ std::string RiderImporter::BuildFixtureFilterPreview(const std::string &text) {
 
 // Aggregates fixture aliases from the same parser output used by scene import.
 std::vector<RiderImporter::FixtureTypeRequest>
-RiderImporter::AnalyzeFixtureTypes(const std::string &text,
-                                   bool textAlreadyFiltered) {
+RiderImporter::AnalyzeFixtureTypes(const std::string &text) {
   const ParsedRiderImport parsed = ParseRiderImport(text);
   std::vector<FixtureTypeRequest> requests;
   std::unordered_map<std::string, size_t> indices;
@@ -1717,7 +1716,6 @@ RiderImporter::AnalyzeFixtureTypes(const std::string &text,
       request.positions.push_back(position);
     }
   }
-  (void)textAlreadyFiltered;
   return requests;
 }
 

--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -1210,6 +1210,32 @@ struct ParsedRiderImport {
   std::string filteredPreviewText;
 };
 
+enum class RiderEquipmentKind { Fixture, ScreenObject, NonFixture };
+
+// Classifies parsed equipment with the same semantics used by analysis and import.
+RiderEquipmentKind ClassifyRiderEquipment(const std::string &position,
+                                          const std::string &description) {
+  const bool screenPosition = NormalizeHangName(position) == "SCREEN";
+  const bool screenDescription =
+      ContainsCaseInsensitive(description, "pantalla") ||
+      ContainsCaseInsensitive(description, "screen") ||
+      ContainsCaseInsensitive(description, "led wall");
+  if (screenPosition && screenDescription)
+    return RiderEquipmentKind::ScreenObject;
+
+  const bool operatorEquipment =
+      ContainsCaseInsensitive(description, "operador") ||
+      ContainsCaseInsensitive(description, "operator");
+  const bool videoControlEquipment = screenPosition &&
+      (ContainsCaseInsensitive(description, "control de contenido") ||
+       ContainsCaseInsensitive(description, "content control") ||
+       ContainsCaseInsensitive(description, "media server") ||
+       ContainsCaseInsensitive(description, "servidor de medios"));
+  if (operatorEquipment || videoControlEquipment)
+    return RiderEquipmentKind::NonFixture;
+  return RiderEquipmentKind::Fixture;
+}
+
 // Parses raw rider text into filtered import requests and preview metadata.
 ParsedRiderImport ParseRiderImport(const std::string &text) {
   ParsedRiderImport parsed;
@@ -1682,7 +1708,14 @@ std::string RiderImporter::BuildFixtureFilterPreview(const std::string &text) {
 // Aggregates fixture aliases from the same parser output used by scene import.
 std::vector<RiderImporter::FixtureTypeRequest>
 RiderImporter::AnalyzeFixtureTypes(const std::string &text) {
+  return AnalyzeText(text).fixtureTypes;
+}
+
+// Prepares fixture resolution and final filtered import data from one parse.
+RiderImporter::TextAnalysis RiderImporter::AnalyzeText(const std::string &text) {
   const ParsedRiderImport parsed = ParseRiderImport(text);
+  TextAnalysis analysis;
+  analysis.filteredText = BuildSceneImportText(parsed);
   std::vector<FixtureTypeRequest> requests;
   std::unordered_map<std::string, size_t> indices;
   for (const std::string &encoded : parsed.fixtureRequests) {
@@ -1698,6 +1731,9 @@ RiderImporter::AnalyzeFixtureTypes(const std::string &text) {
     if (!TryParseInt(match[1].str(), quantity) || quantity <= 0)
       continue;
     const std::string displayName = Trim(match[2].str());
+    if (ClassifyRiderEquipment(position, displayName) !=
+        RiderEquipmentKind::Fixture)
+      continue;
     const std::string normalized = GdtfDictionary::NormalizeTypeKey(displayName);
     if (normalized.empty())
       continue;
@@ -1716,7 +1752,8 @@ RiderImporter::AnalyzeFixtureTypes(const std::string &text) {
       request.positions.push_back(position);
     }
   }
-  return requests;
+  analysis.fixtureTypes = std::move(requests);
+  return analysis;
 }
 
 struct ImportedGdtfMetadata {
@@ -2091,12 +2128,11 @@ bool RiderImporter::ImportText(const std::string &text,
         linearPlacementHangs.insert(currentHang);
       else if (!placementKey.empty())
         seenTypesForHang.insert(placementKey);
-      const bool isScreenHang = NormalizeHangName(currentHang) == "SCREEN";
-      const bool isScreenDescription =
-          ContainsCaseInsensitive(part, "pantalla") ||
-          ContainsCaseInsensitive(part, "screen") ||
-          ContainsCaseInsensitive(part, "led wall");
-      if (isScreenHang && isScreenDescription) {
+      const RiderEquipmentKind equipmentKind =
+          ClassifyRiderEquipment(currentHang, part);
+      if (equipmentKind == RiderEquipmentKind::NonFixture)
+        return;
+      if (equipmentKind == RiderEquipmentKind::ScreenObject) {
         float screenWidthMm = 8000.0f;
         float screenHeightMm = 5000.0f;
         TryParseScreenDimensionsMm(part, screenWidthMm, screenHeightMm);

--- a/core/riderimporter.h
+++ b/core/riderimporter.h
@@ -50,8 +50,7 @@ public:
     static std::string BuildFixtureFilterPreview(const std::string& text);
     // Analyzes unique fixture requests without changing scene or dictionary state.
     static std::vector<FixtureTypeRequest>
-    AnalyzeFixtureTypes(const std::string& text,
-                        bool textAlreadyFiltered = false);
+    AnalyzeFixtureTypes(const std::string& text);
     // Import from raw rider text. Returns true on success.
     static bool ImportText(const std::string& text,
                            ProgressCallback progressCallback = {},

--- a/core/riderimporter.h
+++ b/core/riderimporter.h
@@ -30,6 +30,10 @@ public:
         int quantity = 0;
         std::vector<std::string> positions;
     };
+    struct TextAnalysis {
+        std::string filteredText;
+        std::vector<FixtureTypeRequest> fixtureTypes;
+    };
     struct ProgressState {
         std::string stage;
         int completed = 0;
@@ -51,6 +55,8 @@ public:
     // Analyzes unique fixture requests without changing scene or dictionary state.
     static std::vector<FixtureTypeRequest>
     AnalyzeFixtureTypes(const std::string& text);
+    // Prepares filtered import text and fixture types from one parser pass.
+    static TextAnalysis AnalyzeText(const std::string& text);
     // Import from raw rider text. Returns true on success.
     static bool ImportText(const std::string& text,
                            ProgressCallback progressCallback = {},

--- a/core/riderimporter.h
+++ b/core/riderimporter.h
@@ -19,10 +19,17 @@
 
 #include <functional>
 #include <string>
+#include <vector>
 
 // Parses simple rider files (.txt/.pdf) to create dummy fixtures and trusses
 class RiderImporter {
 public:
+    struct FixtureTypeRequest {
+        std::string typeName;
+        std::string normalizedTypeName;
+        int quantity = 0;
+        std::vector<std::string> positions;
+    };
     struct ProgressState {
         std::string stage;
         int completed = 0;
@@ -41,6 +48,10 @@ public:
     // Build a filtered text preview that keeps only fixture lines that would be
     // considered during text-to-scene import.
     static std::string BuildFixtureFilterPreview(const std::string& text);
+    // Analyzes unique fixture requests without changing scene or dictionary state.
+    static std::vector<FixtureTypeRequest>
+    AnalyzeFixtureTypes(const std::string& text,
+                        bool textAlreadyFiltered = false);
     // Import from raw rider text. Returns true on success.
     static bool ImportText(const std::string& text,
                            ProgressCallback progressCallback = {},

--- a/core/riderimporter.h
+++ b/core/riderimporter.h
@@ -34,6 +34,14 @@ public:
         std::string filteredText;
         std::vector<FixtureTypeRequest> fixtureTypes;
     };
+    struct FixtureImportSelection {
+        std::string originalNormalizedTypeName;
+        std::string effectiveTypeName;
+        bool create = true;
+    };
+    struct ImportPlan {
+        std::vector<FixtureImportSelection> fixtureSelections;
+    };
     struct ProgressState {
         std::string stage;
         int completed = 0;
@@ -60,5 +68,6 @@ public:
     // Import from raw rider text. Returns true on success.
     static bool ImportText(const std::string& text,
                            ProgressCallback progressCallback = {},
-                           bool skipFixtureFilterPreview = false);
+                           bool skipFixtureFilterPreview = false,
+                           const ImportPlan* importPlan = nullptr);
 };

--- a/docs/developer/text_to_scene_rules.md
+++ b/docs/developer/text_to_scene_rules.md
@@ -45,6 +45,12 @@ snapshot.
 Both **Create from text** and file-based **Import Rider** use this prepared
 analysis and the same fixture-resolution preflight before scene mutation.
 
+Each resolution row preserves its immutable parsed fixture identity separately
+from its editable effective fixture type. A prepared import plan applies the
+effective type or skips the original normalized request during fixture creation;
+non-fixture scene elements are unaffected. Automatic resolution delegates to
+`SelectBestDownloadMatch()` from the shared MVR matcher.
+
 This document explains the rules currently applied by Perastage when creating a scene from rider text loaded from `.txt` or extracted from `.pdf`.
 
 It is intended to be the **single source of truth** for:

--- a/docs/developer/text_to_scene_rules.md
+++ b/docs/developer/text_to_scene_rules.md
@@ -64,6 +64,12 @@ uses actual processed unique fixture rows, and the dialog ignores automatic
 results after its import plan has been committed. Resolution provenance maps to
 a shared semantic status palette also used by the MVR GDTF download queue.
 
+Resolver rows have immutable non-zero model keys for the dialog lifetime.
+Matching updates cells and Status attributes in place rather than deleting and
+rebuilding the active data view. The dialog owns a cancellable `std::jthread`;
+confirming or cancelling requests stop, ignores queued results, and preserves
+the finalized import plan.
+
 This document explains the rules currently applied by Perastage when creating a scene from rider text loaded from `.txt` or extracted from `.pdf`.
 
 It is intended to be the **single source of truth** for:

--- a/docs/developer/text_to_scene_rules.md
+++ b/docs/developer/text_to_scene_rules.md
@@ -1,5 +1,23 @@
 # Text-to-scene rules (Rider importer)
 
+## Fixture type resolution preflight
+
+Create from text analyzes unique normalized fixture aliases with the same rider
+parser used by the final import. The analysis is non-destructive and aggregates
+quantity and Positions before any scene objects are created. The active fixture
+dictionary is always checked first; when all referenced profiles exist, scene
+creation proceeds without an additional prompt or catalog work.
+
+Unknown aliases may be compared with the cached GDTF Share catalog, so catalog
+suggestions can be inspected offline. Exact normalized model matches are safe
+suggestions, plausible weaker matches require review, numeric model
+contradictions remain unresolved, and no selection is downloaded merely by
+opening preflight. A confirmed real selection is remembered in the fixture
+dictionary, while Generic means the established fallback for that import and
+does not create a permanent dummy mapping. Profiles with one valid DMX mode may
+select it automatically; profiles with multiple modes require an explicit mode
+choice before their mapping can be committed.
+
 This document explains the rules currently applied by Perastage when creating a scene from rider text loaded from `.txt` or extracted from `.pdf`.
 
 It is intended to be the **single source of truth** for:

--- a/docs/developer/text_to_scene_rules.md
+++ b/docs/developer/text_to_scene_rules.md
@@ -23,9 +23,11 @@ catalog parsing and dictionary-first resolution → `RiderFixtureResolutionDialo
 when intervention is required → confirmed downloads and dictionary persistence
 → `RiderImporter::ImportText`. Cancellation and failed resolution return before
 the importer pushes its undo state or accesses mutable scene content. When no
-cached catalog exists, unknown rows still open as Unresolved; Search may request
-GDTF Share authentication to refresh the shared catalog, while Generic and
-Cancel remain available offline.
+cached catalog exists, the open resolver makes one acquisition attempt through
+`DetermineCatalogAccessAction`, `GdtfCatalogService`, and the established GDTF
+Share credential flow. A successful validated refresh updates the normal shared
+cache and starts matching in the current resolver; cancellation or failure
+leaves Generic and Cancel available offline.
 
 `AnalyzeText()` owns the single raw rider parse used by preflight and returns
 both filtered import text and fixture requests. Final creation imports that
@@ -57,6 +59,9 @@ does not invoke the `@Perastage` derivative publication contract. Recoverable
 authentication, download, validation, mode, and persistence failures update
 only the affected row to Generic fallback. User cancellation remains the only
 normal preflight outcome that cancels the complete import.
+External downloads use the shared portable catalog-identity filename policy;
+the GDTF Share RID remains revision identity and is used as a suffix only when
+the readable local filename collides.
 
 The GUI-independent resolver reports `LoadingCatalog`, `ParsingCatalog`,
 `MatchingFixtures`, `Complete`, and `Unavailable` progress. Matching progress

--- a/docs/developer/text_to_scene_rules.md
+++ b/docs/developer/text_to_scene_rules.md
@@ -28,6 +28,11 @@ cached catalog exists, the open resolver makes one acquisition attempt through
 Share credential flow. A successful validated refresh updates the normal shared
 cache and starts matching in the current resolver; cancellation or failure
 leaves Generic and Cancel available offline.
+The dialog owns the cache and online-acquisition workers. Network login,
+catalog retrieval, parsing, and matching run outside the UI thread and report
+stages to the dialog's existing label and gauge. Only credential entry crosses
+back to a modal UI prompt; automatic acquisition never opens a nested progress
+dialog. Confirming or cancelling stops acceptance of late results.
 
 `AnalyzeText()` owns the single raw rider parse used by preflight and returns
 both filtered import text and fixture requests. Final creation imports that

--- a/docs/developer/text_to_scene_rules.md
+++ b/docs/developer/text_to_scene_rules.md
@@ -58,6 +58,12 @@ authentication, download, validation, mode, and persistence failures update
 only the affected row to Generic fallback. User cancellation remains the only
 normal preflight outcome that cancels the complete import.
 
+The GUI-independent resolver reports `LoadingCatalog`, `ParsingCatalog`,
+`MatchingFixtures`, `Complete`, and `Unavailable` progress. Matching progress
+uses actual processed unique fixture rows, and the dialog ignores automatic
+results after its import plan has been committed. Resolution provenance maps to
+a shared semantic status palette also used by the MVR GDTF download queue.
+
 This document explains the rules currently applied by Perastage when creating a scene from rider text loaded from `.txt` or extracted from `.pdf`.
 
 It is intended to be the **single source of truth** for:

--- a/docs/developer/text_to_scene_rules.md
+++ b/docs/developer/text_to_scene_rules.md
@@ -27,6 +27,24 @@ cached catalog exists, unknown rows still open as Unresolved; Search may request
 GDTF Share authentication to refresh the shared catalog, while Generic and
 Cancel remain available offline.
 
+`AnalyzeText()` owns the single raw rider parse used by preflight and returns
+both filtered import text and fixture requests. Final creation imports that
+prepared text in already-filtered mode. Equipment classification is shared by
+analysis and creation: screen descriptions on the SCREEN Position become scene
+objects, and semantic operator/content-control requests are non-fixture
+equipment rather than dummy fixtures.
+
+The dialog initially receives dictionary-only state and starts validated cached
+catalog loading after it becomes visible. Review and Unresolved rows visibly
+default to Generic; incomplete or mode-ambiguous real selections normalize to
+Generic on confirmation. Catalog payloads are usable only when their schema is
+recognized and at least one downloadable named entry is parsed. Invalid online
+refreshes are rejected before cache publication, preserving the last known good
+snapshot.
+
+Both **Create from text** and file-based **Import Rider** use this prepared
+analysis and the same fixture-resolution preflight before scene mutation.
+
 This document explains the rules currently applied by Perastage when creating a scene from rider text loaded from `.txt` or extracted from `.pdf`.
 
 It is intended to be the **single source of truth** for:

--- a/docs/developer/text_to_scene_rules.md
+++ b/docs/developer/text_to_scene_rules.md
@@ -33,6 +33,9 @@ catalog retrieval, parsing, and matching run outside the UI thread and report
 stages to the dialog's existing label and gauge. Only credential entry crosses
 back to a modal UI prompt; automatic acquisition never opens a nested progress
 dialog. Confirming or cancelling stops acceptance of late results.
+Catalog matching targets only enabled, unresolved, untouched rows. Dictionary,
+DictionaryModified, UserSelection, AutomaticMatch, Generic, and Skipped rows
+are excluded, and determinate progress totals count only the remaining targets.
 
 `AnalyzeText()` owns the single raw rider parse used by preflight and returns
 both filtered import text and fixture requests. Final creation imports that

--- a/docs/developer/text_to_scene_rules.md
+++ b/docs/developer/text_to_scene_rules.md
@@ -18,6 +18,15 @@ does not create a permanent dummy mapping. Profiles with one valid DMX mode may
 select it automatically; profiles with multiple modes require an explicit mode
 choice before their mapping can be committed.
 
+The runtime call chain is `RiderTextDialog` → `AnalyzeFixtureTypes` → cached
+catalog parsing and dictionary-first resolution → `RiderFixtureResolutionDialog`
+when intervention is required → confirmed downloads and dictionary persistence
+→ `RiderImporter::ImportText`. Cancellation and failed resolution return before
+the importer pushes its undo state or accesses mutable scene content. When no
+cached catalog exists, unknown rows still open as Unresolved; Search may request
+GDTF Share authentication to refresh the shared catalog, while Generic and
+Cancel remain available offline.
+
 This document explains the rules currently applied by Perastage when creating a scene from rider text loaded from `.txt` or extracted from `.pdf`.
 
 It is intended to be the **single source of truth** for:

--- a/docs/developer/text_to_scene_rules.md
+++ b/docs/developer/text_to_scene_rules.md
@@ -51,6 +51,13 @@ effective type or skips the original normalized request during fixture creation;
 non-fixture scene elements are unaffected. Automatic resolution delegates to
 `SelectBestDownloadMatch()` from the shared MVR matcher.
 
+Downloaded catalog profiles are registered as validated external library
+sources through `CreateOrUpdateExternalLibraryMapping`; this path deliberately
+does not invoke the `@Perastage` derivative publication contract. Recoverable
+authentication, download, validation, mode, and persistence failures update
+only the affected row to Generic fallback. User cancellation remains the only
+normal preflight outcome that cancels the complete import.
+
 This document explains the rules currently applied by Perastage when creating a scene from rider text loaded from `.txt` or extracted from `.pdf`.
 
 It is intended to be the **single source of truth** for:

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -4,9 +4,10 @@ Changes since **v1.5.0**.
 
 ## Highlights
 
-- Create from text now analyzes unique fixture types before scene creation,
-  prioritizing valid dictionary mappings and preparing conservative cached GDTF
-  Share suggestions without mutating the scene.
+- Create from text now stops before scene creation when a rider contains unknown
+  fixture types, presents a resolution table with cached GDTF Share suggestions,
+  explicit mode selection and Generic fallback, and remembers confirmed GDTF
+  mappings for later riders.
 
 - Automatic DMX patching now keeps logical lighting Positions and their
   physically separate bridge components together whenever universe capacity

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -46,9 +46,6 @@ Changes since **v1.5.0**.
 
 - Create-from-text fixture-resolution checks now use the repository's portable
   test launchers consistently across Debug CI platforms.
-- Windows Debug network tests now synchronize with the MVR-xchange listener
-  before checking its connection limit, avoiding timing-dependent stalls on
-  slower runners.
 
 - Resolve fixture types now builds reliably with MSVC when displaying an empty
   fixture-mode selection.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -44,6 +44,9 @@ Changes since **v1.5.0**.
 
 ## Fixes
 
+- Create-from-text fixture-resolution checks now use the repository's portable
+  test launchers consistently across Debug CI platforms.
+
 - Resolve fixture types now builds reliably with MSVC when displaying an empty
   fixture-mode selection.
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -60,6 +60,9 @@ Changes since **v1.5.0**.
 - Resolve fixture types now shows real catalog and per-fixture matching progress,
   retains a final match summary, and uses the same semantic status colors as the
   MVR GDTF download workflow.
+- Resolve fixture types now keeps stable table rows during background matching
+  and owns its cancellable catalog worker, preventing Debug assertions when
+  rows update or the dialog closes while matching is active.
 
 - Rider-import test executables now link reliably when using the shared fixture
   dictionary alias normalization required by Create from text analysis.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -69,6 +69,10 @@ Changes since **v1.5.0**.
 - Resolve fixture types now reports the mappings actually shown in the final
   table and uses portable separators, avoiding misleading match totals and
   incorrectly encoded summary characters on Windows.
+- New installations can now acquire the shared GDTF catalog directly from the
+  fixture resolver using the established Download GDTF sign-in and cache flow.
+  Manual assignments remain visually distinct, and downloaded profiles use
+  readable catalog-based filenames instead of numeric revision identifiers.
 - Shared colored data-view stores now validate item ownership and model-column
   bounds before value access or sorting, and resolver row updates publish one
   final attribute notification instead of exposing partial Status changes.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -57,6 +57,9 @@ Changes since **v1.5.0**.
 - Downloaded GDTF Share files now retain external-source identity when mapped
   from rider text, and recoverable download, mode, or dictionary failures fall
   back only the affected fixture type instead of cancelling scene creation.
+- Resolve fixture types now shows real catalog and per-fixture matching progress,
+  retains a final match summary, and uses the same semantic status colors as the
+  MVR GDTF download workflow.
 
 - Rider-import test executables now link reliably when using the shared fixture
   dictionary alias normalization required by Create from text analysis.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -63,9 +63,9 @@ Changes since **v1.5.0**.
 - Resolve fixture types now keeps stable table rows during background matching
   and owns its cancellable catalog worker, preventing Debug assertions when
   rows update or the dialog closes while matching is active.
-- Resolve fixture types now registers every custom data-view model column before
-  rows are rendered, fixing the Windows Debug assertion raised when wxWidgets
-  requested Status or Details values from an empty model-column vector.
+- Resolve fixture types now uses a fixed eight-column, analysis-backed table
+  model, preventing Windows Debug assertions caused by an empty model schema
+  while preserving live matching updates, sorting, editing, and status colors.
 - Shared colored data-view stores now validate item ownership and model-column
   bounds before value access or sorting, and resolver row updates publish one
   final attribute notification instead of exposing partial Status changes.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -44,6 +44,9 @@ Changes since **v1.5.0**.
 
 ## Fixes
 
+- Resolve fixture types now builds reliably with MSVC when displaying an empty
+  fixture-mode selection.
+
 - Rider-import test executables now link reliably when using the shared fixture
   dictionary alias normalization required by Create from text analysis.
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -51,6 +51,9 @@ Changes since **v1.5.0**.
   screens and video-control equipment from fixture resolution, shows cached
   suggestions without delaying the dialog, and rejects empty GDTF Share
   catalogs without replacing the last known good cache.
+- Fixture resolution now automatically uses the shared MVR catalog matcher,
+  supports corrected fixture names and per-type creation choices, and searches
+  combined manufacturer and model identities such as GLP JDC1.
 
 - Rider-import test executables now link reliably when using the shared fixture
   dictionary alias normalization required by Create from text analysis.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -43,6 +43,9 @@ Changes since **v1.5.0**.
 
 ## Fixes
 
+- Rider-import test executables now link reliably when using the shared fixture
+  dictionary alias normalization required by Create from text analysis.
+
 - Download GDTF now requests sign-in before loading an uncached catalog and no
   longer opens an unusable empty search window when credentials are missing,
   rejected, or the online catalog cannot be loaded. Cached catalogs remain

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -76,6 +76,9 @@ Changes since **v1.5.0**.
 - Catalog sign-in, download, parsing, and automatic matching progress now stay
   inside Resolve fixture types instead of opening additional progress windows,
   with stable completion, cancellation, and offline-fallback status messages.
+- Automatic rider catalog matching now skips fixture types already resolved by
+  the active dictionary or an explicit choice, reducing unnecessary matching
+  work and making progress totals reflect only unresolved rows.
 - Shared colored data-view stores now validate item ownership and model-column
   bounds before value access or sorting, and resolver row updates publish one
   final attribute notification instead of exposing partial Status changes.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -46,6 +46,9 @@ Changes since **v1.5.0**.
 
 - Create-from-text fixture-resolution checks now use the repository's portable
   test launchers consistently across Debug CI platforms.
+- Windows Debug network tests now synchronize with the MVR-xchange listener
+  before checking its connection limit, avoiding timing-dependent stalls on
+  slower runners.
 
 - Resolve fixture types now builds reliably with MSVC when displaying an empty
   fixture-mode selection.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -63,6 +63,9 @@ Changes since **v1.5.0**.
 - Resolve fixture types now keeps stable table rows during background matching
   and owns its cancellable catalog worker, preventing Debug assertions when
   rows update or the dialog closes while matching is active.
+- Resolve fixture types now registers every custom data-view model column before
+  rows are rendered, fixing the Windows Debug assertion raised when wxWidgets
+  requested Status or Details values from an empty model-column vector.
 
 - Rider-import test executables now link reliably when using the shared fixture
   dictionary alias normalization required by Create from text analysis.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -4,6 +4,10 @@ Changes since **v1.5.0**.
 
 ## Highlights
 
+- Create from text now analyzes unique fixture types before scene creation,
+  prioritizing valid dictionary mappings and preparing conservative cached GDTF
+  Share suggestions without mutating the scene.
+
 - Automatic DMX patching now keeps logical lighting Positions and their
   physically separate bridge components together whenever universe capacity
   allows, including deterministic serpentine patching for parallel side

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -602,6 +602,8 @@ Changes since **v1.5.0**.
 
 ## Internal changes
 
+- Improved MVR-xchange TCP lifecycle diagnostics for cross-platform test runs.
+
 - Made the fixture-symbol processing ownership check portable across the Bash
   versions and filesystem path conventions used by Debug CI runners.
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -73,6 +73,9 @@ Changes since **v1.5.0**.
   fixture resolver using the established Download GDTF sign-in and cache flow.
   Manual assignments remain visually distinct, and downloaded profiles use
   readable catalog-based filenames instead of numeric revision identifiers.
+- Catalog sign-in, download, parsing, and automatic matching progress now stay
+  inside Resolve fixture types instead of opening additional progress windows,
+  with stable completion, cancellation, and offline-fallback status messages.
 - Shared colored data-view stores now validate item ownership and model-column
   bounds before value access or sorting, and resolver row updates publish one
   final attribute notification instead of exposing partial Status changes.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -66,6 +66,9 @@ Changes since **v1.5.0**.
 - Resolve fixture types now uses a fixed eight-column, analysis-backed table
   model, preventing Windows Debug assertions caused by an empty model schema
   while preserving live matching updates, sorting, editing, and status colors.
+- Resolve fixture types now reports the mappings actually shown in the final
+  table and uses portable separators, avoiding misleading match totals and
+  incorrectly encoded summary characters on Windows.
 - Shared colored data-view stores now validate item ownership and model-column
   bounds before value access or sorting, and resolver row updates publish one
   final attribute notification instead of exposing partial Status changes.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -54,6 +54,9 @@ Changes since **v1.5.0**.
 - Fixture resolution now automatically uses the shared MVR catalog matcher,
   supports corrected fixture names and per-type creation choices, and searches
   combined manufacturer and model identities such as GLP JDC1.
+- Downloaded GDTF Share files now retain external-source identity when mapped
+  from rider text, and recoverable download, mode, or dictionary failures fall
+  back only the affected fixture type instead of cancelling scene creation.
 
 - Rider-import test executables now link reliably when using the shared fixture
   dictionary alias normalization required by Create from text analysis.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -66,6 +66,9 @@ Changes since **v1.5.0**.
 - Resolve fixture types now registers every custom data-view model column before
   rows are rendered, fixing the Windows Debug assertion raised when wxWidgets
   requested Status or Details values from an empty model-column vector.
+- Shared colored data-view stores now validate item ownership and model-column
+  bounds before value access or sorting, and resolver row updates publish one
+  final attribute notification instead of exposing partial Status changes.
 
 - Rider-import test executables now link reliably when using the shared fixture
   dictionary alias normalization required by Create from text analysis.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -47,6 +47,11 @@ Changes since **v1.5.0**.
 - Resolve fixture types now builds reliably with MSVC when displaying an empty
   fixture-mode selection.
 
+- Create from text now keeps Generic fallback immediately available, excludes
+  screens and video-control equipment from fixture resolution, shows cached
+  suggestions without delaying the dialog, and rejects empty GDTF Share
+  catalogs without replacing the last known good cache.
+
 - Rider-import test executables now link reliably when using the shared fixture
   dictionary alias normalization required by Create from text analysis.
 

--- a/docs/user/create-from-text.md
+++ b/docs/user/create-from-text.md
@@ -1,5 +1,12 @@
 # Create from Text
 
+Before creating the scene, Perastage checks every unique fixture type against
+the active fixture dictionary. Unknown types can be reviewed against cached
+GDTF Share suggestions without signing in merely to open the review. Downloads
+begin only after confirmation, accepted mappings are remembered for later
+riders, and Generic remains available for a one-time fallback. When a selected
+profile has several DMX modes, you must choose the intended mode explicitly.
+
 Use **Tools → Create from text** to build scene content from rider-style text.
 
 ## Supported inputs

--- a/docs/user/create-from-text.md
+++ b/docs/user/create-from-text.md
@@ -33,6 +33,8 @@ access still leaves Generic fallback available.
 Catalog sign-in, download, parsing, and matching progress remain in the
 **Resolve fixture types** progress area; only the credential-entry dialog opens
 separately when user input is required.
+Automatic catalog matching skips rows already resolved by the active dictionary
+or an explicit selection, so the matching total represents unresolved rows only.
 
 Fixture types can be corrected directly in the table without changing the
 source rider text. The **Create** checkbox can omit every fixture represented

--- a/docs/user/create-from-text.md
+++ b/docs/user/create-from-text.md
@@ -7,6 +7,14 @@ begin only after confirmation, accepted mappings are remembered for later
 riders, and Generic remains available for a one-time fallback. When a selected
 profile has several DMX modes, you must choose the intended mode explicitly.
 
+The **Resolve fixture types** window appears whenever at least one referenced
+fixture has no valid file in the active dictionary, including when no catalog is
+available. **Use suggested** accepts a strong exact catalog match, **Search...**
+opens the existing GDTF Share browser for the selected alias, and **Use generic**
+continues with the one-import fallback without saving a dummy mapping. Selected
+profiles are downloaded only after **Resolve and create** is pressed. Cancelling
+closes the workflow before any scene content or dictionary mapping is changed.
+
 Use **Tools → Create from text** to build scene content from rider-style text.
 
 ## Supported inputs

--- a/docs/user/create-from-text.md
+++ b/docs/user/create-from-text.md
@@ -32,6 +32,12 @@ source rider text. The **Create** checkbox can omit every fixture represented
 by a row while preserving trusses, screens, hoists, and other rider objects.
 Manual GDTF search uses the combined manufacturer and fixture identity.
 
+The resolver shows a compact progress gauge while loading and parsing the
+catalog, followed by real per-fixture matching progress. Its final summary stays
+visible, and the Status column uses distinct colors for dictionary, modified,
+automatic, user-assigned, Generic, and skipped outcomes. **Resolve and create**
+remains available while matching runs.
+
 Double-click a row's **Mode** cell to choose from its valid modes. Dictionary
 rows show the mapped local GDTF filename, and confirmed dictionary-mode changes
 are saved only after **Resolve and create**.

--- a/docs/user/create-from-text.md
+++ b/docs/user/create-from-text.md
@@ -15,6 +15,19 @@ continues with the one-import fallback without saving a dummy mapping. Selected
 profiles are downloaded only after **Resolve and create** is pressed. Cancelling
 closes the workflow before any scene content or dictionary mapping is changed.
 
+Generic fallback is the visible default and never blocks **Resolve and create**.
+Safe suggestions are optional; suggestions without a chosen mode fall back to
+Generic. Screen objects and video-control equipment are not treated as lighting
+fixtures. Cached catalog matching runs after the resolver is visible, and an
+empty or unavailable catalog leaves the offline Generic workflow usable.
+
+Double-click a row's **Mode** cell to choose from its valid modes. Dictionary
+rows show the mapped local GDTF filename, and confirmed dictionary-mode changes
+are saved only after **Resolve and create**.
+
+Importing a rider from a `.txt` or `.pdf` file uses the same preflight and
+fallback behavior as pasting rider text.
+
 Use **Tools → Create from text** to build scene content from rider-style text.
 
 ## Supported inputs

--- a/docs/user/create-from-text.md
+++ b/docs/user/create-from-text.md
@@ -21,6 +21,11 @@ Generic. Screen objects and video-control equipment are not treated as lighting
 fixtures. Cached catalog matching runs after the resolver is visible, and an
 empty or unavailable catalog leaves the offline Generic workflow usable.
 
+Fixture types can be corrected directly in the table without changing the
+source rider text. The **Create** checkbox can omit every fixture represented
+by a row while preserving trusses, screens, hoists, and other rider objects.
+Manual GDTF search uses the combined manufacturer and fixture identity.
+
 Double-click a row's **Mode** cell to choose from its valid modes. Dictionary
 rows show the mapped local GDTF filename, and confirmed dictionary-mode changes
 are saved only after **Resolve and create**.

--- a/docs/user/create-from-text.md
+++ b/docs/user/create-from-text.md
@@ -30,6 +30,9 @@ On a new installation without a usable cache, Perastage makes one catalog
 acquisition attempt through the same GDTF Share sign-in and validated refresh
 workflow as **Tools > Download GDTF**. Cancelling sign-in or losing network
 access still leaves Generic fallback available.
+Catalog sign-in, download, parsing, and matching progress remain in the
+**Resolve fixture types** progress area; only the credential-entry dialog opens
+separately when user input is required.
 
 Fixture types can be corrected directly in the table without changing the
 source rider text. The **Create** checkbox can omit every fixture represented

--- a/docs/user/create-from-text.md
+++ b/docs/user/create-from-text.md
@@ -15,6 +15,12 @@ continues with the one-import fallback without saving a dummy mapping. Selected
 profiles are downloaded only after **Resolve and create** is pressed. Cancelling
 closes the workflow before any scene content or dictionary mapping is changed.
 
+Successful GDTF resolutions are applied when possible. A recoverable download,
+validation, mode, authentication, or dictionary error changes only the affected
+fixture type to Generic fallback; scene creation continues with the remaining
+safe import plan. Downloaded GDTF Share sources retain their external identity
+and are not mislabeled as Perastage-generated derivatives.
+
 Generic fallback is the visible default and never blocks **Resolve and create**.
 Safe suggestions are optional; suggestions without a chosen mode fall back to
 Generic. Screen objects and video-control equipment are not treated as lighting

--- a/docs/user/create-from-text.md
+++ b/docs/user/create-from-text.md
@@ -26,11 +26,17 @@ Safe suggestions are optional; suggestions without a chosen mode fall back to
 Generic. Screen objects and video-control equipment are not treated as lighting
 fixtures. Cached catalog matching runs after the resolver is visible, and an
 empty or unavailable catalog leaves the offline Generic workflow usable.
+On a new installation without a usable cache, Perastage makes one catalog
+acquisition attempt through the same GDTF Share sign-in and validated refresh
+workflow as **Tools > Download GDTF**. Cancelling sign-in or losing network
+access still leaves Generic fallback available.
 
 Fixture types can be corrected directly in the table without changing the
 source rider text. The **Create** checkbox can omit every fixture represented
 by a row while preserving trusses, screens, hoists, and other rider objects.
 Manual GDTF search uses the combined manufacturer and fixture identity.
+Downloaded profiles use a portable catalog-based filename, while their GDTF
+Share revision ID remains the internal download and deduplication identity.
 
 The resolver shows a compact progress gauge while loading and parsing the
 catalog, followed by real per-fixture matching progress. Its final summary stays

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -124,6 +124,8 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/scene_view_refresh.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/stable_dataview_identity_index.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ridertextdialog.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/rider_fixture_resolution_dialog.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/rider_fixture_resolution_workflow.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ridertext_autocomplete_provider.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/riggingpanel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/sceneobjecttablepanel.cpp

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -125,6 +125,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/stable_dataview_identity_index.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ridertextdialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/rider_fixture_resolution_dialog.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/rider_fixture_resolution_model.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/rider_fixture_resolution_workflow.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ridertext_autocomplete_provider.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/riggingpanel.cpp

--- a/gui/colorstore.h
+++ b/gui/colorstore.h
@@ -58,6 +58,8 @@ public:
       hasTextColour = attr.HasColour();
     }
 
+    if (row >= GetItemCount())
+      return hasAttr;
     const wxDataViewItem rowItem = GetItem(row);
     const wxUIntPtr itemKey = rowItem.IsOk() ? GetItemData(rowItem) : 0;
     bool isSelected =

--- a/gui/colorstore.h
+++ b/gui/colorstore.h
@@ -17,6 +17,8 @@
  */
 #pragma once
 #include <algorithm>
+#include <cstdint>
+#include <optional>
 #include <unordered_set>
 #include <vector>
 #include <wx/dataview.h>
@@ -40,6 +42,38 @@ public:
   bool selectionForegroundEnabled = false;
   bool highlightBackgroundEnabled = false;
   bool highlightForegroundEnabled = false;
+
+  // Finds a model-owned row without trusting a transient item identifier.
+  std::optional<unsigned> FindOwnedRow(const wxDataViewItem &item) const {
+    if (!item.IsOk())
+      return std::nullopt;
+    const unsigned count = GetItemCount();
+    for (unsigned row = 0; row < count; ++row) {
+      if (GetItem(row) == item)
+        return row;
+    }
+    return std::nullopt;
+  }
+
+  // Returns a cell value only when both item and model column are valid.
+  void GetValue(wxVariant &value, const wxDataViewItem &item,
+                unsigned int column) const override {
+    const auto row = FindOwnedRow(item);
+    if (!row || column >= GetColumnCount()) {
+      value.MakeNull();
+      return;
+    }
+    wxDataViewListStore::GetValueByRow(value, *row, column);
+  }
+
+  // Updates a cell only when both item and model column are valid.
+  bool SetValue(const wxVariant &value, const wxDataViewItem &item,
+                unsigned int column) override {
+    const auto row = FindOwnedRow(item);
+    return row && column < GetColumnCount()
+               ? wxDataViewListStore::SetValueByRow(value, *row, column)
+               : false;
+  }
 
   bool GetAttrByRow(unsigned row, unsigned col,
                     wxDataViewItemAttr &attr) const override {
@@ -198,21 +232,22 @@ public:
     }
   }
 
-  void SetCellTextColour(unsigned row, unsigned col, const wxColour &colour) {
+  void SetCellTextColour(unsigned row, unsigned col, const wxColour &colour,
+                         bool notify = true) {
     if (row >= cellAttrs.size())
       cellAttrs.resize(row + 1);
     if (col >= cellAttrs[row].size())
       cellAttrs[row].resize(col + 1);
     cellAttrs[row][col].SetColour(colour);
-    if (row < GetItemCount())
+    if (notify && row < GetItemCount())
       RowChanged(row);
   }
 
-  void ClearCellTextColour(unsigned row, unsigned col) {
+  void ClearCellTextColour(unsigned row, unsigned col, bool notify = true) {
     if (row >= cellAttrs.size() || col >= cellAttrs[row].size())
       return;
     cellAttrs[row][col] = wxDataViewItemAttr();
-    if (row < GetItemCount())
+    if (notify && row < GetItemCount())
       RowChanged(row);
   }
 
@@ -318,13 +353,19 @@ public:
 
   int Compare(const wxDataViewItem &item1, const wxDataViewItem &item2,
               unsigned int column, bool ascending) const override {
+    const auto row1 = FindOwnedRow(item1);
+    const auto row2 = FindOwnedRow(item2);
+    if (!row1 || !row2 || column >= GetColumnCount()) {
+      const auto key1 = reinterpret_cast<std::uintptr_t>(item1.GetID());
+      const auto key2 = reinterpret_cast<std::uintptr_t>(item2.GetID());
+      const int fallback = key1 < key2 ? -1 : (key1 > key2 ? 1 : 0);
+      return ascending ? fallback : -fallback;
+    }
     int res = 0;
     if (column == 1) {
       wxVariant v1, v2;
-      const_cast<ColorfulDataViewListStore *>(this)->GetValue(v1, item1,
-                                                              column);
-      const_cast<ColorfulDataViewListStore *>(this)->GetValue(v2, item2,
-                                                              column);
+      wxDataViewListStore::GetValueByRow(v1, *row1, column);
+      wxDataViewListStore::GetValueByRow(v2, *row2, column);
       wxString s1 = v1.GetString();
       wxString s2 = v2.GetString();
 
@@ -352,7 +393,12 @@ public:
         res = s1.Cmp(s2);
       }
     } else {
-      res = wxDataViewListStore::Compare(item1, item2, column, true);
+      wxVariant v1, v2;
+      wxDataViewListStore::GetValueByRow(v1, *row1, column);
+      wxDataViewListStore::GetValueByRow(v2, *row2, column);
+      res = v1.GetString().Cmp(v2.GetString());
+      if (v1.GetType() == "bool" && v2.GetType() == "bool")
+        res = static_cast<int>(v1.GetBool()) - static_cast<int>(v2.GetBool());
     }
 
     if (res == 0) {

--- a/gui/colorstore.h
+++ b/gui/colorstore.h
@@ -43,6 +43,14 @@ public:
   bool highlightBackgroundEnabled = false;
   bool highlightForegroundEnabled = false;
 
+  // Reports the schema registered in the list store instead of the base default.
+  unsigned int GetColumnCount() const override { return m_cols.size(); }
+
+  // Returns a registered column type without indexing outside the schema.
+  wxString GetColumnType(unsigned int column) const override {
+    return column < m_cols.size() ? m_cols[column] : wxString();
+  }
+
   // Finds a model-owned row without trusting a transient item identifier.
   std::optional<unsigned> FindOwnedRow(const wxDataViewItem &item) const {
     if (!item.IsOk())

--- a/gui/gdtf_resolution_status_style.h
+++ b/gui/gdtf_resolution_status_style.h
@@ -3,22 +3,43 @@
 #include "../core/rider_fixture_resolution.h"
 
 #include <wx/colour.h>
+#include <wx/app.h>
+#include <wx/settings.h>
 
-// Returns the established GDTF workflow colour for a semantic resolution status.
+// Reports whether the current system window palette is predominantly dark.
+inline bool IsDarkGdtfResolutionAppearance() {
+  if (!wxTheApp)
+    return false;
+  const wxColour background =
+      wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW);
+  const int luminance = 299 * background.Red() + 587 * background.Green() +
+                        114 * background.Blue();
+  return luminance < 128000;
+}
+
+// Returns the established GDTF workflow colour for an explicit appearance.
 inline wxColour GdtfResolutionStatusColour(
-    rider_fixture_resolution::StatusSemantic semantic) {
+    rider_fixture_resolution::StatusSemantic semantic, bool dark) {
   switch (semantic) {
   case rider_fixture_resolution::StatusSemantic::Success:
-    return wxColour(30, 120, 60);
+    return dark ? wxColour(100, 210, 125) : wxColour(30, 120, 60);
   case rider_fixture_resolution::StatusSemantic::Warning:
-    return wxColour(150, 100, 0);
+    return dark ? wxColour(240, 180, 70) : wxColour(150, 100, 0);
   case rider_fixture_resolution::StatusSemantic::Muted:
-    return wxColour(130, 130, 130);
+    return dark ? wxColour(155, 155, 155) : wxColour(105, 105, 105);
   case rider_fixture_resolution::StatusSemantic::Modified:
+    return dark ? wxColour(195, 145, 255) : wxColour(105, 45, 160);
   case rider_fixture_resolution::StatusSemantic::Information:
-    return wxColour(20, 80, 160);
+    return dark ? wxColour(95, 175, 255) : wxColour(20, 80, 160);
   case rider_fixture_resolution::StatusSemantic::Neutral:
-    return wxColour(80, 80, 80);
+    return dark ? wxColour(235, 235, 235) : wxColour(35, 35, 35);
   }
-  return wxColour(80, 80, 80);
+  return dark ? wxColour(235, 235, 235) : wxColour(35, 35, 35);
+}
+
+// Returns the established GDTF workflow colour for the current appearance.
+inline wxColour GdtfResolutionStatusColour(
+    rider_fixture_resolution::StatusSemantic semantic) {
+  return GdtfResolutionStatusColour(semantic,
+                                    IsDarkGdtfResolutionAppearance());
 }

--- a/gui/gdtf_resolution_status_style.h
+++ b/gui/gdtf_resolution_status_style.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "../core/rider_fixture_resolution.h"
+
+#include <wx/colour.h>
+
+// Returns the established GDTF workflow colour for a semantic resolution status.
+inline wxColour GdtfResolutionStatusColour(
+    rider_fixture_resolution::StatusSemantic semantic) {
+  switch (semantic) {
+  case rider_fixture_resolution::StatusSemantic::Success:
+    return wxColour(30, 120, 60);
+  case rider_fixture_resolution::StatusSemantic::Warning:
+    return wxColour(150, 100, 0);
+  case rider_fixture_resolution::StatusSemantic::Muted:
+    return wxColour(130, 130, 130);
+  case rider_fixture_resolution::StatusSemantic::Modified:
+  case rider_fixture_resolution::StatusSemantic::Information:
+    return wxColour(20, 80, 160);
+  case rider_fixture_resolution::StatusSemantic::Neutral:
+    return wxColour(80, 80, 80);
+  }
+  return wxColour(80, 80, 80);
+}

--- a/gui/gdtfsearchdialog.cpp
+++ b/gui/gdtfsearchdialog.cpp
@@ -368,6 +368,15 @@ std::string GdtfSearchDialog::GetSelectedName() const
     return {};
 }
 
+// Returns the complete selected catalog row for resolver consumers.
+std::optional<mvr::gdtf_catalog_matcher::GdtfCatalogEntry>
+GdtfSearchDialog::GetSelectedEntry() const
+{
+    if (selectedIndex >= 0 && selectedIndex < static_cast<int>(entries.size()))
+        return entries[selectedIndex];
+    return std::nullopt;
+}
+
 std::string GdtfSearchDialog::GetCurrentListData() const
 {
     return currentListData;

--- a/gui/gdtfsearchdialog.cpp
+++ b/gui/gdtfsearchdialog.cpp
@@ -76,7 +76,9 @@ GdtfSearchDialog::GdtfSearchDialog(wxWindow* parent, const std::string& listData
                                    RefreshCatalogFn refreshCatalogFnIn,
                                    GdtfCatalogDisplaySource initialSource,
                                    bool downloadRequiresAuthenticationIn,
-                                   const std::string& initialFixtureQuery)
+                                   const std::string& initialFixtureQuery,
+                                   std::vector<mvr::gdtf_catalog_matcher::GdtfCatalogEntry>
+                                       initialParsedEntries)
     : wxDialog(parent, wxID_ANY, _("Search GDTF"), wxDefaultPosition,
                wxSize(1000,700),
                wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER),
@@ -166,7 +168,10 @@ GdtfSearchDialog::GdtfSearchDialog(wxWindow* parent, const std::string& listData
     Bind(wxEVT_TIMER, &GdtfSearchDialog::OnSearchDebounceTimer, this,
          searchDebounceTimer.GetId());
 
-    ParseList(currentListData);
+    if (initialParsedEntries.empty())
+        ParseList(currentListData);
+    else
+        entries = std::move(initialParsedEntries);
     fixtureCtrl->ChangeValue(wxString::FromUTF8(initialFixtureQuery));
     UpdateResults();
     UpdateStatusMessage(false);

--- a/gui/gdtfsearchdialog.cpp
+++ b/gui/gdtfsearchdialog.cpp
@@ -93,6 +93,10 @@ GdtfSearchDialog::GdtfSearchDialog(wxWindow* parent, const std::string& listData
     wxBoxSizer* sizer = new wxBoxSizer(wxVERTICAL);
 
     wxBoxSizer* searchSizer = new wxBoxSizer(wxHORIZONTAL);
+    searchSizer->Add(new wxStaticText(this, wxID_ANY, _("Search:")), 0, wxALIGN_CENTER_VERTICAL|wxRIGHT, 5);
+    generalQueryCtrl = new wxTextCtrl(this, wxID_ANY, "", wxDefaultPosition,
+                                     wxDefaultSize, wxTE_PROCESS_ENTER);
+    searchSizer->Add(generalQueryCtrl, 1, wxRIGHT, 10);
     searchSizer->Add(new wxStaticText(this, wxID_ANY, _("Manufacturer:")), 0, wxALIGN_CENTER_VERTICAL|wxRIGHT, 5);
     manufacturerCtrl = new wxTextCtrl(this, wxID_ANY, "", wxDefaultPosition,
                                      wxDefaultSize, wxTE_PROCESS_ENTER);
@@ -156,8 +160,10 @@ GdtfSearchDialog::GdtfSearchDialog(wxWindow* parent, const std::string& listData
 
     manufacturerCtrl->Bind(wxEVT_TEXT_ENTER, &GdtfSearchDialog::OnSearch, this);
     fixtureCtrl->Bind(wxEVT_TEXT_ENTER, &GdtfSearchDialog::OnSearch, this);
+    generalQueryCtrl->Bind(wxEVT_TEXT_ENTER, &GdtfSearchDialog::OnSearch, this);
     manufacturerCtrl->Bind(wxEVT_TEXT, &GdtfSearchDialog::OnSearchTextChanged, this);
     fixtureCtrl->Bind(wxEVT_TEXT, &GdtfSearchDialog::OnSearchTextChanged, this);
+    generalQueryCtrl->Bind(wxEVT_TEXT, &GdtfSearchDialog::OnSearchTextChanged, this);
     downloadButton->Bind(wxEVT_BUTTON, &GdtfSearchDialog::OnDownload, this);
     prevPageButton->Bind(wxEVT_BUTTON, &GdtfSearchDialog::OnPrevPage, this);
     nextPageButton->Bind(wxEVT_BUTTON, &GdtfSearchDialog::OnNextPage, this);
@@ -172,7 +178,7 @@ GdtfSearchDialog::GdtfSearchDialog(wxWindow* parent, const std::string& listData
         ParseList(currentListData);
     else
         entries = std::move(initialParsedEntries);
-    fixtureCtrl->ChangeValue(wxString::FromUTF8(initialFixtureQuery));
+    generalQueryCtrl->ChangeValue(wxString::FromUTF8(initialFixtureQuery));
     UpdateResults();
     UpdateStatusMessage(false);
 }
@@ -224,15 +230,23 @@ void GdtfSearchDialog::UpdateResults()
     const auto matches = mvr::gdtf_catalog_parser::FilterCatalogEntries(
         entries, manufacturerCtrl->GetValue().ToStdString(),
         fixtureCtrl->GetValue().ToStdString());
-    for (std::size_t index : matches)
-        filteredIndices.push_back(static_cast<int>(index));
+    const std::string general = mvr::gdtf_catalog_matcher::NormalizeForGdtfMatch(
+        generalQueryCtrl->GetValue().ToStdString());
+    for (std::size_t index : matches) {
+        const auto& entry = entries[index];
+        const std::string identity =
+            mvr::gdtf_catalog_matcher::NormalizeForGdtfMatch(
+                entry.manufacturer + " " + entry.fixtureName);
+        if (general.empty() || identity.find(general) != std::string::npos)
+            filteredIndices.push_back(static_cast<int>(index));
+    }
 
     lastFilterMs = std::chrono::duration_cast<std::chrono::milliseconds>(
                        std::chrono::steady_clock::now() - filterStart)
                        .count();
     MaybeLogVerboseCatalogTrace(wxString::Format(
-        "Filtering manufacturer='%s' fixture='%s' matches=%zu filter_ms=%lld",
-        manufacturerCtrl->GetValue(), fixtureCtrl->GetValue(),
+        "Filtering query='%s' manufacturer='%s' fixture='%s' matches=%zu filter_ms=%lld",
+        generalQueryCtrl->GetValue(), manufacturerCtrl->GetValue(), fixtureCtrl->GetValue(),
         filteredIndices.size(), static_cast<long long>(lastFilterMs)));
 
     currentPage = 0;

--- a/gui/gdtfsearchdialog.cpp
+++ b/gui/gdtfsearchdialog.cpp
@@ -75,7 +75,8 @@ GdtfSearchDialog::GdtfSearchDialog(wxWindow* parent, const std::string& listData
                                    const std::string& cachedUpdatedAt,
                                    RefreshCatalogFn refreshCatalogFnIn,
                                    GdtfCatalogDisplaySource initialSource,
-                                   bool downloadRequiresAuthenticationIn)
+                                   bool downloadRequiresAuthenticationIn,
+                                   const std::string& initialFixtureQuery)
     : wxDialog(parent, wxID_ANY, _("Search GDTF"), wxDefaultPosition,
                wxSize(1000,700),
                wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER),
@@ -166,6 +167,7 @@ GdtfSearchDialog::GdtfSearchDialog(wxWindow* parent, const std::string& listData
          searchDebounceTimer.GetId());
 
     ParseList(currentListData);
+    fixtureCtrl->ChangeValue(wxString::FromUTF8(initialFixtureQuery));
     UpdateResults();
     UpdateStatusMessage(false);
 }

--- a/gui/gdtfsearchdialog.h
+++ b/gui/gdtfsearchdialog.h
@@ -52,7 +52,9 @@ public:
                      RefreshCatalogFn refreshCatalogFn,
                      GdtfCatalogDisplaySource initialSource = GdtfCatalogDisplaySource::Cached,
                      bool downloadRequiresAuthentication = false,
-                     const std::string& initialFixtureQuery = {});
+                     const std::string& initialFixtureQuery = {},
+                     std::vector<mvr::gdtf_catalog_matcher::GdtfCatalogEntry>
+                         initialParsedEntries = {});
     ~GdtfSearchDialog() override;
     std::string GetSelectedId() const;
     std::string GetSelectedUrl() const;

--- a/gui/gdtfsearchdialog.h
+++ b/gui/gdtfsearchdialog.h
@@ -20,6 +20,7 @@
 #include <wx/dataview.h>
 #include <wx/timer.h>
 #include <functional>
+#include <optional>
 #include <thread>
 #include <vector>
 #include "../mvr/gdtf_catalog_matcher.h"
@@ -56,6 +57,8 @@ public:
     std::string GetSelectedId() const;
     std::string GetSelectedUrl() const;
     std::string GetSelectedName() const;
+    std::optional<mvr::gdtf_catalog_matcher::GdtfCatalogEntry>
+    GetSelectedEntry() const;
     std::string GetCurrentListData() const;
 private:
     void ParseList(const std::string& listData);

--- a/gui/gdtfsearchdialog.h
+++ b/gui/gdtfsearchdialog.h
@@ -83,6 +83,7 @@ private:
 
     wxTextCtrl* manufacturerCtrl = nullptr;
     wxTextCtrl* fixtureCtrl = nullptr;
+    wxTextCtrl* generalQueryCtrl = nullptr;
     wxDataViewListCtrl* resultTable = nullptr;
     wxStaticText* statusLabel = nullptr;
     wxButton* prevPageButton = nullptr;

--- a/gui/gdtfsearchdialog.h
+++ b/gui/gdtfsearchdialog.h
@@ -50,7 +50,8 @@ public:
                      const std::string& cachedUpdatedAt,
                      RefreshCatalogFn refreshCatalogFn,
                      GdtfCatalogDisplaySource initialSource = GdtfCatalogDisplaySource::Cached,
-                     bool downloadRequiresAuthentication = false);
+                     bool downloadRequiresAuthentication = false,
+                     const std::string& initialFixtureQuery = {});
     ~GdtfSearchDialog() override;
     std::string GetSelectedId() const;
     std::string GetSelectedUrl() const;

--- a/gui/mainwindow_io.cpp
+++ b/gui/mainwindow_io.cpp
@@ -449,10 +449,11 @@ void MainWindow::OnImportRider(wxCommandEvent &event) {
     return;
   }
   std::string preparedRiderText;
+  RiderImporter::ImportPlan importPlan;
   const auto preflightResult =
       rider_fixture_resolution_gui::RunCreateFromTextPreflight(
           this, GetDefaultGuiConfigServices().LegacyConfigManager(), riderText,
-          &preparedRiderText);
+          &preparedRiderText, &importPlan);
   if (preflightResult != rider_fixture_resolution_gui::PreflightResult::Proceed)
     return;
   std::unique_ptr<wxWindowDisabler> importDisabler =
@@ -464,7 +465,8 @@ void MainWindow::OnImportRider(wxCommandEvent &event) {
   LockViewportInteraction();
   ScopeExit viewportUnlock([this]() { UnlockViewportInteraction(); });
   if (!RiderImporter::ImportText(
-          preparedRiderText.empty() ? riderText : preparedRiderText, {}, true)) {
+          preparedRiderText.empty() ? riderText : preparedRiderText, {}, true,
+          &importPlan)) {
     wxMessageBox("Failed to import rider.", "Error", wxICON_ERROR);
     if (consolePanel)
       consolePanel->AppendMessage("[ERROR] Failed to import " + dlg.GetPath());
@@ -494,10 +496,11 @@ void MainWindow::OnImportRiderText(wxCommandEvent &WXUNUSED(event)) {
   }
 
   std::string preparedRiderText;
+  RiderImporter::ImportPlan importPlan;
   const auto preflightResult =
       rider_fixture_resolution_gui::RunCreateFromTextPreflight(
           this, GetDefaultGuiConfigServices().LegacyConfigManager(), riderText,
-          &preparedRiderText);
+          &preparedRiderText, &importPlan);
   if (preflightResult !=
       rider_fixture_resolution_gui::PreflightResult::Proceed) {
     diagnostics::DiagnosticLogger::Info(
@@ -546,7 +549,7 @@ void MainWindow::OnImportRiderText(wxCommandEvent &WXUNUSED(event)) {
             }
             GetStatusBar()->Update();
           },
-          true)) {
+          true, &importPlan)) {
     wxMessageBox("Failed to import rider text.", "Error", wxICON_ERROR);
     if (consolePanel)
       consolePanel->AppendMessage("[ERROR] Failed to import rider from text.");

--- a/gui/mainwindow_io.cpp
+++ b/gui/mainwindow_io.cpp
@@ -443,6 +443,18 @@ void MainWindow::OnImportRider(wxCommandEvent &event) {
   const std::filesystem::path selectedPath(dlg.GetPath().ToStdWstring());
   const auto pathU8 = selectedPath.u8string();
   const std::string pathUtf8(pathU8.begin(), pathU8.end());
+  const std::string riderText = RiderImporter::LoadText(pathUtf8);
+  if (riderText.empty()) {
+    wxMessageBox(_("Failed to read rider."), _("Error"), wxICON_ERROR, this);
+    return;
+  }
+  std::string preparedRiderText;
+  const auto preflightResult =
+      rider_fixture_resolution_gui::RunCreateFromTextPreflight(
+          this, GetDefaultGuiConfigServices().LegacyConfigManager(), riderText,
+          &preparedRiderText);
+  if (preflightResult != rider_fixture_resolution_gui::PreflightResult::Proceed)
+    return;
   std::unique_ptr<wxWindowDisabler> importDisabler =
       std::make_unique<wxWindowDisabler>();
   std::unique_ptr<wxBusyInfo> importOverlay =
@@ -451,7 +463,8 @@ void MainWindow::OnImportRider(wxCommandEvent &event) {
 
   LockViewportInteraction();
   ScopeExit viewportUnlock([this]() { UnlockViewportInteraction(); });
-  if (!RiderImporter::Import(pathUtf8)) {
+  if (!RiderImporter::ImportText(
+          preparedRiderText.empty() ? riderText : preparedRiderText, {}, true)) {
     wxMessageBox("Failed to import rider.", "Error", wxICON_ERROR);
     if (consolePanel)
       consolePanel->AppendMessage("[ERROR] Failed to import " + dlg.GetPath());
@@ -480,10 +493,11 @@ void MainWindow::OnImportRiderText(wxCommandEvent &WXUNUSED(event)) {
     return;
   }
 
-  const bool riderTextAlreadyFiltered = dlg.IsCurrentTextFilteredPreview();
+  std::string preparedRiderText;
   const auto preflightResult =
       rider_fixture_resolution_gui::RunCreateFromTextPreflight(
-          this, GetDefaultGuiConfigServices().LegacyConfigManager(), riderText);
+          this, GetDefaultGuiConfigServices().LegacyConfigManager(), riderText,
+          &preparedRiderText);
   if (preflightResult !=
       rider_fixture_resolution_gui::PreflightResult::Proceed) {
     diagnostics::DiagnosticLogger::Info(
@@ -503,7 +517,7 @@ void MainWindow::OnImportRiderText(wxCommandEvent &WXUNUSED(event)) {
   wxYieldIfNeeded();
 
   if (!RiderImporter::ImportText(
-          riderText,
+          preparedRiderText.empty() ? riderText : preparedRiderText,
           [&](const RiderImporter::ProgressState &progress) {
             if (!GetStatusBar())
               return;
@@ -532,7 +546,7 @@ void MainWindow::OnImportRiderText(wxCommandEvent &WXUNUSED(event)) {
             }
             GetStatusBar()->Update();
           },
-          riderTextAlreadyFiltered)) {
+          true)) {
     wxMessageBox("Failed to import rider text.", "Error", wxICON_ERROR);
     if (consolePanel)
       consolePanel->AppendMessage("[ERROR] Failed to import rider from text.");

--- a/gui/mainwindow_io.cpp
+++ b/gui/mainwindow_io.cpp
@@ -19,6 +19,7 @@
 #include "mvrxchange/mvr_xchange_dialog.h"
 #include "filesystem_path_utils.h"
 #include "mainwindow_io_controller.h"
+#include "rider_fixture_resolution_workflow.h"
 
 #include <algorithm>
 #include <chrono>
@@ -479,6 +480,19 @@ void MainWindow::OnImportRiderText(wxCommandEvent &WXUNUSED(event)) {
     return;
   }
 
+  const bool riderTextAlreadyFiltered = dlg.IsCurrentTextFilteredPreview();
+  const auto preflightResult =
+      rider_fixture_resolution_gui::RunCreateFromTextPreflight(
+          this, GetDefaultGuiConfigServices().LegacyConfigManager(), riderText);
+  if (preflightResult !=
+      rider_fixture_resolution_gui::PreflightResult::Proceed) {
+    diagnostics::DiagnosticLogger::Info(
+        preflightResult == rider_fixture_resolution_gui::PreflightResult::Cancelled
+            ? "Text/rider fixture preflight cancelled."
+            : "Text/rider fixture preflight failed.");
+    return;
+  }
+
   LockViewportInteraction();
   ScopeExit viewportUnlock([this]() { UnlockViewportInteraction(); });
   std::unique_ptr<wxWindowDisabler> createDisabler =
@@ -488,7 +502,6 @@ void MainWindow::OnImportRiderText(wxCommandEvent &WXUNUSED(event)) {
   std::unique_ptr<wxProgressDialog> createProgress;
   wxYieldIfNeeded();
 
-  const bool riderTextAlreadyFiltered = dlg.IsCurrentTextFilteredPreview();
   if (!RiderImporter::ImportText(
           riderText,
           [&](const RiderImporter::ProgressState &progress) {

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -67,6 +67,7 @@
 #include "fixturetablepanel.h"
 #include "gdtf_catalog_service.h"
 #include "gdtfdictionary.h"
+#include "gdtf_download_workflow.h"
 #include "gdtfloader.h"
 #include "gdtfnet.h"
 #include "gdtf_share_workflow.h"
@@ -766,22 +767,17 @@ void MainWindow::OnDownloadGdtf(wxCommandEvent &WXUNUSED(event)) {
           consolePanel->AppendMessage("[INFO] Downloading via libcurl rid=" +
                                       rid);
         GdtfShareResult downloadResult =
-            gdtfClient.DownloadRevision(WxToUtf8(rid), WxToUtf8(dest));
-        if (downloadResult.category == GdtfShareResultCategory::AuthenticationRejected) {
-          diagnostics::DiagnosticLogger::Info(
-              "GDTF download auth prompt reason=expired_session");
-          activeCredentials.reset();
-          if (requestCredentialsFromDialog()) {
-            gdtfClient.ResetSession();
-            GdtfShareResult retryLogin;
-            if (ensureAuthenticated(retryLogin)) {
-              downloadResult =
-                  gdtfClient.DownloadRevision(WxToUtf8(rid), WxToUtf8(dest));
-            } else {
-              downloadResult = retryLogin;
-            }
-          }
-        }
+            gdtf_download_workflow::DownloadWithExpiredSessionRetry(
+                gdtfClient, WxToUtf8(rid), WxToUtf8(dest), [&]() {
+                  diagnostics::DiagnosticLogger::Info(
+                      "GDTF download auth prompt reason=expired_session");
+                  activeCredentials.reset();
+                  if (!requestCredentialsFromDialog())
+                    return false;
+                  gdtfClient.ResetSession();
+                  GdtfShareResult retryLogin;
+                  return ensureAuthenticated(retryLogin);
+                });
         long dlCode = downloadResult.httpStatus;
         bool ok = downloadResult.Succeeded();
         clearGdtfDownloadBlockingUi();

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -67,6 +67,7 @@
 #include "fixturetablepanel.h"
 #include "gdtf_catalog_service.h"
 #include "gdtfdictionary.h"
+#include "gdtf_download_filename.h"
 #include "gdtf_download_workflow.h"
 #include "gdtfloader.h"
 #include "gdtfnet.h"
@@ -750,9 +751,19 @@ void MainWindow::OnDownloadGdtf(wxCommandEvent &WXUNUSED(event)) {
     wxString rid = wxString::FromUTF8(searchDlg.GetSelectedId());
     wxString name = wxString::FromUTF8(searchDlg.GetSelectedName());
 
+    std::string manufacturer;
+    std::string fixtureName = WxToUtf8(name);
+    if (const auto selectedEntry = searchDlg.GetSelectedEntry()) {
+      manufacturer = selectedEntry->manufacturer;
+      fixtureName = selectedEntry->fixtureName;
+    }
+
     wxString fixDir =
         wxString::FromUTF8(ProjectUtils::GetWritableLibraryPath("fixtures"));
-    wxFileDialog saveDlg(this, "Save GDTF file", fixDir, name + ".gdtf",
+    const wxString suggestedFileName = wxString::FromUTF8(
+        gdtf_download_filename::BuildReadableFileName(manufacturer,
+                                                      fixtureName));
+    wxFileDialog saveDlg(this, "Save GDTF file", fixDir, suggestedFileName,
                          "*.gdtf", wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
     clearGdtfDownloadBlockingUi();
     if (saveDlg.ShowModal() == wxID_OK) {

--- a/gui/rider_fixture_resolution_dialog.cpp
+++ b/gui/rider_fixture_resolution_dialog.cpp
@@ -62,11 +62,13 @@ wxString FormatCatalogIdentity(const rider_fixture_resolution::Item &item) {
 // Creates the modal fixture-resolution review without starting downloads.
 RiderFixtureResolutionDialog::RiderFixtureResolutionDialog(
     wxWindow *parent, rider_fixture_resolution::Analysis analysisIn,
+    std::unordered_map<std::string, GdtfDictionary::Entry> dictionaryIn,
     CatalogLoader cachedCatalogLoaderIn, CatalogLoader onlineCatalogLoaderIn)
     : wxDialog(parent, wxID_ANY, _("Resolve fixture types"), wxDefaultPosition,
                wxSize(1160, 680),
                wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER),
       analysis(std::move(analysisIn)),
+      dictionary(std::move(dictionaryIn)),
       cachedCatalogLoader(std::move(cachedCatalogLoaderIn)),
       onlineCatalogLoader(std::move(onlineCatalogLoaderIn)) {
   BuildLayout();
@@ -99,7 +101,9 @@ void RiderFixtureResolutionDialog::BuildLayout() {
   table = new wxDataViewListCtrl(this, wxID_ANY, wxDefaultPosition,
                                  wxDefaultSize, wxDV_ROW_LINES);
   const int flags = wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE;
-  table->AppendTextColumn(_("Fixture type"), wxDATAVIEW_CELL_INERT, 220,
+  table->AppendToggleColumn(_("Create"), wxDATAVIEW_CELL_ACTIVATABLE, 65,
+                            wxALIGN_CENTER, flags);
+  table->AppendTextColumn(_("Fixture type"), wxDATAVIEW_CELL_EDITABLE, 220,
                           wxALIGN_LEFT, flags);
   table->AppendTextColumn(_("Qty"), wxDATAVIEW_CELL_INERT, 55, wxALIGN_RIGHT,
                           flags);
@@ -142,6 +146,8 @@ void RiderFixtureResolutionDialog::BuildLayout() {
               &RiderFixtureResolutionDialog::OnSelectionChanged, this);
   table->Bind(wxEVT_DATAVIEW_ITEM_ACTIVATED,
               &RiderFixtureResolutionDialog::OnItemActivated, this);
+  table->Bind(wxEVT_DATAVIEW_ITEM_VALUE_CHANGED,
+              &RiderFixtureResolutionDialog::OnValueChanged, this);
   useSuggestedButton->Bind(wxEVT_BUTTON,
                            &RiderFixtureResolutionDialog::OnUseSuggested, this);
   searchButton->Bind(wxEVT_BUTTON, &RiderFixtureResolutionDialog::OnSearch,
@@ -160,14 +166,15 @@ void RiderFixtureResolutionDialog::RefreshTable() {
   table->DeleteAllItems();
   for (const auto &item : analysis.items) {
     wxVector<wxVariant> row;
-    row.push_back(wxString::FromUTF8(item.request.typeName));
+    row.push_back(item.create);
+    row.push_back(wxString::FromUTF8(item.effectiveFixtureType));
     row.push_back(wxString::Format("%d", item.request.quantity));
     row.push_back(JoinPositions(item.request.positions));
     row.push_back(FormatCatalogIdentity(item));
     row.push_back(item.selectedMode.empty()
                       ? wxString("-")
                       : wxString::FromUTF8(item.selectedMode));
-    row.push_back(wxString::FromUTF8(rider_fixture_resolution::StateName(item.state)));
+    row.push_back(wxString::FromUTF8(rider_fixture_resolution::OriginName(item.origin)));
     row.push_back(wxString::FromUTF8(item.details));
     table->AppendItem(row);
   }
@@ -179,23 +186,31 @@ void RiderFixtureResolutionDialog::RefreshTable() {
 // Updates row-action availability for the selected fixture row.
 void RiderFixtureResolutionDialog::RefreshSelectionControls() {
   rider_fixture_resolution::Item *item = SelectedItem();
-  useSuggestedButton->Enable(item && item->state == rider_fixture_resolution::State::Suggested &&
+  useSuggestedButton->Enable(item && item->create && item->state == rider_fixture_resolution::State::Suggested &&
                              item->suggestedEntry.has_value());
-  searchButton->Enable(item && item->state != rider_fixture_resolution::State::Dictionary);
-  useGenericButton->Enable(item && item->state != rider_fixture_resolution::State::Dictionary);
+  searchButton->Enable(item && item->create && item->state != rider_fixture_resolution::State::Dictionary);
+  useGenericButton->Enable(item && item->create && item->state != rider_fixture_resolution::State::Dictionary);
 }
 
 // Updates the real-mapping count while keeping Generic confirmation available.
 void RiderFixtureResolutionDialog::RefreshSummary() {
-  const size_t realMappings = static_cast<size_t>(std::count_if(
+  const size_t created = static_cast<size_t>(std::count_if(
+      analysis.items.begin(), analysis.items.end(), [](const auto &item) {
+        return item.create;
+      }));
+  const size_t automatic = static_cast<size_t>(std::count_if(
       analysis.items.begin(), analysis.items.end(),
       [](const auto &item) {
-        return item.state == rider_fixture_resolution::State::Dictionary ||
-               (item.selectedEntry && !item.RequiresModeSelection());
+        return item.create && item.origin == rider_fixture_resolution::ResolutionOrigin::AutomaticMatch;
       }));
+  const size_t generic = static_cast<size_t>(std::count_if(
+      analysis.items.begin(), analysis.items.end(), [](const auto &item) {
+        return item.create && item.origin == rider_fixture_resolution::ResolutionOrigin::GenericFallback;
+      }));
+  const size_t skipped = analysis.items.size() - created;
   summaryLabel->SetLabel(wxString::Format(
-      _("%zu real mappings selected; remaining rows use Generic"),
-      realMappings));
+      _("%zu fixture types will be created · %zu automatic matches · %zu generic · %zu skipped"),
+      created, automatic, generic, skipped));
   resolveButton->Enable(true);
 }
 
@@ -215,13 +230,15 @@ void RiderFixtureResolutionDialog::OnSelectionChanged(wxDataViewEvent &event) {
 
 // Edits a row mode through the activated Mode cell using valid profile modes.
 void RiderFixtureResolutionDialog::OnItemActivated(wxDataViewEvent &event) {
-  if (event.GetColumn() != 4)
+  if (event.GetColumn() != 5)
     return;
   const int activatedRow = table->ItemToRow(event.GetItem());
   if (activatedRow != wxNOT_FOUND)
     table->SelectRow(activatedRow);
   auto *item = SelectedItem();
   if (!item)
+    return;
+  if (!item->create)
     return;
   std::vector<std::string> modes;
   if (item->state == rider_fixture_resolution::State::Dictionary &&
@@ -251,7 +268,38 @@ void RiderFixtureResolutionDialog::OnItemActivated(wxDataViewEvent &event) {
       return;
     item->selectedMode = choice.GetStringSelection().ToStdString();
   }
+  if (item->dictionaryEntry) {
+    item->origin = item->selectedMode == item->originalDictionaryMode
+        ? rider_fixture_resolution::ResolutionOrigin::Dictionary
+        : rider_fixture_resolution::ResolutionOrigin::DictionaryModified;
+  }
   RefreshTable();
+  RefreshSummary();
+}
+
+// Applies committed Create and Fixture type cell edits to the resolution model.
+void RiderFixtureResolutionDialog::OnValueChanged(wxDataViewEvent &event) {
+  const int row = table->ItemToRow(event.GetItem());
+  if (row == wxNOT_FOUND || row >= static_cast<int>(analysis.items.size()))
+    return;
+  auto &item = analysis.items[static_cast<size_t>(row)];
+  wxVariant value;
+  table->GetValue(value, static_cast<unsigned int>(row),
+                  static_cast<unsigned int>(event.GetColumn()));
+  if (event.GetColumn() == 0) {
+    rider_fixture_resolution::Service::SetCreate(item, value.GetBool());
+    if (item.create)
+      rider_fixture_resolution::Service::ResolveItem(item, dictionary,
+                                                      catalogEntries);
+  } else if (event.GetColumn() == 1) {
+    const std::string edited =
+        mvr::gdtf_catalog_matcher::TrimFixtureIdentity(value.GetString().ToStdString());
+    item.effectiveFixtureType = edited.empty() ? item.originalFixtureType : edited;
+    rider_fixture_resolution::Service::ResolveItem(item, dictionary,
+                                                    catalogEntries);
+  }
+  RefreshTable();
+  RefreshSelectionControls();
   RefreshSummary();
 }
 
@@ -289,12 +337,14 @@ void RiderFixtureResolutionDialog::OnSearch(wxCommandEvent &) {
                               ? GdtfCatalogDisplaySource::Online
                               : GdtfCatalogDisplaySource::Cached,
                           catalogSource != CatalogSource::Online,
-                          item->request.typeName, catalogEntries);
+                          item->effectiveFixtureType, catalogEntries);
   if (dialog.ShowModal() != wxID_OK)
     return;
   const auto selected = dialog.GetSelectedEntry();
   if (selected)
-    rider_fixture_resolution::Service::SelectCatalogEntry(*item, *selected);
+    rider_fixture_resolution::Service::SelectCatalogEntry(
+        *item, *selected,
+        rider_fixture_resolution::ResolutionOrigin::UserSelection);
   RefreshTable();
   RefreshSelectionControls();
   RefreshSummary();
@@ -369,7 +419,13 @@ RiderFixtureResolutionDialog::BuildFixtureRequests() const {
   std::vector<RiderImporter::FixtureTypeRequest> requests;
   requests.reserve(analysis.items.size());
   for (const auto &item : analysis.items)
-    requests.push_back(item.request);
+  {
+    auto request = item.request;
+    request.typeName = item.effectiveFixtureType;
+    request.normalizedTypeName = GdtfDictionary::NormalizeTypeKey(
+        item.effectiveFixtureType);
+    requests.push_back(std::move(request));
+  }
   return requests;
 }
 

--- a/gui/rider_fixture_resolution_dialog.cpp
+++ b/gui/rider_fixture_resolution_dialog.cpp
@@ -141,8 +141,9 @@ void RiderFixtureResolutionDialog::RefreshTable() {
     row.push_back(wxString::Format("%d", item.request.quantity));
     row.push_back(JoinPositions(item.request.positions));
     row.push_back(FormatCatalogIdentity(item));
-    row.push_back(item.selectedMode.empty() ? "-"
-                                            : wxString::FromUTF8(item.selectedMode));
+    row.push_back(item.selectedMode.empty()
+                      ? wxString("-")
+                      : wxString::FromUTF8(item.selectedMode));
     row.push_back(wxString::FromUTF8(rider_fixture_resolution::StateName(item.state)));
     row.push_back(wxString::FromUTF8(item.details));
     table->AppendItem(row);

--- a/gui/rider_fixture_resolution_dialog.cpp
+++ b/gui/rider_fixture_resolution_dialog.cpp
@@ -22,6 +22,8 @@
 namespace {
 
 const wxEventTypeTag<wxThreadEvent> EVT_RIDER_CATALOG_LOADED(wxNewEventType());
+const wxEventTypeTag<wxThreadEvent> EVT_RIDER_ONLINE_CATALOG_LOADED(
+    wxNewEventType());
 const wxEventTypeTag<wxThreadEvent> EVT_RIDER_CATALOG_PROGRESS(wxNewEventType());
 
 } // namespace
@@ -30,14 +32,21 @@ const wxEventTypeTag<wxThreadEvent> EVT_RIDER_CATALOG_PROGRESS(wxNewEventType())
 RiderFixtureResolutionDialog::RiderFixtureResolutionDialog(
     wxWindow *parent, rider_fixture_resolution::Analysis analysisIn,
     std::unordered_map<std::string, GdtfDictionary::Entry> dictionaryIn,
-    CatalogLoader cachedCatalogLoaderIn, CatalogLoader onlineCatalogLoaderIn)
+    CatalogLoader cachedCatalogLoaderIn,
+    OnlineCatalogLoader onlineCatalogLoaderIn,
+    std::optional<CredentialStore::Credentials> initialCredentials,
+    CredentialRequester credentialRequesterIn,
+    CredentialPersistCallback credentialPersistCallbackIn)
     : wxDialog(parent, wxID_ANY, _("Resolve fixture types"), wxDefaultPosition,
                wxSize(1160, 680),
                wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER),
       analysis(std::move(analysisIn)),
       dictionary(std::move(dictionaryIn)),
       cachedCatalogLoader(std::move(cachedCatalogLoaderIn)),
-      onlineCatalogLoader(std::move(onlineCatalogLoaderIn)) {
+      onlineCatalogLoader(std::move(onlineCatalogLoaderIn)),
+      catalogCredentials(std::move(initialCredentials)),
+      credentialRequester(std::move(credentialRequesterIn)),
+      credentialPersistCallback(std::move(credentialPersistCallbackIn)) {
   BuildLayout();
   PopulateTable();
   RefreshSelectionControls();
@@ -47,6 +56,8 @@ RiderFixtureResolutionDialog::RiderFixtureResolutionDialog(
   Bind(wxEVT_SHOW, &RiderFixtureResolutionDialog::OnDialogShown, this);
   Bind(EVT_RIDER_CATALOG_LOADED,
        &RiderFixtureResolutionDialog::OnCatalogLoaded, this);
+  Bind(EVT_RIDER_ONLINE_CATALOG_LOADED,
+       &RiderFixtureResolutionDialog::OnOnlineCatalogLoaded, this);
   Bind(EVT_RIDER_CATALOG_PROGRESS,
        &RiderFixtureResolutionDialog::OnProgress, this);
 }
@@ -72,7 +83,7 @@ void RiderFixtureResolutionDialog::BuildLayout() {
                 _("Review unknown rider fixture types before creating the scene.")),
             0, wxEXPAND | wxALL, 12);
   catalogStatusLabel = new wxStaticText(
-      this, wxID_ANY, _("Loading cached GDTF catalog..."));
+      this, wxID_ANY, _("Checking cached GDTF catalog..."));
   root->Add(catalogStatusLabel, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 12);
   catalogProgressGauge = new wxGauge(this, wxID_ANY, 100, wxDefaultPosition,
                                      wxSize(-1, 6), wxGA_HORIZONTAL | wxGA_SMOOTH);
@@ -183,6 +194,19 @@ void RiderFixtureResolutionDialog::RefreshSummary() {
       summary.created, summary.automaticMatches, summary.genericFallbacks,
       summary.skipped));
   resolveButton->Enable(true);
+}
+
+// Shows a stable completion message derived from the applied resolution plan.
+void RiderFixtureResolutionDialog::RefreshCatalogCompletionStatus() {
+  const auto summary = rider_fixture_resolution::Service::Summarize(analysis);
+  if (summary.automaticMatches == 0) {
+    catalogStatusLabel->SetLabel(
+        _("Automatic matching complete | No additional matches found"));
+    return;
+  }
+  catalogStatusLabel->SetLabel(wxString::Format(
+      _("Automatic matching complete | %zu matches | %zu generic fallbacks"),
+      summary.automaticMatches, summary.genericFallbacks));
 }
 
 // Returns the model item corresponding to the selected table row.
@@ -325,13 +349,14 @@ void RiderFixtureResolutionDialog::OnSearch(wxCommandEvent &) {
                    _("GDTF catalog"), wxOK | wxICON_INFORMATION, this);
       return;
     }
-    const auto loaded = onlineCatalogLoader ? onlineCatalogLoader() : std::nullopt;
-    if (!loaded) {
+    if (onlineCatalogLoader) {
+      onlineCatalogLoadAttempted = true;
+      BeginOnlineCatalogAcquisition();
+    } else {
       wxMessageBox(_("The GDTF catalog is unavailable. You can use generic or cancel without changing the scene."),
                    _("GDTF catalog unavailable"), wxOK | wxICON_INFORMATION, this);
-      return;
     }
-    ApplyCatalog(*loaded);
+    return;
   }
   GdtfSearchDialog dialog(this, catalogPayload, catalogUpdatedAt, nullptr,
                           catalogSource == CatalogSource::Online
@@ -416,14 +441,8 @@ void RiderFixtureResolutionDialog::OnCatalogLoaded(wxThreadEvent &event) {
   if (!loaded) {
     if (onlineCatalogLoader && !onlineCatalogLoadAttempted) {
       onlineCatalogLoadAttempted = true;
-      catalogStatusLabel->SetLabel(
-          _("Acquiring the shared GDTF catalog..."));
-      catalogProgressGauge->Pulse();
-      const auto acquired = onlineCatalogLoader();
-      if (acquired) {
-        ApplyCatalog(*acquired);
-        return;
-      }
+      BeginOnlineCatalogAcquisition();
+      return;
     }
     catalogStatusLabel->SetLabel(
         _("Catalog unavailable; generic fallback remains available."));
@@ -431,6 +450,116 @@ void RiderFixtureResolutionDialog::OnCatalogLoaded(wxThreadEvent &event) {
     return;
   }
   ApplyCatalog(*loaded);
+}
+
+// Requests credentials on the UI thread before starting online acquisition.
+void RiderFixtureResolutionDialog::BeginOnlineCatalogAcquisition(
+    bool rejectedCredentials) {
+  if (!acceptAutomaticResults || shuttingDown.load())
+    return;
+  if (rejectedCredentials)
+    catalogCredentials.reset();
+  if (!catalogCredentials) {
+    catalogStatusLabel->SetLabel(
+        _("Waiting for GDTF Share credentials..."));
+    catalogProgressGauge->Pulse();
+    catalogCredentials = credentialRequester
+                             ? credentialRequester(rejectedCredentials)
+                             : std::nullopt;
+    if (!catalogCredentials) {
+      catalogStatusLabel->SetLabel(
+          _("GDTF catalog sign-in cancelled - generic fallback remains available"));
+      catalogProgressGauge->SetValue(0);
+      return;
+    }
+  }
+  catalogStatusLabel->SetLabel(_("Connecting to GDTF Share..."));
+  catalogProgressGauge->Pulse();
+  StartOnlineCatalogWorker(*catalogCredentials);
+}
+
+// Starts owned background authentication, refresh, parsing, and matching work.
+void RiderFixtureResolutionDialog::StartOnlineCatalogWorker(
+    const CredentialStore::Credentials &credentials) {
+  RequestWorkerStop();
+  if (catalogWorker.joinable())
+    catalogWorker.join();
+  catalogLoading = true;
+  const auto requests = BuildFixtureRequests();
+  const OnlineCatalogLoader loader = onlineCatalogLoader;
+  catalogWorker = std::jthread(
+      [this, loader, credentials, requests](std::stop_token stopToken) mutable {
+    auto report = [this, &stopToken](const ProgressData &progress) {
+      if (stopToken.stop_requested() || shuttingDown.load())
+        return;
+      auto *event = new wxThreadEvent(EVT_RIDER_CATALOG_PROGRESS);
+      event->SetPayload(progress);
+      wxQueueEvent(this, event);
+    };
+    OnlineCatalogResult result = loader(
+        credentials, stopToken,
+        [&](const rider_fixture_resolution::Progress &progress) {
+          report({progress});
+        });
+    if (result.catalog && !stopToken.stop_requested() &&
+        !shuttingDown.load()) {
+      auto &catalog = *result.catalog;
+      const auto matchStarted = std::chrono::steady_clock::now();
+      rider_fixture_resolution::Analysis matches;
+      size_t automaticMatches = 0;
+      for (size_t row = 0; row < requests.size(); ++row) {
+        if (stopToken.stop_requested() || shuttingDown.load())
+          return;
+        auto one = rider_fixture_resolution::Service::Analyze(
+            {requests[row]}, {}, catalog.entries);
+        if (one.items.front().origin ==
+            rider_fixture_resolution::ResolutionOrigin::AutomaticMatch)
+          ++automaticMatches;
+        matches.items.push_back(one.items.front());
+        report({{rider_fixture_resolution::ProgressStage::MatchingFixtures,
+                 row + 1, requests.size(), automaticMatches},
+                row, one.items.front()});
+      }
+      report({{rider_fixture_resolution::ProgressStage::Complete,
+               requests.size(), requests.size(), automaticMatches}});
+      catalog.matches = std::move(matches);
+      catalog.matchMs =
+          std::chrono::duration_cast<std::chrono::milliseconds>(
+              std::chrono::steady_clock::now() - matchStarted).count();
+    }
+    if (stopToken.stop_requested() || shuttingDown.load())
+      return;
+    auto *event = new wxThreadEvent(EVT_RIDER_ONLINE_CATALOG_LOADED);
+    event->SetPayload(result);
+    wxQueueEvent(this, event);
+  });
+}
+
+// Applies online acquisition results or returns to credential entry/fallback.
+void RiderFixtureResolutionDialog::OnOnlineCatalogLoaded(wxThreadEvent &event) {
+  catalogLoading = false;
+  if (!acceptAutomaticResults)
+    return;
+  const auto result = event.GetPayload<OnlineCatalogResult>();
+  if (result.status == OnlineCatalogStatus::AuthenticationRejected) {
+    BeginOnlineCatalogAcquisition(true);
+    return;
+  }
+  if (result.status != OnlineCatalogStatus::Success || !result.catalog) {
+    diagnostics::DiagnosticLogger::Warning(
+        "Rider fixture catalog acquisition unavailable: " + result.error);
+    catalogStatusLabel->SetLabel(
+        _("GDTF catalog unavailable - generic fallback remains available"));
+    catalogProgressGauge->SetValue(0);
+    return;
+  }
+  if (catalogCredentials && credentialPersistCallback)
+    credentialPersistCallback(*catalogCredentials);
+  ApplyCatalog(*result.catalog);
+  catalogProgressGauge->SetRange(
+      static_cast<int>(std::max<size_t>(analysis.items.size(), 1)));
+  catalogProgressGauge->SetValue(static_cast<int>(analysis.items.size()));
+  RefreshCatalogCompletionStatus();
 }
 
 // Updates the visible gauge from real catalog and matching worker progress.
@@ -448,7 +577,19 @@ void RiderFixtureResolutionDialog::OnProgress(wxThreadEvent &event) {
   }
   switch (progress.stage) {
   case rider_fixture_resolution::ProgressStage::LoadingCatalog:
-    catalogStatusLabel->SetLabel(_("Loading cached GDTF catalog..."));
+    catalogStatusLabel->SetLabel(_("Checking cached GDTF catalog..."));
+    catalogProgressGauge->Pulse();
+    break;
+  case rider_fixture_resolution::ProgressStage::WaitingForCredentials:
+    catalogStatusLabel->SetLabel(_("Waiting for GDTF Share credentials..."));
+    catalogProgressGauge->Pulse();
+    break;
+  case rider_fixture_resolution::ProgressStage::Authenticating:
+    catalogStatusLabel->SetLabel(_("Signing in to GDTF Share..."));
+    catalogProgressGauge->Pulse();
+    break;
+  case rider_fixture_resolution::ProgressStage::DownloadingCatalog:
+    catalogStatusLabel->SetLabel(_("Downloading GDTF catalog..."));
     catalogProgressGauge->Pulse();
     break;
   case rider_fixture_resolution::ProgressStage::ParsingCatalog:
@@ -465,10 +606,7 @@ void RiderFixtureResolutionDialog::OnProgress(wxThreadEvent &event) {
   case rider_fixture_resolution::ProgressStage::Complete: {
     catalogProgressGauge->SetRange(static_cast<int>(std::max<size_t>(progress.total, 1)));
     catalogProgressGauge->SetValue(static_cast<int>(progress.total));
-    const auto summary = rider_fixture_resolution::Service::Summarize(analysis);
-    catalogStatusLabel->SetLabel(wxString::Format(
-        _("Automatic matching complete | %zu matches | %zu generic fallbacks"),
-        summary.automaticMatches, summary.genericFallbacks));
+    RefreshCatalogCompletionStatus();
     acceptAllButton->Enable(true);
     break;
   }

--- a/gui/rider_fixture_resolution_dialog.cpp
+++ b/gui/rider_fixture_resolution_dialog.cpp
@@ -1,18 +1,26 @@
 #include "rider_fixture_resolution_dialog.h"
 
 #include "gdtfsearchdialog.h"
+#include "gdtfloader.h"
+#include "../core/diagnostics/DiagnosticLogger.h"
 
 #include <algorithm>
+#include <chrono>
+#include <filesystem>
 #include <sstream>
 
 #include <wx/button.h>
-#include <wx/choice.h>
+#include <wx/choicdlg.h>
 #include <wx/dataview.h>
 #include <wx/msgdlg.h>
 #include <wx/sizer.h>
 #include <wx/stattext.h>
+#include <wx/thread.h>
+#include <wx/weakref.h>
 
 namespace {
+
+const wxEventTypeTag<wxThreadEvent> EVT_RIDER_CATALOG_LOADED(wxNewEventType());
 
 // Joins position labels for compact table presentation.
 wxString JoinPositions(const std::vector<std::string> &positions) {
@@ -27,6 +35,20 @@ wxString JoinPositions(const std::vector<std::string> &positions) {
 
 // Formats the selected or suggested catalog identity for a resolution row.
 wxString FormatCatalogIdentity(const rider_fixture_resolution::Item &item) {
+  if (item.state == rider_fixture_resolution::State::Dictionary &&
+      item.dictionaryEntry && !item.dictionaryEntry->path.empty()) {
+    return wxString::FromUTF8(
+        std::filesystem::path(item.dictionaryEntry->path).filename().string());
+  }
+  if (item.state == rider_fixture_resolution::State::Generic ||
+      (!item.selectedEntry && !item.suggestedEntry))
+    return _("Generic fallback");
+  if (!item.selectedEntry && item.suggestedEntry) {
+    const auto &suggested = *item.suggestedEntry;
+    return wxString::FromUTF8(
+        "Generic fallback (suggested: " + suggested.manufacturer + " / " +
+        suggested.fixtureName + ")");
+  }
   const auto &entry = item.selectedEntry ? item.selectedEntry : item.suggestedEntry;
   if (!entry)
     return "-";
@@ -40,21 +62,22 @@ wxString FormatCatalogIdentity(const rider_fixture_resolution::Item &item) {
 // Creates the modal fixture-resolution review without starting downloads.
 RiderFixtureResolutionDialog::RiderFixtureResolutionDialog(
     wxWindow *parent, rider_fixture_resolution::Analysis analysisIn,
-    std::string catalogPayloadIn, std::string catalogUpdatedAtIn,
-    CatalogLoader catalogLoaderIn)
+    CatalogLoader cachedCatalogLoaderIn, CatalogLoader onlineCatalogLoaderIn)
     : wxDialog(parent, wxID_ANY, _("Resolve fixture types"), wxDefaultPosition,
                wxSize(1160, 680),
                wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER),
       analysis(std::move(analysisIn)),
-      catalogPayload(std::move(catalogPayloadIn)),
-      catalogUpdatedAt(std::move(catalogUpdatedAtIn)),
-      catalogLoader(std::move(catalogLoaderIn)) {
+      cachedCatalogLoader(std::move(cachedCatalogLoaderIn)),
+      onlineCatalogLoader(std::move(onlineCatalogLoaderIn)) {
   BuildLayout();
   RefreshTable();
   RefreshSelectionControls();
   RefreshSummary();
   SetMinSize(wxSize(780, 500));
   CentreOnParent();
+  Bind(wxEVT_SHOW, &RiderFixtureResolutionDialog::OnDialogShown, this);
+  Bind(EVT_RIDER_CATALOG_LOADED,
+       &RiderFixtureResolutionDialog::OnCatalogLoaded, this);
 }
 
 // Returns the user-reviewed resolution model after the modal dialog succeeds.
@@ -69,6 +92,9 @@ void RiderFixtureResolutionDialog::BuildLayout() {
                 this, wxID_ANY,
                 _("Review unknown rider fixture types before creating the scene.")),
             0, wxEXPAND | wxALL, 12);
+  catalogStatusLabel = new wxStaticText(
+      this, wxID_ANY, _("Loading cached GDTF catalog..."));
+  root->Add(catalogStatusLabel, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 12);
 
   table = new wxDataViewListCtrl(this, wxID_ANY, wxDefaultPosition,
                                  wxDefaultSize, wxDV_ROW_LINES);
@@ -93,13 +119,10 @@ void RiderFixtureResolutionDialog::BuildLayout() {
   useSuggestedButton = new wxButton(this, wxID_ANY, _("Use suggested"));
   searchButton = new wxButton(this, wxID_ANY, _("Search..."));
   useGenericButton = new wxButton(this, wxID_ANY, _("Use generic"));
-  modeChoice = new wxChoice(this, wxID_ANY);
   actions->Add(useSuggestedButton, 0, wxRIGHT, 8);
   actions->Add(searchButton, 0, wxRIGHT, 8);
-  actions->Add(useGenericButton, 0, wxRIGHT, 16);
-  actions->Add(new wxStaticText(this, wxID_ANY, _("Mode:")), 0,
-               wxALIGN_CENTER_VERTICAL | wxRIGHT, 6);
-  actions->Add(modeChoice, 1);
+  actions->Add(useGenericButton, 0);
+  actions->AddStretchSpacer(1);
   root->Add(actions, 0, wxEXPAND | wxALL, 12);
 
   auto *footer = new wxBoxSizer(wxHORIZONTAL);
@@ -117,6 +140,8 @@ void RiderFixtureResolutionDialog::BuildLayout() {
 
   table->Bind(wxEVT_DATAVIEW_SELECTION_CHANGED,
               &RiderFixtureResolutionDialog::OnSelectionChanged, this);
+  table->Bind(wxEVT_DATAVIEW_ITEM_ACTIVATED,
+              &RiderFixtureResolutionDialog::OnItemActivated, this);
   useSuggestedButton->Bind(wxEVT_BUTTON,
                            &RiderFixtureResolutionDialog::OnUseSuggested, this);
   searchButton->Bind(wxEVT_BUTTON, &RiderFixtureResolutionDialog::OnSearch,
@@ -125,8 +150,6 @@ void RiderFixtureResolutionDialog::BuildLayout() {
                          &RiderFixtureResolutionDialog::OnUseGeneric, this);
   acceptAllButton->Bind(wxEVT_BUTTON,
                         &RiderFixtureResolutionDialog::OnAcceptAll, this);
-  modeChoice->Bind(wxEVT_CHOICE,
-                   &RiderFixtureResolutionDialog::OnModeSelected, this);
   resolveButton->Bind(wxEVT_BUTTON, &RiderFixtureResolutionDialog::OnResolve,
                       this);
 }
@@ -153,36 +176,27 @@ void RiderFixtureResolutionDialog::RefreshTable() {
                                 static_cast<int>(analysis.items.size()) - 1));
 }
 
-// Updates row-action availability and the explicit mode selector.
+// Updates row-action availability for the selected fixture row.
 void RiderFixtureResolutionDialog::RefreshSelectionControls() {
   rider_fixture_resolution::Item *item = SelectedItem();
   useSuggestedButton->Enable(item && item->state == rider_fixture_resolution::State::Suggested &&
                              item->suggestedEntry.has_value());
   searchButton->Enable(item && item->state != rider_fixture_resolution::State::Dictionary);
   useGenericButton->Enable(item && item->state != rider_fixture_resolution::State::Dictionary);
-  modeChoice->Clear();
-  if (!item || !item->selectedEntry) {
-    modeChoice->Enable(false);
-    return;
-  }
-  for (const auto &mode : item->selectedEntry->modes)
-    modeChoice->Append(wxString::FromUTF8(mode.name));
-  modeChoice->Enable(item->selectedEntry->modes.size() > 1);
-  if (!item->selectedMode.empty()) {
-    const int index = modeChoice->FindString(wxString::FromUTF8(item->selectedMode));
-    if (index != wxNOT_FOUND)
-      modeChoice->SetSelection(index);
-  }
 }
 
-// Updates completion counts and enables confirmation only for ready rows.
+// Updates the real-mapping count while keeping Generic confirmation available.
 void RiderFixtureResolutionDialog::RefreshSummary() {
-  const size_t ready = static_cast<size_t>(std::count_if(
+  const size_t realMappings = static_cast<size_t>(std::count_if(
       analysis.items.begin(), analysis.items.end(),
-      [](const auto &item) { return item.IsReady(); }));
-  summaryLabel->SetLabel(wxString::Format(_("%zu of %zu fixture types ready"),
-                                          ready, analysis.items.size()));
-  resolveButton->Enable(ready == analysis.items.size());
+      [](const auto &item) {
+        return item.state == rider_fixture_resolution::State::Dictionary ||
+               (item.selectedEntry && !item.RequiresModeSelection());
+      }));
+  summaryLabel->SetLabel(wxString::Format(
+      _("%zu real mappings selected; remaining rows use Generic"),
+      realMappings));
+  resolveButton->Enable(true);
 }
 
 // Returns the model item corresponding to the selected table row.
@@ -197,6 +211,48 @@ rider_fixture_resolution::Item *RiderFixtureResolutionDialog::SelectedItem() {
 void RiderFixtureResolutionDialog::OnSelectionChanged(wxDataViewEvent &event) {
   RefreshSelectionControls();
   event.Skip();
+}
+
+// Edits a row mode through the activated Mode cell using valid profile modes.
+void RiderFixtureResolutionDialog::OnItemActivated(wxDataViewEvent &event) {
+  if (event.GetColumn() != 4)
+    return;
+  const int activatedRow = table->ItemToRow(event.GetItem());
+  if (activatedRow != wxNOT_FOUND)
+    table->SelectRow(activatedRow);
+  auto *item = SelectedItem();
+  if (!item)
+    return;
+  std::vector<std::string> modes;
+  if (item->state == rider_fixture_resolution::State::Dictionary &&
+      item->dictionaryEntry) {
+    modes = GetGdtfModes(item->dictionaryEntry->path);
+  } else if (item->selectedEntry) {
+    for (const auto &mode : item->selectedEntry->modes) {
+      if (!mode.name.empty())
+        modes.push_back(mode.name);
+    }
+  }
+  if (modes.empty())
+    return;
+  if (modes.size() == 1) {
+    item->selectedMode = modes.front();
+  } else {
+    wxArrayString choices;
+    for (const std::string &mode : modes)
+      choices.Add(wxString::FromUTF8(mode));
+    wxSingleChoiceDialog choice(
+        this, _("Choose a valid mode for this fixture row."),
+        _("Fixture mode"), choices);
+    const int current = choices.Index(wxString::FromUTF8(item->selectedMode));
+    if (current != wxNOT_FOUND)
+      choice.SetSelection(current);
+    if (choice.ShowModal() != wxID_OK)
+      return;
+    item->selectedMode = choice.GetStringSelection().ToStdString();
+  }
+  RefreshTable();
+  RefreshSummary();
 }
 
 // Accepts the safe suggestion for the selected row.
@@ -214,19 +270,26 @@ void RiderFixtureResolutionDialog::OnSearch(wxCommandEvent &) {
   auto *item = SelectedItem();
   if (!item)
     return;
-  if (catalogPayload.empty()) {
-    const auto loaded = catalogLoader ? catalogLoader() : std::nullopt;
+  if (catalogEntries.empty()) {
+    if (catalogLoading) {
+      wxMessageBox(_("The cached catalog is still loading. Generic fallback remains available."),
+                   _("GDTF catalog"), wxOK | wxICON_INFORMATION, this);
+      return;
+    }
+    const auto loaded = onlineCatalogLoader ? onlineCatalogLoader() : std::nullopt;
     if (!loaded) {
       wxMessageBox(_("The GDTF catalog is unavailable. You can use generic or cancel without changing the scene."),
                    _("GDTF catalog unavailable"), wxOK | wxICON_INFORMATION, this);
       return;
     }
-    catalogPayload = loaded->listData;
-    catalogUpdatedAt = loaded->updatedAt;
+    ApplyCatalog(*loaded);
   }
   GdtfSearchDialog dialog(this, catalogPayload, catalogUpdatedAt, nullptr,
-                          GdtfCatalogDisplaySource::Cached, true,
-                          item->request.typeName);
+                          catalogSource == CatalogSource::Online
+                              ? GdtfCatalogDisplaySource::Online
+                              : GdtfCatalogDisplaySource::Cached,
+                          catalogSource != CatalogSource::Online,
+                          item->request.typeName, catalogEntries);
   if (dialog.ShowModal() != wxID_OK)
     return;
   const auto selected = dialog.GetSelectedEntry();
@@ -235,6 +298,79 @@ void RiderFixtureResolutionDialog::OnSearch(wxCommandEvent &) {
   RefreshTable();
   RefreshSelectionControls();
   RefreshSummary();
+}
+
+// Starts cached catalog parsing only after the modal dialog becomes visible.
+void RiderFixtureResolutionDialog::OnDialogShown(wxShowEvent &event) {
+  event.Skip();
+  if (!event.IsShown() || catalogLoadStarted || !cachedCatalogLoader)
+    return;
+  catalogLoadStarted = true;
+  catalogLoading = true;
+  const CatalogLoader loader = cachedCatalogLoader;
+  const auto requests = BuildFixtureRequests();
+  wxWeakRef<RiderFixtureResolutionDialog> weakDialog(this);
+  std::thread([loader, weakDialog, requests]() mutable {
+    auto loaded = loader();
+    if (loaded) {
+      const auto matchStarted = std::chrono::steady_clock::now();
+      loaded->matches = rider_fixture_resolution::Service::Analyze(
+          requests, {}, loaded->entries);
+      loaded->matchMs =
+          std::chrono::duration_cast<std::chrono::milliseconds>(
+              std::chrono::steady_clock::now() - matchStarted).count();
+    }
+    RiderFixtureResolutionDialog *dialog = weakDialog.get();
+    if (!dialog)
+      return;
+    auto *event = new wxThreadEvent(EVT_RIDER_CATALOG_LOADED);
+    event->SetPayload(loaded);
+    wxQueueEvent(dialog, event);
+  }).detach();
+}
+
+// Applies a completed cached catalog load on the wxWidgets UI thread.
+void RiderFixtureResolutionDialog::OnCatalogLoaded(wxThreadEvent &event) {
+  catalogLoading = false;
+  const auto loaded =
+      event.GetPayload<std::optional<RiderFixtureResolutionDialog::CatalogData>>();
+  if (!loaded) {
+    catalogStatusLabel->SetLabel(
+        _("Catalog unavailable; generic fallback remains available."));
+    return;
+  }
+  ApplyCatalog(*loaded);
+}
+
+// Merges catalog suggestions into untouched rows and refreshes presentation.
+void RiderFixtureResolutionDialog::ApplyCatalog(const CatalogData &catalog) {
+  catalogPayload = catalog.snapshot.listData;
+  catalogUpdatedAt = catalog.snapshot.updatedAt;
+  catalogEntries = catalog.entries;
+  catalogSource = catalog.source;
+  const auto matched = catalog.matches
+      ? *catalog.matches
+      : rider_fixture_resolution::Service::Analyze(BuildFixtureRequests(), {},
+                                                    catalogEntries);
+  diagnostics::DiagnosticLogger::Info(
+      "Rider fixture preflight catalog: catalog_match_ms=" +
+      std::to_string(catalog.matchMs));
+  rider_fixture_resolution::Service::MergeCatalogSuggestions(analysis, matched);
+  catalogStatusLabel->SetLabel(wxString::Format(
+      _("Catalog loaded: %zu entries"), catalogEntries.size()));
+  RefreshTable();
+  RefreshSelectionControls();
+  RefreshSummary();
+}
+
+// Copies fixture requests for pure background catalog matching.
+std::vector<RiderImporter::FixtureTypeRequest>
+RiderFixtureResolutionDialog::BuildFixtureRequests() const {
+  std::vector<RiderImporter::FixtureTypeRequest> requests;
+  requests.reserve(analysis.items.size());
+  for (const auto &item : analysis.items)
+    requests.push_back(item.request);
+  return requests;
 }
 
 // Selects the existing one-import generic fallback for the selected alias.
@@ -260,24 +396,8 @@ void RiderFixtureResolutionDialog::OnAcceptAll(wxCommandEvent &) {
   RefreshSummary();
 }
 
-// Stores the user's explicit mode choice for a multi-mode profile.
-void RiderFixtureResolutionDialog::OnModeSelected(wxCommandEvent &) {
-  auto *item = SelectedItem();
-  if (item && modeChoice->GetSelection() != wxNOT_FOUND)
-    item->selectedMode = modeChoice->GetStringSelection().ToStdString();
-  RefreshTable();
-  RefreshSelectionControls();
-  RefreshSummary();
-}
-
 // Closes successfully only after every non-dictionary row is explicitly ready.
 void RiderFixtureResolutionDialog::OnResolve(wxCommandEvent &) {
-  if (!std::all_of(analysis.items.begin(), analysis.items.end(),
-                   [](const auto &item) { return item.IsReady(); })) {
-    wxMessageBox(_("Resolve every fixture type or choose Use generic before continuing."),
-                 _("Fixture types require attention"), wxOK | wxICON_WARNING,
-                 this);
-    return;
-  }
+  rider_fixture_resolution::Service::FinalizeDefaults(analysis);
   EndModal(wxID_OK);
 }

--- a/gui/rider_fixture_resolution_dialog.cpp
+++ b/gui/rider_fixture_resolution_dialog.cpp
@@ -7,6 +7,7 @@
 #include "../core/diagnostics/DiagnosticLogger.h"
 
 #include <algorithm>
+#include <cassert>
 #include <chrono>
 #include <filesystem>
 #include <sstream>
@@ -122,6 +123,7 @@ void RiderFixtureResolutionDialog::BuildLayout() {
   tableStore->AppendColumn("bool");
   for (int column = 1; column < 8; ++column)
     tableStore->AppendColumn("string");
+  wxASSERT(tableStore->GetColumnCount() == 8);
   table->AssociateModel(tableStore);
   tableStore->DecRef();
   const int flags = wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE;
@@ -202,6 +204,9 @@ void RiderFixtureResolutionDialog::PopulateTable() {
                       : wxString::FromUTF8(item.selectedMode));
     row.push_back(wxString::FromUTF8(rider_fixture_resolution::OriginName(item.origin)));
     row.push_back(wxString::FromUTF8(item.details));
+    wxASSERT(row.size() == tableStore->GetColumnCount());
+    if (row.size() != tableStore->GetColumnCount())
+      continue;
     tableStore->AppendItem(row, static_cast<wxUIntPtr>(index + 1));
     const unsigned rowIndex = static_cast<unsigned>(tableStore->GetItemCount() - 1);
     const unsigned statusColumn = 6;
@@ -236,14 +241,18 @@ void RiderFixtureResolutionDialog::UpdateRow(size_t analysisIndex) {
       rider_fixture_resolution::OriginName(item.origin)));
   values.push_back(wxString::FromUTF8(item.details));
   for (unsigned column = 0; column < values.size(); ++column)
-    tableStore->SetValueByRow(values[column], *row, column);
+    if (column < tableStore->GetColumnCount() &&
+        *row < tableStore->GetItemCount())
+      tableStore->SetValueByRow(values[column], *row, column);
   constexpr unsigned statusColumn = 6;
-  tableStore->ClearCellTextColour(*row, statusColumn);
+  tableStore->ClearCellTextColour(*row, statusColumn, false);
   const auto semantic =
       rider_fixture_resolution::StatusSemanticForOrigin(item.origin);
   if (semantic != rider_fixture_resolution::StatusSemantic::Neutral)
     tableStore->SetCellTextColour(
-        *row, statusColumn, GdtfResolutionStatusColour(semantic));
+        *row, statusColumn, GdtfResolutionStatusColour(semantic), false);
+  if (*row < tableStore->GetItemCount())
+    tableStore->RowChanged(*row);
   modelUpdateInProgress = false;
 }
 

--- a/gui/rider_fixture_resolution_dialog.cpp
+++ b/gui/rider_fixture_resolution_dialog.cpp
@@ -2,14 +2,12 @@
 
 #include "gdtfsearchdialog.h"
 #include "gdtfloader.h"
-#include "colorstore.h"
-#include "gdtf_resolution_status_style.h"
+#include "rider_fixture_resolution_model.h"
 #include "../core/diagnostics/DiagnosticLogger.h"
 
 #include <algorithm>
 #include <cassert>
 #include <chrono>
-#include <filesystem>
 #include <sstream>
 
 #include <wx/button.h>
@@ -25,41 +23,6 @@ namespace {
 
 const wxEventTypeTag<wxThreadEvent> EVT_RIDER_CATALOG_LOADED(wxNewEventType());
 const wxEventTypeTag<wxThreadEvent> EVT_RIDER_CATALOG_PROGRESS(wxNewEventType());
-
-// Joins position labels for compact table presentation.
-wxString JoinPositions(const std::vector<std::string> &positions) {
-  wxString value;
-  for (const std::string &position : positions) {
-    if (!value.empty())
-      value += ", ";
-    value += wxString::FromUTF8(position);
-  }
-  return value;
-}
-
-// Formats the selected or suggested catalog identity for a resolution row.
-wxString FormatCatalogIdentity(const rider_fixture_resolution::Item &item) {
-  if (item.state == rider_fixture_resolution::State::Dictionary &&
-      item.dictionaryEntry && !item.dictionaryEntry->path.empty()) {
-    return wxString::FromUTF8(
-        std::filesystem::path(item.dictionaryEntry->path).filename().string());
-  }
-  if (item.state == rider_fixture_resolution::State::Generic ||
-      (!item.selectedEntry && !item.suggestedEntry))
-    return _("Generic fallback");
-  if (!item.selectedEntry && item.suggestedEntry) {
-    const auto &suggested = *item.suggestedEntry;
-    return wxString::FromUTF8(
-        "Generic fallback (suggested: " + suggested.manufacturer + " / " +
-        suggested.fixtureName + ")");
-  }
-  const auto &entry = item.selectedEntry ? item.selectedEntry : item.suggestedEntry;
-  if (!entry)
-    return "-";
-  if (entry->manufacturer.empty())
-    return wxString::FromUTF8(entry->fixtureName);
-  return wxString::FromUTF8(entry->manufacturer + " / " + entry->fixtureName);
-}
 
 } // namespace
 
@@ -119,13 +82,11 @@ void RiderFixtureResolutionDialog::BuildLayout() {
 
   table = new wxDataViewCtrl(this, wxID_ANY, wxDefaultPosition,
                              wxDefaultSize, wxDV_ROW_LINES);
-  tableStore = new ColorfulDataViewListStore();
-  tableStore->AppendColumn("bool");
-  for (int column = 1; column < 8; ++column)
-    tableStore->AppendColumn("string");
-  wxASSERT(tableStore->GetColumnCount() == 8);
-  table->AssociateModel(tableStore);
-  tableStore->DecRef();
+  tableModel = new RiderFixtureResolutionModel(analysis);
+  wxASSERT(tableModel->GetColumnCount() ==
+           RiderFixtureResolutionModel::ColumnCount);
+  table->AssociateModel(tableModel);
+  tableModel->DecRef();
   const int flags = wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE;
   table->AppendToggleColumn(_("Create"), 0, wxDATAVIEW_CELL_ACTIVATABLE, 65,
                             wxALIGN_CENTER, flags);
@@ -188,71 +149,20 @@ void RiderFixtureResolutionDialog::BuildLayout() {
                      this);
 }
 
-// Populates stable table rows once for the dialog lifetime.
+// Validates the fixed table schema and selects the initial analysis row.
 void RiderFixtureResolutionDialog::PopulateTable() {
-  tableStore->DeleteAllItems();
-  for (size_t index = 0; index < analysis.items.size(); ++index) {
-    const auto &item = analysis.items[index];
-    wxVector<wxVariant> row;
-    row.push_back(item.create);
-    row.push_back(wxString::FromUTF8(item.effectiveFixtureType));
-    row.push_back(wxString::Format("%d", item.request.quantity));
-    row.push_back(JoinPositions(item.request.positions));
-    row.push_back(FormatCatalogIdentity(item));
-    row.push_back(item.selectedMode.empty()
-                      ? wxString("-")
-                      : wxString::FromUTF8(item.selectedMode));
-    row.push_back(wxString::FromUTF8(rider_fixture_resolution::OriginName(item.origin)));
-    row.push_back(wxString::FromUTF8(item.details));
-    wxASSERT(row.size() == tableStore->GetColumnCount());
-    if (row.size() != tableStore->GetColumnCount())
-      continue;
-    tableStore->AppendItem(row, static_cast<wxUIntPtr>(index + 1));
-    const unsigned rowIndex = static_cast<unsigned>(tableStore->GetItemCount() - 1);
-    const unsigned statusColumn = 6;
-    const auto semantic =
-        rider_fixture_resolution::StatusSemanticForOrigin(item.origin);
-    if (semantic != rider_fixture_resolution::StatusSemantic::Neutral)
-      tableStore->SetCellTextColour(
-          rowIndex, statusColumn, GdtfResolutionStatusColour(semantic));
-  }
+  wxASSERT(tableModel->GetColumnCount() ==
+           RiderFixtureResolutionModel::ColumnCount);
   if (!analysis.items.empty())
-    table->Select(tableStore->GetItem(0));
+    table->Select(tableModel->GetItem(0));
 }
 
 // Updates one stable model row and its semantic Status attribute in place.
 void RiderFixtureResolutionDialog::UpdateRow(size_t analysisIndex) {
   if (analysisIndex >= analysis.items.size())
     return;
-  const auto row = StoreRowForAnalysisIndex(analysisIndex);
-  if (!row || *row >= tableStore->GetItemCount())
-    return;
-  const auto &item = analysis.items[analysisIndex];
   modelUpdateInProgress = true;
-  wxVector<wxVariant> values;
-  values.push_back(item.create);
-  values.push_back(wxString::FromUTF8(item.effectiveFixtureType));
-  values.push_back(wxString::Format("%d", item.request.quantity));
-  values.push_back(JoinPositions(item.request.positions));
-  values.push_back(FormatCatalogIdentity(item));
-  values.push_back(item.selectedMode.empty() ? wxString("-")
-                                              : wxString::FromUTF8(item.selectedMode));
-  values.push_back(wxString::FromUTF8(
-      rider_fixture_resolution::OriginName(item.origin)));
-  values.push_back(wxString::FromUTF8(item.details));
-  for (unsigned column = 0; column < values.size(); ++column)
-    if (column < tableStore->GetColumnCount() &&
-        *row < tableStore->GetItemCount())
-      tableStore->SetValueByRow(values[column], *row, column);
-  constexpr unsigned statusColumn = 6;
-  tableStore->ClearCellTextColour(*row, statusColumn, false);
-  const auto semantic =
-      rider_fixture_resolution::StatusSemanticForOrigin(item.origin);
-  if (semantic != rider_fixture_resolution::StatusSemantic::Neutral)
-    tableStore->SetCellTextColour(
-        *row, statusColumn, GdtfResolutionStatusColour(semantic), false);
-  if (*row < tableStore->GetItemCount())
-    tableStore->RowChanged(*row);
+  tableModel->NotifyRowChanged(analysisIndex);
   modelUpdateInProgress = false;
 }
 
@@ -295,30 +205,22 @@ rider_fixture_resolution::Item *RiderFixtureResolutionDialog::SelectedItem() {
   return &analysis.items[*index];
 }
 
-// Resolves stable non-zero model item data to an analysis index.
+// Resolves a stable index-list model item to its analysis row.
 std::optional<size_t> RiderFixtureResolutionDialog::AnalysisIndexForItem(
     const wxDataViewItem &item) const {
   if (!item.IsOk())
     return std::nullopt;
-  const wxUIntPtr key = tableStore->GetItemData(item);
-  if (key == 0)
-    return std::nullopt;
-  const size_t index = static_cast<size_t>(key - 1);
+  const size_t index = static_cast<size_t>(tableModel->GetRow(item));
   return index < analysis.items.size() ? std::optional<size_t>(index)
                                        : std::nullopt;
 }
 
-// Finds the current store row for a stable analysis identity after sorting.
+// Maps stable analysis identity directly to its fixed model row.
 std::optional<unsigned>
 RiderFixtureResolutionDialog::StoreRowForAnalysisIndex(size_t analysisIndex) const {
-  const wxUIntPtr key = static_cast<wxUIntPtr>(analysisIndex + 1);
-  const unsigned count = tableStore->GetItemCount();
-  for (unsigned row = 0; row < count; ++row) {
-    const wxDataViewItem item = tableStore->GetItem(row);
-    if (item.IsOk() && tableStore->GetItemData(item) == key)
-      return row;
-  }
-  return std::nullopt;
+  return analysisIndex < analysis.items.size()
+             ? std::optional<unsigned>(static_cast<unsigned>(analysisIndex))
+             : std::nullopt;
 }
 
 // Refreshes actions when the selected row changes.
@@ -384,12 +286,16 @@ void RiderFixtureResolutionDialog::OnValueChanged(wxDataViewEvent &event) {
   if (!analysisIndex)
     return;
   const auto storeRow = StoreRowForAnalysisIndex(*analysisIndex);
-  if (!storeRow || *storeRow >= tableStore->GetItemCount())
+  if (!storeRow || *storeRow >= analysis.items.size())
     return;
   auto &item = analysis.items[*analysisIndex];
   wxVariant value;
-  tableStore->GetValueByRow(value, *storeRow,
-                            static_cast<unsigned int>(event.GetColumn()));
+  const int eventColumn = event.GetColumn();
+  if (eventColumn < 0 ||
+      static_cast<unsigned>(eventColumn) >= tableModel->GetColumnCount())
+    return;
+  tableModel->GetValueByRow(value, *storeRow,
+                            static_cast<unsigned int>(eventColumn));
   if (event.GetColumn() == 0) {
     rider_fixture_resolution::Service::SetCreate(item, value.GetBool());
     if (item.create)

--- a/gui/rider_fixture_resolution_dialog.cpp
+++ b/gui/rider_fixture_resolution_dialog.cpp
@@ -384,9 +384,11 @@ void RiderFixtureResolutionDialog::OnDialogShown(wxShowEvent &event) {
   catalogLoadStarted = true;
   catalogLoading = true;
   const CatalogLoader loader = cachedCatalogLoader;
-  const auto requests = BuildFixtureRequests();
+  const auto targets = BuildCatalogMatchTargets();
+  const size_t analysisItemCount = analysis.items.size();
   catalogWorker = std::jthread(
-      [this, loader, requests](std::stop_token stopToken) mutable {
+      [this, loader, targets,
+       analysisItemCount](std::stop_token stopToken) mutable {
     auto report = [this, &stopToken](const ProgressData &progress) {
       if (stopToken.stop_requested() || shuttingDown.load())
         return;
@@ -400,22 +402,24 @@ void RiderFixtureResolutionDialog::OnDialogShown(wxShowEvent &event) {
     if (loaded) {
       const auto matchStarted = std::chrono::steady_clock::now();
       rider_fixture_resolution::Analysis matches;
+      matches.items.resize(analysisItemCount);
       size_t automaticMatches = 0;
-      for (size_t row = 0; row < requests.size(); ++row) {
+      for (size_t targetIndex = 0; targetIndex < targets.size(); ++targetIndex) {
         if (stopToken.stop_requested() || shuttingDown.load())
           return;
+        const auto &target = targets[targetIndex];
         auto one = rider_fixture_resolution::Service::Analyze(
-            {requests[row]}, {}, loaded->entries);
+            {target.request}, {}, loaded->entries);
         if (one.items.front().origin ==
             rider_fixture_resolution::ResolutionOrigin::AutomaticMatch)
           ++automaticMatches;
-        matches.items.push_back(one.items.front());
+        matches.items[target.analysisIndex] = one.items.front();
         report({{rider_fixture_resolution::ProgressStage::MatchingFixtures,
-                 row + 1, requests.size(), automaticMatches},
-                row, one.items.front()});
+                 targetIndex + 1, targets.size(), automaticMatches},
+                target.analysisIndex, one.items.front()});
       }
       report({{rider_fixture_resolution::ProgressStage::Complete,
-               requests.size(), requests.size(), automaticMatches}});
+               targets.size(), targets.size(), automaticMatches}});
       loaded->matches = std::move(matches);
       loaded->matchMs =
           std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -485,10 +489,12 @@ void RiderFixtureResolutionDialog::StartOnlineCatalogWorker(
   if (catalogWorker.joinable())
     catalogWorker.join();
   catalogLoading = true;
-  const auto requests = BuildFixtureRequests();
+  const auto targets = BuildCatalogMatchTargets();
+  const size_t analysisItemCount = analysis.items.size();
   const OnlineCatalogLoader loader = onlineCatalogLoader;
   catalogWorker = std::jthread(
-      [this, loader, credentials, requests](std::stop_token stopToken) mutable {
+      [this, loader, credentials, targets,
+       analysisItemCount](std::stop_token stopToken) mutable {
     auto report = [this, &stopToken](const ProgressData &progress) {
       if (stopToken.stop_requested() || shuttingDown.load())
         return;
@@ -506,22 +512,24 @@ void RiderFixtureResolutionDialog::StartOnlineCatalogWorker(
       auto &catalog = *result.catalog;
       const auto matchStarted = std::chrono::steady_clock::now();
       rider_fixture_resolution::Analysis matches;
+      matches.items.resize(analysisItemCount);
       size_t automaticMatches = 0;
-      for (size_t row = 0; row < requests.size(); ++row) {
+      for (size_t targetIndex = 0; targetIndex < targets.size(); ++targetIndex) {
         if (stopToken.stop_requested() || shuttingDown.load())
           return;
+        const auto &target = targets[targetIndex];
         auto one = rider_fixture_resolution::Service::Analyze(
-            {requests[row]}, {}, catalog.entries);
+            {target.request}, {}, catalog.entries);
         if (one.items.front().origin ==
             rider_fixture_resolution::ResolutionOrigin::AutomaticMatch)
           ++automaticMatches;
-        matches.items.push_back(one.items.front());
+        matches.items[target.analysisIndex] = one.items.front();
         report({{rider_fixture_resolution::ProgressStage::MatchingFixtures,
-                 row + 1, requests.size(), automaticMatches},
-                row, one.items.front()});
+                 targetIndex + 1, targets.size(), automaticMatches},
+                target.analysisIndex, one.items.front()});
       }
       report({{rider_fixture_resolution::ProgressStage::Complete,
-               requests.size(), requests.size(), automaticMatches}});
+               targets.size(), targets.size(), automaticMatches}});
       catalog.matches = std::move(matches);
       catalog.matchMs =
           std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -626,10 +634,17 @@ void RiderFixtureResolutionDialog::ApplyCatalog(const CatalogData &catalog) {
   catalogUpdatedAt = catalog.snapshot.updatedAt;
   catalogEntries = catalog.entries;
   catalogSource = catalog.source;
-  const auto matched = catalog.matches
-      ? *catalog.matches
-      : rider_fixture_resolution::Service::Analyze(BuildFixtureRequests(), {},
-                                                    catalogEntries);
+  rider_fixture_resolution::Analysis matched;
+  if (catalog.matches) {
+    matched = *catalog.matches;
+  } else {
+    matched.items.resize(analysis.items.size());
+    for (const auto &target : BuildCatalogMatchTargets()) {
+      auto one = rider_fixture_resolution::Service::Analyze(
+          {target.request}, {}, catalogEntries);
+      matched.items[target.analysisIndex] = std::move(one.items.front());
+    }
+  }
   diagnostics::DiagnosticLogger::Info(
       "Rider fixture preflight catalog: catalog_match_ms=" +
       std::to_string(catalog.matchMs));
@@ -640,20 +655,10 @@ void RiderFixtureResolutionDialog::ApplyCatalog(const CatalogData &catalog) {
   RefreshSummary();
 }
 
-// Copies fixture requests for pure background catalog matching.
-std::vector<RiderImporter::FixtureTypeRequest>
-RiderFixtureResolutionDialog::BuildFixtureRequests() const {
-  std::vector<RiderImporter::FixtureTypeRequest> requests;
-  requests.reserve(analysis.items.size());
-  for (const auto &item : analysis.items)
-  {
-    auto request = item.request;
-    request.typeName = item.effectiveFixtureType;
-    request.normalizedTypeName = GdtfDictionary::NormalizeTypeKey(
-        item.effectiveFixtureType);
-    requests.push_back(std::move(request));
-  }
-  return requests;
+// Selects stable analysis rows that still need pure catalog matching.
+std::vector<rider_fixture_resolution::CatalogMatchTarget>
+RiderFixtureResolutionDialog::BuildCatalogMatchTargets() const {
+  return rider_fixture_resolution::Service::BuildCatalogMatchTargets(analysis);
 }
 
 // Selects the existing one-import generic fallback for the selected alias.

--- a/gui/rider_fixture_resolution_dialog.cpp
+++ b/gui/rider_fixture_resolution_dialog.cpp
@@ -19,7 +19,6 @@
 #include <wx/sizer.h>
 #include <wx/stattext.h>
 #include <wx/thread.h>
-#include <wx/weakref.h>
 
 namespace {
 
@@ -76,7 +75,7 @@ RiderFixtureResolutionDialog::RiderFixtureResolutionDialog(
       cachedCatalogLoader(std::move(cachedCatalogLoaderIn)),
       onlineCatalogLoader(std::move(onlineCatalogLoaderIn)) {
   BuildLayout();
-  RefreshTable();
+  PopulateTable();
   RefreshSelectionControls();
   RefreshSummary();
   SetMinSize(wxSize(780, 500));
@@ -86,6 +85,14 @@ RiderFixtureResolutionDialog::RiderFixtureResolutionDialog(
        &RiderFixtureResolutionDialog::OnCatalogLoaded, this);
   Bind(EVT_RIDER_CATALOG_PROGRESS,
        &RiderFixtureResolutionDialog::OnProgress, this);
+}
+
+// Stops the owned catalog worker before wxWidgets destroys the event handler.
+RiderFixtureResolutionDialog::~RiderFixtureResolutionDialog() {
+  shuttingDown.store(true);
+  RequestWorkerStop();
+  if (catalogWorker.joinable())
+    catalogWorker.join();
 }
 
 // Returns the user-reviewed resolution model after the modal dialog succeeds.
@@ -172,13 +179,15 @@ void RiderFixtureResolutionDialog::BuildLayout() {
                         &RiderFixtureResolutionDialog::OnAcceptAll, this);
   resolveButton->Bind(wxEVT_BUTTON, &RiderFixtureResolutionDialog::OnResolve,
                       this);
+  cancelButton->Bind(wxEVT_BUTTON, &RiderFixtureResolutionDialog::OnCancel,
+                     this);
 }
 
-// Rebuilds table rows from the current resolution model.
-void RiderFixtureResolutionDialog::RefreshTable() {
-  const int selectedRow = SelectedRow();
+// Populates stable table rows once for the dialog lifetime.
+void RiderFixtureResolutionDialog::PopulateTable() {
   tableStore->DeleteAllItems();
-  for (const auto &item : analysis.items) {
+  for (size_t index = 0; index < analysis.items.size(); ++index) {
+    const auto &item = analysis.items[index];
     wxVector<wxVariant> row;
     row.push_back(item.create);
     row.push_back(wxString::FromUTF8(item.effectiveFixtureType));
@@ -190,7 +199,7 @@ void RiderFixtureResolutionDialog::RefreshTable() {
                       : wxString::FromUTF8(item.selectedMode));
     row.push_back(wxString::FromUTF8(rider_fixture_resolution::OriginName(item.origin)));
     row.push_back(wxString::FromUTF8(item.details));
-    tableStore->AppendItem(row);
+    tableStore->AppendItem(row, static_cast<wxUIntPtr>(index + 1));
     const unsigned rowIndex = static_cast<unsigned>(tableStore->GetItemCount() - 1);
     const unsigned statusColumn = 6;
     const auto semantic =
@@ -200,8 +209,39 @@ void RiderFixtureResolutionDialog::RefreshTable() {
           rowIndex, statusColumn, GdtfResolutionStatusColour(semantic));
   }
   if (!analysis.items.empty())
-    table->Select(tableStore->GetItem(static_cast<unsigned>(std::clamp(
-        selectedRow, 0, static_cast<int>(analysis.items.size()) - 1))));
+    table->Select(tableStore->GetItem(0));
+}
+
+// Updates one stable model row and its semantic Status attribute in place.
+void RiderFixtureResolutionDialog::UpdateRow(size_t analysisIndex) {
+  if (analysisIndex >= analysis.items.size())
+    return;
+  const auto row = StoreRowForAnalysisIndex(analysisIndex);
+  if (!row || *row >= tableStore->GetItemCount())
+    return;
+  const auto &item = analysis.items[analysisIndex];
+  modelUpdateInProgress = true;
+  wxVector<wxVariant> values;
+  values.push_back(item.create);
+  values.push_back(wxString::FromUTF8(item.effectiveFixtureType));
+  values.push_back(wxString::Format("%d", item.request.quantity));
+  values.push_back(JoinPositions(item.request.positions));
+  values.push_back(FormatCatalogIdentity(item));
+  values.push_back(item.selectedMode.empty() ? wxString("-")
+                                              : wxString::FromUTF8(item.selectedMode));
+  values.push_back(wxString::FromUTF8(
+      rider_fixture_resolution::OriginName(item.origin)));
+  values.push_back(wxString::FromUTF8(item.details));
+  for (unsigned column = 0; column < values.size(); ++column)
+    tableStore->SetValueByRow(values[column], *row, column);
+  constexpr unsigned statusColumn = 6;
+  tableStore->ClearCellTextColour(*row, statusColumn);
+  const auto semantic =
+      rider_fixture_resolution::StatusSemanticForOrigin(item.origin);
+  if (semantic != rider_fixture_resolution::StatusSemantic::Neutral)
+    tableStore->SetCellTextColour(
+        *row, statusColumn, GdtfResolutionStatusColour(semantic));
+  modelUpdateInProgress = false;
 }
 
 // Updates row-action availability for the selected fixture row.
@@ -237,16 +277,36 @@ void RiderFixtureResolutionDialog::RefreshSummary() {
 
 // Returns the model item corresponding to the selected table row.
 rider_fixture_resolution::Item *RiderFixtureResolutionDialog::SelectedItem() {
-  const int row = SelectedRow();
-  if (row < 0 || row >= static_cast<int>(analysis.items.size()))
+  const auto index = AnalysisIndexForItem(table->GetSelection());
+  if (!index || *index >= analysis.items.size())
     return nullptr;
-  return &analysis.items[static_cast<size_t>(row)];
+  return &analysis.items[*index];
 }
 
-// Returns the currently selected model row or -1 when no row is selected.
-int RiderFixtureResolutionDialog::SelectedRow() const {
-  const wxDataViewItem selected = table->GetSelection();
-  return selected.IsOk() ? static_cast<int>(tableStore->GetRow(selected)) : -1;
+// Resolves stable non-zero model item data to an analysis index.
+std::optional<size_t> RiderFixtureResolutionDialog::AnalysisIndexForItem(
+    const wxDataViewItem &item) const {
+  if (!item.IsOk())
+    return std::nullopt;
+  const wxUIntPtr key = tableStore->GetItemData(item);
+  if (key == 0)
+    return std::nullopt;
+  const size_t index = static_cast<size_t>(key - 1);
+  return index < analysis.items.size() ? std::optional<size_t>(index)
+                                       : std::nullopt;
+}
+
+// Finds the current store row for a stable analysis identity after sorting.
+std::optional<unsigned>
+RiderFixtureResolutionDialog::StoreRowForAnalysisIndex(size_t analysisIndex) const {
+  const wxUIntPtr key = static_cast<wxUIntPtr>(analysisIndex + 1);
+  const unsigned count = tableStore->GetItemCount();
+  for (unsigned row = 0; row < count; ++row) {
+    const wxDataViewItem item = tableStore->GetItem(row);
+    if (item.IsOk() && tableStore->GetItemData(item) == key)
+      return row;
+  }
+  return std::nullopt;
 }
 
 // Refreshes actions when the selected row changes.
@@ -259,12 +319,12 @@ void RiderFixtureResolutionDialog::OnSelectionChanged(wxDataViewEvent &event) {
 void RiderFixtureResolutionDialog::OnItemActivated(wxDataViewEvent &event) {
   if (event.GetColumn() != 5)
     return;
-  const int activatedRow = static_cast<int>(tableStore->GetRow(event.GetItem()));
-  if (activatedRow != wxNOT_FOUND)
-    table->Select(tableStore->GetItem(static_cast<unsigned>(activatedRow)));
-  auto *item = SelectedItem();
-  if (!item)
+  const auto analysisIndex = AnalysisIndexForItem(event.GetItem());
+  if (!analysisIndex)
     return;
+  table->Select(event.GetItem());
+  auto &resolvedItem = analysis.items[*analysisIndex];
+  auto *item = &resolvedItem;
   if (!item->create)
     return;
   std::vector<std::string> modes;
@@ -300,18 +360,23 @@ void RiderFixtureResolutionDialog::OnItemActivated(wxDataViewEvent &event) {
         ? rider_fixture_resolution::ResolutionOrigin::Dictionary
         : rider_fixture_resolution::ResolutionOrigin::DictionaryModified;
   }
-  RefreshTable();
+  UpdateRow(*analysisIndex);
   RefreshSummary();
 }
 
 // Applies committed Create and Fixture type cell edits to the resolution model.
 void RiderFixtureResolutionDialog::OnValueChanged(wxDataViewEvent &event) {
-  const int row = static_cast<int>(tableStore->GetRow(event.GetItem()));
-  if (row == wxNOT_FOUND || row >= static_cast<int>(analysis.items.size()))
+  if (modelUpdateInProgress)
     return;
-  auto &item = analysis.items[static_cast<size_t>(row)];
+  const auto analysisIndex = AnalysisIndexForItem(event.GetItem());
+  if (!analysisIndex)
+    return;
+  const auto storeRow = StoreRowForAnalysisIndex(*analysisIndex);
+  if (!storeRow || *storeRow >= tableStore->GetItemCount())
+    return;
+  auto &item = analysis.items[*analysisIndex];
   wxVariant value;
-  tableStore->GetValueByRow(value, static_cast<unsigned int>(row),
+  tableStore->GetValueByRow(value, *storeRow,
                             static_cast<unsigned int>(event.GetColumn()));
   if (event.GetColumn() == 0) {
     rider_fixture_resolution::Service::SetCreate(item, value.GetBool());
@@ -325,24 +390,27 @@ void RiderFixtureResolutionDialog::OnValueChanged(wxDataViewEvent &event) {
     rider_fixture_resolution::Service::ResolveItem(item, dictionary,
                                                     catalogEntries);
   }
-  RefreshTable();
+  UpdateRow(*analysisIndex);
   RefreshSelectionControls();
   RefreshSummary();
 }
 
 // Accepts the safe suggestion for the selected row.
 void RiderFixtureResolutionDialog::OnUseSuggested(wxCommandEvent &) {
-  auto *item = SelectedItem();
+  const auto analysisIndex = AnalysisIndexForItem(table->GetSelection());
+  auto *item = analysisIndex ? &analysis.items[*analysisIndex] : nullptr;
   if (item && item->suggestedEntry)
     rider_fixture_resolution::Service::SelectCatalogEntry(*item, *item->suggestedEntry);
-  RefreshTable();
+  if (analysisIndex)
+    UpdateRow(*analysisIndex);
   RefreshSelectionControls();
   RefreshSummary();
 }
 
 // Opens the established catalog browser pre-filtered for the rider alias.
 void RiderFixtureResolutionDialog::OnSearch(wxCommandEvent &) {
-  auto *item = SelectedItem();
+  const auto analysisIndex = AnalysisIndexForItem(table->GetSelection());
+  auto *item = analysisIndex ? &analysis.items[*analysisIndex] : nullptr;
   if (!item)
     return;
   if (catalogEntries.empty()) {
@@ -372,7 +440,7 @@ void RiderFixtureResolutionDialog::OnSearch(wxCommandEvent &) {
     rider_fixture_resolution::Service::SelectCatalogEntry(
         *item, *selected,
         rider_fixture_resolution::ResolutionOrigin::UserSelection);
-  RefreshTable();
+  UpdateRow(*analysisIndex);
   RefreshSelectionControls();
   RefreshSummary();
 }
@@ -386,15 +454,14 @@ void RiderFixtureResolutionDialog::OnDialogShown(wxShowEvent &event) {
   catalogLoading = true;
   const CatalogLoader loader = cachedCatalogLoader;
   const auto requests = BuildFixtureRequests();
-  wxWeakRef<RiderFixtureResolutionDialog> weakDialog(this);
-  std::thread([loader, weakDialog, requests]() mutable {
-    auto report = [&weakDialog](const ProgressData &progress) {
-      RiderFixtureResolutionDialog *dialog = weakDialog.get();
-      if (!dialog)
+  catalogWorker = std::jthread(
+      [this, loader, requests](std::stop_token stopToken) mutable {
+    auto report = [this, &stopToken](const ProgressData &progress) {
+      if (stopToken.stop_requested() || shuttingDown.load())
         return;
       auto *event = new wxThreadEvent(EVT_RIDER_CATALOG_PROGRESS);
       event->SetPayload(progress);
-      wxQueueEvent(dialog, event);
+      wxQueueEvent(this, event);
     };
     report({{rider_fixture_resolution::ProgressStage::LoadingCatalog}});
     report({{rider_fixture_resolution::ProgressStage::ParsingCatalog}});
@@ -404,6 +471,8 @@ void RiderFixtureResolutionDialog::OnDialogShown(wxShowEvent &event) {
       rider_fixture_resolution::Analysis matches;
       size_t automaticMatches = 0;
       for (size_t row = 0; row < requests.size(); ++row) {
+        if (stopToken.stop_requested() || shuttingDown.load())
+          return;
         auto one = rider_fixture_resolution::Service::Analyze(
             {requests[row]}, {}, loaded->entries);
         if (one.items.front().origin ==
@@ -423,13 +492,12 @@ void RiderFixtureResolutionDialog::OnDialogShown(wxShowEvent &event) {
     } else {
       report({{rider_fixture_resolution::ProgressStage::Unavailable}});
     }
-    RiderFixtureResolutionDialog *dialog = weakDialog.get();
-    if (!dialog)
+    if (stopToken.stop_requested() || shuttingDown.load())
       return;
     auto *event = new wxThreadEvent(EVT_RIDER_CATALOG_LOADED);
     event->SetPayload(loaded);
-    wxQueueEvent(dialog, event);
-  }).detach();
+    wxQueueEvent(this, event);
+  });
 }
 
 // Applies a completed cached catalog load on the wxWidgets UI thread.
@@ -456,7 +524,7 @@ void RiderFixtureResolutionDialog::OnProgress(wxThreadEvent &event) {
   if (data.matchedItem && data.row < analysis.items.size()) {
     rider_fixture_resolution::Service::MergeCatalogSuggestion(
         analysis.items[data.row], *data.matchedItem);
-    RefreshTable();
+    UpdateRow(data.row);
     RefreshSelectionControls();
     RefreshSummary();
   }
@@ -509,7 +577,8 @@ void RiderFixtureResolutionDialog::ApplyCatalog(const CatalogData &catalog) {
       "Rider fixture preflight catalog: catalog_match_ms=" +
       std::to_string(catalog.matchMs));
   rider_fixture_resolution::Service::MergeCatalogSuggestions(analysis, matched);
-  RefreshTable();
+  for (size_t index = 0; index < analysis.items.size(); ++index)
+    UpdateRow(index);
   RefreshSelectionControls();
   RefreshSummary();
 }
@@ -532,9 +601,11 @@ RiderFixtureResolutionDialog::BuildFixtureRequests() const {
 
 // Selects the existing one-import generic fallback for the selected alias.
 void RiderFixtureResolutionDialog::OnUseGeneric(wxCommandEvent &) {
-  if (auto *item = SelectedItem())
+  const auto analysisIndex = AnalysisIndexForItem(table->GetSelection());
+  if (auto *item = analysisIndex ? &analysis.items[*analysisIndex] : nullptr)
     rider_fixture_resolution::Service::SelectGeneric(*item);
-  RefreshTable();
+  if (analysisIndex)
+    UpdateRow(*analysisIndex);
   RefreshSelectionControls();
   RefreshSummary();
 }
@@ -548,7 +619,8 @@ void RiderFixtureResolutionDialog::OnAcceptAll(wxCommandEvent &) {
                                                              *item.suggestedEntry);
     }
   }
-  RefreshTable();
+  for (size_t index = 0; index < analysis.items.size(); ++index)
+    UpdateRow(index);
   RefreshSelectionControls();
   RefreshSummary();
 }
@@ -556,6 +628,22 @@ void RiderFixtureResolutionDialog::OnAcceptAll(wxCommandEvent &) {
 // Closes successfully only after every non-dictionary row is explicitly ready.
 void RiderFixtureResolutionDialog::OnResolve(wxCommandEvent &) {
   acceptAutomaticResults = false;
+  RequestWorkerStop();
   rider_fixture_resolution::Service::FinalizeDefaults(analysis);
+  for (size_t index = 0; index < analysis.items.size(); ++index)
+    UpdateRow(index);
   EndModal(wxID_OK);
+}
+
+// Cancels the modal workflow and requests cooperative worker shutdown.
+void RiderFixtureResolutionDialog::OnCancel(wxCommandEvent &) {
+  acceptAutomaticResults = false;
+  RequestWorkerStop();
+  EndModal(wxID_CANCEL);
+}
+
+// Requests cooperative cancellation without blocking the modal UI thread.
+void RiderFixtureResolutionDialog::RequestWorkerStop() {
+  if (catalogWorker.joinable())
+    catalogWorker.request_stop();
 }

--- a/gui/rider_fixture_resolution_dialog.cpp
+++ b/gui/rider_fixture_resolution_dialog.cpp
@@ -119,6 +119,9 @@ void RiderFixtureResolutionDialog::BuildLayout() {
   table = new wxDataViewCtrl(this, wxID_ANY, wxDefaultPosition,
                              wxDefaultSize, wxDV_ROW_LINES);
   tableStore = new ColorfulDataViewListStore();
+  tableStore->AppendColumn("bool");
+  for (int column = 1; column < 8; ++column)
+    tableStore->AppendColumn("string");
   table->AssociateModel(tableStore);
   tableStore->DecRef();
   const int flags = wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE;

--- a/gui/rider_fixture_resolution_dialog.cpp
+++ b/gui/rider_fixture_resolution_dialog.cpp
@@ -2,6 +2,8 @@
 
 #include "gdtfsearchdialog.h"
 #include "gdtfloader.h"
+#include "colorstore.h"
+#include "gdtf_resolution_status_style.h"
 #include "../core/diagnostics/DiagnosticLogger.h"
 
 #include <algorithm>
@@ -12,6 +14,7 @@
 #include <wx/button.h>
 #include <wx/choicdlg.h>
 #include <wx/dataview.h>
+#include <wx/gauge.h>
 #include <wx/msgdlg.h>
 #include <wx/sizer.h>
 #include <wx/stattext.h>
@@ -21,6 +24,7 @@
 namespace {
 
 const wxEventTypeTag<wxThreadEvent> EVT_RIDER_CATALOG_LOADED(wxNewEventType());
+const wxEventTypeTag<wxThreadEvent> EVT_RIDER_CATALOG_PROGRESS(wxNewEventType());
 
 // Joins position labels for compact table presentation.
 wxString JoinPositions(const std::vector<std::string> &positions) {
@@ -80,6 +84,8 @@ RiderFixtureResolutionDialog::RiderFixtureResolutionDialog(
   Bind(wxEVT_SHOW, &RiderFixtureResolutionDialog::OnDialogShown, this);
   Bind(EVT_RIDER_CATALOG_LOADED,
        &RiderFixtureResolutionDialog::OnCatalogLoaded, this);
+  Bind(EVT_RIDER_CATALOG_PROGRESS,
+       &RiderFixtureResolutionDialog::OnProgress, this);
 }
 
 // Returns the user-reviewed resolution model after the modal dialog succeeds.
@@ -97,25 +103,33 @@ void RiderFixtureResolutionDialog::BuildLayout() {
   catalogStatusLabel = new wxStaticText(
       this, wxID_ANY, _("Loading cached GDTF catalog..."));
   root->Add(catalogStatusLabel, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 12);
+  catalogProgressGauge = new wxGauge(this, wxID_ANY, 100, wxDefaultPosition,
+                                     wxSize(-1, 6), wxGA_HORIZONTAL | wxGA_SMOOTH);
+  catalogProgressGauge->SetValue(0);
+  root->Add(catalogProgressGauge, 0,
+            wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 12);
 
-  table = new wxDataViewListCtrl(this, wxID_ANY, wxDefaultPosition,
-                                 wxDefaultSize, wxDV_ROW_LINES);
+  table = new wxDataViewCtrl(this, wxID_ANY, wxDefaultPosition,
+                             wxDefaultSize, wxDV_ROW_LINES);
+  tableStore = new ColorfulDataViewListStore();
+  table->AssociateModel(tableStore);
+  tableStore->DecRef();
   const int flags = wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE;
-  table->AppendToggleColumn(_("Create"), wxDATAVIEW_CELL_ACTIVATABLE, 65,
+  table->AppendToggleColumn(_("Create"), 0, wxDATAVIEW_CELL_ACTIVATABLE, 65,
                             wxALIGN_CENTER, flags);
-  table->AppendTextColumn(_("Fixture type"), wxDATAVIEW_CELL_EDITABLE, 220,
+  table->AppendTextColumn(_("Fixture type"), 1, wxDATAVIEW_CELL_EDITABLE, 220,
                           wxALIGN_LEFT, flags);
-  table->AppendTextColumn(_("Qty"), wxDATAVIEW_CELL_INERT, 55, wxALIGN_RIGHT,
+  table->AppendTextColumn(_("Qty"), 2, wxDATAVIEW_CELL_INERT, 55, wxALIGN_RIGHT,
                           flags);
-  table->AppendTextColumn(_("Positions"), wxDATAVIEW_CELL_INERT, 140,
+  table->AppendTextColumn(_("Positions"), 3, wxDATAVIEW_CELL_INERT, 140,
                           wxALIGN_LEFT, flags);
-  table->AppendTextColumn(_("Selected GDTF"), wxDATAVIEW_CELL_INERT, 270,
+  table->AppendTextColumn(_("Selected GDTF"), 4, wxDATAVIEW_CELL_INERT, 270,
                           wxALIGN_LEFT, flags);
-  table->AppendTextColumn(_("Mode"), wxDATAVIEW_CELL_INERT, 130, wxALIGN_LEFT,
+  table->AppendTextColumn(_("Mode"), 5, wxDATAVIEW_CELL_INERT, 130, wxALIGN_LEFT,
                           flags);
-  table->AppendTextColumn(_("Status"), wxDATAVIEW_CELL_INERT, 100, wxALIGN_LEFT,
+  table->AppendTextColumn(_("Status"), 6, wxDATAVIEW_CELL_INERT, 100, wxALIGN_LEFT,
                           flags);
-  table->AppendTextColumn(_("Details"), wxDATAVIEW_CELL_INERT, 220,
+  table->AppendTextColumn(_("Details"), 7, wxDATAVIEW_CELL_INERT, 220,
                           wxALIGN_LEFT, flags);
   root->Add(table, 1, wxEXPAND | wxLEFT | wxRIGHT, 12);
 
@@ -130,8 +144,8 @@ void RiderFixtureResolutionDialog::BuildLayout() {
   root->Add(actions, 0, wxEXPAND | wxALL, 12);
 
   auto *footer = new wxBoxSizer(wxHORIZONTAL);
-  auto *acceptAllButton =
-      new wxButton(this, wxID_ANY, _("Accept all suggestions"));
+  acceptAllButton = new wxButton(this, wxID_ANY, _("Accept all suggestions"));
+  acceptAllButton->Enable(false);
   summaryLabel = new wxStaticText(this, wxID_ANY, wxEmptyString);
   resolveButton = new wxButton(this, wxID_OK, _("Resolve and create"));
   auto *cancelButton = new wxButton(this, wxID_CANCEL, _("Cancel"));
@@ -162,8 +176,8 @@ void RiderFixtureResolutionDialog::BuildLayout() {
 
 // Rebuilds table rows from the current resolution model.
 void RiderFixtureResolutionDialog::RefreshTable() {
-  const int selectedRow = table->GetSelectedRow();
-  table->DeleteAllItems();
+  const int selectedRow = SelectedRow();
+  tableStore->DeleteAllItems();
   for (const auto &item : analysis.items) {
     wxVector<wxVariant> row;
     row.push_back(item.create);
@@ -176,11 +190,18 @@ void RiderFixtureResolutionDialog::RefreshTable() {
                       : wxString::FromUTF8(item.selectedMode));
     row.push_back(wxString::FromUTF8(rider_fixture_resolution::OriginName(item.origin)));
     row.push_back(wxString::FromUTF8(item.details));
-    table->AppendItem(row);
+    tableStore->AppendItem(row);
+    const unsigned rowIndex = static_cast<unsigned>(tableStore->GetItemCount() - 1);
+    const unsigned statusColumn = 6;
+    const auto semantic =
+        rider_fixture_resolution::StatusSemanticForOrigin(item.origin);
+    if (semantic != rider_fixture_resolution::StatusSemantic::Neutral)
+      tableStore->SetCellTextColour(
+          rowIndex, statusColumn, GdtfResolutionStatusColour(semantic));
   }
   if (!analysis.items.empty())
-    table->SelectRow(std::clamp(selectedRow, 0,
-                                static_cast<int>(analysis.items.size()) - 1));
+    table->Select(tableStore->GetItem(static_cast<unsigned>(std::clamp(
+        selectedRow, 0, static_cast<int>(analysis.items.size()) - 1))));
 }
 
 // Updates row-action availability for the selected fixture row.
@@ -216,10 +237,16 @@ void RiderFixtureResolutionDialog::RefreshSummary() {
 
 // Returns the model item corresponding to the selected table row.
 rider_fixture_resolution::Item *RiderFixtureResolutionDialog::SelectedItem() {
-  const int row = table->GetSelectedRow();
+  const int row = SelectedRow();
   if (row < 0 || row >= static_cast<int>(analysis.items.size()))
     return nullptr;
   return &analysis.items[static_cast<size_t>(row)];
+}
+
+// Returns the currently selected model row or -1 when no row is selected.
+int RiderFixtureResolutionDialog::SelectedRow() const {
+  const wxDataViewItem selected = table->GetSelection();
+  return selected.IsOk() ? static_cast<int>(tableStore->GetRow(selected)) : -1;
 }
 
 // Refreshes actions when the selected row changes.
@@ -232,9 +259,9 @@ void RiderFixtureResolutionDialog::OnSelectionChanged(wxDataViewEvent &event) {
 void RiderFixtureResolutionDialog::OnItemActivated(wxDataViewEvent &event) {
   if (event.GetColumn() != 5)
     return;
-  const int activatedRow = table->ItemToRow(event.GetItem());
+  const int activatedRow = static_cast<int>(tableStore->GetRow(event.GetItem()));
   if (activatedRow != wxNOT_FOUND)
-    table->SelectRow(activatedRow);
+    table->Select(tableStore->GetItem(static_cast<unsigned>(activatedRow)));
   auto *item = SelectedItem();
   if (!item)
     return;
@@ -279,13 +306,13 @@ void RiderFixtureResolutionDialog::OnItemActivated(wxDataViewEvent &event) {
 
 // Applies committed Create and Fixture type cell edits to the resolution model.
 void RiderFixtureResolutionDialog::OnValueChanged(wxDataViewEvent &event) {
-  const int row = table->ItemToRow(event.GetItem());
+  const int row = static_cast<int>(tableStore->GetRow(event.GetItem()));
   if (row == wxNOT_FOUND || row >= static_cast<int>(analysis.items.size()))
     return;
   auto &item = analysis.items[static_cast<size_t>(row)];
   wxVariant value;
-  table->GetValue(value, static_cast<unsigned int>(row),
-                  static_cast<unsigned int>(event.GetColumn()));
+  tableStore->GetValueByRow(value, static_cast<unsigned int>(row),
+                            static_cast<unsigned int>(event.GetColumn()));
   if (event.GetColumn() == 0) {
     rider_fixture_resolution::Service::SetCreate(item, value.GetBool());
     if (item.create)
@@ -361,14 +388,40 @@ void RiderFixtureResolutionDialog::OnDialogShown(wxShowEvent &event) {
   const auto requests = BuildFixtureRequests();
   wxWeakRef<RiderFixtureResolutionDialog> weakDialog(this);
   std::thread([loader, weakDialog, requests]() mutable {
+    auto report = [&weakDialog](const ProgressData &progress) {
+      RiderFixtureResolutionDialog *dialog = weakDialog.get();
+      if (!dialog)
+        return;
+      auto *event = new wxThreadEvent(EVT_RIDER_CATALOG_PROGRESS);
+      event->SetPayload(progress);
+      wxQueueEvent(dialog, event);
+    };
+    report({{rider_fixture_resolution::ProgressStage::LoadingCatalog}});
+    report({{rider_fixture_resolution::ProgressStage::ParsingCatalog}});
     auto loaded = loader();
     if (loaded) {
       const auto matchStarted = std::chrono::steady_clock::now();
-      loaded->matches = rider_fixture_resolution::Service::Analyze(
-          requests, {}, loaded->entries);
+      rider_fixture_resolution::Analysis matches;
+      size_t automaticMatches = 0;
+      for (size_t row = 0; row < requests.size(); ++row) {
+        auto one = rider_fixture_resolution::Service::Analyze(
+            {requests[row]}, {}, loaded->entries);
+        if (one.items.front().origin ==
+            rider_fixture_resolution::ResolutionOrigin::AutomaticMatch)
+          ++automaticMatches;
+        matches.items.push_back(one.items.front());
+        report({{rider_fixture_resolution::ProgressStage::MatchingFixtures,
+                 row + 1, requests.size(), automaticMatches},
+                row, one.items.front()});
+      }
+      report({{rider_fixture_resolution::ProgressStage::Complete,
+               requests.size(), requests.size(), automaticMatches}});
+      loaded->matches = std::move(matches);
       loaded->matchMs =
           std::chrono::duration_cast<std::chrono::milliseconds>(
               std::chrono::steady_clock::now() - matchStarted).count();
+    } else {
+      report({{rider_fixture_resolution::ProgressStage::Unavailable}});
     }
     RiderFixtureResolutionDialog *dialog = weakDialog.get();
     if (!dialog)
@@ -382,6 +435,8 @@ void RiderFixtureResolutionDialog::OnDialogShown(wxShowEvent &event) {
 // Applies a completed cached catalog load on the wxWidgets UI thread.
 void RiderFixtureResolutionDialog::OnCatalogLoaded(wxThreadEvent &event) {
   catalogLoading = false;
+  if (!acceptAutomaticResults)
+    return;
   const auto loaded =
       event.GetPayload<std::optional<RiderFixtureResolutionDialog::CatalogData>>();
   if (!loaded) {
@@ -392,8 +447,56 @@ void RiderFixtureResolutionDialog::OnCatalogLoaded(wxThreadEvent &event) {
   ApplyCatalog(*loaded);
 }
 
+// Updates the visible gauge from real catalog and matching worker progress.
+void RiderFixtureResolutionDialog::OnProgress(wxThreadEvent &event) {
+  if (!acceptAutomaticResults)
+    return;
+  const auto data = event.GetPayload<ProgressData>();
+  const auto &progress = data.progress;
+  if (data.matchedItem && data.row < analysis.items.size()) {
+    rider_fixture_resolution::Service::MergeCatalogSuggestion(
+        analysis.items[data.row], *data.matchedItem);
+    RefreshTable();
+    RefreshSelectionControls();
+    RefreshSummary();
+  }
+  switch (progress.stage) {
+  case rider_fixture_resolution::ProgressStage::LoadingCatalog:
+    catalogStatusLabel->SetLabel(_("Loading cached GDTF catalog..."));
+    catalogProgressGauge->Pulse();
+    break;
+  case rider_fixture_resolution::ProgressStage::ParsingCatalog:
+    catalogStatusLabel->SetLabel(_("Parsing GDTF catalog..."));
+    catalogProgressGauge->Pulse();
+    break;
+  case rider_fixture_resolution::ProgressStage::MatchingFixtures:
+    catalogProgressGauge->SetRange(static_cast<int>(std::max<size_t>(progress.total, 1)));
+    catalogProgressGauge->SetValue(static_cast<int>(progress.current));
+    catalogStatusLabel->SetLabel(wxString::Format(
+        _("Matching GDTF candidates... %zu / %zu"), progress.current,
+        progress.total));
+    break;
+  case rider_fixture_resolution::ProgressStage::Complete:
+    catalogProgressGauge->SetRange(static_cast<int>(std::max<size_t>(progress.total, 1)));
+    catalogProgressGauge->SetValue(static_cast<int>(progress.total));
+    catalogStatusLabel->SetLabel(wxString::Format(
+        _("Automatic matching complete | %zu matches | %zu generic fallbacks"),
+        progress.automaticMatches,
+        progress.total - std::min(progress.total, progress.automaticMatches)));
+    acceptAllButton->Enable(true);
+    break;
+  case rider_fixture_resolution::ProgressStage::Unavailable:
+    catalogProgressGauge->SetValue(0);
+    catalogStatusLabel->SetLabel(
+        _("GDTF catalog unavailable - generic fallback remains available"));
+    break;
+  }
+}
+
 // Merges catalog suggestions into untouched rows and refreshes presentation.
 void RiderFixtureResolutionDialog::ApplyCatalog(const CatalogData &catalog) {
+  if (!acceptAutomaticResults)
+    return;
   catalogPayload = catalog.snapshot.listData;
   catalogUpdatedAt = catalog.snapshot.updatedAt;
   catalogEntries = catalog.entries;
@@ -406,8 +509,6 @@ void RiderFixtureResolutionDialog::ApplyCatalog(const CatalogData &catalog) {
       "Rider fixture preflight catalog: catalog_match_ms=" +
       std::to_string(catalog.matchMs));
   rider_fixture_resolution::Service::MergeCatalogSuggestions(analysis, matched);
-  catalogStatusLabel->SetLabel(wxString::Format(
-      _("Catalog loaded: %zu entries"), catalogEntries.size()));
   RefreshTable();
   RefreshSelectionControls();
   RefreshSummary();
@@ -454,6 +555,7 @@ void RiderFixtureResolutionDialog::OnAcceptAll(wxCommandEvent &) {
 
 // Closes successfully only after every non-dictionary row is explicitly ready.
 void RiderFixtureResolutionDialog::OnResolve(wxCommandEvent &) {
+  acceptAutomaticResults = false;
   rider_fixture_resolution::Service::FinalizeDefaults(analysis);
   EndModal(wxID_OK);
 }

--- a/gui/rider_fixture_resolution_dialog.cpp
+++ b/gui/rider_fixture_resolution_dialog.cpp
@@ -414,8 +414,20 @@ void RiderFixtureResolutionDialog::OnCatalogLoaded(wxThreadEvent &event) {
   const auto loaded =
       event.GetPayload<std::optional<RiderFixtureResolutionDialog::CatalogData>>();
   if (!loaded) {
+    if (onlineCatalogLoader && !onlineCatalogLoadAttempted) {
+      onlineCatalogLoadAttempted = true;
+      catalogStatusLabel->SetLabel(
+          _("Acquiring the shared GDTF catalog..."));
+      catalogProgressGauge->Pulse();
+      const auto acquired = onlineCatalogLoader();
+      if (acquired) {
+        ApplyCatalog(*acquired);
+        return;
+      }
+    }
     catalogStatusLabel->SetLabel(
         _("Catalog unavailable; generic fallback remains available."));
+    catalogProgressGauge->SetValue(0);
     return;
   }
   ApplyCatalog(*loaded);

--- a/gui/rider_fixture_resolution_dialog.cpp
+++ b/gui/rider_fixture_resolution_dialog.cpp
@@ -177,23 +177,11 @@ void RiderFixtureResolutionDialog::RefreshSelectionControls() {
 
 // Updates the real-mapping count while keeping Generic confirmation available.
 void RiderFixtureResolutionDialog::RefreshSummary() {
-  const size_t created = static_cast<size_t>(std::count_if(
-      analysis.items.begin(), analysis.items.end(), [](const auto &item) {
-        return item.create;
-      }));
-  const size_t automatic = static_cast<size_t>(std::count_if(
-      analysis.items.begin(), analysis.items.end(),
-      [](const auto &item) {
-        return item.create && item.origin == rider_fixture_resolution::ResolutionOrigin::AutomaticMatch;
-      }));
-  const size_t generic = static_cast<size_t>(std::count_if(
-      analysis.items.begin(), analysis.items.end(), [](const auto &item) {
-        return item.create && item.origin == rider_fixture_resolution::ResolutionOrigin::GenericFallback;
-      }));
-  const size_t skipped = analysis.items.size() - created;
+  const auto summary = rider_fixture_resolution::Service::Summarize(analysis);
   summaryLabel->SetLabel(wxString::Format(
-      _("%zu fixture types will be created · %zu automatic matches · %zu generic · %zu skipped"),
-      created, automatic, generic, skipped));
+      _("%zu fixture types will be created | %zu automatic matches | %zu generic | %zu skipped"),
+      summary.created, summary.automaticMatches, summary.genericFallbacks,
+      summary.skipped));
   resolveButton->Enable(true);
 }
 
@@ -462,15 +450,16 @@ void RiderFixtureResolutionDialog::OnProgress(wxThreadEvent &event) {
         _("Matching GDTF candidates... %zu / %zu"), progress.current,
         progress.total));
     break;
-  case rider_fixture_resolution::ProgressStage::Complete:
+  case rider_fixture_resolution::ProgressStage::Complete: {
     catalogProgressGauge->SetRange(static_cast<int>(std::max<size_t>(progress.total, 1)));
     catalogProgressGauge->SetValue(static_cast<int>(progress.total));
+    const auto summary = rider_fixture_resolution::Service::Summarize(analysis);
     catalogStatusLabel->SetLabel(wxString::Format(
         _("Automatic matching complete | %zu matches | %zu generic fallbacks"),
-        progress.automaticMatches,
-        progress.total - std::min(progress.total, progress.automaticMatches)));
+        summary.automaticMatches, summary.genericFallbacks));
     acceptAllButton->Enable(true);
     break;
+  }
   case rider_fixture_resolution::ProgressStage::Unavailable:
     catalogProgressGauge->SetValue(0);
     catalogStatusLabel->SetLabel(

--- a/gui/rider_fixture_resolution_dialog.cpp
+++ b/gui/rider_fixture_resolution_dialog.cpp
@@ -1,0 +1,282 @@
+#include "rider_fixture_resolution_dialog.h"
+
+#include "gdtfsearchdialog.h"
+
+#include <algorithm>
+#include <sstream>
+
+#include <wx/button.h>
+#include <wx/choice.h>
+#include <wx/dataview.h>
+#include <wx/msgdlg.h>
+#include <wx/sizer.h>
+#include <wx/stattext.h>
+
+namespace {
+
+// Joins position labels for compact table presentation.
+wxString JoinPositions(const std::vector<std::string> &positions) {
+  wxString value;
+  for (const std::string &position : positions) {
+    if (!value.empty())
+      value += ", ";
+    value += wxString::FromUTF8(position);
+  }
+  return value;
+}
+
+// Formats the selected or suggested catalog identity for a resolution row.
+wxString FormatCatalogIdentity(const rider_fixture_resolution::Item &item) {
+  const auto &entry = item.selectedEntry ? item.selectedEntry : item.suggestedEntry;
+  if (!entry)
+    return "-";
+  if (entry->manufacturer.empty())
+    return wxString::FromUTF8(entry->fixtureName);
+  return wxString::FromUTF8(entry->manufacturer + " / " + entry->fixtureName);
+}
+
+} // namespace
+
+// Creates the modal fixture-resolution review without starting downloads.
+RiderFixtureResolutionDialog::RiderFixtureResolutionDialog(
+    wxWindow *parent, rider_fixture_resolution::Analysis analysisIn,
+    std::string catalogPayloadIn, std::string catalogUpdatedAtIn,
+    CatalogLoader catalogLoaderIn)
+    : wxDialog(parent, wxID_ANY, _("Resolve fixture types"), wxDefaultPosition,
+               wxSize(1160, 680),
+               wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER),
+      analysis(std::move(analysisIn)),
+      catalogPayload(std::move(catalogPayloadIn)),
+      catalogUpdatedAt(std::move(catalogUpdatedAtIn)),
+      catalogLoader(std::move(catalogLoaderIn)) {
+  BuildLayout();
+  RefreshTable();
+  RefreshSelectionControls();
+  RefreshSummary();
+  SetMinSize(wxSize(780, 500));
+  CentreOnParent();
+}
+
+// Returns the user-reviewed resolution model after the modal dialog succeeds.
+rider_fixture_resolution::Analysis RiderFixtureResolutionDialog::TakeAnalysis() {
+  return std::move(analysis);
+}
+
+// Builds the wide queue-style table, row actions, and footer controls.
+void RiderFixtureResolutionDialog::BuildLayout() {
+  auto *root = new wxBoxSizer(wxVERTICAL);
+  root->Add(new wxStaticText(
+                this, wxID_ANY,
+                _("Review unknown rider fixture types before creating the scene.")),
+            0, wxEXPAND | wxALL, 12);
+
+  table = new wxDataViewListCtrl(this, wxID_ANY, wxDefaultPosition,
+                                 wxDefaultSize, wxDV_ROW_LINES);
+  const int flags = wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE;
+  table->AppendTextColumn(_("Fixture type"), wxDATAVIEW_CELL_INERT, 220,
+                          wxALIGN_LEFT, flags);
+  table->AppendTextColumn(_("Qty"), wxDATAVIEW_CELL_INERT, 55, wxALIGN_RIGHT,
+                          flags);
+  table->AppendTextColumn(_("Positions"), wxDATAVIEW_CELL_INERT, 140,
+                          wxALIGN_LEFT, flags);
+  table->AppendTextColumn(_("Selected GDTF"), wxDATAVIEW_CELL_INERT, 270,
+                          wxALIGN_LEFT, flags);
+  table->AppendTextColumn(_("Mode"), wxDATAVIEW_CELL_INERT, 130, wxALIGN_LEFT,
+                          flags);
+  table->AppendTextColumn(_("Status"), wxDATAVIEW_CELL_INERT, 100, wxALIGN_LEFT,
+                          flags);
+  table->AppendTextColumn(_("Details"), wxDATAVIEW_CELL_INERT, 220,
+                          wxALIGN_LEFT, flags);
+  root->Add(table, 1, wxEXPAND | wxLEFT | wxRIGHT, 12);
+
+  auto *actions = new wxBoxSizer(wxHORIZONTAL);
+  useSuggestedButton = new wxButton(this, wxID_ANY, _("Use suggested"));
+  searchButton = new wxButton(this, wxID_ANY, _("Search..."));
+  useGenericButton = new wxButton(this, wxID_ANY, _("Use generic"));
+  modeChoice = new wxChoice(this, wxID_ANY);
+  actions->Add(useSuggestedButton, 0, wxRIGHT, 8);
+  actions->Add(searchButton, 0, wxRIGHT, 8);
+  actions->Add(useGenericButton, 0, wxRIGHT, 16);
+  actions->Add(new wxStaticText(this, wxID_ANY, _("Mode:")), 0,
+               wxALIGN_CENTER_VERTICAL | wxRIGHT, 6);
+  actions->Add(modeChoice, 1);
+  root->Add(actions, 0, wxEXPAND | wxALL, 12);
+
+  auto *footer = new wxBoxSizer(wxHORIZONTAL);
+  auto *acceptAllButton =
+      new wxButton(this, wxID_ANY, _("Accept all suggestions"));
+  summaryLabel = new wxStaticText(this, wxID_ANY, wxEmptyString);
+  resolveButton = new wxButton(this, wxID_OK, _("Resolve and create"));
+  auto *cancelButton = new wxButton(this, wxID_CANCEL, _("Cancel"));
+  footer->Add(acceptAllButton, 0, wxRIGHT, 12);
+  footer->Add(summaryLabel, 1, wxALIGN_CENTER_VERTICAL);
+  footer->Add(resolveButton, 0, wxRIGHT, 8);
+  footer->Add(cancelButton, 0);
+  root->Add(footer, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 12);
+  SetSizer(root);
+
+  table->Bind(wxEVT_DATAVIEW_SELECTION_CHANGED,
+              &RiderFixtureResolutionDialog::OnSelectionChanged, this);
+  useSuggestedButton->Bind(wxEVT_BUTTON,
+                           &RiderFixtureResolutionDialog::OnUseSuggested, this);
+  searchButton->Bind(wxEVT_BUTTON, &RiderFixtureResolutionDialog::OnSearch,
+                     this);
+  useGenericButton->Bind(wxEVT_BUTTON,
+                         &RiderFixtureResolutionDialog::OnUseGeneric, this);
+  acceptAllButton->Bind(wxEVT_BUTTON,
+                        &RiderFixtureResolutionDialog::OnAcceptAll, this);
+  modeChoice->Bind(wxEVT_CHOICE,
+                   &RiderFixtureResolutionDialog::OnModeSelected, this);
+  resolveButton->Bind(wxEVT_BUTTON, &RiderFixtureResolutionDialog::OnResolve,
+                      this);
+}
+
+// Rebuilds table rows from the current resolution model.
+void RiderFixtureResolutionDialog::RefreshTable() {
+  const int selectedRow = table->GetSelectedRow();
+  table->DeleteAllItems();
+  for (const auto &item : analysis.items) {
+    wxVector<wxVariant> row;
+    row.push_back(wxString::FromUTF8(item.request.typeName));
+    row.push_back(wxString::Format("%d", item.request.quantity));
+    row.push_back(JoinPositions(item.request.positions));
+    row.push_back(FormatCatalogIdentity(item));
+    row.push_back(item.selectedMode.empty() ? "-"
+                                            : wxString::FromUTF8(item.selectedMode));
+    row.push_back(wxString::FromUTF8(rider_fixture_resolution::StateName(item.state)));
+    row.push_back(wxString::FromUTF8(item.details));
+    table->AppendItem(row);
+  }
+  if (!analysis.items.empty())
+    table->SelectRow(std::clamp(selectedRow, 0,
+                                static_cast<int>(analysis.items.size()) - 1));
+}
+
+// Updates row-action availability and the explicit mode selector.
+void RiderFixtureResolutionDialog::RefreshSelectionControls() {
+  rider_fixture_resolution::Item *item = SelectedItem();
+  useSuggestedButton->Enable(item && item->state == rider_fixture_resolution::State::Suggested &&
+                             item->suggestedEntry.has_value());
+  searchButton->Enable(item && item->state != rider_fixture_resolution::State::Dictionary);
+  useGenericButton->Enable(item && item->state != rider_fixture_resolution::State::Dictionary);
+  modeChoice->Clear();
+  if (!item || !item->selectedEntry) {
+    modeChoice->Enable(false);
+    return;
+  }
+  for (const auto &mode : item->selectedEntry->modes)
+    modeChoice->Append(wxString::FromUTF8(mode.name));
+  modeChoice->Enable(item->selectedEntry->modes.size() > 1);
+  if (!item->selectedMode.empty()) {
+    const int index = modeChoice->FindString(wxString::FromUTF8(item->selectedMode));
+    if (index != wxNOT_FOUND)
+      modeChoice->SetSelection(index);
+  }
+}
+
+// Updates completion counts and enables confirmation only for ready rows.
+void RiderFixtureResolutionDialog::RefreshSummary() {
+  const size_t ready = static_cast<size_t>(std::count_if(
+      analysis.items.begin(), analysis.items.end(),
+      [](const auto &item) { return item.IsReady(); }));
+  summaryLabel->SetLabel(wxString::Format(_("%zu of %zu fixture types ready"),
+                                          ready, analysis.items.size()));
+  resolveButton->Enable(ready == analysis.items.size());
+}
+
+// Returns the model item corresponding to the selected table row.
+rider_fixture_resolution::Item *RiderFixtureResolutionDialog::SelectedItem() {
+  const int row = table->GetSelectedRow();
+  if (row < 0 || row >= static_cast<int>(analysis.items.size()))
+    return nullptr;
+  return &analysis.items[static_cast<size_t>(row)];
+}
+
+// Refreshes actions when the selected row changes.
+void RiderFixtureResolutionDialog::OnSelectionChanged(wxDataViewEvent &event) {
+  RefreshSelectionControls();
+  event.Skip();
+}
+
+// Accepts the safe suggestion for the selected row.
+void RiderFixtureResolutionDialog::OnUseSuggested(wxCommandEvent &) {
+  auto *item = SelectedItem();
+  if (item && item->suggestedEntry)
+    rider_fixture_resolution::Service::SelectCatalogEntry(*item, *item->suggestedEntry);
+  RefreshTable();
+  RefreshSelectionControls();
+  RefreshSummary();
+}
+
+// Opens the established catalog browser pre-filtered for the rider alias.
+void RiderFixtureResolutionDialog::OnSearch(wxCommandEvent &) {
+  auto *item = SelectedItem();
+  if (!item)
+    return;
+  if (catalogPayload.empty()) {
+    const auto loaded = catalogLoader ? catalogLoader() : std::nullopt;
+    if (!loaded) {
+      wxMessageBox(_("The GDTF catalog is unavailable. You can use generic or cancel without changing the scene."),
+                   _("GDTF catalog unavailable"), wxOK | wxICON_INFORMATION, this);
+      return;
+    }
+    catalogPayload = loaded->listData;
+    catalogUpdatedAt = loaded->updatedAt;
+  }
+  GdtfSearchDialog dialog(this, catalogPayload, catalogUpdatedAt, nullptr,
+                          GdtfCatalogDisplaySource::Cached, true,
+                          item->request.typeName);
+  if (dialog.ShowModal() != wxID_OK)
+    return;
+  const auto selected = dialog.GetSelectedEntry();
+  if (selected)
+    rider_fixture_resolution::Service::SelectCatalogEntry(*item, *selected);
+  RefreshTable();
+  RefreshSelectionControls();
+  RefreshSummary();
+}
+
+// Selects the existing one-import generic fallback for the selected alias.
+void RiderFixtureResolutionDialog::OnUseGeneric(wxCommandEvent &) {
+  if (auto *item = SelectedItem())
+    rider_fixture_resolution::Service::SelectGeneric(*item);
+  RefreshTable();
+  RefreshSelectionControls();
+  RefreshSummary();
+}
+
+// Accepts only safe Suggested rows and leaves Review rows untouched.
+void RiderFixtureResolutionDialog::OnAcceptAll(wxCommandEvent &) {
+  for (auto &item : analysis.items) {
+    if (item.state == rider_fixture_resolution::State::Suggested &&
+        item.suggestedEntry) {
+      rider_fixture_resolution::Service::SelectCatalogEntry(item,
+                                                             *item.suggestedEntry);
+    }
+  }
+  RefreshTable();
+  RefreshSelectionControls();
+  RefreshSummary();
+}
+
+// Stores the user's explicit mode choice for a multi-mode profile.
+void RiderFixtureResolutionDialog::OnModeSelected(wxCommandEvent &) {
+  auto *item = SelectedItem();
+  if (item && modeChoice->GetSelection() != wxNOT_FOUND)
+    item->selectedMode = modeChoice->GetStringSelection().ToStdString();
+  RefreshTable();
+  RefreshSelectionControls();
+  RefreshSummary();
+}
+
+// Closes successfully only after every non-dictionary row is explicitly ready.
+void RiderFixtureResolutionDialog::OnResolve(wxCommandEvent &) {
+  if (!std::all_of(analysis.items.begin(), analysis.items.end(),
+                   [](const auto &item) { return item.IsReady(); })) {
+    wxMessageBox(_("Resolve every fixture type or choose Use generic before continuing."),
+                 _("Fixture types require attention"), wxOK | wxICON_WARNING,
+                 this);
+    return;
+  }
+  EndModal(wxID_OK);
+}

--- a/gui/rider_fixture_resolution_dialog.h
+++ b/gui/rider_fixture_resolution_dialog.h
@@ -29,6 +29,7 @@ public:
   using CatalogLoader = std::function<std::optional<CatalogData>()>;
   RiderFixtureResolutionDialog(
       wxWindow *parent, rider_fixture_resolution::Analysis analysis,
+      std::unordered_map<std::string, GdtfDictionary::Entry> dictionary,
       CatalogLoader cachedCatalogLoader, CatalogLoader onlineCatalogLoader);
 
   rider_fixture_resolution::Analysis TakeAnalysis();
@@ -40,6 +41,7 @@ private:
   void RefreshSummary();
   void OnSelectionChanged(wxDataViewEvent &event);
   void OnItemActivated(wxDataViewEvent &event);
+  void OnValueChanged(wxDataViewEvent &event);
   void OnUseSuggested(wxCommandEvent &event);
   void OnSearch(wxCommandEvent &event);
   void OnUseGeneric(wxCommandEvent &event);
@@ -52,6 +54,7 @@ private:
   rider_fixture_resolution::Item *SelectedItem();
 
   rider_fixture_resolution::Analysis analysis;
+  std::unordered_map<std::string, GdtfDictionary::Entry> dictionary;
   std::string catalogPayload;
   std::string catalogUpdatedAt;
   std::vector<mvr::gdtf_catalog_matcher::GdtfCatalogEntry> catalogEntries;

--- a/gui/rider_fixture_resolution_dialog.h
+++ b/gui/rider_fixture_resolution_dialog.h
@@ -2,6 +2,7 @@
 
 #include "../core/rider_fixture_resolution.h"
 #include "../core/gdtf_catalog_service.h"
+#include "../core/credentialstore.h"
 
 #include <string>
 #include <functional>
@@ -36,11 +37,33 @@ public:
     size_t row = 0;
     std::optional<rider_fixture_resolution::Item> matchedItem;
   };
+  enum class OnlineCatalogStatus {
+    Success,
+    AuthenticationRejected,
+    Unavailable
+  };
+  struct OnlineCatalogResult {
+    OnlineCatalogStatus status = OnlineCatalogStatus::Unavailable;
+    std::optional<CatalogData> catalog;
+    std::string error;
+  };
   using CatalogLoader = std::function<std::optional<CatalogData>()>;
+  using OnlineProgressCallback =
+      std::function<void(const rider_fixture_resolution::Progress &)>;
+  using OnlineCatalogLoader = std::function<OnlineCatalogResult(
+      const CredentialStore::Credentials &, std::stop_token,
+      OnlineProgressCallback)>;
+  using CredentialRequester = std::function<
+      std::optional<CredentialStore::Credentials>(bool rejected)>;
+  using CredentialPersistCallback =
+      std::function<void(const CredentialStore::Credentials &)>;
   RiderFixtureResolutionDialog(
       wxWindow *parent, rider_fixture_resolution::Analysis analysis,
       std::unordered_map<std::string, GdtfDictionary::Entry> dictionary,
-      CatalogLoader cachedCatalogLoader, CatalogLoader onlineCatalogLoader);
+      CatalogLoader cachedCatalogLoader, OnlineCatalogLoader onlineCatalogLoader,
+      std::optional<CredentialStore::Credentials> initialCredentials,
+      CredentialRequester credentialRequester,
+      CredentialPersistCallback credentialPersistCallback);
   ~RiderFixtureResolutionDialog() override;
 
   rider_fixture_resolution::Analysis TakeAnalysis();
@@ -51,6 +74,7 @@ private:
   void UpdateRow(size_t analysisIndex);
   void RefreshSelectionControls();
   void RefreshSummary();
+  void RefreshCatalogCompletionStatus();
   void OnSelectionChanged(wxDataViewEvent &event);
   void OnItemActivated(wxDataViewEvent &event);
   void OnValueChanged(wxDataViewEvent &event);
@@ -62,6 +86,7 @@ private:
   void OnCancel(wxCommandEvent &event);
   void OnDialogShown(wxShowEvent &event);
   void OnCatalogLoaded(wxThreadEvent &event);
+  void OnOnlineCatalogLoaded(wxThreadEvent &event);
   void OnProgress(wxThreadEvent &event);
   void ApplyCatalog(const CatalogData &catalog);
   std::vector<RiderImporter::FixtureTypeRequest> BuildFixtureRequests() const;
@@ -69,6 +94,8 @@ private:
   std::optional<size_t> AnalysisIndexForItem(const wxDataViewItem &item) const;
   std::optional<unsigned> StoreRowForAnalysisIndex(size_t analysisIndex) const;
   void RequestWorkerStop();
+  void BeginOnlineCatalogAcquisition(bool rejectedCredentials = false);
+  void StartOnlineCatalogWorker(const CredentialStore::Credentials &credentials);
 
   rider_fixture_resolution::Analysis analysis;
   std::unordered_map<std::string, GdtfDictionary::Entry> dictionary;
@@ -77,7 +104,10 @@ private:
   std::vector<mvr::gdtf_catalog_matcher::GdtfCatalogEntry> catalogEntries;
   CatalogSource catalogSource = CatalogSource::None;
   CatalogLoader cachedCatalogLoader;
-  CatalogLoader onlineCatalogLoader;
+  OnlineCatalogLoader onlineCatalogLoader;
+  std::optional<CredentialStore::Credentials> catalogCredentials;
+  CredentialRequester credentialRequester;
+  CredentialPersistCallback credentialPersistCallback;
   bool catalogLoadStarted = false;
   bool catalogLoading = false;
   bool onlineCatalogLoadAttempted = false;

--- a/gui/rider_fixture_resolution_dialog.h
+++ b/gui/rider_fixture_resolution_dialog.h
@@ -10,18 +10,26 @@
 #include <wx/dialog.h>
 
 class wxButton;
-class wxChoice;
 class wxDataViewEvent;
 class wxDataViewListCtrl;
 class wxStaticText;
+class wxShowEvent;
+class wxThreadEvent;
 
 class RiderFixtureResolutionDialog final : public wxDialog {
 public:
-  using CatalogLoader = std::function<std::optional<GdtfCatalogSnapshot>()>;
+  enum class CatalogSource { None, Cached, Online };
+  struct CatalogData {
+    GdtfCatalogSnapshot snapshot;
+    std::vector<mvr::gdtf_catalog_matcher::GdtfCatalogEntry> entries;
+    CatalogSource source = CatalogSource::None;
+    std::optional<rider_fixture_resolution::Analysis> matches;
+    long long matchMs = 0;
+  };
+  using CatalogLoader = std::function<std::optional<CatalogData>()>;
   RiderFixtureResolutionDialog(
       wxWindow *parent, rider_fixture_resolution::Analysis analysis,
-      std::string catalogPayload, std::string catalogUpdatedAt,
-      CatalogLoader catalogLoader = {});
+      CatalogLoader cachedCatalogLoader, CatalogLoader onlineCatalogLoader);
 
   rider_fixture_resolution::Analysis TakeAnalysis();
 
@@ -31,23 +39,32 @@ private:
   void RefreshSelectionControls();
   void RefreshSummary();
   void OnSelectionChanged(wxDataViewEvent &event);
+  void OnItemActivated(wxDataViewEvent &event);
   void OnUseSuggested(wxCommandEvent &event);
   void OnSearch(wxCommandEvent &event);
   void OnUseGeneric(wxCommandEvent &event);
   void OnAcceptAll(wxCommandEvent &event);
-  void OnModeSelected(wxCommandEvent &event);
   void OnResolve(wxCommandEvent &event);
+  void OnDialogShown(wxShowEvent &event);
+  void OnCatalogLoaded(wxThreadEvent &event);
+  void ApplyCatalog(const CatalogData &catalog);
+  std::vector<RiderImporter::FixtureTypeRequest> BuildFixtureRequests() const;
   rider_fixture_resolution::Item *SelectedItem();
 
   rider_fixture_resolution::Analysis analysis;
   std::string catalogPayload;
   std::string catalogUpdatedAt;
-  CatalogLoader catalogLoader;
+  std::vector<mvr::gdtf_catalog_matcher::GdtfCatalogEntry> catalogEntries;
+  CatalogSource catalogSource = CatalogSource::None;
+  CatalogLoader cachedCatalogLoader;
+  CatalogLoader onlineCatalogLoader;
+  bool catalogLoadStarted = false;
+  bool catalogLoading = false;
   wxDataViewListCtrl *table = nullptr;
-  wxChoice *modeChoice = nullptr;
   wxButton *useSuggestedButton = nullptr;
   wxButton *searchButton = nullptr;
   wxButton *useGenericButton = nullptr;
   wxButton *resolveButton = nullptr;
   wxStaticText *summaryLabel = nullptr;
+  wxStaticText *catalogStatusLabel = nullptr;
 };

--- a/gui/rider_fixture_resolution_dialog.h
+++ b/gui/rider_fixture_resolution_dialog.h
@@ -80,6 +80,7 @@ private:
   CatalogLoader onlineCatalogLoader;
   bool catalogLoadStarted = false;
   bool catalogLoading = false;
+  bool onlineCatalogLoadAttempted = false;
   bool acceptAutomaticResults = true;
   bool modelUpdateInProgress = false;
   std::atomic<bool> shuttingDown{false};

--- a/gui/rider_fixture_resolution_dialog.h
+++ b/gui/rider_fixture_resolution_dialog.h
@@ -6,6 +6,8 @@
 #include <string>
 #include <functional>
 #include <optional>
+#include <atomic>
+#include <thread>
 
 #include <wx/dialog.h>
 
@@ -13,6 +15,7 @@ class wxButton;
 class wxGauge;
 class wxDataViewEvent;
 class wxDataViewCtrl;
+class wxDataViewItem;
 class wxStaticText;
 class wxShowEvent;
 class wxThreadEvent;
@@ -38,12 +41,14 @@ public:
       wxWindow *parent, rider_fixture_resolution::Analysis analysis,
       std::unordered_map<std::string, GdtfDictionary::Entry> dictionary,
       CatalogLoader cachedCatalogLoader, CatalogLoader onlineCatalogLoader);
+  ~RiderFixtureResolutionDialog() override;
 
   rider_fixture_resolution::Analysis TakeAnalysis();
 
 private:
   void BuildLayout();
-  void RefreshTable();
+  void PopulateTable();
+  void UpdateRow(size_t analysisIndex);
   void RefreshSelectionControls();
   void RefreshSummary();
   void OnSelectionChanged(wxDataViewEvent &event);
@@ -54,13 +59,16 @@ private:
   void OnUseGeneric(wxCommandEvent &event);
   void OnAcceptAll(wxCommandEvent &event);
   void OnResolve(wxCommandEvent &event);
+  void OnCancel(wxCommandEvent &event);
   void OnDialogShown(wxShowEvent &event);
   void OnCatalogLoaded(wxThreadEvent &event);
   void OnProgress(wxThreadEvent &event);
   void ApplyCatalog(const CatalogData &catalog);
   std::vector<RiderImporter::FixtureTypeRequest> BuildFixtureRequests() const;
   rider_fixture_resolution::Item *SelectedItem();
-  int SelectedRow() const;
+  std::optional<size_t> AnalysisIndexForItem(const wxDataViewItem &item) const;
+  std::optional<unsigned> StoreRowForAnalysisIndex(size_t analysisIndex) const;
+  void RequestWorkerStop();
 
   rider_fixture_resolution::Analysis analysis;
   std::unordered_map<std::string, GdtfDictionary::Entry> dictionary;
@@ -73,6 +81,9 @@ private:
   bool catalogLoadStarted = false;
   bool catalogLoading = false;
   bool acceptAutomaticResults = true;
+  bool modelUpdateInProgress = false;
+  std::atomic<bool> shuttingDown{false};
+  std::jthread catalogWorker;
   wxDataViewCtrl *table = nullptr;
   ColorfulDataViewListStore *tableStore = nullptr;
   wxButton *useSuggestedButton = nullptr;

--- a/gui/rider_fixture_resolution_dialog.h
+++ b/gui/rider_fixture_resolution_dialog.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "../core/rider_fixture_resolution.h"
+#include "../core/gdtf_catalog_service.h"
+
+#include <string>
+#include <functional>
+#include <optional>
+
+#include <wx/dialog.h>
+
+class wxButton;
+class wxChoice;
+class wxDataViewEvent;
+class wxDataViewListCtrl;
+class wxStaticText;
+
+class RiderFixtureResolutionDialog final : public wxDialog {
+public:
+  using CatalogLoader = std::function<std::optional<GdtfCatalogSnapshot>()>;
+  RiderFixtureResolutionDialog(
+      wxWindow *parent, rider_fixture_resolution::Analysis analysis,
+      std::string catalogPayload, std::string catalogUpdatedAt,
+      CatalogLoader catalogLoader = {});
+
+  rider_fixture_resolution::Analysis TakeAnalysis();
+
+private:
+  void BuildLayout();
+  void RefreshTable();
+  void RefreshSelectionControls();
+  void RefreshSummary();
+  void OnSelectionChanged(wxDataViewEvent &event);
+  void OnUseSuggested(wxCommandEvent &event);
+  void OnSearch(wxCommandEvent &event);
+  void OnUseGeneric(wxCommandEvent &event);
+  void OnAcceptAll(wxCommandEvent &event);
+  void OnModeSelected(wxCommandEvent &event);
+  void OnResolve(wxCommandEvent &event);
+  rider_fixture_resolution::Item *SelectedItem();
+
+  rider_fixture_resolution::Analysis analysis;
+  std::string catalogPayload;
+  std::string catalogUpdatedAt;
+  CatalogLoader catalogLoader;
+  wxDataViewListCtrl *table = nullptr;
+  wxChoice *modeChoice = nullptr;
+  wxButton *useSuggestedButton = nullptr;
+  wxButton *searchButton = nullptr;
+  wxButton *useGenericButton = nullptr;
+  wxButton *resolveButton = nullptr;
+  wxStaticText *summaryLabel = nullptr;
+};

--- a/gui/rider_fixture_resolution_dialog.h
+++ b/gui/rider_fixture_resolution_dialog.h
@@ -10,11 +10,13 @@
 #include <wx/dialog.h>
 
 class wxButton;
+class wxGauge;
 class wxDataViewEvent;
-class wxDataViewListCtrl;
+class wxDataViewCtrl;
 class wxStaticText;
 class wxShowEvent;
 class wxThreadEvent;
+class ColorfulDataViewListStore;
 
 class RiderFixtureResolutionDialog final : public wxDialog {
 public:
@@ -25,6 +27,11 @@ public:
     CatalogSource source = CatalogSource::None;
     std::optional<rider_fixture_resolution::Analysis> matches;
     long long matchMs = 0;
+  };
+  struct ProgressData {
+    rider_fixture_resolution::Progress progress;
+    size_t row = 0;
+    std::optional<rider_fixture_resolution::Item> matchedItem;
   };
   using CatalogLoader = std::function<std::optional<CatalogData>()>;
   RiderFixtureResolutionDialog(
@@ -49,9 +56,11 @@ private:
   void OnResolve(wxCommandEvent &event);
   void OnDialogShown(wxShowEvent &event);
   void OnCatalogLoaded(wxThreadEvent &event);
+  void OnProgress(wxThreadEvent &event);
   void ApplyCatalog(const CatalogData &catalog);
   std::vector<RiderImporter::FixtureTypeRequest> BuildFixtureRequests() const;
   rider_fixture_resolution::Item *SelectedItem();
+  int SelectedRow() const;
 
   rider_fixture_resolution::Analysis analysis;
   std::unordered_map<std::string, GdtfDictionary::Entry> dictionary;
@@ -63,11 +72,15 @@ private:
   CatalogLoader onlineCatalogLoader;
   bool catalogLoadStarted = false;
   bool catalogLoading = false;
-  wxDataViewListCtrl *table = nullptr;
+  bool acceptAutomaticResults = true;
+  wxDataViewCtrl *table = nullptr;
+  ColorfulDataViewListStore *tableStore = nullptr;
   wxButton *useSuggestedButton = nullptr;
   wxButton *searchButton = nullptr;
   wxButton *useGenericButton = nullptr;
   wxButton *resolveButton = nullptr;
+  wxButton *acceptAllButton = nullptr;
+  wxGauge *catalogProgressGauge = nullptr;
   wxStaticText *summaryLabel = nullptr;
   wxStaticText *catalogStatusLabel = nullptr;
 };

--- a/gui/rider_fixture_resolution_dialog.h
+++ b/gui/rider_fixture_resolution_dialog.h
@@ -89,7 +89,8 @@ private:
   void OnOnlineCatalogLoaded(wxThreadEvent &event);
   void OnProgress(wxThreadEvent &event);
   void ApplyCatalog(const CatalogData &catalog);
-  std::vector<RiderImporter::FixtureTypeRequest> BuildFixtureRequests() const;
+  std::vector<rider_fixture_resolution::CatalogMatchTarget>
+  BuildCatalogMatchTargets() const;
   rider_fixture_resolution::Item *SelectedItem();
   std::optional<size_t> AnalysisIndexForItem(const wxDataViewItem &item) const;
   std::optional<unsigned> StoreRowForAnalysisIndex(size_t analysisIndex) const;

--- a/gui/rider_fixture_resolution_dialog.h
+++ b/gui/rider_fixture_resolution_dialog.h
@@ -19,7 +19,7 @@ class wxDataViewItem;
 class wxStaticText;
 class wxShowEvent;
 class wxThreadEvent;
-class ColorfulDataViewListStore;
+class RiderFixtureResolutionModel;
 
 class RiderFixtureResolutionDialog final : public wxDialog {
 public:
@@ -85,7 +85,7 @@ private:
   std::atomic<bool> shuttingDown{false};
   std::jthread catalogWorker;
   wxDataViewCtrl *table = nullptr;
-  ColorfulDataViewListStore *tableStore = nullptr;
+  RiderFixtureResolutionModel *tableModel = nullptr;
   wxButton *useSuggestedButton = nullptr;
   wxButton *searchButton = nullptr;
   wxButton *useGenericButton = nullptr;

--- a/gui/rider_fixture_resolution_model.cpp
+++ b/gui/rider_fixture_resolution_model.cpp
@@ -1,0 +1,157 @@
+#include "rider_fixture_resolution_model.h"
+
+#include "gdtf_resolution_status_style.h"
+
+#include <filesystem>
+
+#include <wx/translation.h>
+
+namespace {
+
+// Joins position labels for compact table presentation.
+wxString JoinPositions(const std::vector<std::string> &positions) {
+  wxString value;
+  for (const std::string &position : positions) {
+    if (!value.empty())
+      value += ", ";
+    value += wxString::FromUTF8(position);
+  }
+  return value;
+}
+
+// Formats the selected or suggested catalog identity for a resolution row.
+wxString FormatCatalogIdentity(const rider_fixture_resolution::Item &item) {
+  if (item.state == rider_fixture_resolution::State::Dictionary &&
+      item.dictionaryEntry && !item.dictionaryEntry->path.empty()) {
+    return wxString::FromUTF8(
+        std::filesystem::path(item.dictionaryEntry->path).filename().string());
+  }
+  if (item.state == rider_fixture_resolution::State::Generic ||
+      (!item.selectedEntry && !item.suggestedEntry))
+    return _("Generic fallback");
+  if (!item.selectedEntry && item.suggestedEntry) {
+    const auto &suggested = *item.suggestedEntry;
+    return wxString::FromUTF8(
+        "Generic fallback (suggested: " + suggested.manufacturer + " / " +
+        suggested.fixtureName + ")");
+  }
+  const auto &entry = item.selectedEntry ? item.selectedEntry : item.suggestedEntry;
+  if (!entry)
+    return _("-");
+  if (entry->manufacturer.empty())
+    return wxString::FromUTF8(entry->fixtureName);
+  return wxString::FromUTF8(entry->manufacturer + " / " + entry->fixtureName);
+}
+
+} // namespace
+
+// Creates a fixed-schema view over the authoritative resolution analysis.
+RiderFixtureResolutionModel::RiderFixtureResolutionModel(
+    rider_fixture_resolution::Analysis &analysisIn)
+    : wxDataViewIndexListModel(
+          static_cast<unsigned int>(analysisIn.items.size())),
+      analysis(analysisIn) {}
+
+// Returns the resolver's compile-time model column count.
+unsigned int RiderFixtureResolutionModel::GetColumnCount() const {
+  return ColumnCount;
+}
+
+// Returns the renderer-compatible variant type for a model column.
+wxString RiderFixtureResolutionModel::GetColumnType(unsigned int column) const {
+  if (column >= ColumnCount)
+    return wxString();
+  return column == Create ? wxS("bool") : wxS("string");
+}
+
+// Exposes one analysis field without maintaining a duplicate variant row.
+void RiderFixtureResolutionModel::GetValueByRow(wxVariant &value,
+                                                 unsigned int row,
+                                                 unsigned int column) const {
+  if (row >= analysis.items.size() || column >= ColumnCount) {
+    value.MakeNull();
+    return;
+  }
+  const auto &item = analysis.items[row];
+  switch (column) {
+  case Create: value = item.create; break;
+  case FixtureType: value = wxString::FromUTF8(item.effectiveFixtureType); break;
+  case Quantity: value = wxString::Format("%d", item.request.quantity); break;
+  case Positions: value = JoinPositions(item.request.positions); break;
+  case SelectedGdtf: value = FormatCatalogIdentity(item); break;
+  case Mode:
+    value = item.selectedMode.empty() ? wxString("-")
+                                      : wxString::FromUTF8(item.selectedMode);
+    break;
+  case Status:
+    value = wxString::FromUTF8(rider_fixture_resolution::OriginName(item.origin));
+    break;
+  case Details: value = wxString::FromUTF8(item.details); break;
+  default: value.MakeNull(); break;
+  }
+}
+
+// Commits only the two directly editable table fields to the analysis.
+bool RiderFixtureResolutionModel::SetValueByRow(const wxVariant &value,
+                                                 unsigned int row,
+                                                 unsigned int column) {
+  if (row >= analysis.items.size() || column >= ColumnCount)
+    return false;
+  auto &item = analysis.items[row];
+  if (column == Create) {
+    item.create = value.GetBool();
+    return true;
+  }
+  if (column == FixtureType) {
+    item.effectiveFixtureType = value.GetString().ToStdString();
+    return true;
+  }
+  return false;
+}
+
+// Applies semantic coloring only to the authoritative Status cell.
+bool RiderFixtureResolutionModel::GetAttrByRow(unsigned int row,
+                                                unsigned int column,
+                                                wxDataViewItemAttr &attr) const {
+  if (row >= analysis.items.size() || column != Status)
+    return false;
+  const auto semantic = rider_fixture_resolution::StatusSemanticForOrigin(
+      analysis.items[row].origin);
+  if (semantic == rider_fixture_resolution::StatusSemantic::Neutral)
+    return false;
+  attr.SetColour(GdtfResolutionStatusColour(semantic));
+  return true;
+}
+
+// Sorts valid model values while preserving analysis-index identity as a tie-break.
+int RiderFixtureResolutionModel::Compare(const wxDataViewItem &item1,
+                                          const wxDataViewItem &item2,
+                                          unsigned int column,
+                                          bool ascending) const {
+  if (!item1.IsOk() || !item2.IsOk() || column >= ColumnCount)
+    return 0;
+  const unsigned row1 = GetRow(item1);
+  const unsigned row2 = GetRow(item2);
+  if (row1 >= analysis.items.size() || row2 >= analysis.items.size())
+    return 0;
+  wxVariant value1;
+  wxVariant value2;
+  GetValueByRow(value1, row1, column);
+  GetValueByRow(value2, row2, column);
+  int result = 0;
+  if (column == Create) {
+    result = static_cast<int>(value1.GetBool()) -
+             static_cast<int>(value2.GetBool());
+  } else {
+    result = value1.GetString().CmpNoCase(value2.GetString());
+  }
+  if (result == 0)
+    result = row1 < row2 ? -1 : row1 > row2 ? 1 : 0;
+  return ascending ? result : -result;
+}
+
+// Notifies the view that one stable analysis row changed in place.
+void RiderFixtureResolutionModel::NotifyRowChanged(size_t row) {
+  if (row < analysis.items.size())
+    RowChanged(static_cast<unsigned int>(row));
+}

--- a/gui/rider_fixture_resolution_model.h
+++ b/gui/rider_fixture_resolution_model.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "../core/rider_fixture_resolution.h"
+
+#include <wx/dataview.h>
+
+// Adapts the fixture-resolution analysis to a fixed wxDataView schema.
+class RiderFixtureResolutionModel final : public wxDataViewIndexListModel {
+public:
+  enum Column : unsigned {
+    Create = 0,
+    FixtureType,
+    Quantity,
+    Positions,
+    SelectedGdtf,
+    Mode,
+    Status,
+    Details,
+    ColumnCount
+  };
+
+  explicit RiderFixtureResolutionModel(
+      rider_fixture_resolution::Analysis &analysis);
+
+  unsigned int GetColumnCount() const override;
+  wxString GetColumnType(unsigned int column) const override;
+  void GetValueByRow(wxVariant &value, unsigned int row,
+                     unsigned int column) const override;
+  bool SetValueByRow(const wxVariant &value, unsigned int row,
+                     unsigned int column) override;
+  bool GetAttrByRow(unsigned int row, unsigned int column,
+                    wxDataViewItemAttr &attr) const override;
+  int Compare(const wxDataViewItem &item1, const wxDataViewItem &item2,
+              unsigned int column, bool ascending) const override;
+
+  void NotifyRowChanged(size_t row);
+
+private:
+  rider_fixture_resolution::Analysis &analysis;
+};
+
+static_assert(RiderFixtureResolutionModel::ColumnCount == 8);

--- a/gui/rider_fixture_resolution_workflow.cpp
+++ b/gui/rider_fixture_resolution_workflow.cpp
@@ -1,0 +1,271 @@
+#include "rider_fixture_resolution_workflow.h"
+
+#include "rider_fixture_resolution_dialog.h"
+#include "logindialog.h"
+#include "mainwindow_gdtf_credentials.h"
+#include "../core/diagnostics/DiagnosticLogger.h"
+#include "../core/gdtf_catalog_service.h"
+#include "../core/gdtfdictionary.h"
+#include "../core/gdtf_download_workflow.h"
+#include "../core/gdtfnet.h"
+#include "../core/projectutils.h"
+#include "../core/riderimporter.h"
+#include "../mvr/gdtf_catalog_parser.h"
+#include "gdtfloader.h"
+
+#include <algorithm>
+#include <cctype>
+#include <chrono>
+#include <filesystem>
+#include <future>
+#include <map>
+#include <set>
+#include <thread>
+
+#include <wx/datetime.h>
+#include <wx/choicdlg.h>
+#include <wx/msgdlg.h>
+#include <wx/progdlg.h>
+#include <wx/utils.h>
+
+namespace rider_fixture_resolution_gui {
+namespace {
+
+// Replaces unsafe filename characters in a catalog revision identifier.
+std::string SafeFileStem(std::string value) {
+  for (char &character : value) {
+    const unsigned char byte = static_cast<unsigned char>(character);
+    if (!std::isalnum(byte) && character != '-' && character != '_')
+      character = '_';
+  }
+  return value.empty() ? "gdtf-share-fixture" : value;
+}
+
+// Waits for a network task while keeping wxWidgets event processing responsive.
+template <typename Result>
+Result WaitForNetworkTask(wxWindow *parent, const wxString &title,
+                          const wxString &message,
+                          std::future<Result> future) {
+  wxProgressDialog progress(title, message, 100, parent,
+                            wxPD_APP_MODAL | wxPD_SMOOTH);
+  int pulse = 0;
+  while (future.wait_for(std::chrono::milliseconds(30)) !=
+         std::future_status::ready) {
+    progress.Update(++pulse % 100, message);
+    wxYieldIfNeeded();
+    std::this_thread::sleep_for(std::chrono::milliseconds(15));
+  }
+  return future.get();
+}
+
+// Prompts for credentials only when authenticated GDTF Share access is needed.
+bool EnsureAuthenticated(wxWindow *parent, ConfigManager &configManager,
+                         GdtfShareClient &client,
+                         std::optional<CredentialStore::Credentials> &credentials) {
+  if (client.IsAuthenticated())
+    return true;
+  if (!credentials || credentials->username.empty() || credentials->password.empty()) {
+    const auto loaded = LoadGdtfCredentialsForGuiDetailed(configManager);
+    credentials = loaded.credentials;
+    const std::string initialUser = credentials
+        ? credentials->username
+        : loaded.usernameHint.value_or(std::string());
+    GdtfLoginDialog login(parent, initialUser, std::string());
+    if (login.ShowModal() != wxID_OK)
+      return false;
+    credentials = CredentialStore::Credentials{login.GetUsername(),
+                                                login.GetPassword()};
+  }
+  if (!credentials || credentials->username.empty() || credentials->password.empty())
+    return false;
+  client.ResetSession();
+  const auto result = WaitForNetworkTask(
+      parent, _("GDTF Share"), _("Signing in to GDTF Share..."),
+      std::async(std::launch::async, [&client, &credentials]() {
+        return client.Login(credentials->username, credentials->password);
+      }));
+  if (!result.Succeeded()) {
+    wxMessageBox(wxString::FromUTF8(FormatGdtfShareUserMessage(result, "login")),
+                 _("GDTF Share sign-in failed"), wxOK | wxICON_ERROR, parent);
+    credentials.reset();
+    return false;
+  }
+  (void)PersistGdtfCredentialsForGui(*credentials, configManager);
+  return true;
+}
+
+// Logs stable aggregate counts for the preflight decision.
+void LogAnalysisCounts(const rider_fixture_resolution::Analysis &analysis) {
+  std::map<rider_fixture_resolution::State, size_t> counts;
+  for (const auto &item : analysis.items)
+    ++counts[item.state];
+  diagnostics::DiagnosticLogger::Info(
+      "Rider fixture preflight: unique=" + std::to_string(analysis.items.size()) +
+      " dictionary=" + std::to_string(counts[rider_fixture_resolution::State::Dictionary]) +
+      " suggested=" + std::to_string(counts[rider_fixture_resolution::State::Suggested]) +
+      " review=" + std::to_string(counts[rider_fixture_resolution::State::Review]) +
+      " unresolved=" + std::to_string(counts[rider_fixture_resolution::State::Unresolved]) +
+      " generic=" + std::to_string(counts[rider_fixture_resolution::State::Generic]));
+}
+
+} // namespace
+
+// Runs the complete non-destructive resolution gate before rider scene import.
+PreflightResult RunCreateFromTextPreflight(wxWindow *parent,
+                                           ConfigManager &configManager,
+                                           const std::string &text) {
+  const auto requests = RiderImporter::AnalyzeFixtureTypes(text);
+  const auto dictionary = GdtfDictionary::Load().value_or(
+      std::unordered_map<std::string, GdtfDictionary::Entry>{});
+  auto analysis = rider_fixture_resolution::Service::Analyze(requests, dictionary, {});
+  LogAnalysisCounts(analysis);
+  if (!analysis.RequiresPreflight())
+    return PreflightResult::Proceed;
+
+  GdtfCatalogService catalogService;
+  auto snapshot = catalogService.GetCatalogSnapshot();
+  const auto parsedCatalog = snapshot
+      ? mvr::gdtf_catalog_parser::ParseCatalog(snapshot->listData).entries
+      : std::vector<mvr::gdtf_catalog_matcher::GdtfCatalogEntry>{};
+  analysis = rider_fixture_resolution::Service::Analyze(requests, dictionary,
+                                                         parsedCatalog);
+  LogAnalysisCounts(analysis);
+
+  GdtfShareClient client;
+  std::optional<CredentialStore::Credentials> credentials;
+  auto loadOnlineCatalog = [&]() -> std::optional<GdtfCatalogSnapshot> {
+    if (!EnsureAuthenticated(parent, configManager, client, credentials))
+      return std::nullopt;
+    const auto result = catalogService.RefreshCatalogIfStale(
+        [&](std::string &payload) {
+          const GdtfShareResult online = WaitForNetworkTask(
+              parent, _("GDTF Share"), _("Refreshing the GDTF catalog..."),
+              std::async(std::launch::async,
+                         [&client]() { return client.GetCatalog(); }));
+          payload = online.payload;
+          return online.Succeeded() && !payload.empty();
+        },
+        wxDateTime::UNow().FormatISOCombined(' ').ToStdString(), 0);
+    return result.snapshot;
+  };
+
+  RiderFixtureResolutionDialog dialog(
+      parent, std::move(analysis), snapshot ? snapshot->listData : std::string{},
+      snapshot ? snapshot->updatedAt : std::string{}, loadOnlineCatalog);
+  if (dialog.ShowModal() != wxID_OK)
+    return PreflightResult::Cancelled;
+  analysis = dialog.TakeAnalysis();
+  LogAnalysisCounts(analysis);
+
+  struct DownloadedSelection {
+    std::filesystem::path path;
+    std::vector<std::string> modes;
+  };
+  std::map<std::string, DownloadedSelection> downloads;
+  const std::filesystem::path fixtureDirectory(
+      ProjectUtils::GetWritableLibraryPath("fixtures"));
+  std::error_code directoryError;
+  std::filesystem::create_directories(fixtureDirectory, directoryError);
+  for (const auto &item : analysis.items) {
+    if (!item.selectedEntry)
+      continue;
+    const std::string rid = item.selectedEntry->rid;
+    if (downloads.find(rid) != downloads.end())
+      continue;
+    const std::filesystem::path destination =
+        fixtureDirectory / (SafeFileStem(rid) + ".gdtf");
+    if (std::filesystem::exists(destination)) {
+      auto existingModes = GetGdtfModes(destination.string());
+      if (!existingModes.empty()) {
+        downloads.emplace(
+            rid, DownloadedSelection{destination, std::move(existingModes)});
+        diagnostics::DiagnosticLogger::Info(
+            "Rider fixture GDTF reused locally: revision=" + rid);
+        continue;
+      }
+    }
+    if (!EnsureAuthenticated(parent, configManager, client, credentials))
+      return PreflightResult::Failed;
+    const CredentialStore::Credentials downloadCredentials = *credentials;
+    GdtfShareResult download = WaitForNetworkTask(
+        parent, _("Resolve fixture types"), _("Downloading selected GDTF..."),
+        std::async(std::launch::async,
+                   [&client, &rid, &destination, downloadCredentials]() {
+          return gdtf_download_workflow::DownloadWithExpiredSessionRetry(
+              client, rid, destination.string(), [&]() {
+                client.ResetSession();
+                return client.Login(downloadCredentials.username,
+                                    downloadCredentials.password)
+                    .Succeeded();
+              });
+        }));
+    if (!download.Succeeded() || !std::filesystem::exists(destination)) {
+      diagnostics::DiagnosticLogger::Error(
+          "Rider fixture GDTF download failed: alias=" +
+          item.request.typeName + " revision=" + rid);
+      wxMessageBox(wxString::Format(_("Could not download the GDTF selected for %s. No scene objects were created."),
+                                    wxString::FromUTF8(item.request.typeName)),
+                   _("Fixture resolution failed"), wxOK | wxICON_ERROR, parent);
+      return PreflightResult::Failed;
+    }
+    auto modes = GetGdtfModes(destination.string());
+    if (modes.empty()) {
+      wxMessageBox(_("The downloaded file does not contain a usable GDTF mode. No scene objects were created."),
+                   _("Fixture resolution failed"), wxOK | wxICON_ERROR, parent);
+      return PreflightResult::Failed;
+    }
+    downloads.emplace(rid, DownloadedSelection{destination, std::move(modes)});
+    diagnostics::DiagnosticLogger::Info(
+        "Rider fixture GDTF download completed: revision=" + rid);
+  }
+
+  for (auto &item : analysis.items) {
+    if (!item.selectedEntry)
+      continue;
+    const auto found = downloads.find(item.selectedEntry->rid);
+    if (found == downloads.end())
+      return PreflightResult::Failed;
+    if (item.selectedMode.empty() && found->second.modes.size() == 1)
+      item.selectedMode = found->second.modes.front();
+    if (item.selectedMode.empty() && found->second.modes.size() > 1) {
+      wxArrayString choices;
+      for (const std::string &mode : found->second.modes)
+        choices.Add(wxString::FromUTF8(mode));
+      wxSingleChoiceDialog modeDialog(
+          parent,
+          wxString::Format(_("Select a GDTF mode for %s."),
+                           wxString::FromUTF8(item.request.typeName)),
+          _("Select fixture mode"), choices);
+      if (modeDialog.ShowModal() != wxID_OK)
+        return PreflightResult::Cancelled;
+      item.selectedMode = modeDialog.GetStringSelection().ToStdString();
+    }
+    if (std::find(found->second.modes.begin(), found->second.modes.end(),
+                  item.selectedMode) == found->second.modes.end()) {
+      wxMessageBox(wxString::Format(_("The selected mode for %s is not present in the downloaded GDTF. No scene objects were created."),
+                                    wxString::FromUTF8(item.request.typeName)),
+                   _("Fixture resolution failed"), wxOK | wxICON_ERROR, parent);
+      return PreflightResult::Failed;
+    }
+  }
+
+  for (const auto &item : analysis.items) {
+    if (!item.selectedEntry)
+      continue;
+    const auto &downloaded = downloads.at(item.selectedEntry->rid);
+    const auto persisted = GdtfDictionary::CreateOrUpdatePerastageLibraryDerivative(
+        item.request.typeName, downloaded.path.string(), item.selectedMode);
+    if (!persisted) {
+      wxMessageBox(wxString::Format(_("Could not save the fixture dictionary mapping for %s. No scene objects were created."),
+                                    wxString::FromUTF8(item.request.typeName)),
+                   _("Fixture resolution failed"), wxOK | wxICON_ERROR, parent);
+      return PreflightResult::Failed;
+    }
+    diagnostics::DiagnosticLogger::Info(
+        "Rider fixture mapping accepted: alias=" + item.request.typeName +
+        " revision=" + item.selectedEntry->rid + " mode=" + item.selectedMode);
+  }
+  return PreflightResult::Proceed;
+}
+
+} // namespace rider_fixture_resolution_gui

--- a/gui/rider_fixture_resolution_workflow.cpp
+++ b/gui/rider_fixture_resolution_workflow.cpp
@@ -159,62 +159,99 @@ PreflightResult RunCreateFromTextPreflight(wxWindow *parent,
   };
 
   GdtfShareClient client;
-  std::optional<CredentialStore::Credentials> credentials;
-  auto loadOnlineCatalog = [&]()
-      -> std::optional<RiderFixtureResolutionDialog::CatalogData> {
-    const CredentialStore::LoadResult loadedCredentials =
-        LoadGdtfCredentialsForGuiDetailed(configManager);
-    const auto credentialAvailability =
-        gdtf_share_workflow::DetermineCredentialAvailability(
-            loadedCredentials);
-    const auto initialAction =
-        gdtf_share_workflow::DetermineCatalogAccessAction(
-            false, credentialAvailability, std::nullopt, false);
-    if (initialAction == gdtf_share_workflow::CatalogAccessAction::Cancel ||
-        initialAction ==
-            gdtf_share_workflow::CatalogAccessAction::OpenCachedCatalog)
-      return std::nullopt;
-    if (!EnsureAuthenticated(parent, configManager, client, credentials))
-      return std::nullopt;
+  const CredentialStore::LoadResult loadedCredentials =
+      LoadGdtfCredentialsForGuiDetailed(configManager);
+  std::optional<CredentialStore::Credentials> credentials =
+      loadedCredentials.credentials;
+  const std::string catalogRefreshTime =
+      wxDateTime::UNow().FormatISOCombined(' ').ToStdString();
+  auto loadOnlineCatalog =
+      [&](const CredentialStore::Credentials &onlineCredentials,
+          std::stop_token stopToken,
+          RiderFixtureResolutionDialog::OnlineProgressCallback report)
+      -> RiderFixtureResolutionDialog::OnlineCatalogResult {
+    using OnlineStatus = RiderFixtureResolutionDialog::OnlineCatalogStatus;
+    if (stopToken.stop_requested())
+      return {OnlineStatus::Unavailable, std::nullopt, "cancelled"};
+    report({rider_fixture_resolution::ProgressStage::Authenticating});
+    GdtfShareClient catalogClient;
+    const GdtfShareResult login = catalogClient.Login(
+        onlineCredentials.username, onlineCredentials.password);
+    if (!login.Succeeded()) {
+      const auto action = gdtf_share_workflow::DetermineCatalogAccessAction(
+          false, gdtf_share_workflow::CredentialAvailability::Complete, login,
+          false);
+      return {action == gdtf_share_workflow::CatalogAccessAction::RequestCredentials
+                  ? OnlineStatus::AuthenticationRejected
+                  : OnlineStatus::Unavailable,
+              std::nullopt, FormatGdtfShareUserMessage(login, "login")};
+    }
+    if (stopToken.stop_requested())
+      return {OnlineStatus::Unavailable, std::nullopt, "cancelled"};
+    report({rider_fixture_resolution::ProgressStage::DownloadingCatalog});
     const auto result = catalogService.RefreshCatalogIfStale(
         [&](std::string &payload) {
-          const GdtfShareResult online = WaitForNetworkTask(
-              parent, _("GDTF Share"), _("Refreshing the GDTF catalog..."),
-              std::async(std::launch::async,
-                         [&client]() { return client.GetCatalog(); }));
+          if (stopToken.stop_requested())
+            return false;
+          const GdtfShareResult online = catalogClient.GetCatalog();
           payload = online.payload;
+          if (online.Succeeded() && !payload.empty())
+            report({rider_fixture_resolution::ProgressStage::ParsingCatalog});
           return online.Succeeded() && !payload.empty();
         },
-        wxDateTime::UNow().FormatISOCombined(' ').ToStdString(), 0);
+        catalogRefreshTime, 0);
     if (!result.snapshot)
-      return std::nullopt;
+      return {OnlineStatus::Unavailable, std::nullopt,
+              result.failureMessage};
     if (!result.parsedCatalog || !result.parsedCatalog->IsUsable())
-      return std::nullopt;
+      return {OnlineStatus::Unavailable, std::nullopt,
+              "catalog payload is unusable"};
     const auto resolvedAction =
         gdtf_share_workflow::DetermineCatalogAccessAction(
             result.source == GdtfCatalogResultSource::Cache,
-            credentialAvailability, std::nullopt,
+            gdtf_share_workflow::CredentialAvailability::Complete, login,
             result.source == GdtfCatalogResultSource::Online);
     if (resolvedAction !=
             gdtf_share_workflow::CatalogAccessAction::OpenOnlineCatalog &&
         resolvedAction !=
             gdtf_share_workflow::CatalogAccessAction::OpenCachedCatalog)
-      return std::nullopt;
+      return {OnlineStatus::Unavailable, std::nullopt,
+              "catalog access policy rejected the result"};
     RiderFixtureResolutionDialog::CatalogData data{
         *result.snapshot, result.parsedCatalog->entries,
         result.source == GdtfCatalogResultSource::Online
             ? RiderFixtureResolutionDialog::CatalogSource::Online
             : RiderFixtureResolutionDialog::CatalogSource::Cached};
-    const auto matchStarted = std::chrono::steady_clock::now();
-    data.matches = WaitForNetworkTask(
-        parent, _("GDTF catalog"), _("Matching rider fixture types..."),
-        std::async(std::launch::async, [&requests, &data]() {
-          return rider_fixture_resolution::Service::Analyze(requests, {},
-                                                             data.entries);
-        }));
-    data.matchMs = std::chrono::duration_cast<std::chrono::milliseconds>(
-        std::chrono::steady_clock::now() - matchStarted).count();
-    return data;
+    return {OnlineStatus::Success, std::move(data), {}};
+  };
+
+  auto requestCatalogCredentials =
+      [&](bool rejected) -> std::optional<CredentialStore::Credentials> {
+    (void)rejected;
+    const std::string initialUser =
+        credentials ? credentials->username
+                    : loadedCredentials.usernameHint.value_or(std::string());
+    GdtfLoginDialog login(parent, initialUser, std::string());
+    if (login.ShowModal() != wxID_OK)
+      return std::nullopt;
+    CredentialStore::Credentials entered{login.GetUsername(),
+                                         login.GetPassword()};
+    if (entered.username.empty() || entered.password.empty())
+      return std::nullopt;
+    credentials = entered;
+    return entered;
+  };
+
+  auto persistCatalogCredentials =
+      [&](const CredentialStore::Credentials &authenticatedCredentials) {
+    credentials = authenticatedCredentials;
+    const CredentialStore::Result persisted =
+        PersistGdtfCredentialsForGui(authenticatedCredentials, configManager);
+    if (!persisted.Succeeded()) {
+      wxMessageBox(
+          _("GDTF Share authentication succeeded, but the credentials could not be saved securely. You may need to enter them again after restart."),
+          _("GDTF Share credentials"), wxOK | wxICON_WARNING, parent);
+    }
   };
 
   const auto dialogVisibleMs = std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -225,7 +262,9 @@ PreflightResult RunCreateFromTextPreflight(wxWindow *parent,
       std::to_string(dictionaryLoadMs) + " dialog_visible_ms=" +
       std::to_string(dialogVisibleMs));
   RiderFixtureResolutionDialog dialog(parent, std::move(analysis), dictionary,
-                                      loadCachedCatalog, loadOnlineCatalog);
+                                      loadCachedCatalog, loadOnlineCatalog,
+                                      credentials, requestCatalogCredentials,
+                                      persistCatalogCredentials);
   if (dialog.ShowModal() != wxID_OK)
     return PreflightResult::Cancelled;
   analysis = dialog.TakeAnalysis();

--- a/gui/rider_fixture_resolution_workflow.cpp
+++ b/gui/rider_fixture_resolution_workflow.cpp
@@ -98,7 +98,8 @@ bool EnsureAuthenticated(wxWindow *parent, ConfigManager &configManager,
       return true;
     }
     wxMessageBox(wxString::FromUTF8(FormatGdtfShareUserMessage(result, "login")),
-                 _("GDTF Share sign-in failed"), wxOK | wxICON_ERROR, parent);
+                 _("GDTF Share sign-in unavailable"), wxOK | wxICON_WARNING,
+                 parent);
     if (result.category != GdtfShareResultCategory::AuthenticationRejected)
       return false;
     credentials.reset();
@@ -215,14 +216,6 @@ PreflightResult RunCreateFromTextPreflight(wxWindow *parent,
   if (dialog.ShowModal() != wxID_OK)
     return PreflightResult::Cancelled;
   analysis = dialog.TakeAnalysis();
-  if (importPlanOut) {
-    importPlanOut->fixtureSelections.clear();
-    for (const auto &item : analysis.items) {
-      importPlanOut->fixtureSelections.push_back({
-          item.request.normalizedTypeName, item.effectiveFixtureType,
-          item.create});
-    }
-  }
   LogAnalysisCounts(analysis);
 
   struct DownloadedSelection {
@@ -234,15 +227,10 @@ PreflightResult RunCreateFromTextPreflight(wxWindow *parent,
       ProjectUtils::GetWritableLibraryPath("fixtures"));
   std::error_code directoryError;
   std::filesystem::create_directories(fixtureDirectory, directoryError);
-  auto rollbackDictionary = [&]() {
-    std::string rollbackError;
-    if (!GdtfDictionary::Save(dictionary, &rollbackError)) {
-      diagnostics::DiagnosticLogger::Error(
-          "Rider fixture dictionary rollback failed: " + rollbackError);
-    }
-  };
+  size_t recoverableFailureCount = 0;
+  bool authenticationUnavailable = false;
 
-  for (const auto &item : analysis.items) {
+  for (auto &item : analysis.items) {
     if (!item.create)
       continue;
     if (!item.selectedEntry)
@@ -262,8 +250,18 @@ PreflightResult RunCreateFromTextPreflight(wxWindow *parent,
         continue;
       }
     }
-    if (!EnsureAuthenticated(parent, configManager, client, credentials))
-      return PreflightResult::Failed;
+    if (authenticationUnavailable ||
+        !EnsureAuthenticated(parent, configManager, client, credentials)) {
+      authenticationUnavailable = true;
+      rider_fixture_resolution::Service::FallbackAfterFailure(
+          item, "Authentication unavailable");
+      ++recoverableFailureCount;
+      diagnostics::DiagnosticLogger::Warning(
+          "Rider fixture resolution fallback: alias=" + item.request.typeName +
+          " effective_type=" + item.effectiveFixtureType +
+          " rid=" + rid + " stage=authenticate");
+      continue;
+    }
     const CredentialStore::Credentials downloadCredentials = *credentials;
     GdtfShareResult download = WaitForNetworkTask(
         parent, _("Resolve fixture types"), _("Downloading selected GDTF..."),
@@ -281,40 +279,57 @@ PreflightResult RunCreateFromTextPreflight(wxWindow *parent,
       diagnostics::DiagnosticLogger::Error(
           "Rider fixture GDTF download failed: alias=" +
           item.request.typeName + " revision=" + rid);
-      wxMessageBox(wxString::Format(_("Could not download the GDTF selected for %s. No scene objects were created."),
-                                    wxString::FromUTF8(item.request.typeName)),
-                   _("Fixture resolution failed"), wxOK | wxICON_ERROR, parent);
-      return PreflightResult::Failed;
+      rider_fixture_resolution::Service::FallbackAfterFailure(
+          item, "Download failed");
+      ++recoverableFailureCount;
+      continue;
     }
     auto modes = GetGdtfModes(destination.string());
     if (modes.empty()) {
-      wxMessageBox(_("The downloaded file does not contain a usable GDTF mode. No scene objects were created."),
-                   _("Fixture resolution failed"), wxOK | wxICON_ERROR, parent);
-      return PreflightResult::Failed;
+      rider_fixture_resolution::Service::FallbackAfterFailure(
+          item, "Downloaded GDTF is invalid");
+      ++recoverableFailureCount;
+      diagnostics::DiagnosticLogger::Warning(
+          "Rider fixture resolution fallback: alias=" + item.request.typeName +
+          " effective_type=" + item.effectiveFixtureType + " rid=" + rid +
+          " source=" + destination.filename().string() +
+          " source_valid=false stage=validate-gdtf");
+      continue;
     }
     downloads.emplace(rid, DownloadedSelection{destination, std::move(modes)});
     diagnostics::DiagnosticLogger::Info(
         "Rider fixture GDTF download completed: revision=" + rid);
   }
 
-  for (const auto &item : analysis.items) {
+  for (auto &item : analysis.items) {
     if (!item.create)
       continue;
     if (!item.selectedEntry)
       continue;
     const auto found = downloads.find(item.selectedEntry->rid);
-    if (found == downloads.end())
-      return PreflightResult::Failed;
+    if (found == downloads.end()) {
+      rider_fixture_resolution::Service::FallbackAfterFailure(
+          item, "Selected GDTF is unavailable");
+      ++recoverableFailureCount;
+      continue;
+    }
     if (std::find(found->second.modes.begin(), found->second.modes.end(),
                   item.selectedMode) == found->second.modes.end()) {
-      wxMessageBox(wxString::Format(_("The selected mode for %s is not present in the downloaded GDTF. No scene objects were created."),
-                                    wxString::FromUTF8(item.request.typeName)),
-                   _("Fixture resolution failed"), wxOK | wxICON_ERROR, parent);
-      return PreflightResult::Failed;
+      const std::string failedRid = item.selectedEntry->rid;
+      const std::string failedMode = item.selectedMode;
+      rider_fixture_resolution::Service::FallbackAfterFailure(
+          item, "Selected mode is not present in the GDTF");
+      ++recoverableFailureCount;
+      diagnostics::DiagnosticLogger::Warning(
+          "Rider fixture resolution fallback: alias=" + item.request.typeName +
+          " effective_type=" + item.effectiveFixtureType +
+          " rid=" + failedRid + " mode=" + failedMode +
+          " stage=validate-mode");
+      continue;
     }
   }
 
-  for (const auto &item : analysis.items) {
+  for (auto &item : analysis.items) {
     if (!item.create)
       continue;
     if (item.state != rider_fixture_resolution::State::Dictionary ||
@@ -326,29 +341,56 @@ PreflightResult RunCreateFromTextPreflight(wxWindow *parent,
     GdtfDictionary::UpdateDictionaryEntry(item.request.typeName, changed);
     const auto persisted = GdtfDictionary::Get(item.request.typeName);
     if (!persisted || persisted->mode != item.selectedMode) {
-      rollbackDictionary();
-      return PreflightResult::Failed;
+      item.selectedMode = item.originalDictionaryMode;
+      item.origin = rider_fixture_resolution::ResolutionOrigin::Dictionary;
+      item.details = "Dictionary mode change could not be saved; original mode retained";
+      ++recoverableFailureCount;
+      diagnostics::DiagnosticLogger::Warning(
+          "Rider fixture dictionary mode fallback: alias=" +
+          item.request.typeName + " effective_type=" + item.effectiveFixtureType +
+          " mode=" + item.selectedMode + " stage=save-dictionary-mode");
     }
   }
 
-  for (const auto &item : analysis.items) {
+  for (auto &item : analysis.items) {
     if (!item.create)
       continue;
     if (!item.selectedEntry)
       continue;
     const auto &downloaded = downloads.at(item.selectedEntry->rid);
-    const auto persisted = GdtfDictionary::CreateOrUpdatePerastageLibraryDerivative(
+    const auto persisted = GdtfDictionary::CreateOrUpdateExternalLibraryMapping(
         item.request.typeName, downloaded.path.string(), item.selectedMode);
-    if (!persisted) {
-      rollbackDictionary();
-      wxMessageBox(wxString::Format(_("Could not save the fixture dictionary mapping for %s. No scene objects were created."),
-                                    wxString::FromUTF8(item.request.typeName)),
-                   _("Fixture resolution failed"), wxOK | wxICON_ERROR, parent);
-      return PreflightResult::Failed;
+    if (!persisted.success) {
+      diagnostics::DiagnosticLogger::Warning(
+          "Rider fixture resolution fallback: alias=" + item.request.typeName +
+          " effective_type=" + item.effectiveFixtureType +
+          " rid=" + item.selectedEntry->rid + " mode=" + item.selectedMode +
+          " source=" + downloaded.path.filename().string() +
+          " source_valid=true derivative_attempted=false stage=" +
+          persisted.failureStage + " reason=" + persisted.error);
+      rider_fixture_resolution::Service::FallbackAfterFailure(
+          item, "Dictionary mapping could not be saved");
+      ++recoverableFailureCount;
+      continue;
     }
     diagnostics::DiagnosticLogger::Info(
         "Rider fixture mapping accepted: alias=" + item.request.typeName +
         " revision=" + item.selectedEntry->rid + " mode=" + item.selectedMode);
+  }
+  if (importPlanOut) {
+    importPlanOut->fixtureSelections.clear();
+    for (const auto &item : analysis.items) {
+      importPlanOut->fixtureSelections.push_back({
+          item.request.normalizedTypeName, item.effectiveFixtureType,
+          item.create});
+    }
+  }
+  if (recoverableFailureCount > 0) {
+    wxMessageBox(
+        wxString::Format(
+            _("%zu fixture types used generic fallback because GDTF resolution failed. See the diagnostic log for details."),
+            recoverableFailureCount),
+        _("Fixture resolution warning"), wxOK | wxICON_WARNING, parent);
   }
   return PreflightResult::Proceed;
 }

--- a/gui/rider_fixture_resolution_workflow.cpp
+++ b/gui/rider_fixture_resolution_workflow.cpp
@@ -6,15 +6,16 @@
 #include "../core/diagnostics/DiagnosticLogger.h"
 #include "../core/gdtf_catalog_service.h"
 #include "../core/gdtfdictionary.h"
+#include "../core/gdtf_download_filename.h"
 #include "../core/gdtf_download_workflow.h"
 #include "../core/gdtfnet.h"
+#include "../core/gdtf_share_workflow.h"
 #include "../core/projectutils.h"
 #include "../core/riderimporter.h"
 #include "../mvr/gdtf_catalog_parser.h"
 #include "gdtfloader.h"
 
 #include <algorithm>
-#include <cctype>
 #include <chrono>
 #include <filesystem>
 #include <future>
@@ -29,16 +30,6 @@
 
 namespace rider_fixture_resolution_gui {
 namespace {
-
-// Replaces unsafe filename characters in a catalog revision identifier.
-std::string SafeFileStem(std::string value) {
-  for (char &character : value) {
-    const unsigned char byte = static_cast<unsigned char>(character);
-    if (!std::isalnum(byte) && character != '-' && character != '_')
-      character = '_';
-  }
-  return value.empty() ? "gdtf-share-fixture" : value;
-}
 
 // Waits for a network task while keeping wxWidgets event processing responsive.
 template <typename Result>
@@ -171,6 +162,18 @@ PreflightResult RunCreateFromTextPreflight(wxWindow *parent,
   std::optional<CredentialStore::Credentials> credentials;
   auto loadOnlineCatalog = [&]()
       -> std::optional<RiderFixtureResolutionDialog::CatalogData> {
+    const CredentialStore::LoadResult loadedCredentials =
+        LoadGdtfCredentialsForGuiDetailed(configManager);
+    const auto credentialAvailability =
+        gdtf_share_workflow::DetermineCredentialAvailability(
+            loadedCredentials);
+    const auto initialAction =
+        gdtf_share_workflow::DetermineCatalogAccessAction(
+            false, credentialAvailability, std::nullopt, false);
+    if (initialAction == gdtf_share_workflow::CatalogAccessAction::Cancel ||
+        initialAction ==
+            gdtf_share_workflow::CatalogAccessAction::OpenCachedCatalog)
+      return std::nullopt;
     if (!EnsureAuthenticated(parent, configManager, client, credentials))
       return std::nullopt;
     const auto result = catalogService.RefreshCatalogIfStale(
@@ -186,6 +189,16 @@ PreflightResult RunCreateFromTextPreflight(wxWindow *parent,
     if (!result.snapshot)
       return std::nullopt;
     if (!result.parsedCatalog || !result.parsedCatalog->IsUsable())
+      return std::nullopt;
+    const auto resolvedAction =
+        gdtf_share_workflow::DetermineCatalogAccessAction(
+            result.source == GdtfCatalogResultSource::Cache,
+            credentialAvailability, std::nullopt,
+            result.source == GdtfCatalogResultSource::Online);
+    if (resolvedAction !=
+            gdtf_share_workflow::CatalogAccessAction::OpenOnlineCatalog &&
+        resolvedAction !=
+            gdtf_share_workflow::CatalogAccessAction::OpenCachedCatalog)
       return std::nullopt;
     RiderFixtureResolutionDialog::CatalogData data{
         *result.snapshot, result.parsedCatalog->entries,
@@ -239,7 +252,9 @@ PreflightResult RunCreateFromTextPreflight(wxWindow *parent,
     if (downloads.find(rid) != downloads.end())
       continue;
     const std::filesystem::path destination =
-        fixtureDirectory / (SafeFileStem(rid) + ".gdtf");
+        gdtf_download_filename::ChooseDestination(
+            fixtureDirectory, item.selectedEntry->manufacturer,
+            item.selectedEntry->fixtureName, rid);
     if (std::filesystem::exists(destination)) {
       auto existingModes = GetGdtfModes(destination.string());
       if (!existingModes.empty()) {

--- a/gui/rider_fixture_resolution_workflow.cpp
+++ b/gui/rider_fixture_resolution_workflow.cpp
@@ -125,7 +125,8 @@ void LogAnalysisCounts(const rider_fixture_resolution::Analysis &analysis) {
 PreflightResult RunCreateFromTextPreflight(wxWindow *parent,
                                            ConfigManager &configManager,
                                            const std::string &text,
-                                           std::string *filteredTextOut) {
+                                           std::string *filteredTextOut,
+                                           RiderImporter::ImportPlan *importPlanOut) {
   const auto preflightStarted = std::chrono::steady_clock::now();
   const auto riderStarted = std::chrono::steady_clock::now();
   const RiderImporter::TextAnalysis riderAnalysis =
@@ -209,11 +210,19 @@ PreflightResult RunCreateFromTextPreflight(wxWindow *parent,
       std::to_string(riderAnalysisMs) + " dictionary_load_ms=" +
       std::to_string(dictionaryLoadMs) + " dialog_visible_ms=" +
       std::to_string(dialogVisibleMs));
-  RiderFixtureResolutionDialog dialog(parent, std::move(analysis),
+  RiderFixtureResolutionDialog dialog(parent, std::move(analysis), dictionary,
                                       loadCachedCatalog, loadOnlineCatalog);
   if (dialog.ShowModal() != wxID_OK)
     return PreflightResult::Cancelled;
   analysis = dialog.TakeAnalysis();
+  if (importPlanOut) {
+    importPlanOut->fixtureSelections.clear();
+    for (const auto &item : analysis.items) {
+      importPlanOut->fixtureSelections.push_back({
+          item.request.normalizedTypeName, item.effectiveFixtureType,
+          item.create});
+    }
+  }
   LogAnalysisCounts(analysis);
 
   struct DownloadedSelection {
@@ -234,6 +243,8 @@ PreflightResult RunCreateFromTextPreflight(wxWindow *parent,
   };
 
   for (const auto &item : analysis.items) {
+    if (!item.create)
+      continue;
     if (!item.selectedEntry)
       continue;
     const std::string rid = item.selectedEntry->rid;
@@ -287,6 +298,8 @@ PreflightResult RunCreateFromTextPreflight(wxWindow *parent,
   }
 
   for (const auto &item : analysis.items) {
+    if (!item.create)
+      continue;
     if (!item.selectedEntry)
       continue;
     const auto found = downloads.find(item.selectedEntry->rid);
@@ -302,6 +315,8 @@ PreflightResult RunCreateFromTextPreflight(wxWindow *parent,
   }
 
   for (const auto &item : analysis.items) {
+    if (!item.create)
+      continue;
     if (item.state != rider_fixture_resolution::State::Dictionary ||
         !item.dictionaryEntry ||
         item.selectedMode == item.dictionaryEntry->mode)
@@ -317,6 +332,8 @@ PreflightResult RunCreateFromTextPreflight(wxWindow *parent,
   }
 
   for (const auto &item : analysis.items) {
+    if (!item.create)
+      continue;
     if (!item.selectedEntry)
       continue;
     const auto &downloaded = downloads.at(item.selectedEntry->rid);

--- a/gui/rider_fixture_resolution_workflow.cpp
+++ b/gui/rider_fixture_resolution_workflow.cpp
@@ -357,7 +357,14 @@ PreflightResult RunCreateFromTextPreflight(wxWindow *parent,
       continue;
     if (!item.selectedEntry)
       continue;
-    const auto &downloaded = downloads.at(item.selectedEntry->rid);
+    const auto downloadedIt = downloads.find(item.selectedEntry->rid);
+    if (downloadedIt == downloads.end()) {
+      rider_fixture_resolution::Service::FallbackAfterFailure(
+          item, "Selected GDTF is unavailable");
+      ++recoverableFailureCount;
+      continue;
+    }
+    const auto &downloaded = downloadedIt->second;
     const auto persisted = GdtfDictionary::CreateOrUpdateExternalLibraryMapping(
         item.request.typeName, downloaded.path.string(), item.selectedMode);
     if (!persisted.success) {

--- a/gui/rider_fixture_resolution_workflow.cpp
+++ b/gui/rider_fixture_resolution_workflow.cpp
@@ -23,7 +23,6 @@
 #include <thread>
 
 #include <wx/datetime.h>
-#include <wx/choicdlg.h>
 #include <wx/msgdlg.h>
 #include <wx/progdlg.h>
 #include <wx/utils.h>
@@ -64,34 +63,46 @@ bool EnsureAuthenticated(wxWindow *parent, ConfigManager &configManager,
                          std::optional<CredentialStore::Credentials> &credentials) {
   if (client.IsAuthenticated())
     return true;
-  if (!credentials || credentials->username.empty() || credentials->password.empty()) {
-    const auto loaded = LoadGdtfCredentialsForGuiDetailed(configManager);
+  const auto loaded = LoadGdtfCredentialsForGuiDetailed(configManager);
+  if (!credentials)
     credentials = loaded.credentials;
-    const std::string initialUser = credentials
-        ? credentials->username
-        : loaded.usernameHint.value_or(std::string());
-    GdtfLoginDialog login(parent, initialUser, std::string());
-    if (login.ShowModal() != wxID_OK)
+  while (true) {
+    if (!credentials || credentials->username.empty() ||
+        credentials->password.empty()) {
+      const std::string initialUser = credentials
+          ? credentials->username
+          : loaded.usernameHint.value_or(std::string());
+      GdtfLoginDialog login(parent, initialUser, std::string());
+      if (login.ShowModal() != wxID_OK)
+        return false;
+      credentials = CredentialStore::Credentials{login.GetUsername(),
+                                                  login.GetPassword()};
+    }
+    if (!credentials || credentials->username.empty() ||
+        credentials->password.empty())
       return false;
-    credentials = CredentialStore::Credentials{login.GetUsername(),
-                                                login.GetPassword()};
-  }
-  if (!credentials || credentials->username.empty() || credentials->password.empty())
-    return false;
-  client.ResetSession();
-  const auto result = WaitForNetworkTask(
-      parent, _("GDTF Share"), _("Signing in to GDTF Share..."),
-      std::async(std::launch::async, [&client, &credentials]() {
-        return client.Login(credentials->username, credentials->password);
-      }));
-  if (!result.Succeeded()) {
+    client.ResetSession();
+    const auto result = WaitForNetworkTask(
+        parent, _("GDTF Share"), _("Signing in to GDTF Share..."),
+        std::async(std::launch::async, [&client, &credentials]() {
+          return client.Login(credentials->username, credentials->password);
+        }));
+    if (result.Succeeded()) {
+      const CredentialStore::Result persisted =
+          PersistGdtfCredentialsForGui(*credentials, configManager);
+      if (!persisted.Succeeded()) {
+        wxMessageBox(
+            _("GDTF Share authentication succeeded, but the credentials could not be saved securely. You may need to enter them again after restart."),
+            _("GDTF Share credentials"), wxOK | wxICON_WARNING, parent);
+      }
+      return true;
+    }
     wxMessageBox(wxString::FromUTF8(FormatGdtfShareUserMessage(result, "login")),
                  _("GDTF Share sign-in failed"), wxOK | wxICON_ERROR, parent);
+    if (result.category != GdtfShareResultCategory::AuthenticationRejected)
+      return false;
     credentials.reset();
-    return false;
   }
-  (void)PersistGdtfCredentialsForGui(*credentials, configManager);
-  return true;
 }
 
 // Logs stable aggregate counts for the preflight decision.
@@ -113,27 +124,51 @@ void LogAnalysisCounts(const rider_fixture_resolution::Analysis &analysis) {
 // Runs the complete non-destructive resolution gate before rider scene import.
 PreflightResult RunCreateFromTextPreflight(wxWindow *parent,
                                            ConfigManager &configManager,
-                                           const std::string &text) {
-  const auto requests = RiderImporter::AnalyzeFixtureTypes(text);
+                                           const std::string &text,
+                                           std::string *filteredTextOut) {
+  const auto preflightStarted = std::chrono::steady_clock::now();
+  const auto riderStarted = std::chrono::steady_clock::now();
+  const RiderImporter::TextAnalysis riderAnalysis =
+      RiderImporter::AnalyzeText(text);
+  const auto riderAnalysisMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+      std::chrono::steady_clock::now() - riderStarted).count();
+  if (filteredTextOut)
+    *filteredTextOut = riderAnalysis.filteredText;
+  const auto &requests = riderAnalysis.fixtureTypes;
+  const auto dictionaryStarted = std::chrono::steady_clock::now();
   const auto dictionary = GdtfDictionary::Load().value_or(
       std::unordered_map<std::string, GdtfDictionary::Entry>{});
+  const auto dictionaryLoadMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+      std::chrono::steady_clock::now() - dictionaryStarted).count();
   auto analysis = rider_fixture_resolution::Service::Analyze(requests, dictionary, {});
   LogAnalysisCounts(analysis);
   if (!analysis.RequiresPreflight())
     return PreflightResult::Proceed;
 
   GdtfCatalogService catalogService;
-  auto snapshot = catalogService.GetCatalogSnapshot();
-  const auto parsedCatalog = snapshot
-      ? mvr::gdtf_catalog_parser::ParseCatalog(snapshot->listData).entries
-      : std::vector<mvr::gdtf_catalog_matcher::GdtfCatalogEntry>{};
-  analysis = rider_fixture_resolution::Service::Analyze(requests, dictionary,
-                                                         parsedCatalog);
-  LogAnalysisCounts(analysis);
+  auto loadCachedCatalog = []()
+      -> std::optional<RiderFixtureResolutionDialog::CatalogData> {
+    GdtfCatalogService catalogService;
+    const auto cacheStarted = std::chrono::steady_clock::now();
+    const auto catalog = catalogService.GetParsedCatalogSnapshot();
+    const auto cacheReadMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - cacheStarted).count();
+    if (!catalog)
+      return std::nullopt;
+    diagnostics::DiagnosticLogger::Info(
+        "Rider fixture preflight catalog: catalog_cache_read_ms=" +
+        std::to_string(cacheReadMs) + " catalog_parse_ms=" +
+        std::to_string(catalog->parsed.parseMs) + " entries=" +
+        std::to_string(catalog->parsed.usableEntryCount));
+    return RiderFixtureResolutionDialog::CatalogData{
+        catalog->snapshot, catalog->parsed.entries,
+        RiderFixtureResolutionDialog::CatalogSource::Cached};
+  };
 
   GdtfShareClient client;
   std::optional<CredentialStore::Credentials> credentials;
-  auto loadOnlineCatalog = [&]() -> std::optional<GdtfCatalogSnapshot> {
+  auto loadOnlineCatalog = [&]()
+      -> std::optional<RiderFixtureResolutionDialog::CatalogData> {
     if (!EnsureAuthenticated(parent, configManager, client, credentials))
       return std::nullopt;
     const auto result = catalogService.RefreshCatalogIfStale(
@@ -146,12 +181,36 @@ PreflightResult RunCreateFromTextPreflight(wxWindow *parent,
           return online.Succeeded() && !payload.empty();
         },
         wxDateTime::UNow().FormatISOCombined(' ').ToStdString(), 0);
-    return result.snapshot;
+    if (!result.snapshot)
+      return std::nullopt;
+    if (!result.parsedCatalog || !result.parsedCatalog->IsUsable())
+      return std::nullopt;
+    RiderFixtureResolutionDialog::CatalogData data{
+        *result.snapshot, result.parsedCatalog->entries,
+        result.source == GdtfCatalogResultSource::Online
+            ? RiderFixtureResolutionDialog::CatalogSource::Online
+            : RiderFixtureResolutionDialog::CatalogSource::Cached};
+    const auto matchStarted = std::chrono::steady_clock::now();
+    data.matches = WaitForNetworkTask(
+        parent, _("GDTF catalog"), _("Matching rider fixture types..."),
+        std::async(std::launch::async, [&requests, &data]() {
+          return rider_fixture_resolution::Service::Analyze(requests, {},
+                                                             data.entries);
+        }));
+    data.matchMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - matchStarted).count();
+    return data;
   };
 
-  RiderFixtureResolutionDialog dialog(
-      parent, std::move(analysis), snapshot ? snapshot->listData : std::string{},
-      snapshot ? snapshot->updatedAt : std::string{}, loadOnlineCatalog);
+  const auto dialogVisibleMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+      std::chrono::steady_clock::now() - preflightStarted).count();
+  diagnostics::DiagnosticLogger::Info(
+      "Rider fixture preflight timing: rider_analysis_ms=" +
+      std::to_string(riderAnalysisMs) + " dictionary_load_ms=" +
+      std::to_string(dictionaryLoadMs) + " dialog_visible_ms=" +
+      std::to_string(dialogVisibleMs));
+  RiderFixtureResolutionDialog dialog(parent, std::move(analysis),
+                                      loadCachedCatalog, loadOnlineCatalog);
   if (dialog.ShowModal() != wxID_OK)
     return PreflightResult::Cancelled;
   analysis = dialog.TakeAnalysis();
@@ -166,6 +225,14 @@ PreflightResult RunCreateFromTextPreflight(wxWindow *parent,
       ProjectUtils::GetWritableLibraryPath("fixtures"));
   std::error_code directoryError;
   std::filesystem::create_directories(fixtureDirectory, directoryError);
+  auto rollbackDictionary = [&]() {
+    std::string rollbackError;
+    if (!GdtfDictionary::Save(dictionary, &rollbackError)) {
+      diagnostics::DiagnosticLogger::Error(
+          "Rider fixture dictionary rollback failed: " + rollbackError);
+    }
+  };
+
   for (const auto &item : analysis.items) {
     if (!item.selectedEntry)
       continue;
@@ -219,32 +286,32 @@ PreflightResult RunCreateFromTextPreflight(wxWindow *parent,
         "Rider fixture GDTF download completed: revision=" + rid);
   }
 
-  for (auto &item : analysis.items) {
+  for (const auto &item : analysis.items) {
     if (!item.selectedEntry)
       continue;
     const auto found = downloads.find(item.selectedEntry->rid);
     if (found == downloads.end())
       return PreflightResult::Failed;
-    if (item.selectedMode.empty() && found->second.modes.size() == 1)
-      item.selectedMode = found->second.modes.front();
-    if (item.selectedMode.empty() && found->second.modes.size() > 1) {
-      wxArrayString choices;
-      for (const std::string &mode : found->second.modes)
-        choices.Add(wxString::FromUTF8(mode));
-      wxSingleChoiceDialog modeDialog(
-          parent,
-          wxString::Format(_("Select a GDTF mode for %s."),
-                           wxString::FromUTF8(item.request.typeName)),
-          _("Select fixture mode"), choices);
-      if (modeDialog.ShowModal() != wxID_OK)
-        return PreflightResult::Cancelled;
-      item.selectedMode = modeDialog.GetStringSelection().ToStdString();
-    }
     if (std::find(found->second.modes.begin(), found->second.modes.end(),
                   item.selectedMode) == found->second.modes.end()) {
       wxMessageBox(wxString::Format(_("The selected mode for %s is not present in the downloaded GDTF. No scene objects were created."),
                                     wxString::FromUTF8(item.request.typeName)),
                    _("Fixture resolution failed"), wxOK | wxICON_ERROR, parent);
+      return PreflightResult::Failed;
+    }
+  }
+
+  for (const auto &item : analysis.items) {
+    if (item.state != rider_fixture_resolution::State::Dictionary ||
+        !item.dictionaryEntry ||
+        item.selectedMode == item.dictionaryEntry->mode)
+      continue;
+    GdtfDictionary::Entry changed = *item.dictionaryEntry;
+    changed.mode = item.selectedMode;
+    GdtfDictionary::UpdateDictionaryEntry(item.request.typeName, changed);
+    const auto persisted = GdtfDictionary::Get(item.request.typeName);
+    if (!persisted || persisted->mode != item.selectedMode) {
+      rollbackDictionary();
       return PreflightResult::Failed;
     }
   }
@@ -256,6 +323,7 @@ PreflightResult RunCreateFromTextPreflight(wxWindow *parent,
     const auto persisted = GdtfDictionary::CreateOrUpdatePerastageLibraryDerivative(
         item.request.typeName, downloaded.path.string(), item.selectedMode);
     if (!persisted) {
+      rollbackDictionary();
       wxMessageBox(wxString::Format(_("Could not save the fixture dictionary mapping for %s. No scene objects were created."),
                                     wxString::FromUTF8(item.request.typeName)),
                    _("Fixture resolution failed"), wxOK | wxICON_ERROR, parent);

--- a/gui/rider_fixture_resolution_workflow.h
+++ b/gui/rider_fixture_resolution_workflow.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "../core/riderimporter.h"
+
 #include <string>
 
 class ConfigManager;
@@ -12,6 +14,7 @@ enum class PreflightResult { Proceed, Cancelled, Failed };
 PreflightResult RunCreateFromTextPreflight(wxWindow *parent,
                                            ConfigManager &configManager,
                                            const std::string &text,
-                                           std::string *filteredTextOut = nullptr);
+                                           std::string *filteredTextOut = nullptr,
+                                           RiderImporter::ImportPlan *importPlanOut = nullptr);
 
 } // namespace rider_fixture_resolution_gui

--- a/gui/rider_fixture_resolution_workflow.h
+++ b/gui/rider_fixture_resolution_workflow.h
@@ -11,6 +11,7 @@ enum class PreflightResult { Proceed, Cancelled, Failed };
 
 PreflightResult RunCreateFromTextPreflight(wxWindow *parent,
                                            ConfigManager &configManager,
-                                           const std::string &text);
+                                           const std::string &text,
+                                           std::string *filteredTextOut = nullptr);
 
 } // namespace rider_fixture_resolution_gui

--- a/gui/rider_fixture_resolution_workflow.h
+++ b/gui/rider_fixture_resolution_workflow.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <string>
+
+class ConfigManager;
+class wxWindow;
+
+namespace rider_fixture_resolution_gui {
+
+enum class PreflightResult { Proceed, Cancelled, Failed };
+
+PreflightResult RunCreateFromTextPreflight(wxWindow *parent,
+                                           ConfigManager &configManager,
+                                           const std::string &text);
+
+} // namespace rider_fixture_resolution_gui

--- a/mvr/gdtf_catalog_matcher.cpp
+++ b/mvr/gdtf_catalog_matcher.cpp
@@ -463,7 +463,11 @@ GdtfDownloadMatch SelectBestDownloadMatch(
       const auto requestedModel = BuildCanonicalFixtureModel(
           identity, request.manufacturer,
           FixtureIdentitySource::AuthoritativeGdtf);
-      auto tier = ComputeFixtureNameMatchTier(entry.fixtureName, identity);
+      auto tier = std::max(
+          ComputeFixtureNameMatchTier(entry.fixtureName, identity),
+          ComputeFixtureNameMatchTier(entry.manufacturer + " " +
+                                          entry.fixtureName,
+                                      identity));
       if (tier < FixtureNameMatchTier::CoreName && !catalogModel.canonicalText.empty() &&
           catalogModel.canonicalText == requestedModel.canonicalText)
         tier = FixtureNameMatchTier::CoreName;

--- a/mvr/gdtf_catalog_parser.cpp
+++ b/mvr/gdtf_catalog_parser.cpp
@@ -9,6 +9,7 @@
 #include <iomanip>
 #include <initializer_list>
 #include <sstream>
+#include <chrono>
 
 namespace mvr::gdtf_catalog_parser {
 namespace {
@@ -145,15 +146,23 @@ ParseModes(const Json &item) {
 
 // Parses one catalog payload into displayable shared domain records.
 GdtfCatalogParseResult ParseCatalog(const std::string &payload) {
+  const auto started = std::chrono::steady_clock::now();
   GdtfCatalogParseResult result;
   result.payloadBytes = payload.size();
   result.payloadFingerprint = FingerprintPayload(payload);
   Json list = Json::parse(payload, nullptr, false);
-  if (list.is_discarded())
+  if (list.is_discarded()) {
+    result.parseMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - started).count();
     return result;
+  }
   const Json *catalogArray = FindCatalogArray(list);
-  if (!catalogArray)
+  if (!catalogArray) {
+    result.parseMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - started).count();
     return result;
+  }
+  result.schemaRecognized = true;
 
   for (const auto &item : *catalogArray) {
     if (!item.is_object())
@@ -176,8 +185,12 @@ GdtfCatalogParseResult ParseCatalog(const std::string &payload) {
     entry.downloadable = !entry.rid.empty();
     if (!entry.downloadable)
       entry.downloadabilityReason = "missing revision identifier";
+    if (entry.downloadable && !entry.fixtureName.empty())
+      ++result.usableEntryCount;
     result.entries.push_back(std::move(entry));
   }
+  result.parseMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+      std::chrono::steady_clock::now() - started).count();
   return result;
 }
 

--- a/mvr/gdtf_catalog_parser.h
+++ b/mvr/gdtf_catalog_parser.h
@@ -11,6 +11,14 @@ struct GdtfCatalogParseResult {
   std::vector<gdtf_catalog_matcher::GdtfCatalogEntry> entries;
   std::size_t payloadBytes = 0;
   std::string payloadFingerprint;
+  std::size_t usableEntryCount = 0;
+  bool schemaRecognized = false;
+  long long parseMs = 0;
+
+  // Reports whether parsing found a recognized catalog with usable entries.
+  bool IsUsable() const {
+    return schemaRecognized && usableEntryCount > 0;
+  }
 };
 
 GdtfCatalogParseResult ParseCatalog(const std::string &payload);

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "mvrimporter.h"
+#include "../gui/gdtf_resolution_status_style.h"
 #include "apppaths.h"
 #include "build_info.h"
 #include "configmanager.h"
@@ -4016,16 +4017,21 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
               auto rowTextColor = [](DownloadRowState state) -> wxColour {
                 switch (state) {
                 case DownloadRowState::Downloaded:
-                  return wxColour(30, 120, 60);
+                  return GdtfResolutionStatusColour(
+                      rider_fixture_resolution::StatusSemantic::Success);
                 case DownloadRowState::Fallback:
-                  return wxColour(150, 100, 0);
+                  return GdtfResolutionStatusColour(
+                      rider_fixture_resolution::StatusSemantic::Warning);
                 case DownloadRowState::Canceled:
-                  return wxColour(130, 130, 130);
+                  return GdtfResolutionStatusColour(
+                      rider_fixture_resolution::StatusSemantic::Muted);
                 case DownloadRowState::Downloading:
-                  return wxColour(20, 80, 160);
+                  return GdtfResolutionStatusColour(
+                      rider_fixture_resolution::StatusSemantic::Information);
                 case DownloadRowState::Pending:
                 default:
-                  return wxColour(80, 80, 80);
+                  return GdtfResolutionStatusColour(
+                      rider_fixture_resolution::StatusSemantic::Neutral);
                 }
               };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2818,6 +2818,18 @@ target_link_libraries(colorful_dataview_store_bounds_test PRIVATE
 add_test(NAME ColorfulDataViewStoreBounds
          COMMAND colorful_dataview_store_bounds_test)
 
+add_executable(rider_fixture_resolution_model_test
+               rider_fixture_resolution_model_test.cpp
+               ../gui/rider_fixture_resolution_model.cpp
+               ../core/rider_fixture_resolution.cpp
+               ../mvr/gdtf_catalog_matcher.cpp)
+target_include_directories(rider_fixture_resolution_model_test PRIVATE
+                           ../gui ../core ../mvr ../third_party)
+target_link_libraries(rider_fixture_resolution_model_test PRIVATE
+                      ${wxWidgets_LIBRARIES})
+add_test(NAME RiderFixtureResolutionModel
+         COMMAND rider_fixture_resolution_model_test)
+
 # Reuse the production mesh parsers in every standalone test that owns truss loading/building.
 get_property(perastage_geometry_test_targets DIRECTORY PROPERTY BUILDSYSTEM_TARGETS)
 foreach(perastage_geometry_target IN LISTS perastage_geometry_test_targets)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1066,6 +1066,10 @@ add_executable(rider_fixture_resolution_test
 target_include_directories(rider_fixture_resolution_test PRIVATE
                            ../core ../mvr ../third_party)
 add_test(NAME RiderFixtureResolution COMMAND rider_fixture_resolution_test)
+if(UNIX)
+  add_test(NAME RiderFixturePreflightWiring
+           COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/check_rider_fixture_preflight_wiring.sh)
+endif()
 
 add_executable(rider_truss_dictionary_normalization_test
                rider_truss_dictionary_normalization_test.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2810,6 +2810,14 @@ add_test(NAME FixtureGeometryBoundsRendererUnitParity
 add_test(NAME FixtureGeometryBoundsTranslatedChild
          COMMAND fixture_geometry_bounds_test)
 
+add_executable(colorful_dataview_store_bounds_test
+               colorful_dataview_store_bounds_test.cpp)
+target_include_directories(colorful_dataview_store_bounds_test PRIVATE ../gui)
+target_link_libraries(colorful_dataview_store_bounds_test PRIVATE
+                      ${wxWidgets_LIBRARIES})
+add_test(NAME ColorfulDataViewStoreBounds
+         COMMAND colorful_dataview_store_bounds_test)
+
 # Reuse the production mesh parsers in every standalone test that owns truss loading/building.
 get_property(perastage_geometry_test_targets DIRECTORY PROPERTY BUILDSYSTEM_TARGETS)
 foreach(perastage_geometry_target IN LISTS perastage_geometry_test_targets)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2830,6 +2830,12 @@ target_link_libraries(rider_fixture_resolution_model_test PRIVATE
 add_test(NAME RiderFixtureResolutionModel
          COMMAND rider_fixture_resolution_model_test)
 
+add_executable(gdtf_download_filename_test
+               gdtf_download_filename_test.cpp
+               ../core/gdtf_download_filename.cpp)
+target_include_directories(gdtf_download_filename_test PRIVATE ../core)
+add_test(NAME GdtfDownloadFilename COMMAND gdtf_download_filename_test)
+
 # Reuse the production mesh parsers in every standalone test that owns truss loading/building.
 get_property(perastage_geometry_test_targets DIRECTORY PROPERTY BUILDSYSTEM_TARGETS)
 foreach(perastage_geometry_target IN LISTS perastage_geometry_test_targets)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1066,10 +1066,8 @@ add_executable(rider_fixture_resolution_test
 target_include_directories(rider_fixture_resolution_test PRIVATE
                            ../core ../mvr ../third_party)
 add_test(NAME RiderFixtureResolution COMMAND rider_fixture_resolution_test)
-if(UNIX)
-  add_test(NAME RiderFixturePreflightWiring
-           COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/check_rider_fixture_preflight_wiring.sh)
-endif()
+add_bash_policy_test(RiderFixturePreflightWiring
+                     ${CMAKE_CURRENT_SOURCE_DIR}/check_rider_fixture_preflight_wiring.sh)
 
 add_executable(rider_truss_dictionary_normalization_test
                rider_truss_dictionary_normalization_test.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1059,6 +1059,14 @@ target_link_libraries(truss_path_encoding_regression_test PRIVATE
                       ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
 add_test(NAME TrussPathEncodingRegression COMMAND truss_path_encoding_regression_test)
 
+add_executable(rider_fixture_resolution_test
+               rider_fixture_resolution_test.cpp
+               ../core/rider_fixture_resolution.cpp
+               ../mvr/gdtf_catalog_matcher.cpp)
+target_include_directories(rider_fixture_resolution_test PRIVATE
+                           ../core ../mvr ../third_party)
+add_test(NAME RiderFixtureResolution COMMAND rider_fixture_resolution_test)
+
 add_executable(rider_truss_dictionary_normalization_test
                rider_truss_dictionary_normalization_test.cpp
                support/gdtf_test_fixture_builder.cpp

--- a/tests/check_rider_fixture_preflight_wiring.sh
+++ b/tests/check_rider_fixture_preflight_wiring.sh
@@ -29,6 +29,12 @@ for label, token in required.items():
 
 if "GdtfSearchDialog dialog" not in dialog or "item->effectiveFixtureType" not in dialog:
     raise SystemExit("Resolver Search must call GdtfSearchDialog with the rider alias")
+if "onlineCatalogLoadAttempted" not in dialog or "onlineCatalogLoader()" not in dialog:
+    raise SystemExit("Resolver must attempt shared online catalog acquisition after a cache miss")
+if "DetermineCatalogAccessAction" not in workflow:
+    raise SystemExit("Resolver catalog acquisition must use the shared GDTF access policy")
+if "gdtf_download_filename::ChooseDestination" not in workflow:
+    raise SystemExit("Resolver downloads must use the shared readable filename policy")
 for source in ("rider_fixture_resolution_dialog.cpp",
                "rider_fixture_resolution_model.cpp",
                "rider_fixture_resolution_workflow.cpp"):

--- a/tests/check_rider_fixture_preflight_wiring.sh
+++ b/tests/check_rider_fixture_preflight_wiring.sh
@@ -2,8 +2,9 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$repo_root/tests/test_tool_requirements.sh"
 
-python3 - "$repo_root" <<'PY'
+run_test_python - "$repo_root" <<'PY'
 from pathlib import Path
 import sys
 

--- a/tests/check_rider_fixture_preflight_wiring.sh
+++ b/tests/check_rider_fixture_preflight_wiring.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+python3 - "$repo_root" <<'PY'
+from pathlib import Path
+import sys
+
+root = Path(sys.argv[1])
+io_source = (root / "gui/mainwindow_io.cpp").read_text(encoding="utf-8")
+workflow = (root / "gui/rider_fixture_resolution_workflow.cpp").read_text(encoding="utf-8")
+dialog = (root / "gui/rider_fixture_resolution_dialog.cpp").read_text(encoding="utf-8")
+gui_cmake = (root / "gui/CMakeLists.txt").read_text(encoding="utf-8")
+
+preflight = io_source.find("RunCreateFromTextPreflight")
+scene_import = io_source.find("RiderImporter::ImportText", preflight)
+if preflight < 0 or scene_import < 0 or preflight >= scene_import:
+    raise SystemExit("Create from text must run fixture preflight before ImportText")
+
+required = {
+    "runtime service analysis": "rider_fixture_resolution::Service::Analyze",
+    "modal resolver": "RiderFixtureResolutionDialog dialog",
+    "dictionary persistence": "CreateOrUpdatePerastageLibraryDerivative",
+}
+for label, token in required.items():
+    if token not in workflow:
+        raise SystemExit(f"Missing {label}: {token}")
+
+if "GdtfSearchDialog dialog" not in dialog or "item->request.typeName" not in dialog:
+    raise SystemExit("Resolver Search must call GdtfSearchDialog with the rider alias")
+for source in ("rider_fixture_resolution_dialog.cpp",
+               "rider_fixture_resolution_workflow.cpp"):
+    if source not in gui_cmake:
+        raise SystemExit(f"GUI CMake does not compile {source}")
+
+print("OK: Create from text is gated by the compiled fixture-resolution workflow.")
+PY

--- a/tests/check_rider_fixture_preflight_wiring.sh
+++ b/tests/check_rider_fixture_preflight_wiring.sh
@@ -48,6 +48,8 @@ if "Acquiring the shared GDTF catalog" in dialog:
     raise SystemExit("Resolver must not retain the obsolete non-terminal acquisition label")
 if "RefreshCatalogCompletionStatus" not in dialog:
     raise SystemExit("Resolver acquisition must publish a stable final status")
+if "BuildCatalogMatchTargets" not in dialog:
+    raise SystemExit("Resolver matching must skip dictionary and explicit rows")
 for source in ("rider_fixture_resolution_dialog.cpp",
                "rider_fixture_resolution_model.cpp",
                "rider_fixture_resolution_workflow.cpp"):

--- a/tests/check_rider_fixture_preflight_wiring.sh
+++ b/tests/check_rider_fixture_preflight_wiring.sh
@@ -29,12 +29,25 @@ for label, token in required.items():
 
 if "GdtfSearchDialog dialog" not in dialog or "item->effectiveFixtureType" not in dialog:
     raise SystemExit("Resolver Search must call GdtfSearchDialog with the rider alias")
-if "onlineCatalogLoadAttempted" not in dialog or "onlineCatalogLoader()" not in dialog:
+if "onlineCatalogLoadAttempted" not in dialog or "BeginOnlineCatalogAcquisition" not in dialog:
     raise SystemExit("Resolver must attempt shared online catalog acquisition after a cache miss")
 if "DetermineCatalogAccessAction" not in workflow:
     raise SystemExit("Resolver catalog acquisition must use the shared GDTF access policy")
 if "gdtf_download_filename::ChooseDestination" not in workflow:
     raise SystemExit("Resolver downloads must use the shared readable filename policy")
+online_loader_start = workflow.find("auto loadOnlineCatalog")
+credential_request_start = workflow.find("auto requestCatalogCredentials", online_loader_start)
+if online_loader_start < 0 or credential_request_start < 0:
+    raise SystemExit("Resolver must expose focused online catalog and credential callbacks")
+automatic_online_path = workflow[online_loader_start:credential_request_start]
+if "WaitForNetworkTask" in automatic_online_path or "wxProgressDialog" in automatic_online_path:
+    raise SystemExit("Automatic resolver catalog acquisition must not open nested progress dialogs")
+if "std::stop_token" not in automatic_online_path:
+    raise SystemExit("Automatic resolver catalog acquisition must support owned cancellation")
+if "Acquiring the shared GDTF catalog" in dialog:
+    raise SystemExit("Resolver must not retain the obsolete non-terminal acquisition label")
+if "RefreshCatalogCompletionStatus" not in dialog:
+    raise SystemExit("Resolver acquisition must publish a stable final status")
 for source in ("rider_fixture_resolution_dialog.cpp",
                "rider_fixture_resolution_model.cpp",
                "rider_fixture_resolution_workflow.cpp"):

--- a/tests/check_rider_fixture_preflight_wiring.sh
+++ b/tests/check_rider_fixture_preflight_wiring.sh
@@ -21,13 +21,13 @@ if preflight < 0 or scene_import < 0 or preflight >= scene_import:
 required = {
     "runtime service analysis": "rider_fixture_resolution::Service::Analyze",
     "modal resolver": "RiderFixtureResolutionDialog dialog",
-    "dictionary persistence": "CreateOrUpdatePerastageLibraryDerivative",
+    "external dictionary persistence": "CreateOrUpdateExternalLibraryMapping",
 }
 for label, token in required.items():
     if token not in workflow:
         raise SystemExit(f"Missing {label}: {token}")
 
-if "GdtfSearchDialog dialog" not in dialog or "item->request.typeName" not in dialog:
+if "GdtfSearchDialog dialog" not in dialog or "item->effectiveFixtureType" not in dialog:
     raise SystemExit("Resolver Search must call GdtfSearchDialog with the rider alias")
 for source in ("rider_fixture_resolution_dialog.cpp",
                "rider_fixture_resolution_workflow.cpp"):

--- a/tests/check_rider_fixture_preflight_wiring.sh
+++ b/tests/check_rider_fixture_preflight_wiring.sh
@@ -30,6 +30,7 @@ for label, token in required.items():
 if "GdtfSearchDialog dialog" not in dialog or "item->effectiveFixtureType" not in dialog:
     raise SystemExit("Resolver Search must call GdtfSearchDialog with the rider alias")
 for source in ("rider_fixture_resolution_dialog.cpp",
+               "rider_fixture_resolution_model.cpp",
                "rider_fixture_resolution_workflow.cpp"):
     if source not in gui_cmake:
         raise SystemExit(f"GUI CMake does not compile {source}")

--- a/tests/colorful_dataview_store_bounds_test.cpp
+++ b/tests/colorful_dataview_store_bounds_test.cpp
@@ -23,6 +23,19 @@ int main() {
     store.GetValueByRow(value, 0, column);
     assert(!value.IsNull());
   }
+  wxVector<wxVariant> secondValues(values);
+  secondValues[1] = wxString("second row");
+  store.AppendItem(secondValues, 2);
+  const wxDataViewItem firstItem = store.GetItem(0);
+  const wxDataViewItem secondItem = store.GetItem(1);
+  for (unsigned column = 0; column < 8; ++column)
+    (void)store.Compare(firstItem, secondItem, column, true);
+  (void)store.Compare(firstItem, secondItem, 8, true);
+  wxVariant invalidValue;
+  store.GetValue(invalidValue, firstItem, 8);
+  assert(invalidValue.IsNull());
+  store.DeleteItem(1);
+  (void)store.Compare(firstItem, secondItem, 1, true);
   wxDataViewItemAttr attr;
   assert(!store.GetAttrByRow(1, 0, attr));
   store.DeleteAllItems();

--- a/tests/colorful_dataview_store_bounds_test.cpp
+++ b/tests/colorful_dataview_store_bounds_test.cpp
@@ -10,9 +10,19 @@ int main() {
   if (!initializer.IsOk())
     return 0;
   ColorfulDataViewListStore store;
+  store.AppendColumn("bool");
+  for (int column = 1; column < 8; ++column)
+    store.AppendColumn("string");
   wxVector<wxVariant> values;
-  values.push_back(wxString("row"));
+  values.push_back(true);
+  for (int column = 1; column < 8; ++column)
+    values.push_back(wxString::Format("cell-%d", column));
   store.AppendItem(values, 1);
+  for (unsigned column = 0; column < 8; ++column) {
+    wxVariant value;
+    store.GetValueByRow(value, 0, column);
+    assert(!value.IsNull());
+  }
   wxDataViewItemAttr attr;
   assert(!store.GetAttrByRow(1, 0, attr));
   store.DeleteAllItems();

--- a/tests/colorful_dataview_store_bounds_test.cpp
+++ b/tests/colorful_dataview_store_bounds_test.cpp
@@ -1,0 +1,21 @@
+#include "colorstore.h"
+
+#include <cassert>
+
+#include <wx/init.h>
+
+// Verifies stale attribute requests cannot index beyond the live store rows.
+int main() {
+  wxInitializer initializer;
+  if (!initializer.IsOk())
+    return 0;
+  ColorfulDataViewListStore store;
+  wxVector<wxVariant> values;
+  values.push_back(wxString("row"));
+  store.AppendItem(values, 1);
+  wxDataViewItemAttr attr;
+  assert(!store.GetAttrByRow(1, 0, attr));
+  store.DeleteAllItems();
+  assert(!store.GetAttrByRow(0, 0, attr));
+  return 0;
+}

--- a/tests/colorful_dataview_store_bounds_test.cpp
+++ b/tests/colorful_dataview_store_bounds_test.cpp
@@ -10,9 +10,15 @@ int main() {
   if (!initializer.IsOk())
     return 0;
   ColorfulDataViewListStore store;
+  assert(store.GetColumnCount() == 0);
   store.AppendColumn("bool");
+  assert(store.GetColumnCount() == 1);
   for (int column = 1; column < 8; ++column)
     store.AppendColumn("string");
+  assert(store.GetColumnCount() == 8);
+  assert(store.GetColumnType(0) == "bool");
+  assert(store.GetColumnType(7) == "string");
+  assert(store.GetColumnType(8).empty());
   wxVector<wxVariant> values;
   values.push_back(true);
   for (int column = 1; column < 8; ++column)

--- a/tests/gdtf_dictionary_color_roundtrip_test.cpp
+++ b/tests/gdtf_dictionary_color_roundtrip_test.cpp
@@ -88,6 +88,10 @@ int main() {
   const std::filesystem::path nestedDummyFixtureFile =
       fixturesDir / "Dummy 1ch.gdtf";
   tests::gdtf::BuildMinimalValidFixture().WriteArchive(fixtureFile);
+  const std::filesystem::path externalFixtureFile =
+      isolatedRoot / "downloads" / "GLP@JDC1.gdtf";
+  std::filesystem::create_directories(externalFixtureFile.parent_path());
+  tests::gdtf::BuildMinimalValidFixture().WriteArchive(externalFixtureFile);
   WriteFile(unknownFixtureFile, "not a zip archive");
   WriteNestedDescriptionGdtf(nestedDummyFixtureFile);
 
@@ -129,6 +133,17 @@ int main() {
       "");
   dummyCanonicalPathEntry = GdtfDictionary::Get("Some Type");
   assert(!dummyCanonicalPathEntry.has_value());
+
+  const auto externalMapping =
+      GdtfDictionary::CreateOrUpdateExternalLibraryMapping(
+          "GLP JDC1", externalFixtureFile.string(), "ModeA");
+  assert(externalMapping.success);
+  assert(externalMapping.entry.mode == "ModeA");
+  assert(std::filesystem::exists(externalMapping.entry.path));
+  assert(std::filesystem::path(externalMapping.entry.path).filename() ==
+         "GLP@JDC1.gdtf");
+  assert(!GdtfDictionary::IsPerastageNamedGdtfFile(
+      externalMapping.entry.path));
 
   assert(GdtfDictionary::Save(*loadedOpt));
 

--- a/tests/gdtf_download_filename_test.cpp
+++ b/tests/gdtf_download_filename_test.cpp
@@ -1,0 +1,33 @@
+#include "gdtf_download_filename.h"
+
+#include <cassert>
+#include <fstream>
+
+// Verifies readable deterministic names and collision-safe revision suffixes.
+int main() {
+  using namespace gdtf_download_filename;
+  assert(BuildReadableFileName("GLP", "JDC1") == "GLP JDC1.gdtf");
+  assert(BuildReadableFileName("GLP", "JDC1") ==
+         BuildReadableFileName("GLP", "JDC1"));
+  assert(BuildReadableFileName("Maker/Unsafe", "Fixture:*?") ==
+         "Maker_Unsafe Fixture___.gdtf");
+  assert(BuildReadableFileName("", "CON") == "_CON.gdtf");
+
+  const auto directory = std::filesystem::temp_directory_path() /
+                         "perastage-gdtf-download-filename-test";
+  std::error_code error;
+  std::filesystem::remove_all(directory, error);
+  std::filesystem::create_directories(directory, error);
+  assert(!error);
+  const auto readable = ChooseDestination(directory, "GLP", "JDC1", "123456");
+  assert(readable.filename() == "GLP JDC1.gdtf");
+  assert(readable.filename() != "123456.gdtf");
+  std::ofstream(readable).put('\n');
+  const auto collision =
+      ChooseDestination(directory, "GLP", "JDC1", "123456");
+  assert(collision.filename() == "GLP JDC1 - 123456.gdtf");
+  assert(collision ==
+         ChooseDestination(directory, "GLP", "JDC1", "123456"));
+  std::filesystem::remove_all(directory, error);
+  return 0;
+}

--- a/tests/mvr_gdtf_import_matching_test.cpp
+++ b/tests/mvr_gdtf_import_matching_test.cpp
@@ -258,6 +258,7 @@ static void VerifySharedMacCatalogPipeline() {
     {"manufacturer":"Martin Professional","fixture":"MAC Quantum Profile","uuid":"display-only"}
   ]}})json";
   const auto parsed = parser::ParseCatalog(payload);
+  assert(parsed.IsUsable());
   assert(parsed.entries.size() == 7);
   assert(parsed.payloadBytes == payload.size());
   assert(!parsed.payloadFingerprint.empty());
@@ -301,6 +302,10 @@ static void VerifyCatalogWrapperCompatibility() {
              .entries.size() == 1);
   assert(parser::ParseCatalog("{\"results\":{\"items\":[" + record + "]}}")
              .entries.size() == 1);
+  const auto emptyCatalog =
+      parser::ParseCatalog("{\"result\":true,\"list\":[]}");
+  assert(emptyCatalog.schemaRecognized);
+  assert(!emptyCatalog.IsUsable());
 }
 
 // Verifies structured GDTF manufacturer metadata reaches the real request builder.

--- a/tests/mvr_xchange_protocol_test.cpp
+++ b/tests/mvr_xchange_protocol_test.cpp
@@ -1023,11 +1023,17 @@ static void TestTcpServerIdleStop() {
   settings.stationName = "Idle server";
   settings.stationUuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
   for (int iteration = 0; iteration < 10; ++iteration) {
+    std::cerr << "[MvrXchangeProtocol] TestTcpServerIdleStop iteration=" << iteration
+              << " starting" << std::endl;
     MvrXchangeTcpServer server;
     assert(server.Start(settings, {}, {}, {}, {}, {}, {}));
     auto idleClient = ConnectLoopback(server.Port());
+    std::cerr << "[MvrXchangeProtocol] TestTcpServerIdleStop iteration=" << iteration
+              << " before Stop" << std::endl;
     const auto stopStarted = std::chrono::steady_clock::now();
     server.Stop();
+    std::cerr << "[MvrXchangeProtocol] TestTcpServerIdleStop iteration=" << iteration
+              << " after Stop" << std::endl;
     assert(std::chrono::steady_clock::now() - stopStarted < std::chrono::seconds(2));
     CloseLoopback(idleClient);
   }
@@ -1103,29 +1109,37 @@ static void TestTcpTypedErrorResponses() {
   server.Stop();
 }
 
+// Runs one internal protocol test with flushed begin and end diagnostics.
+template <typename TestFunction>
+static void RunNamedTest(const char *name, TestFunction testFunction) {
+  std::cerr << "[MvrXchangeProtocol] BEGIN " << name << std::endl;
+  testFunction();
+  std::cerr << "[MvrXchangeProtocol] END " << name << std::endl;
+}
+
 // Runs focused non-GUI MVR-xchange protocol coverage.
 int main() {
   [[maybe_unused]] TestSocketRuntime socketRuntime;
-  TestCommitStore();
-  TestPackets();
-  TestMessages();
-  TestRequestSourceStations();
-  TestLeaveMessages();
-  TestTypedErrors();
-  TestMalformedMessages();
-  TestInventoryCompatibility();
-  TestPacketRejection();
-  TestMdnsRecordCache();
-  TestRawMdnsDatagram();
-  TestDnsNames();
-  TestCanonicalUuidUse();
-  TestStationRegistry();
-  TestPublicationDestinationPolicy();
-  TestNetworkInterfaces();
-  TestTcpTransactions();
-  TestPersistentTcpConnection();
-  TestTcpServerIdleStop();
-  TestPersistentConnectionLimit();
-  TestTcpTypedErrorResponses();
+  RunNamedTest("TestCommitStore", TestCommitStore);
+  RunNamedTest("TestPackets", TestPackets);
+  RunNamedTest("TestMessages", TestMessages);
+  RunNamedTest("TestRequestSourceStations", TestRequestSourceStations);
+  RunNamedTest("TestLeaveMessages", TestLeaveMessages);
+  RunNamedTest("TestTypedErrors", TestTypedErrors);
+  RunNamedTest("TestMalformedMessages", TestMalformedMessages);
+  RunNamedTest("TestInventoryCompatibility", TestInventoryCompatibility);
+  RunNamedTest("TestPacketRejection", TestPacketRejection);
+  RunNamedTest("TestMdnsRecordCache", TestMdnsRecordCache);
+  RunNamedTest("TestRawMdnsDatagram", TestRawMdnsDatagram);
+  RunNamedTest("TestDnsNames", TestDnsNames);
+  RunNamedTest("TestCanonicalUuidUse", TestCanonicalUuidUse);
+  RunNamedTest("TestStationRegistry", TestStationRegistry);
+  RunNamedTest("TestPublicationDestinationPolicy", TestPublicationDestinationPolicy);
+  RunNamedTest("TestNetworkInterfaces", TestNetworkInterfaces);
+  RunNamedTest("TestTcpTransactions", TestTcpTransactions);
+  RunNamedTest("TestPersistentTcpConnection", TestPersistentTcpConnection);
+  RunNamedTest("TestTcpServerIdleStop", TestTcpServerIdleStop);
+  RunNamedTest("TestPersistentConnectionLimit", TestPersistentConnectionLimit);
+  RunNamedTest("TestTcpTypedErrorResponses", TestTcpTypedErrorResponses);
   return 0;
 }

--- a/tests/mvr_xchange_protocol_test.cpp
+++ b/tests/mvr_xchange_protocol_test.cpp
@@ -13,6 +13,8 @@
 #include "json.hpp"
 #include <cassert>
 #include <chrono>
+#include <condition_variable>
+#include <mutex>
 #include <set>
 #include <string>
 #include <thread>
@@ -890,14 +892,34 @@ static void TestPersistentConnectionLimit() {
   MvrXchangeSettings settings;
   settings.stationName = "Connection limit server";
   settings.stationUuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+  std::mutex logMutex;
+  std::condition_variable logChanged;
+  std::size_t acceptedConnections = 0;
+  bool connectionRejected = false;
   MvrXchangeTcpServer server;
-  assert(server.Start(settings, {}, {}, {}, {}, {}, {}));
+  assert(server.Start(settings, {}, {},
+                      [&](const std::string &message) {
+                        std::lock_guard lock(logMutex);
+                        if (message.find("TCP client connected") != std::string::npos) ++acceptedConnections;
+                        if (message.find("connection limit was reached") != std::string::npos) connectionRejected = true;
+                        logChanged.notify_all();
+                      },
+                      {}, {}, {}));
   std::vector<LoopbackConnection> clients;
   for (int index = 0; index < 16; ++index) {
     clients.push_back(ConnectLoopback(server.Port()));
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    std::unique_lock lock(logMutex);
+    const bool accepted = logChanged.wait_for(lock, std::chrono::seconds(2), [&] {
+      return acceptedConnections == clients.size();
+    });
+    assert(accepted);
   }
   auto rejected = ConnectLoopback(server.Port());
+  {
+    std::unique_lock lock(logMutex);
+    const bool rejectedAtLimit = logChanged.wait_for(lock, std::chrono::seconds(2), [&] { return connectionRejected; });
+    assert(rejectedAtLimit);
+  }
   char byte = 0;
   assert(recv(rejected.fd, &byte, 1, 0) == 0);
   CloseLoopback(rejected);

--- a/tests/mvr_xchange_protocol_test.cpp
+++ b/tests/mvr_xchange_protocol_test.cpp
@@ -12,8 +12,11 @@
 #include "xchange/mvr_xchange_tcp_server.h"
 #include "json.hpp"
 #include <cassert>
+#include <cerrno>
 #include <chrono>
 #include <condition_variable>
+#include <cstdlib>
+#include <iostream>
 #include <mutex>
 #include <set>
 #include <string>
@@ -24,6 +27,7 @@
 #include <ws2tcpip.h>
 #else
 #include <arpa/inet.h>
+#include <fcntl.h>
 #include <sys/socket.h>
 #include <unistd.h>
 #endif
@@ -32,6 +36,153 @@ struct LoopbackConnection {
   std::intptr_t fd = -1;
   std::vector<std::uint8_t> receiveBuffer;
 };
+
+enum class SocketReadiness {
+  Ready,
+  Error,
+  Timeout
+};
+
+enum class PeerCloseResult {
+  Closed,
+  UnexpectedData,
+  SocketError,
+  Timeout
+};
+
+class TestSocketRuntime {
+public:
+  TestSocketRuntime();
+  ~TestSocketRuntime();
+};
+
+// Keeps Winsock available for every client socket owned by this test executable.
+TestSocketRuntime::TestSocketRuntime() {
+#ifdef _WIN32
+  WSADATA data;
+  const int startupResult = WSAStartup(MAKEWORD(2, 2), &data);
+  if (startupResult != 0) {
+    std::cerr << "Winsock initialization failed for the MVR-xchange protocol test; error="
+              << startupResult << std::endl;
+    std::abort();
+  }
+#endif
+}
+
+// Releases the test executable's Winsock ownership after all sockets are closed.
+TestSocketRuntime::~TestSocketRuntime() {
+#ifdef _WIN32
+  WSACleanup();
+#endif
+}
+
+// Waits for a socket read operation to become safe within a fixed deadline.
+static SocketReadiness WaitForSocketReadable(std::intptr_t fd, std::chrono::milliseconds timeout) {
+  const auto deadline = std::chrono::steady_clock::now() + timeout;
+  while (true) {
+    const auto remaining = std::chrono::duration_cast<std::chrono::microseconds>(deadline - std::chrono::steady_clock::now());
+    if (remaining <= std::chrono::microseconds::zero()) return SocketReadiness::Timeout;
+    fd_set readSet;
+    FD_ZERO(&readSet);
+    FD_SET(fd, &readSet);
+    timeval wait{};
+    wait.tv_sec = static_cast<long>(remaining.count() / 1000000);
+    wait.tv_usec = static_cast<long>(remaining.count() % 1000000);
+#ifdef _WIN32
+    const int ready = select(0, &readSet, nullptr, nullptr, &wait);
+    if (ready < 0 && WSAGetLastError() == WSAEINTR) continue;
+    if (ready < 0) return SocketReadiness::Error;
+#else
+    const int ready = select(static_cast<int>(fd + 1), &readSet, nullptr, nullptr, &wait);
+    if (ready < 0 && errno == EINTR) continue;
+    if (ready < 0) return SocketReadiness::Error;
+#endif
+    if (ready == 0) return SocketReadiness::Timeout;
+    return FD_ISSET(fd, &readSet) ? SocketReadiness::Ready : SocketReadiness::Error;
+  }
+}
+
+// Requires bounded socket readability before a test performs a receive operation.
+static void RequireSocketReadable(std::intptr_t fd, const char *operation) {
+  const auto readiness = WaitForSocketReadable(fd, std::chrono::seconds(2));
+  if (readiness == SocketReadiness::Ready) return;
+  std::cerr << operation << " did not become readable within the test deadline; result="
+            << (readiness == SocketReadiness::Timeout ? "timeout" : "socket error") << std::endl;
+  std::abort();
+}
+
+// Waits for a peer to close without allowing recv to block the test executable.
+static PeerCloseResult WaitForPeerClose(std::intptr_t fd, std::chrono::milliseconds timeout) {
+  const auto readiness = WaitForSocketReadable(fd, timeout);
+  if (readiness == SocketReadiness::Timeout) return PeerCloseResult::Timeout;
+  if (readiness == SocketReadiness::Error) return PeerCloseResult::SocketError;
+  char probe = 0;
+  const int received = static_cast<int>(recv(fd, &probe, 1, 0));
+  if (received == 0) return PeerCloseResult::Closed;
+  return received > 0 ? PeerCloseResult::UnexpectedData : PeerCloseResult::SocketError;
+}
+
+// Connects a test socket without allowing a stalled loopback connection to hang CTest.
+static bool ConnectSocketWithDeadline(std::intptr_t fd, const sockaddr_in &address, std::chrono::milliseconds timeout) {
+#ifdef _WIN32
+  u_long nonBlocking = 1;
+  if (ioctlsocket(fd, FIONBIO, &nonBlocking) != 0) return false;
+#else
+  const int originalFlags = fcntl(static_cast<int>(fd), F_GETFL, 0);
+  if (originalFlags < 0 || fcntl(static_cast<int>(fd), F_SETFL, originalFlags | O_NONBLOCK) != 0) return false;
+#endif
+  const int connectResult = connect(fd, reinterpret_cast<const sockaddr *>(&address), sizeof(address));
+#ifdef _WIN32
+  const int connectError = connectResult == 0 ? 0 : WSAGetLastError();
+  const bool pending = connectError == WSAEWOULDBLOCK || connectError == WSAEINPROGRESS || connectError == WSAEALREADY;
+#else
+  const int connectError = connectResult == 0 ? 0 : errno;
+  const bool pending = connectError == EINPROGRESS;
+#endif
+  bool connected = connectResult == 0;
+  if (!connected && pending) {
+    fd_set writeSet;
+    FD_ZERO(&writeSet);
+    FD_SET(fd, &writeSet);
+    timeval wait{};
+    wait.tv_sec = static_cast<long>(timeout.count() / 1000);
+    wait.tv_usec = static_cast<long>((timeout.count() % 1000) * 1000);
+#ifdef _WIN32
+    const int ready = select(0, nullptr, &writeSet, nullptr, &wait);
+#else
+    const int ready = select(static_cast<int>(fd + 1), nullptr, &writeSet, nullptr, &wait);
+#endif
+    int socketError = 0;
+#ifdef _WIN32
+    int errorLength = sizeof(socketError);
+#else
+    socklen_t errorLength = sizeof(socketError);
+#endif
+    connected = ready > 0 && getsockopt(fd, SOL_SOCKET, SO_ERROR,
+                                         reinterpret_cast<char *>(&socketError), &errorLength) == 0 && socketError == 0;
+  }
+#ifdef _WIN32
+  u_long blocking = 0;
+  if (ioctlsocket(fd, FIONBIO, &blocking) != 0) connected = false;
+#else
+  if (fcntl(static_cast<int>(fd), F_SETFL, originalFlags) != 0) connected = false;
+#endif
+  return connected;
+}
+
+// Bounds test-side sends so a stalled peer fails instead of hanging CTest.
+static bool ApplyTestSocketSendTimeout(std::intptr_t fd, std::chrono::milliseconds timeout) {
+#ifdef _WIN32
+  const DWORD timeoutMs = static_cast<DWORD>(timeout.count());
+  return setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO,
+                    reinterpret_cast<const char *>(&timeoutMs), sizeof(timeoutMs)) == 0;
+#else
+  timeval sendTimeout{};
+  sendTimeout.tv_sec = static_cast<long>(timeout.count() / 1000);
+  sendTimeout.tv_usec = static_cast<long>((timeout.count() % 1000) * 1000);
+  return setsockopt(static_cast<int>(fd), SOL_SOCKET, SO_SNDTIMEO, &sendTimeout, sizeof(sendTimeout)) == 0;
+#endif
+}
 
 // Opens one reusable TCP connection to a loopback MVR-xchange server.
 static LoopbackConnection ConnectLoopback(int port) {
@@ -42,7 +193,14 @@ static LoopbackConnection ConnectLoopback(int port) {
   address.sin_family = AF_INET;
   address.sin_port = htons(static_cast<std::uint16_t>(port));
   inet_pton(AF_INET, "127.0.0.1", &address.sin_addr);
-  assert(connect(connection.fd, reinterpret_cast<sockaddr *>(&address), sizeof(address)) == 0);
+  if (!ConnectSocketWithDeadline(connection.fd, address, std::chrono::seconds(2))) {
+    std::cerr << "Loopback MVR-xchange connection did not complete within the test deadline." << std::endl;
+    std::abort();
+  }
+  if (!ApplyTestSocketSendTimeout(connection.fd, std::chrono::seconds(2))) {
+    std::cerr << "Loopback MVR-xchange send timeout could not be configured." << std::endl;
+    std::abort();
+  }
   return connection;
 }
 
@@ -67,6 +225,7 @@ static mvr::xchange::Packet ReceivePersistentPacket(LoopbackConnection &connecti
     if (status == mvr::xchange::DecodeStatus::Complete) return packet;
     assert(status == mvr::xchange::DecodeStatus::NeedMoreData);
     char buffer[4096];
+    RequireSocketReadable(connection.fd, "Persistent MVR-xchange response");
     const int received = static_cast<int>(recv(connection.fd, buffer, sizeof(buffer), 0));
     assert(received > 0);
     connection.receiveBuffer.insert(connection.receiveBuffer.end(), buffer, buffer + received);
@@ -85,37 +244,24 @@ static void CloseLoopback(LoopbackConnection &connection) {
 
 // Exchanges one raw JSON transaction with a loopback test server.
 static std::string ExchangeRawJson(int port, const std::string &json) {
-  const auto fd = socket(AF_INET, SOCK_STREAM, 0);
-#ifdef _WIN32
-  assert(fd != INVALID_SOCKET);
-#else
-  assert(fd >= 0);
-#endif
-  sockaddr_in address{};
-  address.sin_family = AF_INET;
-  address.sin_port = htons(static_cast<std::uint16_t>(port));
-  inet_pton(AF_INET, "127.0.0.1", &address.sin_addr);
-  assert(connect(fd, reinterpret_cast<sockaddr *>(&address), sizeof(address)) == 0);
+  auto connection = ConnectLoopback(port);
   const std::vector<std::uint8_t> payload(json.begin(), json.end());
   const auto packet = mvr::xchange::EncodePacket(mvr::xchange::PacketType::Json, payload);
   std::size_t sent = 0;
   while (sent < packet.size()) {
-    const int count = static_cast<int>(send(fd, reinterpret_cast<const char *>(packet.data() + sent), static_cast<int>(packet.size() - sent), 0));
+    const int count = static_cast<int>(send(connection.fd, reinterpret_cast<const char *>(packet.data() + sent), static_cast<int>(packet.size() - sent), 0));
     assert(count > 0);
     sent += static_cast<std::size_t>(count);
   }
   std::vector<std::uint8_t> response;
   char buffer[4096];
   while (true) {
-    const int received = static_cast<int>(recv(fd, buffer, sizeof(buffer), 0));
+    RequireSocketReadable(connection.fd, "Raw MVR-xchange response");
+    const int received = static_cast<int>(recv(connection.fd, buffer, sizeof(buffer), 0));
     assert(received > 0);
     response.insert(response.end(), buffer, buffer + received);
     if (auto decoded = mvr::xchange::TryDecodePacket(response)) {
-#ifdef _WIN32
-      closesocket(fd);
-#else
-      close(fd);
-#endif
+      CloseLoopback(connection);
       return {decoded->payload.begin(), decoded->payload.end()};
     }
   }
@@ -920,11 +1066,17 @@ static void TestPersistentConnectionLimit() {
     const bool rejectedAtLimit = logChanged.wait_for(lock, std::chrono::seconds(2), [&] { return connectionRejected; });
     assert(rejectedAtLimit);
   }
-  char byte = 0;
-  assert(recv(rejected.fd, &byte, 1, 0) == 0);
+  const auto closeResult = WaitForPeerClose(rejected.fd, std::chrono::seconds(2));
+  if (closeResult != PeerCloseResult::Closed) {
+    std::cerr << "Rejected MVR-xchange connection was not closed within the test deadline; result="
+              << (closeResult == PeerCloseResult::Timeout ? "timeout" :
+                  closeResult == PeerCloseResult::UnexpectedData ? "unexpected data" : "socket error")
+              << std::endl;
+    std::abort();
+  }
   CloseLoopback(rejected);
-  server.Stop();
   for (auto &client : clients) CloseLoopback(client);
+  server.Stop();
 }
 
 // Verifies the server returns the RET matching each recognizable malformed request.
@@ -953,6 +1105,7 @@ static void TestTcpTypedErrorResponses() {
 
 // Runs focused non-GUI MVR-xchange protocol coverage.
 int main() {
+  [[maybe_unused]] TestSocketRuntime socketRuntime;
   TestCommitStore();
   TestPackets();
   TestMessages();

--- a/tests/rider_filter_preview_test.cpp
+++ b/tests/rider_filter_preview_test.cpp
@@ -95,8 +95,8 @@ int main() {
   }
   assert(HasCanonicalSerialization(preview));
 
-  const auto rawRequests = RiderImporter::AnalyzeFixtureTypes(input, false);
-  const auto filteredRequests = RiderImporter::AnalyzeFixtureTypes(preview, true);
+  const auto rawRequests = RiderImporter::AnalyzeFixtureTypes(input);
+  const auto filteredRequests = RiderImporter::AnalyzeFixtureTypes(preview);
   assert(rawRequests.size() == 4);
   assert(filteredRequests.size() == rawRequests.size());
   for (size_t i = 0; i < rawRequests.size(); ++i) {
@@ -105,7 +105,7 @@ int main() {
     assert(rawRequests[i].positions == filteredRequests[i].positions);
   }
   const auto aggregated = RiderImporter::AnalyzeFixtureTypes(
-      "LX1:\n8 GLP JDC1\nLX2:\n4 GLP JDC1\n", false);
+      "LX1:\n8 GLP JDC1\nLX2:\n4 GLP JDC1\n");
   assert(aggregated.size() == 1);
   assert(aggregated.front().quantity == 12);
   assert((aggregated.front().positions ==

--- a/tests/rider_filter_preview_test.cpp
+++ b/tests/rider_filter_preview_test.cpp
@@ -304,6 +304,15 @@ int main() {
          englishExpected);
   assertImportParity(englishRegression);
 
+  const auto screenAnalysis = RiderImporter::AnalyzeText(
+      "VIDEO\nPANTALLA LED\n1 PANTALLA LED 10x5m\n");
+  assert(screenAnalysis.fixtureTypes.empty());
+  assert(screenAnalysis.filteredText.find("PANTALLA LED 10x5m") !=
+         std::string::npos);
+  const auto nonFixtureVideoAnalysis = RiderImporter::AnalyzeFixtureTypes(
+      "VIDEO\nPANTALLA LED\n1 ASUS CONTROL DE CONTENIDO\n");
+  assert(nonFixtureVideoAnalysis.empty());
+
   const std::string keywordFixtureRegression =
       "FLOOR\n1 FIXTURE VIDEO CONTROL AUDIO LIGHTING\n2 HAZER\n";
   assert(RiderImporter::BuildFixtureFilterPreview(keywordFixtureRegression) ==

--- a/tests/rider_filter_preview_test.cpp
+++ b/tests/rider_filter_preview_test.cpp
@@ -95,6 +95,22 @@ int main() {
   }
   assert(HasCanonicalSerialization(preview));
 
+  const auto rawRequests = RiderImporter::AnalyzeFixtureTypes(input, false);
+  const auto filteredRequests = RiderImporter::AnalyzeFixtureTypes(preview, true);
+  assert(rawRequests.size() == 4);
+  assert(filteredRequests.size() == rawRequests.size());
+  for (size_t i = 0; i < rawRequests.size(); ++i) {
+    assert(rawRequests[i].typeName == filteredRequests[i].typeName);
+    assert(rawRequests[i].quantity == filteredRequests[i].quantity);
+    assert(rawRequests[i].positions == filteredRequests[i].positions);
+  }
+  const auto aggregated = RiderImporter::AnalyzeFixtureTypes(
+      "LX1:\n8 GLP JDC1\nLX2:\n4 GLP JDC1\n", false);
+  assert(aggregated.size() == 1);
+  assert(aggregated.front().quantity == 12);
+  assert((aggregated.front().positions ==
+          std::vector<std::string>{"LX1", "LX2"}));
+
   const std::string crlfPreview =
       RiderImporter::BuildFixtureFilterPreview(ToCrLf(input));
   assert(crlfPreview == preview);

--- a/tests/rider_fixture_resolution_model_test.cpp
+++ b/tests/rider_fixture_resolution_model_test.cpp
@@ -1,0 +1,86 @@
+#include "rider_fixture_resolution_model.h"
+
+#include <cassert>
+
+namespace GdtfDictionary {
+
+// Supplies the dictionary lookup contract required by the isolated model test.
+std::optional<Entry> FindInLoadedDictionary(
+    const std::unordered_map<std::string, Entry> &, const std::string &, bool) {
+  return std::nullopt;
+}
+
+} // namespace GdtfDictionary
+
+// Verifies the fixed resolver schema and its direct analysis-backed values.
+int main() {
+  using namespace rider_fixture_resolution;
+  Analysis analysis;
+  Item item;
+  item.request = {"GLP JDC1", "GLPJDC1", 4, {"LX1", "LX2"}};
+  item.originalFixtureType = "GLP JDC1";
+  item.effectiveFixtureType = "GLP JDC1";
+  item.selectedEntry = mvr::gdtf_catalog_matcher::GdtfCatalogEntry{
+      "rid-jdc1", "GLP", "JDC1", {{"Standard", 62}}, 1, 5.0f};
+  item.selectedMode = "Standard";
+  item.state = State::Suggested;
+  item.origin = ResolutionOrigin::AutomaticMatch;
+  item.details = "Selected by the shared GDTF catalog matcher";
+  analysis.items.push_back(item);
+  item.effectiveFixtureType = "Unknown fixture";
+  item.request.quantity = 1;
+  item.request.positions = {"FLOOR"};
+  item.selectedEntry.reset();
+  item.selectedMode.clear();
+  item.state = State::Generic;
+  item.origin = ResolutionOrigin::GenericFallback;
+  item.details = "Generic fallback selected for this import";
+  analysis.items.push_back(item);
+
+  RiderFixtureResolutionModel model(analysis);
+  assert(model.GetColumnCount() == 8);
+  assert(model.GetColumnType(RiderFixtureResolutionModel::Create) == "bool");
+  for (unsigned column = RiderFixtureResolutionModel::FixtureType;
+       column < RiderFixtureResolutionModel::ColumnCount; ++column)
+    assert(model.GetColumnType(column) == "string");
+  assert(model.GetColumnType(RiderFixtureResolutionModel::ColumnCount).empty());
+
+  const wxString expected[] = {"", "GLP JDC1", "4", "LX1, LX2",
+                               "GLP / JDC1", "Standard", "Automatic match",
+                               "Selected by the shared GDTF catalog matcher"};
+  for (unsigned column = 0;
+       column < RiderFixtureResolutionModel::ColumnCount; ++column) {
+    wxVariant value;
+    model.GetValueByRow(value, 0, column);
+    assert(!value.IsNull());
+    if (column == RiderFixtureResolutionModel::Create)
+      assert(value.GetBool());
+    else
+      assert(value.GetString() == expected[column]);
+  }
+
+  wxVariant invalid;
+  model.GetValueByRow(invalid, 0, RiderFixtureResolutionModel::ColumnCount);
+  assert(invalid.IsNull());
+  assert(!model.SetValueByRow(wxString("ignored"), 0,
+                              RiderFixtureResolutionModel::Status));
+  assert(model.SetValueByRow(false, 0, RiderFixtureResolutionModel::Create));
+  assert(model.SetValueByRow(wxString("GLP JDC-1"), 0,
+                             RiderFixtureResolutionModel::FixtureType));
+  assert(!analysis.items[0].create);
+  assert(analysis.items[0].effectiveFixtureType == "GLP JDC-1");
+  model.NotifyRowChanged(0);
+
+  wxDataViewItemAttr attr;
+  assert(model.GetAttrByRow(0, RiderFixtureResolutionModel::Status, attr));
+  assert(!model.GetAttrByRow(0, RiderFixtureResolutionModel::Mode, attr));
+  for (unsigned column = 0;
+       column < RiderFixtureResolutionModel::ColumnCount; ++column) {
+    const int compared = model.Compare(model.GetItem(0), model.GetItem(1),
+                                       column, true);
+    assert(compared != 0);
+  }
+  assert(model.Compare(model.GetItem(0), model.GetItem(1),
+                       RiderFixtureResolutionModel::ColumnCount, true) == 0);
+  return 0;
+}

--- a/tests/rider_fixture_resolution_model_test.cpp
+++ b/tests/rider_fixture_resolution_model_test.cpp
@@ -1,4 +1,5 @@
 #include "rider_fixture_resolution_model.h"
+#include "gdtf_resolution_status_style.h"
 
 #include <cassert>
 
@@ -74,6 +75,21 @@ int main() {
   wxDataViewItemAttr attr;
   assert(model.GetAttrByRow(0, RiderFixtureResolutionModel::Status, attr));
   assert(!model.GetAttrByRow(0, RiderFixtureResolutionModel::Mode, attr));
+  analysis.items[0].origin = ResolutionOrigin::Dictionary;
+  wxDataViewItemAttr dictionaryAttr;
+  assert(!model.GetAttrByRow(0, RiderFixtureResolutionModel::Status,
+                             dictionaryAttr));
+  analysis.items[0].origin = ResolutionOrigin::UserSelection;
+  wxDataViewItemAttr userSelectionAttr;
+  assert(model.GetAttrByRow(0, RiderFixtureResolutionModel::Status,
+                            userSelectionAttr));
+  assert(userSelectionAttr.HasColour());
+  for (const bool dark : {false, true}) {
+    assert(GdtfResolutionStatusColour(StatusSemantic::Information, dark) !=
+           GdtfResolutionStatusColour(StatusSemantic::Neutral, dark));
+    assert(GdtfResolutionStatusColour(StatusSemantic::Information, dark) !=
+           GdtfResolutionStatusColour(StatusSemantic::Success, dark));
+  }
   for (unsigned column = 0;
        column < RiderFixtureResolutionModel::ColumnCount; ++column) {
     const int compared = model.Compare(model.GetItem(0), model.GetItem(1),

--- a/tests/rider_fixture_resolution_test.cpp
+++ b/tests/rider_fixture_resolution_test.cpp
@@ -100,6 +100,52 @@ int main() {
   assert(!analysis.items[1].selectedEntry);
   assert(analysis.items[1].details.find("Download failed") != std::string::npos);
 
+  assert(Service::IsValidProgressTransition(
+      {ProgressStage::LoadingCatalog}, {ProgressStage::ParsingCatalog}));
+  assert(Service::IsValidProgressTransition(
+      {ProgressStage::ParsingCatalog},
+      {ProgressStage::MatchingFixtures, 1, 2, 1}));
+  assert(Service::IsValidProgressTransition(
+      {ProgressStage::MatchingFixtures, 1, 2, 1},
+      {ProgressStage::MatchingFixtures, 2, 2, 1}));
+  assert(Service::IsValidProgressTransition(
+      {ProgressStage::MatchingFixtures, 2, 2, 1},
+      {ProgressStage::Complete, 2, 2, 1}));
+  assert(!Service::IsValidProgressTransition(
+      {ProgressStage::MatchingFixtures, 2, 2, 1},
+      {ProgressStage::MatchingFixtures, 3, 2, 1}));
+  assert(Service::IsValidProgressTransition(
+      {ProgressStage::LoadingCatalog}, {ProgressStage::Unavailable}));
+  assert(StatusSemanticForOrigin(ResolutionOrigin::Dictionary) ==
+         StatusSemantic::Neutral);
+  assert(StatusSemanticForOrigin(ResolutionOrigin::DictionaryModified) ==
+         StatusSemantic::Modified);
+  assert(StatusSemanticForOrigin(ResolutionOrigin::AutomaticMatch) ==
+         StatusSemantic::Success);
+  assert(StatusSemanticForOrigin(ResolutionOrigin::UserSelection) ==
+         StatusSemantic::Information);
+  assert(StatusSemanticForOrigin(ResolutionOrigin::GenericFallback) ==
+         StatusSemantic::Warning);
+  assert(StatusSemanticForOrigin(ResolutionOrigin::Skipped) ==
+         StatusSemantic::Muted);
+
+  std::vector<Progress> reportedProgress;
+  const Analysis progressAnalysis = Service::Analyze(
+      {requests[1], requests[2]}, {}, catalog,
+      [&](const Progress &progress) { reportedProgress.push_back(progress); });
+  assert(progressAnalysis.items.size() == 2);
+  assert(reportedProgress.size() == 3);
+  assert(reportedProgress[0].stage == ProgressStage::MatchingFixtures);
+  assert(reportedProgress[0].current == 1 && reportedProgress[0].total == 2);
+  assert(reportedProgress[1].current == 2 && reportedProgress[1].total == 2);
+  assert(reportedProgress[2].stage == ProgressStage::Complete);
+  assert(reportedProgress[2].automaticMatches == 1);
+
+  Analysis renamedDuringMatch = Service::Analyze({requests[1]}, {}, {});
+  renamedDuringMatch.items.front().effectiveFixtureType = "Edited after start";
+  Service::MergeCatalogSuggestions(renamedDuringMatch, backgroundMatch);
+  assert(!renamedDuringMatch.items.front().selectedEntry);
+
   std::filesystem::remove(profilePath);
   return 0;
 }

--- a/tests/rider_fixture_resolution_test.cpp
+++ b/tests/rider_fixture_resolution_test.cpp
@@ -141,6 +141,31 @@ int main() {
   assert(reportedProgress[2].stage == ProgressStage::Complete);
   assert(reportedProgress[2].automaticMatches == 1);
 
+  Analysis displayedPlan;
+  displayedPlan.items.resize(7);
+  for (size_t index = 0; index < 5; ++index) {
+    displayedPlan.items[index].create = true;
+    displayedPlan.items[index].origin = ResolutionOrigin::Dictionary;
+  }
+  for (size_t index = 5; index < 7; ++index) {
+    displayedPlan.items[index].create = true;
+    displayedPlan.items[index].origin = ResolutionOrigin::GenericFallback;
+  }
+  const Summary displayedSummary = Service::Summarize(displayedPlan);
+  assert(displayedSummary.created == 7);
+  assert(displayedSummary.dictionary == 5);
+  assert(displayedSummary.automaticMatches == 0);
+  assert(displayedSummary.genericFallbacks == 2);
+  displayedPlan.items[0].origin = ResolutionOrigin::AutomaticMatch;
+  displayedPlan.items[1].create = false;
+  displayedPlan.items[1].origin = ResolutionOrigin::Skipped;
+  const Summary changedSummary = Service::Summarize(displayedPlan);
+  assert(changedSummary.created == 6);
+  assert(changedSummary.dictionary == 3);
+  assert(changedSummary.automaticMatches == 1);
+  assert(changedSummary.genericFallbacks == 2);
+  assert(changedSummary.skipped == 1);
+
   Analysis renamedDuringMatch = Service::Analyze({requests[1]}, {}, {});
   renamedDuringMatch.items.front().effectiveFixtureType = "Edited after start";
   Service::MergeCatalogSuggestions(renamedDuringMatch, backgroundMatch);

--- a/tests/rider_fixture_resolution_test.cpp
+++ b/tests/rider_fixture_resolution_test.cpp
@@ -1,0 +1,72 @@
+#include "rider_fixture_resolution.h"
+
+#include <cassert>
+#include <filesystem>
+#include <fstream>
+
+namespace GdtfDictionary {
+
+// Normalizes aliases for this isolated service test.
+std::string NormalizeTypeKey(const std::string &type) {
+  std::string result;
+  for (unsigned char character : type) {
+    if (!std::isspace(character))
+      result.push_back(static_cast<char>(std::toupper(character)));
+  }
+  return result;
+}
+
+// Implements the production dictionary lookup contract for isolated testing.
+std::optional<Entry> FindInLoadedDictionary(
+    const std::unordered_map<std::string, Entry> &dictionary,
+    const std::string &type, bool validateExistingPath) {
+  const std::string key = NormalizeTypeKey(type);
+  for (const auto &[alias, entry] : dictionary) {
+    if (NormalizeTypeKey(alias) != key)
+      continue;
+    if (validateExistingPath && !entry.path.empty() &&
+        !std::filesystem::exists(entry.path))
+      return std::nullopt;
+    return entry;
+  }
+  return std::nullopt;
+}
+
+} // namespace GdtfDictionary
+
+// Verifies conservative matching, dictionary priority, and mode ambiguity.
+int main() {
+  using namespace mvr::gdtf_catalog_matcher;
+  using namespace rider_fixture_resolution;
+
+  const auto profilePath =
+      std::filesystem::temp_directory_path() / "perastage-resolution-test.gdtf";
+  std::ofstream(profilePath).put('\n');
+  std::unordered_map<std::string, GdtfDictionary::Entry> dictionary{
+      {"GLP JDC1", {profilePath.string(), "Mode 1"}}};
+  std::vector<RiderImporter::FixtureTypeRequest> requests{
+      {"GLP JDC1", "GLPJDC1", 12, {"LX1", "LX2"}},
+      {"PIXEL STROBE 400 RGB", "PIXELSTROBE400RGB", 8, {"LX2"}},
+      {"PIXEL STROBE 800 RGB", "PIXELSTROBE800RGB", 2, {"LX3"}}};
+  std::vector<GdtfCatalogEntry> catalog{
+      {"revision-400", "Prolight Spain", "PIXEL STROBE 400 RGB",
+       {{"Standard", 24}}, 10, 5.0f}};
+
+  Analysis analysis = Service::Analyze(requests, dictionary, catalog);
+  assert(analysis.RequiresPreflight());
+  assert(analysis.items[0].state == State::Dictionary);
+  assert(analysis.items[1].state == State::Suggested);
+  assert(analysis.items[2].state != State::Suggested);
+
+  Service::SelectCatalogEntry(analysis.items[1], *analysis.items[1].suggestedEntry);
+  assert(analysis.items[1].selectedMode == "Standard");
+  GdtfCatalogEntry multiMode{"multi", "Maker", "Model", {{"A", 8}, {"B", 16}},
+                             1, 1.0f};
+  Service::SelectCatalogEntry(analysis.items[1], multiMode);
+  assert(analysis.items[1].RequiresModeSelection());
+  Service::SelectGeneric(analysis.items[2]);
+  assert(analysis.items[2].IsReady());
+
+  std::filesystem::remove(profilePath);
+  return 0;
+}

--- a/tests/rider_fixture_resolution_test.cpp
+++ b/tests/rider_fixture_resolution_test.cpp
@@ -95,6 +95,11 @@ int main() {
   Service::SetCreate(edited.items.front(), false);
   assert(edited.items.front().origin == ResolutionOrigin::Skipped);
 
+  Service::FallbackAfterFailure(analysis.items[1], "Download failed");
+  assert(analysis.items[1].origin == ResolutionOrigin::GenericFallback);
+  assert(!analysis.items[1].selectedEntry);
+  assert(analysis.items[1].details.find("Download failed") != std::string::npos);
+
   std::filesystem::remove(profilePath);
   return 0;
 }

--- a/tests/rider_fixture_resolution_test.cpp
+++ b/tests/rider_fixture_resolution_test.cpp
@@ -40,7 +40,8 @@ int main() {
       {"PIXEL STROBE 800 RGB", "PIXELSTROBE800RGB", 2, {"LX3"}}};
   std::vector<GdtfCatalogEntry> catalog{
       {"revision-400", "Prolight Spain", "PIXEL STROBE 400 RGB",
-       {{"Standard", 24}}, 10, 5.0f}};
+       {{"Standard", 24}}, 10, 5.0f},
+      {"revision-jdc1", "GLP", "JDC1", {{"Standard", 62}}, 11, 5.0f}};
 
   Analysis analysis = Service::Analyze(requests, dictionary, catalog);
   assert(analysis.RequiresPreflight());
@@ -79,6 +80,20 @@ int main() {
       Service::Analyze({requests[1]}, dictionary, catalog);
   Service::MergeCatalogSuggestions(preservedChoice, backgroundMatch);
   assert(preservedChoice.items.front().state == State::Generic);
+
+  RiderImporter::FixtureTypeRequest editedRequest{
+      "GLP JDC1 16CH", "GLPJDC116CH", 4, {"LX1"}};
+  Analysis edited = Service::Analyze({editedRequest}, {}, catalog);
+  assert(edited.items.front().originalFixtureType == "GLP JDC1 16CH");
+  edited.items.front().effectiveFixtureType = "GLP JDC1";
+  Service::ResolveItem(edited.items.front(), {}, catalog);
+  assert(edited.items.front().originalFixtureType == "GLP JDC1 16CH");
+  assert(edited.items.front().effectiveFixtureType == "GLP JDC1");
+  assert(edited.items.front().selectedEntry);
+  assert(edited.items.front().selectedEntry->rid == "revision-jdc1");
+  assert(edited.items.front().origin == ResolutionOrigin::AutomaticMatch);
+  Service::SetCreate(edited.items.front(), false);
+  assert(edited.items.front().origin == ResolutionOrigin::Skipped);
 
   std::filesystem::remove(profilePath);
   return 0;

--- a/tests/rider_fixture_resolution_test.cpp
+++ b/tests/rider_fixture_resolution_test.cpp
@@ -48,6 +48,18 @@ int main() {
   assert(analysis.items[0].state == State::Dictionary);
   assert(analysis.items[1].state == State::Suggested);
   assert(analysis.items[2].state != State::Suggested);
+  const auto remainingAfterInitialMatch =
+      Service::BuildCatalogMatchTargets(analysis);
+  assert(remainingAfterInitialMatch.size() == 1);
+  assert(remainingAfterInitialMatch.front().analysisIndex == 2);
+
+  Analysis dictionaryOnlyPreflight = Service::Analyze(requests, dictionary, {});
+  const auto catalogTargets =
+      Service::BuildCatalogMatchTargets(dictionaryOnlyPreflight);
+  assert(catalogTargets.size() == 2);
+  assert(catalogTargets[0].analysisIndex == 1);
+  assert(catalogTargets[1].analysisIndex == 2);
+  assert(catalogTargets[0].request.typeName == requests[1].typeName);
 
   const Analysis allKnown = Service::Analyze({requests.front()}, dictionary, {});
   assert(!allKnown.RequiresPreflight());

--- a/tests/rider_fixture_resolution_test.cpp
+++ b/tests/rider_fixture_resolution_test.cpp
@@ -66,6 +66,20 @@ int main() {
   Service::SelectGeneric(analysis.items[2]);
   assert(analysis.items[2].IsReady());
 
+  Analysis defaultFallback = Service::Analyze({requests[2]}, dictionary, {});
+  Service::FinalizeDefaults(defaultFallback);
+  assert(defaultFallback.items.front().state == State::Generic);
+  Analysis ambiguousFallback = Service::Analyze({requests[1]}, dictionary, catalog);
+  Service::SelectCatalogEntry(ambiguousFallback.items.front(), multiMode);
+  Service::FinalizeDefaults(ambiguousFallback);
+  assert(ambiguousFallback.items.front().state == State::Generic);
+  Analysis preservedChoice = Service::Analyze({requests[1]}, dictionary, {});
+  Service::SelectGeneric(preservedChoice.items.front());
+  const Analysis backgroundMatch =
+      Service::Analyze({requests[1]}, dictionary, catalog);
+  Service::MergeCatalogSuggestions(preservedChoice, backgroundMatch);
+  assert(preservedChoice.items.front().state == State::Generic);
+
   std::filesystem::remove(profilePath);
   return 0;
 }

--- a/tests/rider_fixture_resolution_test.cpp
+++ b/tests/rider_fixture_resolution_test.cpp
@@ -48,6 +48,15 @@ int main() {
   assert(analysis.items[1].state == State::Suggested);
   assert(analysis.items[2].state != State::Suggested);
 
+  const Analysis allKnown = Service::Analyze({requests.front()}, dictionary, {});
+  assert(!allKnown.RequiresPreflight());
+  const Analysis offlineUnknown = Service::Analyze({requests[2]}, dictionary, {});
+  assert(offlineUnknown.RequiresPreflight());
+  assert(offlineUnknown.items.front().state == State::Unresolved);
+  const Analysis emptyPath = Service::Analyze(
+      {requests.front()}, {{"GLP JDC1", GdtfDictionary::Entry{}}}, {});
+  assert(emptyPath.RequiresPreflight());
+
   Service::SelectCatalogEntry(analysis.items[1], *analysis.items[1].suggestedEntry);
   assert(analysis.items[1].selectedMode == "Standard");
   GdtfCatalogEntry multiMode{"multi", "Maker", "Model", {{"A", 8}, {"B", 16}},

--- a/tests/rider_fixture_resolution_test.cpp
+++ b/tests/rider_fixture_resolution_test.cpp
@@ -104,6 +104,18 @@ int main() {
       {ProgressStage::LoadingCatalog}, {ProgressStage::ParsingCatalog}));
   assert(Service::IsValidProgressTransition(
       {ProgressStage::ParsingCatalog},
+      {ProgressStage::WaitingForCredentials}));
+  assert(Service::IsValidProgressTransition(
+      {ProgressStage::WaitingForCredentials},
+      {ProgressStage::Authenticating}));
+  assert(Service::IsValidProgressTransition(
+      {ProgressStage::Authenticating},
+      {ProgressStage::DownloadingCatalog}));
+  assert(Service::IsValidProgressTransition(
+      {ProgressStage::DownloadingCatalog},
+      {ProgressStage::ParsingCatalog}));
+  assert(Service::IsValidProgressTransition(
+      {ProgressStage::ParsingCatalog},
       {ProgressStage::MatchingFixtures, 1, 2, 1}));
   assert(Service::IsValidProgressTransition(
       {ProgressStage::MatchingFixtures, 1, 2, 1},

--- a/tests/rider_fixture_resolution_test.cpp
+++ b/tests/rider_fixture_resolution_test.cpp
@@ -146,6 +146,17 @@ int main() {
   Service::MergeCatalogSuggestions(renamedDuringMatch, backgroundMatch);
   assert(!renamedDuringMatch.items.front().selectedEntry);
 
+  Analysis stableRows = Service::Analyze({requests[1], requests[2]}, {}, {});
+  const std::string neighborIdentity =
+      stableRows.items[1].originalFixtureType;
+  const Analysis firstMatch = Service::Analyze({requests[1]}, {}, catalog);
+  Service::MergeCatalogSuggestion(stableRows.items[0], firstMatch.items[0]);
+  assert(stableRows.items.size() == 2);
+  assert(stableRows.items[1].originalFixtureType == neighborIdentity);
+  Service::MergeCatalogSuggestion(stableRows.items[0], firstMatch.items[0]);
+  assert(stableRows.items.size() == 2);
+  assert(stableRows.items[1].originalFixtureType == neighborIdentity);
+
   std::filesystem::remove(profilePath);
   return 0;
 }

--- a/tests/rider_fixture_resolution_test.cpp
+++ b/tests/rider_fixture_resolution_test.cpp
@@ -6,16 +6,6 @@
 
 namespace GdtfDictionary {
 
-// Normalizes aliases for this isolated service test.
-std::string NormalizeTypeKey(const std::string &type) {
-  std::string result;
-  for (unsigned char character : type) {
-    if (!std::isspace(character))
-      result.push_back(static_cast<char>(std::toupper(character)));
-  }
-  return result;
-}
-
 // Implements the production dictionary lookup contract for isolated testing.
 std::optional<Entry> FindInLoadedDictionary(
     const std::unordered_map<std::string, Entry> &dictionary,


### PR DESCRIPTION
### Motivation
- Provide a non-destructive preflight for Create from text that analyzes unique rider fixture aliases before mutating the scene. 
- Reuse existing dictionary, catalog parser, and catalog matcher systems so the preflight can present conservative suggestions without reimplementing matching or download/auth logic. 
- Keep business logic GUI-independent so a wx dialog can be added later to present results, accept suggestions, and trigger downloads/persistence.

### Description
- Added `RiderImporter::AnalyzeFixtureTypes()` to expose a parser-driven, non-destructive aggregation of unique normalized fixture type requests including display name, normalized key, quantity, and positions. 
- Introduced a GUI-independent resolver model and service in `core/rider_fixture_resolution.{h,cpp}` that represents per-type resolution rows (states: `Dictionary`, `Suggested`, `Review`, `Unresolved`, `Generic`) and implements dictionary-first resolution and conservative catalog matching using the existing `mvr::gdtf_catalog_matcher`. 
- Exposed the dictionary normalization helper via `GdtfDictionary::NormalizeTypeKey()` (wrapper around an internal impl) so analysis and dictionary lookup use identical normalization semantics. 
- Extended `GdtfSearchDialog` with an optional initial fixture query parameter so the existing search UI can be reused by the resolver for manual corrections. 
- Updated `core/CMakeLists.txt` to add the new resolution source and added/registered tests and a small resolution-focused unit test `tests/rider_fixture_resolution_test.cpp`. 
- Updated developer and user documentation (`docs/developer/text_to_scene_rules.md`, `docs/user/create-from-text.md`) and added a release-notes entry describing the new preflight foundation. 

### Testing
- Ran the added unit runner `rider_fixture_resolution_test` (compiled with local `g++` invocation) and the test executed successfully. 
- Extended `tests/rider_filter_preview_test` to assert analysis parity between raw and filtered text and aggregation semantics, and the test passed when run locally with the compiled unit. 
- Project checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh` were executed and succeeded. 
- Attempted a full CMake configure/build in this environment but the configure step failed due to missing system `wxWidgets` libraries, so full project build/tests could not be exercised here; CI with the project toolchain should validate complete integration (catalog loading, GUI dialog, download flow, and final `RiderImporter::ImportText()` integration).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8d9b4f147c8324bbe68b0b5a340688)