### PR TITLE
Fixture-to-truss: screen-space acquisition for fixture attachment paths in 3D viewer

### DIFF
--- a/core/magnet_snap.cpp
+++ b/core/magnet_snap.cpp
@@ -592,9 +592,10 @@ struct JointMatch {
   std::size_t second = 0;
 };
 
-// Removes connector candidates already paired with an opposing nearby truss connector.
-std::vector<truss_attachment::Candidate> FilterOccupiedCandidates(
-    std::vector<truss_attachment::Candidate> candidates) {
+// Removes connector candidates already paired with an opposing nearby truss
+// connector.
+std::vector<truss_attachment::Candidate>
+FilterOccupiedCandidates(std::vector<truss_attachment::Candidate> candidates) {
   std::sort(candidates.begin(), candidates.end(),
             [](const auto &left, const auto &right) {
               return std::tie(left.ownerTrussUuid, left.stableId) <
@@ -681,6 +682,63 @@ BuildGroupCandidatesImpl(const MvrScene &scene, const Bounds &bounds,
           Scale(Normalize(insertionTransform.w), -bounds.size[2] * 0.5f));
   return truss_attachment::BuildAmbiguousCandidates(
       bounds.size, insertionTransform, groupUuid);
+}
+
+// Tests one continuous fixture path using screen-space or legacy world
+// acquisition.
+void ConsiderFixturePath(const SnapSource &source,
+                         const std::string &targetUuid,
+                         const truss_attachment_paths::Path &path,
+                         const std::array<float, 3> &insertion,
+                         const SnapSettings &settings, CandidateRank &bestRank,
+                         float &bestDistance, std::optional<SnapResult> &best) {
+  std::array<float, 3> target{};
+  float pathParameter = 0.0f;
+  CandidateRank rank;
+  rank.targetUuid = targetUuid;
+  rank.targetCandidateId = path.stableId;
+  if (settings.fixturePathProjection) {
+    const auto projected = truss_screen_snap::ClosestPointOnProjectedPolyline(
+        *settings.fixturePathProjection, path.worldPointsMm, insertion);
+    if (!projected || projected->screenDistanceLogicalPx >
+                          settings.fixturePathScreenApertureLogicalPx)
+      return;
+    target = projected->worldPointMm;
+    pathParameter = projected->pathParameter;
+    rank.primary = projected->screenDistanceLogicalPx;
+    rank.depthDifference = projected->depthDifference;
+    rank.worldDistance = projected->worldDistanceMm;
+    if (!IsBetterRank(rank, bestRank))
+      return;
+    bestRank = rank;
+  } else {
+    const auto closest =
+        truss_attachment_paths::ClosestPointOnPath(path, insertion, true);
+    if (!closest)
+      return;
+    target = closest->pointMm;
+    pathParameter = closest->pathParameter;
+    const float distance =
+        WeightedLength(Subtract(target, insertion), settings.axisWeights);
+    if (distance > settings.thresholdMm || distance >= bestDistance)
+      return;
+    bestDistance = distance;
+  }
+
+  SnapResult result;
+  result.snapped = true;
+  result.kind = SnapKind::FixtureToTruss;
+  result.sourceUuid = source.uuid;
+  result.targetUuid = targetUuid;
+  result.sourceType = source.type;
+  result.targetType = ObjectType::Truss;
+  result.translationDeltaMm = Subtract(target, insertion);
+  result.needsGrouping = true;
+  result.targetAttachmentPathId = path.stableId;
+  result.targetAttachmentPathParameter = pathParameter;
+  result.targetAttachmentProvenance = path.provenance;
+  result.targetAttachmentConfidence = path.diagnostics.confidence;
+  best = result;
 }
 
 } // namespace
@@ -828,15 +886,12 @@ std::optional<SnapResult> FindSnap(const MvrScene &scene,
 
   if (source.type == ObjectType::Fixture) {
     const std::array<float, 3> insertion = sourceBounds->transform.o;
-    auto &resolver = settings.pathResolver ? *settings.pathResolver
-                                           : DefaultPathResolver();
+    auto &resolver =
+        settings.pathResolver ? *settings.pathResolver : DefaultPathResolver();
     for (const auto &[uuid, truss] : scene.trusses) {
       const Bounds targetBounds = MakeTrussBounds(truss);
       const auto resolution = resolver.Resolve(scene, truss);
-      auto consider = [&](const std::array<float, 3> &closest,
-                          const std::string &pathId, float pathParameter,
-                          truss_attachment_paths::Provenance provenance,
-                          float confidence) {
+      auto considerFallback = [&](const std::array<float, 3> &closest) {
         const std::array<float, 3> delta = Subtract(closest, insertion);
         const float distance = WeightedLength(delta, settings.axisWeights);
         if (distance > settings.thresholdMm || distance >= bestDistance)
@@ -851,23 +906,15 @@ std::optional<SnapResult> FindSnap(const MvrScene &scene,
         result.targetType = ObjectType::Truss;
         result.translationDeltaMm = delta;
         result.needsGrouping = true;
-        result.targetAttachmentPathId = pathId;
-        result.targetAttachmentPathParameter = pathParameter;
-        result.targetAttachmentProvenance = provenance;
-        result.targetAttachmentConfidence = confidence;
+        result.targetAttachmentProvenance =
+            truss_attachment_paths::Provenance::ApproximateBoundsFallback;
         best = result;
       };
-      for (const auto &path : resolution.paths) {
-        const auto point = truss_attachment_paths::ClosestPointOnPath(
-            path, insertion, true);
-        if (point)
-          consider(point->pointMm, path.stableId, point->pathParameter,
-                   path.provenance, path.diagnostics.confidence);
-      }
+      for (const auto &path : resolution.paths)
+        ConsiderFixturePath(source, uuid, path, insertion, settings,
+                            bestCandidateRank, bestDistance, best);
       if (resolution.paths.empty())
-        consider(ClosestPointOnSurface(targetBounds, insertion), {}, 0.0f,
-                 truss_attachment_paths::Provenance::ApproximateBoundsFallback,
-                 0.0f);
+        considerFallback(ClosestPointOnSurface(targetBounds, insertion));
     }
     return best;
   }

--- a/core/magnet_snap.h
+++ b/core/magnet_snap.h
@@ -34,6 +34,9 @@ struct SnapSettings {
   std::optional<truss_screen_snap::ProjectionSnapshot> trussProjection;
   double trussScreenApertureLogicalPx =
       truss_screen_snap::kDefaultTrussScreenSnapApertureLogicalPx;
+  std::optional<truss_screen_snap::ProjectionSnapshot> fixturePathProjection;
+  double fixturePathScreenApertureLogicalPx =
+      truss_screen_snap::kDefaultFixturePathScreenSnapApertureLogicalPx;
 };
 
 struct SnapResult {

--- a/core/truss_screen_snap.cpp
+++ b/core/truss_screen_snap.cpp
@@ -1,5 +1,6 @@
 #include "truss_screen_snap.h"
 
+#include <algorithm>
 #include <cmath>
 
 namespace truss_screen_snap {
@@ -43,7 +44,94 @@ Project(const ProjectionSnapshot &snapshot,
           snapshot.contentScale,
       (snapshot.viewport[1] + (y + 1.0) * snapshot.viewport[3] * 0.5) /
           snapshot.contentScale,
-      eye[2]};
+      eye[2], clip[3]};
+}
+
+// Finds the screen-nearest point and reconstructs its perspective-correct world
+// position.
+std::optional<ProjectedPolylinePoint> ClosestPointOnProjectedPolyline(
+    const ProjectionSnapshot &snapshot,
+    const std::vector<std::array<float, 3>> &worldPointsMm,
+    const std::array<float, 3> &queryWorldPointMm) {
+  if (worldPointsMm.size() < 2)
+    return std::nullopt;
+  const auto query = Project(snapshot, queryWorldPointMm);
+  if (!query)
+    return std::nullopt;
+
+  std::vector<double> segmentLengths;
+  double totalLength = 0.0;
+  for (std::size_t index = 1; index < worldPointsMm.size(); ++index) {
+    double squaredLength = 0.0;
+    for (int axis = 0; axis < 3; ++axis) {
+      const double delta =
+          worldPointsMm[index][axis] - worldPointsMm[index - 1][axis];
+      squaredLength += delta * delta;
+    }
+    segmentLengths.push_back(std::sqrt(squaredLength));
+    totalLength += segmentLengths.back();
+  }
+
+  std::optional<ProjectedPolylinePoint> best;
+  double precedingLength = 0.0;
+  for (std::size_t index = 1; index < worldPointsMm.size(); ++index) {
+    const auto start = Project(snapshot, worldPointsMm[index - 1]);
+    const auto end = Project(snapshot, worldPointsMm[index]);
+    if (!start || !end) {
+      precedingLength += segmentLengths[index - 1];
+      continue;
+    }
+    const double dx = end->logicalX - start->logicalX;
+    const double dy = end->logicalY - start->logicalY;
+    const double lengthSquared = dx * dx + dy * dy;
+    const double screenParameter =
+        lengthSquared > 1e-12
+            ? std::clamp(((query->logicalX - start->logicalX) * dx +
+                          (query->logicalY - start->logicalY) * dy) /
+                             lengthSquared,
+                         0.0, 1.0)
+            : 0.0;
+    const double denominator =
+        (1.0 - screenParameter) * end->clipW + screenParameter * start->clipW;
+    if (std::fabs(denominator) <= 1e-12) {
+      precedingLength += segmentLengths[index - 1];
+      continue;
+    }
+    const double worldParameter = screenParameter * start->clipW / denominator;
+    std::array<float, 3> worldPoint{};
+    double worldDistanceSquared = 0.0;
+    for (int axis = 0; axis < 3; ++axis) {
+      worldPoint[axis] = static_cast<float>(
+          worldPointsMm[index - 1][axis] +
+          (worldPointsMm[index][axis] - worldPointsMm[index - 1][axis]) *
+              worldParameter);
+      const double delta = worldPoint[axis] - queryWorldPointMm[axis];
+      worldDistanceSquared += delta * delta;
+    }
+    const double nearestX = start->logicalX + dx * screenParameter;
+    const double nearestY = start->logicalY + dy * screenParameter;
+    const double screenDistance =
+        std::hypot(nearestX - query->logicalX, nearestY - query->logicalY);
+    const auto projectedWorldPoint = Project(snapshot, worldPoint);
+    if (!projectedWorldPoint) {
+      precedingLength += segmentLengths[index - 1];
+      continue;
+    }
+    ProjectedPolylinePoint candidate{
+        worldPoint,
+        totalLength > 1e-12
+            ? static_cast<float>((precedingLength +
+                                  worldParameter * segmentLengths[index - 1]) /
+                                 totalLength)
+            : 0.0f,
+        screenDistance, std::fabs(projectedWorldPoint->depth - query->depth),
+        std::sqrt(worldDistanceSquared)};
+    if (!best ||
+        candidate.screenDistanceLogicalPx < best->screenDistanceLogicalPx)
+      best = candidate;
+    precedingLength += segmentLengths[index - 1];
+  }
+  return best;
 }
 
 } // namespace truss_screen_snap

--- a/core/truss_screen_snap.h
+++ b/core/truss_screen_snap.h
@@ -2,10 +2,12 @@
 
 #include <array>
 #include <optional>
+#include <vector>
 
 namespace truss_screen_snap {
 
 constexpr double kDefaultTrussScreenSnapApertureLogicalPx = 16.0;
+constexpr double kDefaultFixturePathScreenSnapApertureLogicalPx = 16.0;
 
 struct ProjectionSnapshot {
   std::array<double, 16> modelView{};
@@ -18,10 +20,26 @@ struct ProjectedPoint {
   double logicalX = 0.0;
   double logicalY = 0.0;
   double depth = 0.0;
+  double clipW = 1.0;
+};
+
+struct ProjectedPolylinePoint {
+  std::array<float, 3> worldPointMm{};
+  float pathParameter = 0.0f;
+  double screenDistanceLogicalPx = 0.0;
+  double depthDifference = 0.0;
+  double worldDistanceMm = 0.0;
 };
 
 // Projects a scene-millimetre point using an immutable OpenGL-style snapshot.
 std::optional<ProjectedPoint> Project(const ProjectionSnapshot &snapshot,
                                       const std::array<float, 3> &worldPointMm);
+
+// Finds the screen-nearest point and reconstructs its perspective-correct world
+// position.
+std::optional<ProjectedPolylinePoint> ClosestPointOnProjectedPolyline(
+    const ProjectionSnapshot &snapshot,
+    const std::vector<std::array<float, 3>> &worldPointsMm,
+    const std::array<float, 3> &queryWorldPointMm);
 
 } // namespace truss_screen_snap

--- a/docs/developer/truss_fixture_attachment_paths.md
+++ b/docs/developer/truss_fixture_attachment_paths.md
@@ -71,9 +71,19 @@ Fixture snapping uses reliable paths first and records the selected runtime path
 parameter, provenance, and confidence in transient `SnapResult` state. If no
 analyzable geometry or stable chord is available, the previous oriented-bounds
 surface calculation remains as an explicitly low-confidence
-`ApproximateBoundsFallback`. Fixture overlays project every point and draw continuous segments from the same
-resolved polylines; they do not expose truss connector Magnets. Truss and truss-group overlays
-continue to show the independent discrete connector candidates.
+`ApproximateBoundsFallback`. In the 3D viewer, continuous fixture paths are
+acquired within a 16-logical-pixel screen aperture. Camera-depth separation does
+not reject a visible path; depth and full world distance are deterministic
+tie-breakers after screen distance. Perspective-correct reconstruction resolves
+the selected screen position back onto the actual runtime polyline, so the
+committed result remains a complete 3D translation and retains its continuous
+path parameter. Calls without a fixture projection retain the existing
+world-space behavior, including the 2D viewers and headless callers.
+
+Fixture overlays project every point and draw continuous segments from the same
+resolved polylines; they do not expose truss connector Magnets. Truss and
+truss-group overlays continue to show the independent discrete connector
+candidates, whose acquisition and ranking are unchanged.
 
 The detector currently supports straight trusses with a clearly dominant axis.
 Curved, circular, corner, unusually sparse, and heavily occluded geometry will

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -44,6 +44,10 @@ Changes since **v1.5.0**.
 
 ## Fixes
 
+- Fixture placement in the 3D viewer now acquires visible truss attachment
+  paths within a small screen-space aperture regardless of camera-depth
+  separation, while still committing fixtures onto the actual 3D path.
+
 - Create-from-text fixture-resolution checks now use the repository's portable
   test launchers consistently across Debug CI platforms.
 

--- a/tests/truss_screen_snap_test.cpp
+++ b/tests/truss_screen_snap_test.cpp
@@ -40,5 +40,36 @@ int main() {
   assert(truss_screen_snap::Project(perspective, {100, 0, 500}));
   assert(!truss_screen_snap::Project(perspective, {100, 0, -500}));
   assert(!truss_screen_snap::Project(Snapshot(1.0), {2000, 0, 0}));
+
+  const auto depthIndependent =
+      truss_screen_snap::ClosestPointOnProjectedPolyline(
+          Snapshot(1.0), {{-500.0f, 0.0f, 800.0f}, {500.0f, 0.0f, 800.0f}},
+          {0.0f, 20.0f, -800.0f});
+  assert(depthIndependent);
+  assert(std::fabs(depthIndependent->screenDistanceLogicalPx - 10.0) < 0.001);
+  assert(std::fabs(depthIndependent->worldPointMm[2] - 800.0f) < 0.001f);
+  assert(std::fabs(depthIndependent->pathParameter - 0.5f) < 0.001f);
+  assert(depthIndependent->worldDistanceMm > 1500.0);
+
+  const auto outsideAperture =
+      truss_screen_snap::ClosestPointOnProjectedPolyline(
+          Snapshot(1.0), {{-500.0f, 0.0f, 800.0f}, {500.0f, 0.0f, 800.0f}},
+          {0.0f, 40.0f, -800.0f});
+  assert(outsideAperture);
+  assert(outsideAperture->screenDistanceLogicalPx >
+         truss_screen_snap::kDefaultFixturePathScreenSnapApertureLogicalPx);
+
+  auto perspectivePolyline = Snapshot(1.0);
+  perspectivePolyline.projection = {1, 0, 0, 0, 0, 1, 0, 0,
+                                    0, 0, 1, 1, 0, 0, 0, 0};
+  const auto perspectiveClosest =
+      truss_screen_snap::ClosestPointOnProjectedPolyline(
+          perspectivePolyline,
+          {{-200.0f, 0.0f, 400.0f}, {800.0f, 0.0f, 800.0f}},
+          {0.0f, 20.0f, 500.0f});
+  assert(perspectiveClosest);
+  assert(std::fabs(perspectiveClosest->worldPointMm[0]) < 0.01f);
+  assert(std::fabs(perspectiveClosest->worldPointMm[2] - 480.0f) < 0.01f);
+  assert(std::fabs(perspectiveClosest->pathParameter - 0.2f) < 0.001f);
   return 0;
 }

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -3202,7 +3202,8 @@ magnet_snap::SnapSettings Viewer3DPanel::BuildActiveMagnetSettings(
     for (int axis = 0; axis < 3; ++axis)
     settings.axisWeights[axis] =
         std::max(kMinimumViewAxisWeight, 1.0f - std::fabs(forward[axis]));
-    if (source.type == magnet_snap::ObjectType::Truss ||
+    if (source.type == magnet_snap::ObjectType::Fixture ||
+        source.type == magnet_snap::ObjectType::Truss ||
         source.type == magnet_snap::ObjectType::TrussGroup) {
         truss_screen_snap::ProjectionSnapshot snapshot;
         GLdouble modelView[16] = {};
@@ -3219,7 +3220,10 @@ magnet_snap::SnapSettings Viewer3DPanel::BuildActiveMagnetSettings(
                   snapshot.viewport.begin());
         snapshot.contentScale =
             std::max(1.0, static_cast<double>(GetContentScaleFactor()));
-        settings.trussProjection = snapshot;
+        if (source.type == magnet_snap::ObjectType::Fixture)
+            settings.fixturePathProjection = snapshot;
+        else
+            settings.trussProjection = snapshot;
     }
     return settings;
 }

--- a/viewer_common/magnet_anchor_overlay.cpp
+++ b/viewer_common/magnet_anchor_overlay.cpp
@@ -79,7 +79,8 @@ void DrawFixtureAttachmentPathOverlay(
   glPushMatrix();
   glLoadIdentity();
   glColor3f(1.0f, 0.1f, 0.1f);
-  glLineWidth(3.0f);
+  constexpr float kFixtureAttachmentPathLineWidth = 2.0f;
+  glLineWidth(kFixtureAttachmentPathLineWidth);
   for (const auto &path : paths) {
     glBegin(GL_LINE_STRIP);
     for (const auto &point : path.points)


### PR DESCRIPTION
### Motivation

- Users reported fixture insertion failing to snap when the insertion point visually passed a red continuous truss attachment path because camera depth blocked acquisition; the existing implementation selected the world-space closest point and applied view-weighted axis thresholds.  
- The change must be a small, localized UX improvement limited to FixtureToTruss continuous attachment-path snapping and must preserve truss-to-truss Magnet semantics and existing world-space fallback behavior.  

### Description

- Added a GUI-independent projected-polyline helper `ClosestPointOnProjectedPolyline` in `core/truss_screen_snap.{h,cpp}` that finds the nearest screen-space point on a projected path and reconstructs the perspective-correct world point using clip-space `w` (so the final committed translation is an actual 3D delta).  
- Plumbed a fixture-specific projection and aperture through `magnet_snap::SnapSettings` (`fixturePathProjection`, `fixturePathScreenApertureLogicalPx`) and set `fixturePathProjection` in `Viewer3DPanel::BuildActiveMagnetSettings()` only for fixture sources so truss-to-truss behavior is unchanged.  
- Implemented `ConsiderFixturePath(...)` in `core/magnet_snap.cpp` to prefer screen-distance acquisition when a fixture projection snapshot is present and to fall back to the existing world-space `ClosestPointOnPath` behavior when not. Ranking uses screen distance as primary and depth/world distance as deterministic tie-breakers; all `SnapResult` metadata (path id, parameter, provenance, confidence, translation, grouping) is preserved.  
- Kept the core boundary: projection math and polyline acquisition live in `core/truss_screen_snap` (no new `core -> viewer_common` dependency).  
- Made only the red continuous fixture attachment overlay slightly thinner by changing the line width from `3.0f` to a named `2.0f` constant in `viewer_common/magnet_anchor_overlay.cpp`.  
- Updated documentation in `docs/developer/truss_fixture_attachment_paths.md` to describe the new 3D acquisition semantics and added a short release-note entry in `docs/release-notes-draft.md`.  

### Testing

- Ran the projection unit test linked to the new helper by compiling and running the focused test: `g++ -std=c++20 -Wall -Wextra -pedantic tests/truss_screen_snap_test.cpp core/truss_screen_snap.cpp -Icore -o /tmp/truss_screen_snap_test && /tmp/truss_screen_snap_test`; the test passed the new depth-independent and perspective checks.  
- Executed repository checks required by `AGENTS.md`: `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both reported OK.  
- Ran `git diff --check` (no whitespace or check errors).  
- Attempted full CMake configure/build for the larger test binaries but the environment lacked system `wxWidgets` headers/libraries, so `cmake` configuration failed and the full `magnet_snap` and `truss_attachment_paths` test executables were not built in this run; their expectations were not altered.  

If you want, I can (1) add an additional pure-math unit test for the perspective-to-world reconstruction helper, (2) run the full test suite in an environment with `wxWidgets` available, or (3) prepare a minimal reviewer checklist showing the exact lines changed for quick code review.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8f117f2a708324b5c1d8a124191bc5)