### PR TITLE
Restore EFFECTS equipment parsing and historical Smoke placement

### DIFF
--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -1317,8 +1317,16 @@ ParsedRiderImport ParseRiderImport(const std::string &text) {
       continue;
     }
     const rider_text::Section section = rider_text::ClassifySectionHeader(line);
-    if (section == rider_text::Section::Effects ||
-        section == rider_text::Section::LightingControl ||
+    if (section == rider_text::Section::Effects) {
+      seenSectionHeader = true;
+      inFixtures = true;
+      inRigging = false;
+      inControl = false;
+      currentHang = "FLOOR";
+      havePending = false;
+      continue;
+    }
+    if (section == rider_text::Section::LightingControl ||
         section == rider_text::Section::Video ||
         section == rider_text::Section::Ignored) {
       seenSectionHeader = true;
@@ -2242,8 +2250,16 @@ bool RiderImporter::ImportText(const std::string &text,
       continue;
     }
     const rider_text::Section section = rider_text::ClassifySectionHeader(line);
-    if (section == rider_text::Section::Effects ||
-        section == rider_text::Section::LightingControl ||
+    if (section == rider_text::Section::Effects) {
+      seenSectionHeader = true;
+      inFixtures = true;
+      inRigging = false;
+      inControl = false;
+      currentHang = "FLOOR";
+      havePending = false;
+      continue;
+    }
+    if (section == rider_text::Section::LightingControl ||
         section == rider_text::Section::Video ||
         section == rider_text::Section::Ignored) {
       seenSectionHeader = true;

--- a/docs/developer/text_to_scene_rules.md
+++ b/docs/developer/text_to_scene_rules.md
@@ -206,9 +206,10 @@ as `iluminar`, `control`, `video`, or `audio`.
 
 - `ILUMINACION` / `LIGHTING` and `APARATOS` / `FIXTURES` enter fixture mode.
 - `RIGGING` and `RIGGING Y ESTRUCTURAS` enter rigging mode.
-- `EFECTOS` / `EFFECTS` is an ignored equipment-category boundary, not a
-  physical position. An effect explicitly listed under `FLOOR` or another
-  physical hang remains importable.
+- `EFECTOS` / `EFFECTS` enters fixture mode with the canonical physical
+  position `FLOOR`. Equipment in this section follows the normal dictionary,
+  GDTF, and category resolution pipeline; the section does not assign the
+  `Smoke` category.
 - `CONTROL DE ILUMINACION` / `LIGHTING CONTROL` stops fixture collection.
 - `VIDEO` establishes video context without itself selecting a physical hang;
   a following screen heading selects `SCREEN` and enables screen collection.
@@ -245,7 +246,8 @@ Behavior:
   alias (`CALLES` -> `LX SIDES`).
 - Front, middle, and rear semantic headings normalize to `LX1`, `LX2`, and
   `LX3`; an explicit `LX<number>` always takes precedence.
-- Physical floor aliases are normalized to `FLOOR`; `EFFECTS` is not a hang.
+- Physical floor aliases are normalized to `FLOOR`; `EFFECTS` selects that
+  placement context without becoming a position name itself.
 - Side-position aliases are normalized to the canonical value `LX SIDES`.
 - Explicit normalized headers such as `LX SIDES` are accepted as hang labels
   in both filtered text and direct import input.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -4,6 +4,11 @@ Changes since **v1.5.0**.
 
 ## Highlights
 
+- Create from text once again imports equipment listed below `EFECTOS` or
+  `EFFECTS` on the floor, including the established mirrored floor placement
+  for haze, smoke, fog, and fan fixtures while leaving other effects in their
+  normally resolved categories.
+
 - Create from text now stops before scene creation when a rider contains unknown
   fixture types, presents a resolution table with cached GDTF Share suggestions,
   explicit mode selection and Generic fallback, and remembers confirmed GDTF

--- a/docs/user/create-from-text.md
+++ b/docs/user/create-from-text.md
@@ -88,6 +88,8 @@ Current parser behavior includes:
 - Quantity + type fixture lines (for example, `12 Spot`)
 - Compound lines split by `+` (for example, `8 Wash + 4 Beam`)
 - Hang/position detection (`LX1`, `LX2`, `FLOOR`, `SIDES`, `SCREEN`, `BACKDROP`)
+- `EFECTOS` / `EFFECTS` equipment imported on `FLOOR`, with atmospheric
+  fixtures retaining the existing mirrored, floor-level Smoke placement
 - Truss/pipe parsing with optional hang target
 - Hoist/motor extraction from rigging lines
 - Optional coordinate and margin hints in rigging targets

--- a/tests/rider_filter_preview_test.cpp
+++ b/tests/rider_filter_preview_test.cpp
@@ -73,6 +73,8 @@ int main() {
       "\n"
       "FLOOR\n"
       "4 LITELEE B-EYE L10R\n"
+      "4 TOUR HAZER II\n"
+      "4 TURBINA\n"
       "2 LED BAR\n"
       "\n"
       "RIGGING\n"
@@ -97,7 +99,7 @@ int main() {
 
   const auto rawRequests = RiderImporter::AnalyzeFixtureTypes(input);
   const auto filteredRequests = RiderImporter::AnalyzeFixtureTypes(preview);
-  assert(rawRequests.size() == 4);
+  assert(rawRequests.size() == 6);
   assert(filteredRequests.size() == rawRequests.size());
   for (size_t i = 0; i < rawRequests.size(); ++i) {
     assert(rawRequests[i].typeName == filteredRequests[i].typeName);
@@ -278,7 +280,7 @@ int main() {
   const std::string spanishExpected =
       "LX1\n8 BLINDER\n\nLX2\n6 WASH\n\nLX3\n8 PROFILE\n\n"
       "LX SIDES\n8 LED BAR\n\nFLOOR\n4 BEAM\n1 FOLLOWSPOT\n1 OPERADOR\n"
-      "4 PAR LED PARA ILUMINAR ESCALERA\n\n"
+      "4 PAR LED PARA ILUMINAR ESCALERA\n2 HAZER\n2 TURBINA\n\n"
       "SCREEN\n1 PANTALLA LED 10X5m 1664x832 PIXELS\n\nRIGGING\n"
       "4 MOTOR 2000Kg FOR P.A.\n2 MOTOR 500Kg FOR LX1\n"
       "2 MOTOR 500Kg FOR LX2\n2 MOTOR 500Kg FOR LX3\n"
@@ -298,7 +300,7 @@ int main() {
       "1 LED WALL 10 x 5 m\n";
   const std::string englishExpected =
       "LX1\n8 BLINDER\n\nLX2\n6 WASH\n\nLX3\n8 PROFILE\n\n"
-      "LX SIDES\n8 LED BAR\n\nFLOOR\n4 BEAM\n\n"
+      "LX SIDES\n8 LED BAR\n\nFLOOR\n4 BEAM\n2 HAZER\n\n"
       "SCREEN\n1 LED WALL 10 x 5 m";
   assert(RiderImporter::BuildFixtureFilterPreview(englishRegression) ==
          englishExpected);

--- a/tests/rider_import_category_test.cpp
+++ b/tests/rider_import_category_test.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <cassert>
 #include <cmath>
 #include <string>
@@ -91,6 +92,71 @@ int main() {
          kTolerance);
   assert(std::fabs(strobes.front()->transform.o[2] - (bottomZ + 200.0f)) <
          kTolerance);
+
+  cfg.Reset();
+  const std::string effectsRider =
+      "ILUMINACION\n"
+      "LX1\n"
+      "1 TRUSS GENERIC 10m LX1\n"
+      "EFECTOS\n"
+      "4 TOUR HAZER II + TURBINA\n"
+      "4 MAQUINA DE HUMO VERTICAL ANTARI M9\n"
+      "2 SPARKULAR\n"
+      "CONTROL DE ILUMINACION\n"
+      "1 GRAND MA3\n";
+  assert(RiderImporter::ImportText(effectsRider));
+
+  const auto &effectsFixtures = cfg.GetScene().fixtures;
+  assert(effectsFixtures.size() == 14);
+  int tourHazerCount = 0;
+  int turbineCount = 0;
+  int smokeMachineCount = 0;
+  int sparkularCount = 0;
+  std::vector<float> leftSmokeY;
+  std::vector<float> rightSmokeY;
+  for (const auto &[uuid, fixture] : effectsFixtures) {
+    (void)uuid;
+    assert(fixture.positionName == "FLOOR");
+    if (fixture.typeName == "SPARKULAR") {
+      ++sparkularCount;
+      assert(fixture.category != GdtfFixtureCategory::kSmoke);
+      assert(std::fabs(fixture.transform.o[0]) < 1000.0f);
+      continue;
+    }
+
+    assert(fixture.category == GdtfFixtureCategory::kSmoke);
+    assert(std::fabs(fixture.transform.o[2]) < kTolerance);
+    if (fixture.typeName == "TOUR HAZER II")
+      ++tourHazerCount;
+    else if (fixture.typeName == "TURBINA")
+      ++turbineCount;
+    else if (fixture.typeName == "MAQUINA DE HUMO VERTICAL ANTARI M9")
+      ++smokeMachineCount;
+    else
+      assert(false && "Unexpected EFFECTS fixture type");
+
+    if (fixture.transform.o[0] < 0.0f) {
+      assert(std::fabs(fixture.transform.o[0] + 4500.0f) < kTolerance);
+      leftSmokeY.push_back(fixture.transform.o[1]);
+    } else {
+      assert(std::fabs(fixture.transform.o[0] - 4500.0f) < kTolerance);
+      rightSmokeY.push_back(fixture.transform.o[1]);
+    }
+  }
+  assert(tourHazerCount == 4);
+  assert(turbineCount == 4);
+  assert(smokeMachineCount == 4);
+  assert(sparkularCount == 2);
+  assert(leftSmokeY.size() == 6);
+  assert(rightSmokeY.size() == 6);
+  for (std::vector<float> *sideY : {&leftSmokeY, &rightSmokeY}) {
+    std::sort(sideY->begin(), sideY->end());
+    for (size_t index = 0; index < sideY->size(); ++index) {
+      assert(std::fabs((*sideY)[index] -
+                       (1000.0f + static_cast<float>(index) * 500.0f)) <
+             kTolerance);
+    }
+  }
 
   return 0;
 }


### PR DESCRIPTION
### Motivation
- Fix a regression that prevented equipment listed under `EFECTOS`/`EFFECTS` from entering the normal fixture import pipeline and from reaching the historical Smoke placement logic.
- Preserve the existing dictionary/GDTF/category resolution and the historical Smoke side-floor placement algorithm instead of reimplementing placement behavior.
- Ensure EFFECTS remains a semantic FLOOR context (not a Smoke category) so non-Smoke effects keep their original placement behavior.

### Description
- Reconnected the text parser and importer so `EFECTOS`/`EFFECTS` sets the active hang to `FLOOR` during analysis and import, by setting `currentHang = "FLOOR"` when `rider_text::Section::Effects` is encountered in parse and import loops in `core/riderimporter.cpp`.
- Left downstream Smoke classification and placement code unchanged so fixtures resolve normally via the dictionary/GDTF pipeline and Smoke fixtures continue to use the existing side-floor mirrored placement implementation.
- Extended and adjusted unit/regression tests: updated `tests/rider_filter_preview_test.cpp` to include EFFECTS fixtures in the filtered preview and added a focused scene-transform regression in `tests/rider_import_category_test.cpp` that asserts EFFECTS fixtures are created on `FLOOR`, that Smoke fixtures have `transform.o[2] == 0`, that Smoke fixtures are split left/right with historical anchors/fallback spacing, and that non-Smoke effects are unaffected.
- Updated documentation to reflect restored semantics: `docs/developer/text_to_scene_rules.md`, `docs/user/create-from-text.md`, and added a release-note entry in `docs/release-notes-draft.md` describing the restored behavior.

### Testing
- Ran repository checks: `tests/check_perastage_tree_modules.sh` (passed) and `tests/check_no_configmanager_get_in_gui.sh` (passed).
- Ran `git diff --check` (no problems reported).
- Attempted a focused CMake configure/build with `cmake --preset wsl-x64-debug -DPERASTAGE_ENABLE_MVR_XCHANGE_MDNS=OFF`; configuration failed in this environment because the container lacks wxWidgets development libraries, so the C++ test binaries could not be built here.
- Added/updated automated tests (`tests/rider_filter_preview_test.cpp`, `tests/rider_import_category_test.cpp`) to cover EFFECTS→FLOOR parsing and Smoke placement; these tests are included in the tree and should pass when built in a developer environment with the project's build dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9128166bd48324a537de67ebe1880a)