### PR TITLE
ORG-001: add reproducible repository structure baseline and audit

### DIFF
--- a/docs/developer/repository_layout.md
+++ b/docs/developer/repository_layout.md
@@ -2,6 +2,13 @@
 
 This page provides a concise map of the main Perastage repository areas. For the broader high-level tree, see [perastage_tree.md](perastage_tree.md). For architectural boundaries and contribution rules, see [Architecture](architecture.md).
 
+The machine-readable ORG-001 baseline is
+[`repository_structure_baseline.json`](repository_structure_baseline.json). The
+`RepositoryStructureBaseline` policy test validates its required directories,
+root-file roles, build/development entry points, and current CMake ownership
+model. The JSON file is the authoritative categorized top-level directory list;
+this page remains its human-readable architectural counterpart.
+
 ## Top-level structure
 
 | Path | Purpose |
@@ -39,6 +46,35 @@ viewer_common/
 ```
 
 Keep this list aligned with `CMakeLists.txt` whenever a new top-level source module is introduced.
+
+The current arrangement is intentionally descriptive rather than fully
+decentralized. The root `CMakeLists.txt` creates the application target, directly
+registers `main.cpp`, generated `build_info.cpp`, and source groups from
+`models/`, `mvr/`, and `core/`. The five modules above contribute their explicit
+source lists through their own `CMakeLists.txt` files. `tests/` is added
+conditionally when testing is enabled. No recursive project-source discovery is
+used.
+
+The repository currently also contains `viewport_interaction_scope.h` at the
+root. ORG-001 records that compatibility header without deciding its future
+ownership. The baseline audit treats `main.cpp` and that header as the complete
+small set of accepted root C/C++ files and rejects any additional root source or
+header, case-insensitively by extension, with an actionable diagnostic.
+
+## Repository-root roles and development entry points
+
+Root files are grouped by structural role in the machine-readable baseline. In
+summary, `main.cpp` is the application entry point; `CMakeLists.txt` and
+`CMakePresets.json` are build entry points; `setup.sh` and `setup_windows.ps1`
+are setup/build launchers; `vcpkg.json` describes dependencies; and `VERSION`
+and the license files provide project metadata. `README.md`, `help.md`, the
+community documents, and `AGENTS.md` are documentation or repository guidance.
+
+`CMakeSettings.json` and `CppProperties.json` are recorded as committed legacy
+development configuration. Their future status is deliberately outside this
+baseline task. Repository-visible validation starts at `tests/CMakeLists.txt`
+and `.github/workflows/ci-tests.yml`; packaging entry points include
+`packaging/arch/PKGBUILD` and `packaging/windows/Perastage.iss`.
 
 ## Documentation layout
 

--- a/docs/developer/repository_structure_baseline.json
+++ b/docs/developer/repository_structure_baseline.json
@@ -1,0 +1,65 @@
+{
+  "schema_version": 1,
+  "top_level_directories": {
+    "source_modules": [
+      "core",
+      "gui",
+      "models",
+      "mvr",
+      "viewer2d",
+      "viewer3d",
+      "viewer_common"
+    ],
+    "runtime_content": ["library", "resources"],
+    "build_support": ["cmake", "scripts"],
+    "packaging": ["packaging"],
+    "quality_and_documentation": ["docs", "tests"],
+    "vendored_dependencies": ["third_party"],
+    "licenses": ["licenses"],
+    "automation_metadata": [".github"]
+  },
+  "root_file_roles": {
+    "application_entry_point": ["main.cpp"],
+    "compatibility_header": ["viewport_interaction_scope.h"],
+    "build_entry_points": ["CMakeLists.txt", "CMakePresets.json"],
+    "committed_legacy_development_configuration": [
+      "CMakeSettings.json",
+      "CppProperties.json"
+    ],
+    "setup_launchers": ["setup.sh", "setup_windows.ps1"],
+    "dependency_metadata": ["vcpkg.json"],
+    "project_metadata": ["VERSION", "LICENSE.txt", "THIRD_PARTY_LICENSES.md"],
+    "documentation_and_community": [
+      "README.md",
+      "help.md",
+      "CONTRIBUTING.md",
+      "CODE_OF_CONDUCT.md",
+      "SECURITY.md"
+    ],
+    "repository_guidance": ["AGENTS.md"]
+  },
+  "source_registration": {
+    "model": "Explicit source lists; no recursive project-source discovery.",
+    "module_cmake_directories": [
+      "core",
+      "gui",
+      "viewer2d",
+      "viewer3d",
+      "viewer_common"
+    ],
+    "root_registered_source_groups": ["models", "mvr", "core"],
+    "root_project_sources": ["main.cpp", "viewport_interaction_scope.h"],
+    "root_compiled_entry_points": ["main.cpp"],
+    "generated_sources": ["generated/build_info.cpp"],
+    "conditional_subdirectories": ["tests"]
+  },
+  "development_entry_points": {
+    "build": ["CMakeLists.txt", "CMakePresets.json", "setup.sh", "setup_windows.ps1"],
+    "tests": ["tests/CMakeLists.txt"],
+    "continuous_integration": [".github/workflows/ci-tests.yml"],
+    "packaging": [
+      "packaging/arch/PKGBUILD",
+      "packaging/windows/Perastage.iss"
+    ]
+  }
+}

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -12,6 +12,8 @@ Changes since **v1.6.0**.
 
 ## Technical and packaging changes
 
+- Added a reproducible repository-structure baseline and policy validation to protect current module and build ownership during future organization work.
+
 ## Downloads and installation
 
 Choose the package that matches your operating system:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -180,6 +180,12 @@ if(BASH_EXECUTABLE)
 endif()
 
 if(Python3_Interpreter_FOUND)
+    add_repository_policy_test(RepositoryStructureBaseline ${Python3_EXECUTABLE}
+                               ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_repository_structure_baseline.py
+                               LABELS standard-strict policy cmake)
+    add_repository_policy_test(RepositoryStructureBaselineFixtures ${Python3_EXECUTABLE}
+                               ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_repository_structure_baseline_fixtures.py
+                               LABELS standard-strict policy cmake)
     add_repository_policy_test(DocsLinks ${Python3_EXECUTABLE}
                                ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_docs_links.py)
     add_repository_policy_test(TestTargetsNoSourceRootIncludes ${Python3_EXECUTABLE}

--- a/tests/check_repository_structure_baseline.py
+++ b/tests/check_repository_structure_baseline.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Validate the recorded ORG-001 repository structure baseline."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+
+SOURCE_SUFFIXES = {".c", ".cc", ".cpp", ".cxx", ".h", ".hh", ".hpp", ".hxx"}
+
+
+def load_baseline(path: Path) -> dict:
+    """Load the JSON baseline and reject malformed top-level data."""
+    with path.open(encoding="utf-8") as stream:
+        baseline = json.load(stream)
+    if baseline.get("schema_version") != 1:
+        raise ValueError(f"unsupported schema_version in {path}")
+    return baseline
+
+
+def flatten_groups(groups: dict[str, list[str]]) -> list[str]:
+    """Flatten categorized path lists while retaining deterministic order."""
+    return [path for paths in groups.values() for path in paths]
+
+
+def audit_repository(root: Path, baseline: dict) -> list[str]:
+    """Return actionable violations of the repository structure baseline."""
+    errors: list[str] = []
+    required_directories = flatten_groups(baseline["top_level_directories"])
+    required_files = flatten_groups(baseline["root_file_roles"])
+    entry_points = flatten_groups(baseline["development_entry_points"])
+
+    for relative in required_directories:
+        if not (root / relative).is_dir():
+            errors.append(f"required top-level directory is missing: {relative}/")
+    for relative in required_files + entry_points:
+        if not (root / relative).is_file():
+            errors.append(f"required repository entry point is missing: {relative}")
+
+    allowed_root_sources = set(baseline["source_registration"]["root_project_sources"])
+    actual_root_sources = {
+        path.name
+        for path in root.iterdir()
+        if path.is_file() and path.suffix.lower() in SOURCE_SUFFIXES
+    }
+    for relative in sorted(actual_root_sources - allowed_root_sources):
+        errors.append(
+            f"unexpected root project source: {relative}; root-level C/C++ files must be "
+            "recorded architectural entry points in repository_structure_baseline.json"
+        )
+    for relative in sorted(allowed_root_sources - actual_root_sources):
+        errors.append(f"recorded root project source is missing: {relative}")
+
+    root_cmake_path = root / "CMakeLists.txt"
+    if root_cmake_path.is_file():
+        cmake = root_cmake_path.read_text(encoding="utf-8")
+        actual_subdirectories = set(re.findall(r"add_subdirectory\s*\(\s*([^\s\)]+)", cmake))
+        expected_subdirectories = set(baseline["source_registration"]["module_cmake_directories"])
+        expected_subdirectories.update(baseline["source_registration"]["conditional_subdirectories"])
+        if actual_subdirectories != expected_subdirectories:
+            errors.append(
+                "root add_subdirectory registrations differ from the baseline: "
+                f"expected {sorted(expected_subdirectories)}, found {sorted(actual_subdirectories)}"
+            )
+        for module in baseline["source_registration"]["module_cmake_directories"]:
+            module_cmake = root / module / "CMakeLists.txt"
+            if not module_cmake.is_file():
+                errors.append(f"module source-registration file is missing: {module}/CMakeLists.txt")
+            elif re.search(
+                r"file\s*\(\s*GLOB_RECURSE\b",
+                module_cmake.read_text(encoding="utf-8"),
+                re.IGNORECASE,
+            ):
+                errors.append(f"{module}/CMakeLists.txt uses forbidden recursive project-source discovery")
+        executable_match = re.search(r"add_executable\s*\(([^)]*)\)", cmake, re.DOTALL)
+        executable_sources = executable_match.group(1) if executable_match else ""
+        for entry_point in baseline["source_registration"]["root_compiled_entry_points"]:
+            if not re.search(rf"\b{re.escape(entry_point)}\b", executable_sources):
+                errors.append(f"root compiled entry point is not registered by add_executable: {entry_point}")
+        for group in baseline["source_registration"]["root_registered_source_groups"]:
+            if not re.search(rf"(^|\s){re.escape(group)}/", executable_sources):
+                errors.append(f"root source group is not registered by add_executable: {group}/")
+        if re.search(r"file\s*\(\s*GLOB_RECURSE\b", cmake, re.IGNORECASE):
+            errors.append("root CMakeLists.txt uses forbidden recursive project-source discovery")
+
+    return errors
+
+
+def main() -> int:
+    """Parse command-line paths, run the audit, and report its result."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    default_root = Path(__file__).resolve().parent.parent
+    parser.add_argument("--repo-root", type=Path, default=default_root)
+    parser.add_argument(
+        "--baseline",
+        type=Path,
+        default=default_root / "docs/developer/repository_structure_baseline.json",
+    )
+    args = parser.parse_args()
+
+    try:
+        baseline = load_baseline(args.baseline.resolve())
+        errors = audit_repository(args.repo_root.resolve(), baseline)
+    except (OSError, ValueError, KeyError, json.JSONDecodeError) as error:
+        print(f"ERROR: cannot audit repository structure: {error}", file=sys.stderr)
+        return 2
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    print("OK: repository structure matches the recorded ORG-001 baseline.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/check_repository_structure_baseline_fixtures.py
+++ b/tests/check_repository_structure_baseline_fixtures.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Exercise positive and negative fixtures for the ORG-001 structure audit."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parent.parent
+AUDIT = REPOSITORY_ROOT / "tests/check_repository_structure_baseline.py"
+BASELINE = REPOSITORY_ROOT / "docs/developer/repository_structure_baseline.json"
+
+
+class RepositoryStructureBaselineTests(unittest.TestCase):
+    """Verify current-tree success and representative baseline failures."""
+
+    def run_audit(self, root: Path) -> subprocess.CompletedProcess[str]:
+        """Run the audit against a supplied repository fixture root."""
+        return subprocess.run(
+            [sys.executable, str(AUDIT), "--repo-root", str(root), "--baseline", str(BASELINE)],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def create_fixture(self, root: Path) -> None:
+        """Create the smallest tree that satisfies the recorded baseline."""
+        baseline = json.loads(BASELINE.read_text(encoding="utf-8"))
+        for paths in baseline["top_level_directories"].values():
+            for relative in paths:
+                (root / relative).mkdir(parents=True, exist_ok=True)
+        required_files = baseline["root_file_roles"].values()
+        entry_points = baseline["development_entry_points"].values()
+        for paths in [*required_files, *entry_points]:
+            for relative in paths:
+                path = root / relative
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.touch()
+        registration = baseline["source_registration"]
+        root_groups = " ".join(f"{group}/placeholder.cpp" for group in registration["root_registered_source_groups"])
+        cmake_lines = [f"add_executable(Perastage main.cpp {root_groups})"]
+        for directory in registration["module_cmake_directories"]:
+            (root / directory / "CMakeLists.txt").touch()
+            cmake_lines.append(f"add_subdirectory({directory})")
+        for directory in registration["conditional_subdirectories"]:
+            cmake_lines.append(f"add_subdirectory({directory})")
+        (root / "CMakeLists.txt").write_text("\n".join(cmake_lines), encoding="utf-8")
+
+    def test_current_repository_passes(self) -> None:
+        """Accept the checked-in repository state."""
+        result = self.run_audit(REPOSITORY_ROOT)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_unexpected_root_source_is_rejected(self) -> None:
+        """Reject an unregistered root source without changing the working tree."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.create_fixture(root)
+            (root / "unexpected_root_helper.CPP").touch()
+            result = self.run_audit(root)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("unexpected root project source: unexpected_root_helper.CPP", result.stderr)
+
+    def test_missing_directory_is_actionable(self) -> None:
+        """Report a missing required component by its repository-relative path."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.create_fixture(root)
+            (root / "models").rmdir()
+            result = self.run_audit(root)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("required top-level directory is missing: models/", result.stderr)
+
+    def test_unlisted_non_source_root_file_is_accepted(self) -> None:
+        """Avoid turning root policy into a complete filename allowlist."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.create_fixture(root)
+            (root / "local-maintainer-note.txt").touch()
+            result = self.run_audit(root)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Establish a deterministic, machine-readable baseline of the repository layout required by ORG-001 so future reorganization work cannot silently drift the top-level structure. 
- Provide an automated, deterministic audit that integrates into the existing repository-policy/CTest infrastructure and that detects unexpected root-level C/C++ sources without relying on a complete allowlist. 
- Implement ORG-001 only and do not change application, MVR/GDTF, packaging, or UI behavior.

### Description

- Add `docs/developer/repository_structure_baseline.json`, a categorized JSON baseline that records accepted top-level directories, root-file roles, the current CMake source-registration model, and build/test/CI/packaging entry points. 
- Add a deterministic Python audit `tests/check_repository_structure_baseline.py` that validates required directories/files, enforces the baseline CMake ownership expectations, detects unexpected root-level C/C++ source/header files (case-insensitive extensions), and rejects recursive `file(GLOB_RECURSE ...)` source discovery. 
- Add regression fixtures `tests/check_repository_structure_baseline_fixtures.py` which exercise positive and negative cases (current tree passes; synthetic unregistered root source is rejected; missing module is reported; non-source root files remain allowed). 
- Wire the new audit and fixture tests into the existing policy-test helpers by registering them in `tests/CMakeLists.txt`, and update `docs/developer/repository_layout.md` and `docs/release-notes-draft.md` to document the baseline and its human-readable counterpart.

### Testing

- Executed and passed: `python3 tests/check_repository_structure_baseline.py` (OK) and `python3 tests/check_repository_structure_baseline_fixtures.py` (OK). 
- Executed and passed related repository-policy checks: `tests/check_perastage_tree_modules.sh`, `tests/check_no_configmanager_get_in_gui.sh`, `python3 tests/check_bash_test_registration.py`, `python3 tests/check_policy_working_directories.py --bash "$(command -v bash)"`, and `python3 tests/check_docs_links.py`. 
- Static validations passed: `python3 -m py_compile tests/check_repository_structure_baseline.py tests/check_repository_structure_baseline_fixtures.py`, `python3 -m json.tool docs/developer/repository_structure_baseline.json`, and `git diff --check`. 
- Local CMake configure attempt (`cmake -S . -B /tmp/perastage-org001-build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON -DPERASTAGE_REQUIRE_SECURE_CREDENTIAL_STORE=OFF`) reached dependency discovery but could not complete in this environment because wxWidgets development libraries are not available, so full CTest inventory/configure validation is left to CI where the workflow exercises the new tests; CI remains authoritative for cross-platform configure/build/CTest. 
- Scope confirmation: this change implements ORG-001 only and does not alter runtime behavior or migrate source ownership.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a97c9c1f04083249f9658065afe4c68)