### PR TITLE
Restore macOS 15 rider resolver thread compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ option(PERASTAGE_ENABLE_MVR_XCHANGE_MDNS "Enable MVR-xchange mDNS discovery usin
 option(PERASTAGE_ENABLE_LOCALIZATION "Enable gettext-based UI localization catalogs" ON)
 option(PERASTAGE_REQUIRE_SECURE_CREDENTIAL_STORE "Require wxSecretStore support in the wxWidgets build" OFF)
 option(PERASTAGE_MACOS15_LEGACY_THREAD_COMPAT
-       "Use the fixture-symbol worker fallback for the macOS 15 hosted toolchain" OFF)
+       "Use legacy worker-thread fallbacks for the macOS 15 hosted toolchain" OFF)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/docs/developer/text_to_scene_rules.md
+++ b/docs/developer/text_to_scene_rules.md
@@ -79,9 +79,11 @@ a shared semantic status palette also used by the MVR GDTF download queue.
 
 Resolver rows have immutable non-zero model keys for the dialog lifetime.
 Matching updates cells and Status attributes in place rather than deleting and
-rebuilding the active data view. The dialog owns a cancellable `std::jthread`;
+rebuilding the active data view. The dialog owns a cancellable managed worker;
 confirming or cancelling requests stop, ignores queued results, and preserves
-the finalized import plan.
+the finalized import plan. Current toolchains use `std::jthread`, while the
+dedicated macOS 15 compatibility build uses an owned, explicitly joined
+`std::thread` with equivalent cooperative cancellation.
 
 This document explains the rules currently applied by Perastage when creating a scene from rider text loaded from `.txt` or extracted from `.pdf`.
 

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -128,6 +128,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/rider_fixture_resolution_dialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/rider_fixture_resolution_model.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/rider_fixture_resolution_workflow.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/rider_fixture_resolution_worker.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ridertext_autocomplete_provider.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/riggingpanel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/sceneobjecttablepanel.cpp

--- a/gui/rider_fixture_resolution_dialog.cpp
+++ b/gui/rider_fixture_resolution_dialog.cpp
@@ -66,8 +66,7 @@ RiderFixtureResolutionDialog::RiderFixtureResolutionDialog(
 RiderFixtureResolutionDialog::~RiderFixtureResolutionDialog() {
   shuttingDown.store(true);
   RequestWorkerStop();
-  if (catalogWorker.joinable())
-    catalogWorker.join();
+  catalogWorker.Join();
 }
 
 // Returns the user-reviewed resolution model after the modal dialog succeeds.
@@ -386,9 +385,9 @@ void RiderFixtureResolutionDialog::OnDialogShown(wxShowEvent &event) {
   const CatalogLoader loader = cachedCatalogLoader;
   const auto targets = BuildCatalogMatchTargets();
   const size_t analysisItemCount = analysis.items.size();
-  catalogWorker = std::jthread(
+  catalogWorker.Start(
       [this, loader, targets,
-       analysisItemCount](std::stop_token stopToken) mutable {
+       analysisItemCount](RiderFixtureResolutionStopToken stopToken) mutable {
     auto report = [this, &stopToken](const ProgressData &progress) {
       if (stopToken.stop_requested() || shuttingDown.load())
         return;
@@ -486,15 +485,14 @@ void RiderFixtureResolutionDialog::BeginOnlineCatalogAcquisition(
 void RiderFixtureResolutionDialog::StartOnlineCatalogWorker(
     const CredentialStore::Credentials &credentials) {
   RequestWorkerStop();
-  if (catalogWorker.joinable())
-    catalogWorker.join();
+  catalogWorker.Join();
   catalogLoading = true;
   const auto targets = BuildCatalogMatchTargets();
   const size_t analysisItemCount = analysis.items.size();
   const OnlineCatalogLoader loader = onlineCatalogLoader;
-  catalogWorker = std::jthread(
+  catalogWorker.Start(
       [this, loader, credentials, targets,
-       analysisItemCount](std::stop_token stopToken) mutable {
+       analysisItemCount](RiderFixtureResolutionStopToken stopToken) mutable {
     auto report = [this, &stopToken](const ProgressData &progress) {
       if (stopToken.stop_requested() || shuttingDown.load())
         return;
@@ -706,6 +704,5 @@ void RiderFixtureResolutionDialog::OnCancel(wxCommandEvent &) {
 
 // Requests cooperative cancellation without blocking the modal UI thread.
 void RiderFixtureResolutionDialog::RequestWorkerStop() {
-  if (catalogWorker.joinable())
-    catalogWorker.request_stop();
+  catalogWorker.RequestStop();
 }

--- a/gui/rider_fixture_resolution_dialog.h
+++ b/gui/rider_fixture_resolution_dialog.h
@@ -3,12 +3,12 @@
 #include "../core/rider_fixture_resolution.h"
 #include "../core/gdtf_catalog_service.h"
 #include "../core/credentialstore.h"
+#include "rider_fixture_resolution_worker.h"
 
 #include <string>
 #include <functional>
 #include <optional>
 #include <atomic>
-#include <thread>
 
 #include <wx/dialog.h>
 
@@ -51,7 +51,7 @@ public:
   using OnlineProgressCallback =
       std::function<void(const rider_fixture_resolution::Progress &)>;
   using OnlineCatalogLoader = std::function<OnlineCatalogResult(
-      const CredentialStore::Credentials &, std::stop_token,
+      const CredentialStore::Credentials &, RiderFixtureResolutionStopToken,
       OnlineProgressCallback)>;
   using CredentialRequester = std::function<
       std::optional<CredentialStore::Credentials>(bool rejected)>;
@@ -115,7 +115,7 @@ private:
   bool acceptAutomaticResults = true;
   bool modelUpdateInProgress = false;
   std::atomic<bool> shuttingDown{false};
-  std::jthread catalogWorker;
+  RiderFixtureResolutionWorker catalogWorker;
   wxDataViewCtrl *table = nullptr;
   RiderFixtureResolutionModel *tableModel = nullptr;
   wxButton *useSuggestedButton = nullptr;

--- a/gui/rider_fixture_resolution_worker.cpp
+++ b/gui/rider_fixture_resolution_worker.cpp
@@ -1,0 +1,68 @@
+#include "rider_fixture_resolution_worker.h"
+
+#include <utility>
+
+#if defined(PERASTAGE_MACOS15_LEGACY_THREAD_COMPAT)
+// Creates a legacy cancellation view over worker-owned atomic state.
+RiderFixtureResolutionStopToken::RiderFixtureResolutionStopToken(
+    const std::atomic<bool> *stopRequested)
+    : stopRequested_(stopRequested) {}
+#else
+// Creates a cancellation view over the managed C++20 stop token.
+RiderFixtureResolutionStopToken::RiderFixtureResolutionStopToken(
+    std::stop_token stopToken)
+    : stopToken_(stopToken) {}
+#endif
+
+// Reports whether cooperative cancellation has been requested.
+bool RiderFixtureResolutionStopToken::stop_requested() const {
+#if defined(PERASTAGE_MACOS15_LEGACY_THREAD_COMPAT)
+  return stopRequested_->load();
+#else
+  return stopToken_.stop_requested();
+#endif
+}
+
+// Stops and joins active work before releasing the owned thread.
+RiderFixtureResolutionWorker::~RiderFixtureResolutionWorker() {
+  RequestStop();
+  Join();
+}
+
+// Replaces any previous task with newly owned asynchronous work.
+void RiderFixtureResolutionWorker::Start(Task task) {
+  RequestStop();
+  Join();
+#if defined(PERASTAGE_MACOS15_LEGACY_THREAD_COMPAT)
+  stopRequested_.store(false);
+  thread_ = std::thread([this, task = std::move(task)]() mutable {
+    task(RiderFixtureResolutionStopToken(&stopRequested_));
+  });
+#else
+  thread_ =
+      std::jthread([task = std::move(task)](std::stop_token stopToken) mutable {
+        task(RiderFixtureResolutionStopToken(stopToken));
+      });
+#endif
+}
+
+// Requests cooperative cancellation from the active task.
+void RiderFixtureResolutionWorker::RequestStop() {
+#if defined(PERASTAGE_MACOS15_LEGACY_THREAD_COMPAT)
+  stopRequested_.store(true);
+#else
+  if (thread_.joinable())
+    thread_.request_stop();
+#endif
+}
+
+// Waits for active work to finish without detaching it.
+void RiderFixtureResolutionWorker::Join() {
+  if (thread_.joinable())
+    thread_.join();
+}
+
+// Reports whether the worker currently owns a joinable thread.
+bool RiderFixtureResolutionWorker::Joinable() const {
+  return thread_.joinable();
+}

--- a/gui/rider_fixture_resolution_worker.h
+++ b/gui/rider_fixture_resolution_worker.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <atomic>
+#include <functional>
+#include <thread>
+
+// Exposes cooperative cancellation without requiring stop_token on legacy
+// libc++.
+class RiderFixtureResolutionStopToken {
+public:
+#if defined(PERASTAGE_MACOS15_LEGACY_THREAD_COMPAT)
+  explicit RiderFixtureResolutionStopToken(
+      const std::atomic<bool> *stopRequested);
+#else
+  explicit RiderFixtureResolutionStopToken(std::stop_token stopToken);
+#endif
+
+  bool stop_requested() const;
+
+private:
+#if defined(PERASTAGE_MACOS15_LEGACY_THREAD_COMPAT)
+  const std::atomic<bool> *stopRequested_;
+#else
+  std::stop_token stopToken_;
+#endif
+};
+
+// Owns one replaceable fixture-resolution task and always joins it on shutdown.
+class RiderFixtureResolutionWorker {
+public:
+  using Task = std::function<void(RiderFixtureResolutionStopToken)>;
+
+  RiderFixtureResolutionWorker() = default;
+  ~RiderFixtureResolutionWorker();
+
+  RiderFixtureResolutionWorker(const RiderFixtureResolutionWorker &) = delete;
+  RiderFixtureResolutionWorker &
+  operator=(const RiderFixtureResolutionWorker &) = delete;
+
+  void Start(Task task);
+  void RequestStop();
+  void Join();
+  bool Joinable() const;
+
+private:
+#if defined(PERASTAGE_MACOS15_LEGACY_THREAD_COMPAT)
+  std::atomic<bool> stopRequested_{false};
+  std::thread thread_;
+#else
+  std::jthread thread_;
+#endif
+};

--- a/gui/rider_fixture_resolution_workflow.cpp
+++ b/gui/rider_fixture_resolution_workflow.cpp
@@ -167,7 +167,7 @@ PreflightResult RunCreateFromTextPreflight(wxWindow *parent,
       wxDateTime::UNow().FormatISOCombined(' ').ToStdString();
   auto loadOnlineCatalog =
       [&](const CredentialStore::Credentials &onlineCredentials,
-          std::stop_token stopToken,
+          RiderFixtureResolutionStopToken stopToken,
           RiderFixtureResolutionDialog::OnlineProgressCallback report)
       -> RiderFixtureResolutionDialog::OnlineCatalogResult {
     using OnlineStatus = RiderFixtureResolutionDialog::OnlineCatalogStatus;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2436,6 +2436,23 @@ foreach(worker_backend normal compatibility)
              COMMAND ${test_target})
 endforeach()
 
+set(RIDER_FIXTURE_RESOLUTION_WORKER_TEST_SOURCES
+    rider_fixture_resolution_worker_test.cpp
+    ../gui/rider_fixture_resolution_worker.cpp)
+
+foreach(worker_backend normal compatibility)
+    set(test_target rider_fixture_resolution_worker_${worker_backend}_test)
+    add_executable(${test_target}
+                   ${RIDER_FIXTURE_RESOLUTION_WORKER_TEST_SOURCES})
+    target_include_directories(${test_target} PRIVATE ../gui)
+    if(worker_backend STREQUAL "compatibility")
+        target_compile_definitions(${test_target} PRIVATE
+            PERASTAGE_MACOS15_LEGACY_THREAD_COMPAT=1)
+    endif()
+    add_test(NAME RiderFixtureResolutionWorker.${worker_backend}
+             COMMAND ${test_target})
+endforeach()
+
 add_executable(fixture_symbol_svg_cache_test
                fixture_symbol_svg_cache_test.cpp
                ../core/symbols/fixture_symbol_svg_cache.cpp

--- a/tests/check_rider_fixture_preflight_wiring.sh
+++ b/tests/check_rider_fixture_preflight_wiring.sh
@@ -12,6 +12,10 @@ root = Path(sys.argv[1])
 io_source = (root / "gui/mainwindow_io.cpp").read_text(encoding="utf-8")
 workflow = (root / "gui/rider_fixture_resolution_workflow.cpp").read_text(encoding="utf-8")
 dialog = (root / "gui/rider_fixture_resolution_dialog.cpp").read_text(encoding="utf-8")
+dialog_header = (root / "gui/rider_fixture_resolution_dialog.h").read_text(encoding="utf-8")
+worker = (root / "gui/rider_fixture_resolution_worker.cpp").read_text(encoding="utf-8")
+worker_header = (root / "gui/rider_fixture_resolution_worker.h").read_text(encoding="utf-8")
+macos15_workflow = (root / ".github/workflows/macos-15-manual-installer.yml").read_text(encoding="utf-8")
 gui_cmake = (root / "gui/CMakeLists.txt").read_text(encoding="utf-8")
 
 preflight = io_source.find("RunCreateFromTextPreflight")
@@ -43,8 +47,24 @@ if online_loader_start < 0 or credential_request_start < 0:
 automatic_online_path = workflow[online_loader_start:credential_request_start]
 if "WaitForNetworkTask" in automatic_online_path or "wxProgressDialog" in automatic_online_path:
     raise SystemExit("Automatic resolver catalog acquisition must not open nested progress dialogs")
-if "std::stop_token" not in automatic_online_path:
-    raise SystemExit("Automatic resolver catalog acquisition must support owned cancellation")
+if "stopToken.stop_requested()" not in automatic_online_path:
+    raise SystemExit("Automatic resolver catalog acquisition must remain cooperatively cancellable")
+if "RiderFixtureResolutionStopToken" not in dialog_header:
+    raise SystemExit("Online acquisition must use the resolver cancellation boundary")
+if "RiderFixtureResolutionWorker catalogWorker" not in dialog_header:
+    raise SystemExit("The resolver dialog must own its catalog worker")
+for token in ("RequestWorkerStop();", "catalogWorker.Join();"):
+    if token not in dialog:
+        raise SystemExit(f"Resolver shutdown/replacement must retain {token}")
+for token in ("std::jthread", "std::stop_token"):
+    if token not in worker + worker_header:
+        raise SystemExit(f"Normal resolver backend must retain managed {token}")
+if "PERASTAGE_MACOS15_LEGACY_THREAD_COMPAT" not in worker + worker_header:
+    raise SystemExit("Resolver worker must provide the explicit compatibility backend")
+if "std::thread" not in worker + worker_header or "std::atomic<bool>" not in worker_header:
+    raise SystemExit("Compatibility backend must own a thread-safe cancellable worker")
+if "PERASTAGE_MACOS15_LEGACY_THREAD_COMPAT=ON" not in macos15_workflow:
+    raise SystemExit("Dedicated macOS 15 workflow must explicitly select compatibility")
 if "Acquiring the shared GDTF catalog" in dialog:
     raise SystemExit("Resolver must not retain the obsolete non-terminal acquisition label")
 if "RefreshCatalogCompletionStatus" not in dialog:

--- a/tests/rider_fixture_resolution_worker_test.cpp
+++ b/tests/rider_fixture_resolution_worker_test.cpp
@@ -1,0 +1,89 @@
+#include "rider_fixture_resolution_worker.h"
+
+#include <atomic>
+#include <cassert>
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+
+using namespace std::chrono_literals;
+
+// Waits until a worker task confirms that it has started.
+static void WaitForStart(std::mutex &mutex, std::condition_variable &condition,
+                         bool &started) {
+  std::unique_lock<std::mutex> lock(mutex);
+  assert(condition.wait_for(lock, 2s, [&started]() { return started; }));
+}
+
+// Verifies cancellation suppresses publication and joins the owned task.
+static void TestStopAndJoin() {
+  RiderFixtureResolutionWorker worker;
+  std::mutex mutex;
+  std::condition_variable condition;
+  bool started = false;
+  std::atomic<bool> published{false};
+  worker.Start([&](RiderFixtureResolutionStopToken stopToken) {
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      started = true;
+    }
+    condition.notify_one();
+    while (!stopToken.stop_requested())
+      std::this_thread::yield();
+    if (!stopToken.stop_requested())
+      published.store(true);
+  });
+  WaitForStart(mutex, condition, started);
+  worker.RequestStop();
+  worker.Join();
+  assert(!worker.Joinable());
+  assert(!published.load());
+}
+
+// Verifies starting replacement work safely stops and joins previous work.
+static void TestReplacement() {
+  RiderFixtureResolutionWorker worker;
+  std::atomic<bool> firstStopped{false};
+  std::atomic<bool> replacementRan{false};
+  std::mutex mutex;
+  std::condition_variable condition;
+  bool started = false;
+  worker.Start([&](RiderFixtureResolutionStopToken stopToken) {
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      started = true;
+    }
+    condition.notify_one();
+    while (!stopToken.stop_requested())
+      std::this_thread::yield();
+    firstStopped.store(true);
+  });
+  WaitForStart(mutex, condition, started);
+  worker.Start(
+      [&](RiderFixtureResolutionStopToken) { replacementRan.store(true); });
+  worker.Join();
+  assert(firstStopped.load());
+  assert(replacementRan.load());
+}
+
+// Verifies destruction requests cancellation and waits for active work.
+static void TestActiveDestruction() {
+  std::atomic<bool> stopped{false};
+  {
+    RiderFixtureResolutionWorker worker;
+    worker.Start([&](RiderFixtureResolutionStopToken stopToken) {
+      while (!stopToken.stop_requested())
+        std::this_thread::yield();
+      stopped.store(true);
+    });
+  }
+  assert(stopped.load());
+}
+
+// Runs the owned-worker contract against the selected threading backend.
+int main() {
+  TestStopAndJoin();
+  TestReplacement();
+  TestActiveDestruction();
+  return 0;
+}


### PR DESCRIPTION
### Motivation

- The regression was caused by unconditional uses of `std::jthread` and `std::stop_token` crossing the rider fixture-resolution dialog and online-catalog callback boundary, which fail to compile under the hosted macOS 15/Xcode libc++ toolchain. 
- Only the macOS 15 hosted toolchain is affected because that environment (selected by CI) lacks the modern `std::jthread` / `std::stop_token` support while current toolchains do provide it. 
- The change implements a focused compatibility fallback selected by the existing `PERASTAGE_MACOS15_LEGACY_THREAD_COMPAT` option so the dedicated macOS-15 workflow can continue to build without changing observable behavior.

### Description

- Introduced a small cancellation/worker abstraction: `RiderFixtureResolutionStopToken` and `RiderFixtureResolutionWorker` to expose the same cooperative-cancellation contract while hiding `std::jthread`/`std::stop_token` from the compatibility backend. 
- Replaced the dialog-owned `std::jthread catalogWorker` with `RiderFixtureResolutionWorker catalogWorker` and updated the online-catalog loader signature to accept `RiderFixtureResolutionStopToken`, propagating the cancellation boundary through the workflow. 
- Preserved the native managed C++20 path (`std::jthread` + `std::stop_token`) on normal toolchains and implemented an owned-`std::thread` + `std::atomic<bool>` cooperative-stop fallback when `PERASTAGE_MACOS15_LEGACY_THREAD_COMPAT` is defined. 
- Updated buildfiles and small docs/checks: added the new worker source to `gui/CMakeLists.txt`, generalized the `PERASTAGE_MACOS15_LEGACY_THREAD_COMPAT` option description in `CMakeLists.txt`, added unit tests and CMake test targets, and updated the developer text-to-scene rules and the rider-preflight wiring checker to validate the cancellation contract instead of requiring a literal `std::stop_token` string.

### Testing

- Built and ran the focused worker test locally for both backends using: `c++ -std=c++20 -pthread -Igui tests/rider_fixture_resolution_worker_test.cpp gui/rider_fixture_resolution_worker.cpp -o /tmp/rider-worker-normal` and the same command with `-DPERASTAGE_MACOS15_LEGACY_THREAD_COMPAT=1`, and both test binaries ran successfully. 
- Executed the project preflight checks `tests/check_rider_fixture_preflight_wiring.sh`, `tests/check_perastage_tree_modules.sh`, `tests/check_no_configmanager_get_in_gui.sh`, and `tests/check_fixture_symbol_preparation_architecture.sh` with `PERASTAGE_TEST_PYTHON` set and observed success for the modified checks. 
- Performed source/residual checks to ensure no unconditional `std::jthread`/`std::stop_token` references are exposed to the macOS 15 compatibility path and updated the preflight test to assert the dedicated macOS-15 workflow selects compatibility. 
- Note: full macOS 15 end-to-end packaging (CMake configure, Release build, `perastage_stage`, bundling, ad-hoc signing, deployment-target validation, DMG creation/validation and artifact upload) could not be executed in this Linux container; the dedicated workflow `.github/workflows/macos-15-manual-installer.yml` remains configured with `PERASTAGE_MACOS15_LEGACY_THREAD_COMPAT=ON` and must perform the final binary-level verification that all bundled Mach-O dependencies target macOS 15.0 or earlier.

Files changed (key items): `CMakeLists.txt`, `gui/CMakeLists.txt`, `gui/rider_fixture_resolution_worker.h`, `gui/rider_fixture_resolution_worker.cpp`, `gui/rider_fixture_resolution_dialog.h`, `gui/rider_fixture_resolution_dialog.cpp`, `gui/rider_fixture_resolution_workflow.cpp`, `tests/CMakeLists.txt`, `tests/rider_fixture_resolution_worker_test.cpp`, `tests/check_rider_fixture_preflight_wiring.sh`, and `docs/developer/text_to_scene_rules.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a913fc2b48083248957837d91189729)