### PR TITLE
ORG-002: strengthen repository structural regression guards

### DIFF
--- a/docs/developer/repository_layout.md
+++ b/docs/developer/repository_layout.md
@@ -61,6 +61,29 @@ ownership. The baseline audit treats `main.cpp` and that header as the complete
 small set of accepted root C/C++ files and rejects any additional root source or
 header, case-insensitively by extension, with an actionable diagnostic.
 
+## Structural regression guard
+
+The ORG-002 guard extends the ORG-001 audit rather than creating a parallel
+repository checker. It enumerates Git-tracked files, so ignored builds, IDE
+state, caches, and other untracked local artifacts do not affect results. It
+rejects unrecorded root C/C++ files, CMake globs that discover production source
+or header files, and machine-specific absolute paths in shared build and
+development configuration. The check uses no branch name or checkout-path
+assumption and accepts an explicit tracked-file manifest for isolated fixtures.
+
+Intentional architecture changes should update the declarative baseline and the
+corresponding focused fixtures in the same pull request. Source ownership is not
+otherwise frozen: later ORG work can move registration into module-owned CMake
+files while retaining explicit source lists.
+
+The baseline temporarily records exact file, value, and occurrence counts for
+existing `C:/vcpkg` and `C:\vcpkg` references in `CMakeLists.txt`,
+`CMakePresets.json`, `CMakeSettings.json`, `CppProperties.json`, and
+`setup_windows.ps1`. These narrow exceptions do not permit different values or
+additional occurrences. ORG-005 through ORG-011 are expected to remove the
+relevant legacy configuration and its exceptions; ORG-002 deliberately does not
+perform that cleanup.
+
 ## Repository-root roles and development entry points
 
 Root files are grouped by structural role in the machine-readable baseline. In

--- a/docs/developer/repository_layout.md
+++ b/docs/developer/repository_layout.md
@@ -66,23 +66,44 @@ header, case-insensitively by extension, with an actionable diagnostic.
 The ORG-002 guard extends the ORG-001 audit rather than creating a parallel
 repository checker. It enumerates Git-tracked files, so ignored builds, IDE
 state, caches, and other untracked local artifacts do not affect results. It
-rejects unrecorded root C/C++ files, CMake globs that discover production source
-or header files, and machine-specific absolute paths in shared build and
-development configuration. The check uses no branch name or checkout-path
-assumption and accepts an explicit tracked-file manifest for isolated fixtures.
+protects four invariants:
 
-Intentional architecture changes should update the declarative baseline and the
-corresponding focused fixtures in the same pull request. Source ownership is not
-otherwise frozen: later ORG work can move registration into module-owned CMake
-files while retaining explicit source lists.
+1. Vendored C/C++ code belongs under `third_party/`. The audit conservatively
+   detects vendor-style source directories and explicit upstream-provenance
+   metadata outside that owner; ordinary first-party copyright or license
+   headers are not treated as evidence of vendoring.
+2. Shared build/development configuration cannot acquire developer-specific
+   Windows, Linux, macOS, or WSL absolute paths outside the exact transitional
+   state recorded in the baseline.
+3. A top-level directory containing production C/C++ code must be classified by
+   the baseline. `tests/` and `third_party/` remain distinct from application
+   source modules, while source-free support directories are not misclassified.
+4. CMake cannot discover production sources through `file(GLOB ...)` or
+   `file(GLOB_RECURSE ...)`; resource globs remain valid.
+
+The check uses no branch name or checkout-path assumption and accepts an
+explicit tracked-file manifest for isolated fixtures.
+
+Intentional architecture changes should update the declarative baseline,
+document the new module's responsibility in the architecture and repository
+layout, add appropriate explicit CMake ownership where applicable, and update
+the focused fixtures in the same pull request. Source ownership is not otherwise
+frozen: later ORG work can move registration into module-owned CMake files while
+retaining explicit source lists.
 
 The baseline temporarily records exact file, value, and occurrence counts for
 existing `C:/vcpkg` and `C:\vcpkg` references in `CMakeLists.txt`,
 `CMakePresets.json`, `CMakeSettings.json`, `CppProperties.json`, and
-`setup_windows.ps1`. These narrow exceptions do not permit different values or
-additional occurrences. ORG-005 through ORG-011 are expected to remove the
-relevant legacy configuration and its exceptions; ORG-002 deliberately does not
-perform that cleanup.
+`setup_windows.ps1`. Each count describes the exact current repository state,
+not reusable permission: both additional and missing occurrences fail. ORG-005
+through ORG-011 must reduce or remove these entries together with the relevant
+legacy configuration; ORG-002 deliberately does not perform that cleanup.
+
+The `/mnt/c` values in the WSL presets are intentionally portable platform
+isolation paths: they prevent Linux package discovery from crossing into the
+standard Windows drive mount and are therefore accepted without an exception.
+User-specific paths below WSL drive mounts, such as
+`/mnt/d/Users/alice/toolchain`, remain forbidden.
 
 ## Repository-root roles and development entry points
 

--- a/docs/developer/repository_structure_baseline.json
+++ b/docs/developer/repository_structure_baseline.json
@@ -53,6 +53,28 @@
     "generated_sources": ["generated/build_info.cpp"],
     "conditional_subdirectories": ["tests"]
   },
+  "structural_guard": {
+    "machine_path_scan": {
+      "root_files": [
+        "CMakeLists.txt",
+        "CMakePresets.json",
+        "CMakeSettings.json",
+        "CppProperties.json",
+        "setup.sh",
+        "setup_windows.ps1",
+        "vcpkg.json"
+      ],
+      "directory_prefixes": [".github/workflows/", "cmake/", "scripts/"],
+      "file_suffixes": [".cmake", ".json", ".ps1", ".sh", ".yaml", ".yml"],
+      "grandfathered_occurrences": [
+        {"file": "CMakeLists.txt", "value": "C:/vcpkg", "count": 1},
+        {"file": "CMakePresets.json", "value": "C:/vcpkg/scripts/buildsystems/vcpkg.cmake", "count": 2},
+        {"file": "CMakeSettings.json", "value": "C:/vcpkg/scripts/buildsystems/vcpkg.cmake", "count": 2},
+        {"file": "CppProperties.json", "value": "C:/vcpkg/installed/x64-windows/include", "count": 1},
+        {"file": "setup_windows.ps1", "value": "C:\\vcpkg", "count": 2}
+      ]
+    }
+  },
   "development_entry_points": {
     "build": ["CMakeLists.txt", "CMakePresets.json", "setup.sh", "setup_windows.ps1"],
     "tests": ["tests/CMakeLists.txt"],

--- a/docs/developer/repository_structure_baseline.json
+++ b/docs/developer/repository_structure_baseline.json
@@ -54,6 +54,15 @@
     "conditional_subdirectories": ["tests"]
   },
   "structural_guard": {
+    "third_party_ownership": {
+      "owned_directory": "third_party",
+      "vendor_directory_names": ["external", "externals", "thirdparty", "vendor", "vendors"],
+      "provenance_markers": [
+        "Vendored from ",
+        "Upstream-Repository:"
+      ],
+      "exceptions": []
+    },
     "machine_path_scan": {
       "root_files": [
         "CMakeLists.txt",

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -13,7 +13,7 @@ Changes since **v1.6.0**.
 ## Technical and packaging changes
 
 - Added a reproducible repository-structure baseline and policy validation to protect current module and build ownership during future organization work.
-- Strengthened repository policy checks to prevent accidental root-source additions, machine-specific shared configuration, and implicit CMake source discovery.
+- Strengthened repository policy checks to protect third-party ownership, top-level module ownership, portable shared configuration, and explicit CMake source registration.
 
 ## Downloads and installation
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -13,6 +13,7 @@ Changes since **v1.6.0**.
 ## Technical and packaging changes
 
 - Added a reproducible repository-structure baseline and policy validation to protect current module and build ownership during future organization work.
+- Strengthened repository policy checks to prevent accidental root-source additions, machine-specific shared configuration, and implicit CMake source discovery.
 
 ## Downloads and installation
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -14,6 +14,7 @@ Changes since **v1.6.0**.
 
 - Added a reproducible repository-structure baseline and policy validation to protect current module and build ownership during future organization work.
 - Strengthened repository policy checks to protect third-party ownership, top-level module ownership, portable shared configuration, and explicit CMake source registration.
+- Improved cross-platform reliability of the repository policy regression fixtures without weakening machine-specific path detection.
 
 ## Downloads and installation
 

--- a/tests/check_repository_structure_baseline.py
+++ b/tests/check_repository_structure_baseline.py
@@ -4,13 +4,24 @@
 from __future__ import annotations
 
 import argparse
+from collections import Counter
 import json
 import re
+import subprocess
 import sys
 from pathlib import Path
 
 
 SOURCE_SUFFIXES = {".c", ".cc", ".cpp", ".cxx", ".h", ".hh", ".hpp", ".hxx"}
+MACHINE_PATH_PATTERN = re.compile(
+    r"(?<![A-Za-z])(?:[A-Za-z]:[/\\](?:[^\s\"']+)|/(?:home|Users)/[^\s\"']+)"
+)
+SOURCE_GLOB_PATTERN = re.compile(
+    r"file\s*\(\s*GLOB(?:_RECURSE)?\b(?P<body>.*?)\)", re.IGNORECASE | re.DOTALL
+)
+SOURCE_GLOB_SUFFIX_PATTERN = re.compile(
+    r"(?:\*|\[[^]]+\])\.(?:c|cc|cpp|cxx|h|hh|hpp|hxx)\b", re.IGNORECASE
+)
 
 
 def load_baseline(path: Path) -> dict:
@@ -27,7 +38,91 @@ def flatten_groups(groups: dict[str, list[str]]) -> list[str]:
     return [path for paths in groups.values() for path in paths]
 
 
-def audit_repository(root: Path, baseline: dict) -> list[str]:
+def tracked_files(root: Path, manifest: Path | None = None) -> set[str]:
+    """Return normalized repository-controlled paths without consulting a branch."""
+    if manifest is not None:
+        return {
+            line.strip().replace("\\", "/")
+            for line in manifest.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        }
+    result = subprocess.run(
+        ["git", "-C", str(root), "ls-files", "-z"],
+        check=False,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        diagnostic = result.stderr.decode(errors="replace").strip()
+        raise OSError(f"cannot enumerate tracked files with git ls-files: {diagnostic}")
+    return {path.decode(errors="surrogateescape") for path in result.stdout.split(b"\0") if path}
+
+
+def is_machine_path_configuration(relative: str, policy: dict) -> bool:
+    """Identify tracked shared build/development configuration covered by the path guard."""
+    if relative in policy["root_files"]:
+        return True
+    return any(relative.startswith(prefix) for prefix in policy["directory_prefixes"]) and any(
+        relative.lower().endswith(suffix) for suffix in policy["file_suffixes"]
+    )
+
+
+def audit_machine_paths(root: Path, files: set[str], policy: dict) -> list[str]:
+    """Reject suspicious absolute paths beyond the exact transitional allowance."""
+    allowed = Counter(
+        (item["file"], item["value"])
+        for item in policy["grandfathered_occurrences"]
+        for _ in range(item["count"])
+    )
+    found: Counter[tuple[str, str]] = Counter()
+    locations: dict[tuple[str, str], list[int]] = {}
+    for relative in sorted(files):
+        if not is_machine_path_configuration(relative, policy):
+            continue
+        path = root / relative
+        if not path.is_file():
+            continue
+        for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            for match in MACHINE_PATH_PATTERN.finditer(line):
+                key = (relative, match.group(0).rstrip(",;)"))
+                found[key] += 1
+                locations.setdefault(key, []).append(line_number)
+    errors = []
+    for (relative, value), count in sorted((found - allowed).items()):
+        line_numbers = locations[(relative, value)][-count:]
+        errors.append(
+            f"{relative}:{line_numbers[0]} contains machine-specific absolute path {value!r} "
+            f"({count} unapproved occurrence(s)); use a project/environment variable or update "
+            "the narrow transitional baseline during an intentional migration"
+        )
+    return errors
+
+
+def audit_source_discovery(root: Path, files: set[str]) -> list[str]:
+    """Reject CMake globs that discover production C/C++ sources."""
+    errors = []
+    cmake_files = sorted(
+        relative
+        for relative in files
+        if relative.endswith("CMakeLists.txt") or relative.lower().endswith(".cmake")
+    )
+    for relative in cmake_files:
+        path = root / relative
+        if not path.is_file():
+            continue
+        cmake = re.sub(r"(?m)#.*$", "", path.read_text(encoding="utf-8"))
+        for match in SOURCE_GLOB_PATTERN.finditer(cmake):
+            construct = match.group(0)
+            if SOURCE_GLOB_SUFFIX_PATTERN.search(match.group("body")):
+                line_number = cmake.count("\n", 0, match.start()) + 1
+                compact = " ".join(construct.split())
+                errors.append(
+                    f"{relative}:{line_number} uses forbidden production-source discovery "
+                    f"{compact!r}; register C/C++ sources explicitly in their owning CMake target"
+                )
+    return errors
+
+
+def audit_repository(root: Path, baseline: dict, files: set[str]) -> list[str]:
     """Return actionable violations of the repository structure baseline."""
     errors: list[str] = []
     required_directories = flatten_groups(baseline["top_level_directories"])
@@ -43,9 +138,7 @@ def audit_repository(root: Path, baseline: dict) -> list[str]:
 
     allowed_root_sources = set(baseline["source_registration"]["root_project_sources"])
     actual_root_sources = {
-        path.name
-        for path in root.iterdir()
-        if path.is_file() and path.suffix.lower() in SOURCE_SUFFIXES
+        relative for relative in files if "/" not in relative and Path(relative).suffix.lower() in SOURCE_SUFFIXES
     }
     for relative in sorted(actual_root_sources - allowed_root_sources):
         errors.append(
@@ -70,12 +163,6 @@ def audit_repository(root: Path, baseline: dict) -> list[str]:
             module_cmake = root / module / "CMakeLists.txt"
             if not module_cmake.is_file():
                 errors.append(f"module source-registration file is missing: {module}/CMakeLists.txt")
-            elif re.search(
-                r"file\s*\(\s*GLOB_RECURSE\b",
-                module_cmake.read_text(encoding="utf-8"),
-                re.IGNORECASE,
-            ):
-                errors.append(f"{module}/CMakeLists.txt uses forbidden recursive project-source discovery")
         executable_match = re.search(r"add_executable\s*\(([^)]*)\)", cmake, re.DOTALL)
         executable_sources = executable_match.group(1) if executable_match else ""
         for entry_point in baseline["source_registration"]["root_compiled_entry_points"]:
@@ -84,8 +171,10 @@ def audit_repository(root: Path, baseline: dict) -> list[str]:
         for group in baseline["source_registration"]["root_registered_source_groups"]:
             if not re.search(rf"(^|\s){re.escape(group)}/", executable_sources):
                 errors.append(f"root source group is not registered by add_executable: {group}/")
-        if re.search(r"file\s*\(\s*GLOB_RECURSE\b", cmake, re.IGNORECASE):
-            errors.append("root CMakeLists.txt uses forbidden recursive project-source discovery")
+
+    guard = baseline["structural_guard"]
+    errors.extend(audit_machine_paths(root, files, guard["machine_path_scan"]))
+    errors.extend(audit_source_discovery(root, files))
 
     return errors
 
@@ -100,11 +189,18 @@ def main() -> int:
         type=Path,
         default=default_root / "docs/developer/repository_structure_baseline.json",
     )
+    parser.add_argument(
+        "--tracked-files-from",
+        type=Path,
+        help="newline-delimited tracked paths for deterministic non-Git fixtures",
+    )
     args = parser.parse_args()
 
     try:
         baseline = load_baseline(args.baseline.resolve())
-        errors = audit_repository(args.repo_root.resolve(), baseline)
+        root = args.repo_root.resolve()
+        files = tracked_files(root, args.tracked_files_from)
+        errors = audit_repository(root, baseline, files)
     except (OSError, ValueError, KeyError, json.JSONDecodeError) as error:
         print(f"ERROR: cannot audit repository structure: {error}", file=sys.stderr)
         return 2

--- a/tests/check_repository_structure_baseline.py
+++ b/tests/check_repository_structure_baseline.py
@@ -14,7 +14,8 @@ from pathlib import Path
 
 SOURCE_SUFFIXES = {".c", ".cc", ".cpp", ".cxx", ".h", ".hh", ".hpp", ".hxx"}
 MACHINE_PATH_PATTERN = re.compile(
-    r"(?<![A-Za-z])(?:[A-Za-z]:[/\\](?:[^\s\"']+)|/(?:home|Users)/[^\s\"']+)"
+    r"(?<![A-Za-z])(?:[A-Za-z]:[/\\](?:[^\s\"']+)|/(?:home|Users)/[^\s\"']+|"
+    r"/mnt/[A-Za-z]/(?:Users|home)/[^\s\"']+)"
 )
 SOURCE_GLOB_PATTERN = re.compile(
     r"file\s*\(\s*GLOB(?:_RECURSE)?\b(?P<body>.*?)\)", re.IGNORECASE | re.DOTALL
@@ -67,7 +68,7 @@ def is_machine_path_configuration(relative: str, policy: dict) -> bool:
 
 
 def audit_machine_paths(root: Path, files: set[str], policy: dict) -> list[str]:
-    """Reject suspicious absolute paths beyond the exact transitional allowance."""
+    """Require suspicious absolute paths to match the exact transitional state."""
     allowed = Counter(
         (item["file"], item["value"])
         for item in policy["grandfathered_occurrences"]
@@ -94,6 +95,67 @@ def audit_machine_paths(root: Path, files: set[str], policy: dict) -> list[str]:
             f"({count} unapproved occurrence(s)); use a project/environment variable or update "
             "the narrow transitional baseline during an intentional migration"
         )
+    for (relative, value), count in sorted((allowed - found).items()):
+        errors.append(
+            f"stale grandfathered machine-path baseline for {relative}: expected {count} more "
+            f"occurrence(s) of {value!r}; update or remove the exception with the configuration change"
+        )
+    return errors
+
+
+def audit_top_level_source_modules(files: set[str], baseline: dict) -> list[str]:
+    """Reject production-looking source trees not classified by the top-level baseline."""
+    classified_directories = set(flatten_groups(baseline["top_level_directories"]))
+    classified_directories.update(
+        Path(relative).parts[0]
+        for relative in baseline["source_registration"]["generated_sources"]
+        if len(Path(relative).parts) > 1
+    )
+    unknown_modules = {
+        relative.split("/", 1)[0]
+        for relative in files
+        if "/" in relative
+        and Path(relative).suffix.lower() in SOURCE_SUFFIXES
+        and relative.split("/", 1)[0] not in classified_directories
+    }
+    return [
+        f"unregistered top-level source module: {directory}/; introducing production C/C++ code "
+        "requires intentional baseline classification, documented ownership, appropriate CMake "
+        "registration, and architecture/repository-layout documentation"
+        for directory in sorted(unknown_modules)
+    ]
+
+
+def audit_third_party_ownership(root: Path, files: set[str], policy: dict) -> list[str]:
+    """Reject conservative evidence of vendored C/C++ code outside its owned directory."""
+    owned_directory = policy["owned_directory"]
+    vendor_names = {name.lower() for name in policy["vendor_directory_names"]}
+    exceptions = set(policy["exceptions"])
+    errors = []
+    for relative in sorted(files):
+        if relative in exceptions or relative == owned_directory or relative.startswith(f"{owned_directory}/"):
+            continue
+        parts = Path(relative).parts
+        is_source = Path(relative).suffix.lower() in SOURCE_SUFFIXES
+        if is_source and any(part.lower() in vendor_names for part in parts[:-1]):
+            errors.append(
+                f"third-party ownership violation: {relative} is under a vendor-style directory "
+                f"outside {owned_directory}/; move vendored code under {owned_directory}/ or record "
+                "a narrow, justified exception"
+            )
+            continue
+        if not is_source:
+            continue
+        path = root / relative
+        if not path.is_file():
+            continue
+        content = path.read_text(encoding="utf-8", errors="replace")
+        marker = next((item for item in policy["provenance_markers"] if item in content), None)
+        if marker is not None:
+            errors.append(
+                f"third-party ownership violation: {relative} contains vendored provenance marker "
+                f"{marker!r} outside {owned_directory}/; move the code or declare a justified exception"
+            )
     return errors
 
 
@@ -173,6 +235,8 @@ def audit_repository(root: Path, baseline: dict, files: set[str]) -> list[str]:
                 errors.append(f"root source group is not registered by add_executable: {group}/")
 
     guard = baseline["structural_guard"]
+    errors.extend(audit_top_level_source_modules(files, baseline))
+    errors.extend(audit_third_party_ownership(root, files, guard["third_party_ownership"]))
     errors.extend(audit_machine_paths(root, files, guard["machine_path_scan"]))
     errors.extend(audit_source_discovery(root, files))
 

--- a/tests/check_repository_structure_baseline_fixtures.py
+++ b/tests/check_repository_structure_baseline_fixtures.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Exercise positive and negative fixtures for the ORG-001 structure audit."""
+"""Exercise ORG-001 baseline and ORG-002 structural regression fixtures."""
 
 from __future__ import annotations
 
@@ -215,11 +215,17 @@ class RepositoryStructureBaselineTests(unittest.TestCase):
             result = self.run_audit(root)
         self.assertEqual(result.returncode, 1)
         self.assertIn("scripts/new-build-config.json:1 contains machine-specific absolute path", result.stderr)
-        self.assertIn(value, result.stderr)
+        self.assertIn(repr(value), result.stderr)
 
     def test_windows_machine_path_is_rejected(self) -> None:
         """Reject a new Windows drive-based development path."""
         self.assert_machine_path_rejected("D:/Development/toolchain/sdk")
+
+    def test_windows_user_path_with_backslashes_is_rejected(self) -> None:
+        """Reject deterministic Windows user paths written with backslashes."""
+        self.assert_machine_path_rejected(
+            r"C:\Users\RUNNER~1\AppData\Local\Temp\checkout"
+        )
 
     def test_linux_home_path_is_rejected(self) -> None:
         """Reject a new user-specific Linux home path."""
@@ -291,13 +297,33 @@ class RepositoryStructureBaselineTests(unittest.TestCase):
         """Reject a user-specific path reached through a WSL drive mount."""
         self.assert_machine_path_rejected("/mnt/d/Users/alice/toolchain/sdk")
 
-    def test_checkout_path_and_url_are_not_machine_paths(self) -> None:
-        """Ignore fixture locations and URL schemes while scanning configuration."""
+    def test_checkout_location_does_not_trigger_machine_path_guard(self) -> None:
+        """Ignore the physical fixture location when it is not stored in shared configuration."""
         with tempfile.TemporaryDirectory(prefix="home-user-src-Perastage-") as temporary_directory:
             root = Path(temporary_directory)
             self.create_fixture(root)
+            result = self.run_audit(root)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_urls_are_not_treated_as_machine_paths(self) -> None:
+        """Accept normal URLs in scanned shared configuration."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.create_fixture(root)
             (root / "scripts/portable-config.json").write_text(
-                f"https://example.com/tool\ncheckout={root}\n", encoding="utf-8")
+                "https://example.com/tool\n", encoding="utf-8"
+            )
+            result = self.run_audit(root)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_portable_project_path_indirection_is_accepted(self) -> None:
+        """Accept the existing project-directory variable form instead of a literal checkout path."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.create_fixture(root)
+            (root / "scripts/portable-config.json").write_text(
+                "${projectDir}\\out\\build\n", encoding="utf-8"
+            )
             result = self.run_audit(root)
         self.assertEqual(result.returncode, 0, result.stderr)
 

--- a/tests/check_repository_structure_baseline_fixtures.py
+++ b/tests/check_repository_structure_baseline_fixtures.py
@@ -21,8 +21,20 @@ class RepositoryStructureBaselineTests(unittest.TestCase):
 
     def run_audit(self, root: Path) -> subprocess.CompletedProcess[str]:
         """Run the audit against a supplied repository fixture root."""
+        manifest = root / "tracked-files.txt"
+        manifest.write_text(
+            "\n".join(
+                sorted(
+                    path.relative_to(root).as_posix()
+                    for path in root.rglob("*")
+                    if path.is_file() and path != manifest
+                )
+            ),
+            encoding="utf-8",
+        )
         return subprocess.run(
-            [sys.executable, str(AUDIT), "--repo-root", str(root), "--baseline", str(BASELINE)],
+            [sys.executable, str(AUDIT), "--repo-root", str(root), "--baseline", str(BASELINE),
+             "--tracked-files-from", str(manifest)],
             check=False,
             capture_output=True,
             text=True,
@@ -53,7 +65,7 @@ class RepositoryStructureBaselineTests(unittest.TestCase):
 
     def test_current_repository_passes(self) -> None:
         """Accept the checked-in repository state."""
-        result = self.run_audit(REPOSITORY_ROOT)
+        result = subprocess.run([sys.executable, str(AUDIT)], check=False, capture_output=True, text=True)
         self.assertEqual(result.returncode, 0, result.stderr)
 
     def test_unexpected_root_source_is_rejected(self) -> None:
@@ -65,6 +77,16 @@ class RepositoryStructureBaselineTests(unittest.TestCase):
             result = self.run_audit(root)
         self.assertEqual(result.returncode, 1)
         self.assertIn("unexpected root project source: unexpected_root_helper.CPP", result.stderr)
+
+    def test_unexpected_root_header_is_rejected(self) -> None:
+        """Reject an unregistered root header case-insensitively."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.create_fixture(root)
+            (root / "temporary_api.HXX").touch()
+            result = self.run_audit(root)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("unexpected root project source: temporary_api.HXX", result.stderr)
 
     def test_missing_directory_is_actionable(self) -> None:
         """Report a missing required component by its repository-relative path."""
@@ -84,6 +106,91 @@ class RepositoryStructureBaselineTests(unittest.TestCase):
             (root / "local-maintainer-note.txt").touch()
             result = self.run_audit(root)
         self.assertEqual(result.returncode, 0, result.stderr)
+
+    def assert_machine_path_rejected(self, value: str) -> None:
+        """Verify a new shared-config machine path produces an actionable error."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.create_fixture(root)
+            (root / "scripts/new-build-config.json").write_text(value, encoding="utf-8")
+            result = self.run_audit(root)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("scripts/new-build-config.json:1 contains machine-specific absolute path", result.stderr)
+        self.assertIn(value, result.stderr)
+
+    def test_windows_machine_path_is_rejected(self) -> None:
+        """Reject a new Windows drive-based development path."""
+        self.assert_machine_path_rejected("D:/Development/toolchain/sdk")
+
+    def test_linux_home_path_is_rejected(self) -> None:
+        """Reject a new user-specific Linux home path."""
+        self.assert_machine_path_rejected("/home/alice/toolchains/sdk")
+
+    def test_macos_home_path_is_rejected(self) -> None:
+        """Reject a new user-specific macOS home path."""
+        self.assert_machine_path_rejected("/Users/alice/toolchains/sdk")
+
+    def test_grandfathered_legacy_configuration_passes(self) -> None:
+        """Accept only the recorded count of the legacy CMakeSettings path."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.create_fixture(root)
+            (root / "CMakeSettings.json").write_text(
+                "C:/vcpkg/scripts/buildsystems/vcpkg.cmake\n" * 2, encoding="utf-8")
+            result = self.run_audit(root)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_additional_legacy_configuration_path_is_rejected(self) -> None:
+        """Reject occurrences beyond the exact grandfathered legacy count."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.create_fixture(root)
+            (root / "CMakeSettings.json").write_text(
+                "C:/vcpkg/scripts/buildsystems/vcpkg.cmake\n" * 3, encoding="utf-8")
+            result = self.run_audit(root)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("1 unapproved occurrence(s)", result.stderr)
+
+    def test_checkout_path_and_url_are_not_machine_paths(self) -> None:
+        """Ignore fixture locations and URL schemes while scanning configuration."""
+        with tempfile.TemporaryDirectory(prefix="home-user-src-Perastage-") as temporary_directory:
+            root = Path(temporary_directory)
+            self.create_fixture(root)
+            (root / "scripts/portable-config.json").write_text(
+                f"https://example.com/tool\ncheckout={root}\n", encoding="utf-8")
+            result = self.run_audit(root)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_explicit_source_registration_passes(self) -> None:
+        """Accept explicit source registration and unrelated resource globs."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.create_fixture(root)
+            (root / "core/CMakeLists.txt").write_text(
+                'target_sources(perastage PRIVATE widget.cpp)\nfile(GLOB icons "*.svg")\n', encoding="utf-8")
+            result = self.run_audit(root)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_production_source_glob_is_rejected(self) -> None:
+        """Reject a generic CMake production-source glob."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.create_fixture(root)
+            (root / "core/CMakeLists.txt").write_text('file(GLOB sources "*.cpp")\n', encoding="utf-8")
+            result = self.run_audit(root)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("forbidden production-source discovery", result.stderr)
+
+    def test_recursive_source_glob_case_and_whitespace_is_rejected(self) -> None:
+        """Reject case and whitespace variations of recursive source discovery."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.create_fixture(root)
+            (root / "core/CMakeLists.txt").write_text(
+                'FiLe (  GLOB_RECURSE\n sources CONFIGURE_DEPENDS "*.HPP" )\n', encoding="utf-8")
+            result = self.run_audit(root)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("GLOB_RECURSE", result.stderr)
 
 
 if __name__ == "__main__":

--- a/tests/check_repository_structure_baseline_fixtures.py
+++ b/tests/check_repository_structure_baseline_fixtures.py
@@ -19,7 +19,7 @@ BASELINE = REPOSITORY_ROOT / "docs/developer/repository_structure_baseline.json"
 class RepositoryStructureBaselineTests(unittest.TestCase):
     """Verify current-tree success and representative baseline failures."""
 
-    def run_audit(self, root: Path) -> subprocess.CompletedProcess[str]:
+    def run_audit(self, root: Path, baseline_path: Path = BASELINE) -> subprocess.CompletedProcess[str]:
         """Run the audit against a supplied repository fixture root."""
         manifest = root / "tracked-files.txt"
         manifest.write_text(
@@ -33,7 +33,7 @@ class RepositoryStructureBaselineTests(unittest.TestCase):
             encoding="utf-8",
         )
         return subprocess.run(
-            [sys.executable, str(AUDIT), "--repo-root", str(root), "--baseline", str(BASELINE),
+            [sys.executable, str(AUDIT), "--repo-root", str(root), "--baseline", str(baseline_path),
              "--tracked-files-from", str(manifest)],
             check=False,
             capture_output=True,
@@ -62,6 +62,17 @@ class RepositoryStructureBaselineTests(unittest.TestCase):
         for directory in registration["conditional_subdirectories"]:
             cmake_lines.append(f"add_subdirectory({directory})")
         (root / "CMakeLists.txt").write_text("\n".join(cmake_lines), encoding="utf-8")
+        for item in baseline["structural_guard"]["machine_path_scan"]["grandfathered_occurrences"]:
+            path = root / item["file"]
+            existing = path.read_text(encoding="utf-8") if path.is_file() else ""
+            occurrences = (item["value"] + "\n") * item["count"]
+            path.write_text(existing + occurrences, encoding="utf-8")
+
+    def write_baseline(self, root: Path, baseline: dict) -> Path:
+        """Write a fixture-specific declarative baseline outside the tracked manifest."""
+        path = root / "fixture-baseline.json"
+        path.write_text(json.dumps(baseline), encoding="utf-8")
+        return path
 
     def test_current_repository_passes(self) -> None:
         """Accept the checked-in repository state."""
@@ -104,6 +115,94 @@ class RepositoryStructureBaselineTests(unittest.TestCase):
             root = Path(temporary_directory)
             self.create_fixture(root)
             (root / "local-maintainer-note.txt").touch()
+            result = self.run_audit(root)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_declared_modules_tests_third_party_and_support_data_pass(self) -> None:
+        """Accept classified source trees and source-free unclassified support data."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.create_fixture(root)
+            (root / "core/current.cpp").touch()
+            (root / "tests/policy_test.cpp").touch()
+            (root / "third_party/vendor.hpp").write_text(
+                "// Vendored from https://example.invalid/upstream\n",
+                encoding="utf-8",
+            )
+            (root / "maintainer-data/owners.txt").parent.mkdir()
+            (root / "maintainer-data/owners.txt").touch()
+            result = self.run_audit(root)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_unregistered_top_level_source_module_is_rejected(self) -> None:
+        """Reject production implementation files under an unclassified top-level directory."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.create_fixture(root)
+            (root / "network/foo.cpp").parent.mkdir()
+            (root / "network/foo.cpp").touch()
+            result = self.run_audit(root)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("unregistered top-level source module: network/", result.stderr)
+        self.assertIn("documented ownership", result.stderr)
+
+    def test_unregistered_top_level_header_module_is_rejected(self) -> None:
+        """Reject header-only module code under an unclassified top-level directory."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.create_fixture(root)
+            (root / "newmodule/include/foo.hpp").parent.mkdir(parents=True)
+            (root / "newmodule/include/foo.hpp").touch()
+            result = self.run_audit(root)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("unregistered top-level source module: newmodule/", result.stderr)
+
+    def test_intentionally_classified_source_module_passes(self) -> None:
+        """Allow architecture evolution when the declarative classification changes with it."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.create_fixture(root)
+            (root / "network/foo.cpp").parent.mkdir()
+            (root / "network/foo.cpp").touch()
+            baseline = json.loads(BASELINE.read_text(encoding="utf-8"))
+            baseline["top_level_directories"]["source_modules"].append("network")
+            result = self.run_audit(root, self.write_baseline(root, baseline))
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_vendored_marker_in_first_party_module_is_rejected(self) -> None:
+        """Reject conservative provenance evidence outside third_party ownership."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.create_fixture(root)
+            (root / "core/copied.cpp").write_text(
+                "// Vendored from https://example.invalid/upstream\n",
+                encoding="utf-8",
+            )
+            result = self.run_audit(root)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("third-party ownership violation: core/copied.cpp", result.stderr)
+
+    def test_vendor_style_source_directory_outside_owner_is_rejected(self) -> None:
+        """Reject obvious vendor-style source placement outside third_party."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.create_fixture(root)
+            (root / "core/vendor/library.cpp").parent.mkdir()
+            (root / "core/vendor/library.cpp").touch()
+            result = self.run_audit(root)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("third-party ownership violation: core/vendor/library.cpp", result.stderr)
+
+    def test_first_party_license_header_is_not_rejected(self) -> None:
+        """Avoid interpreting an ordinary first-party copyright header as vendored evidence."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.create_fixture(root)
+            (root / "core/owned.cpp").write_text(
+                "// Copyright 2026 Perastage contributors\n"
+                "// Permission is hereby granted, free of charge, to any person obtaining a copy\n",
+                encoding="utf-8",
+            )
             result = self.run_audit(root)
         self.assertEqual(result.returncode, 0, result.stderr)
 
@@ -150,6 +249,47 @@ class RepositoryStructureBaselineTests(unittest.TestCase):
             result = self.run_audit(root)
         self.assertEqual(result.returncode, 1)
         self.assertIn("1 unapproved occurrence(s)", result.stderr)
+
+    def test_missing_legacy_occurrence_is_rejected_as_stale(self) -> None:
+        """Reject a stale exception when configuration contains fewer recorded occurrences."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.create_fixture(root)
+            (root / "CMakeSettings.json").write_text(
+                "C:/vcpkg/scripts/buildsystems/vcpkg.cmake\n", encoding="utf-8"
+            )
+            result = self.run_audit(root)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("stale grandfathered machine-path baseline for CMakeSettings.json", result.stderr)
+
+    def test_removing_legacy_path_and_exception_together_passes(self) -> None:
+        """Accept cleanup that removes both legacy configuration and its exact exception."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.create_fixture(root)
+            (root / "CMakeSettings.json").write_text("{}\n", encoding="utf-8")
+            baseline = json.loads(BASELINE.read_text(encoding="utf-8"))
+            exceptions = baseline["structural_guard"]["machine_path_scan"]["grandfathered_occurrences"]
+            baseline["structural_guard"]["machine_path_scan"]["grandfathered_occurrences"] = [
+                item for item in exceptions if item["file"] != "CMakeSettings.json"
+            ]
+            result = self.run_audit(root, self.write_baseline(root, baseline))
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_portable_wsl_ignore_paths_are_accepted(self) -> None:
+        """Accept standard WSL Windows-drive isolation paths used by supported presets."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.create_fixture(root)
+            (root / "scripts/wsl-config.json").write_text(
+                "/mnt/c;/mnt/c/vcpkg/installed/x64-windows\n", encoding="utf-8"
+            )
+            result = self.run_audit(root)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_user_specific_wsl_path_is_rejected(self) -> None:
+        """Reject a user-specific path reached through a WSL drive mount."""
+        self.assert_machine_path_rejected("/mnt/d/Users/alice/toolchain/sdk")
 
     def test_checkout_path_and_url_are_not_machine_paths(self) -> None:
         """Ignore fixture locations and URL schemes while scanning configuration."""


### PR DESCRIPTION
### Motivation

- Prevent accidental repository-structure regressions by extending the ORG-001 baseline with deterministic guards that run under CTest and GitHub Actions.  
- Specifically block: unexpected root-level production C/C++ sources, machine-specific absolute paths in tracked shared build/development configuration, and implicit/recursive CMake production-source discovery.  
- Keep the guard transition-safe for known legacy `vcpkg` references by recording narrow, occurrence-counted grandfathered exceptions in the baseline.

### Description

- Added a declarative `structural_guard.machine_path_scan` section to `docs/developer/repository_structure_baseline.json` describing files/directories to scan, portable suffixes, and exact grandfathered file/value/occurrence tuples for known legacy `vcpkg` references.  
- Extended the existing audit `tests/check_repository_structure_baseline.py` to enumerate tracked files deterministically (`git ls-files`) with an optional manifest fallback, detect suspicious absolute machine paths with actionable diagnostics and exact occurrence handling, and detect CMake `file(GLOB...)` / `file(GLOB_RECURSE...)` constructs that appear to discover production C/C++ sources while allowing unrelated resource globs.  
- Updated `tests/check_repository_structure_baseline_fixtures.py` with focused positive and negative fixtures covering root-source additions, root headers, Windows/Linux/macOS machine paths, grandfathered counts vs excess occurrences, explicit source registration vs production `file(GLOB...)`, and case/whitespace variations of `GLOB_RECURSE`.  
- Documented the guard and the temporary legacy exemptions in `docs/developer/repository_layout.md` and added a concise release-note entry to `docs/release-notes-draft.md` describing the strengthened checks and how intentional architecture changes should update the baseline and fixtures.

### Testing

- Local execution: `python3 tests/check_repository_structure_baseline.py` — PASS, `python3 tests/check_repository_structure_baseline_fixtures.py -v` — PASS (14 fixtures), and `python3 -m py_compile tests/check_repository_structure_baseline.py tests/check_repository_structure_baseline_fixtures.py` — PASS.  
- Policy and helper checks: `python3 -m json.tool docs/developer/repository_structure_baseline.json` — PASS; `tests/check_perastage_tree_modules.sh` — PASS; `tests/check_no_configmanager_get_in_gui.sh` — PASS; `git diff --check` — PASS.  
- Build/config validation: attempted a local configure with `cmake -S . -B /tmp/perastage-org002-build -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Debug` which reached dependency discovery but could not complete due to missing system wxWidgets libraries in this environment.  
- CI/Actions: GitHub Actions full-matrix validation was not executed from this environment because remote push/`gh` authentication was not available; the added tests are integrated via `tests/CMakeLists.txt` using the existing `add_repository_policy_test(...)` registration so they will run in normal CI.  

Scope confirmation: only ORG-002 guard behavior was implemented (no application, MVR/GDTF, UI, packaging, or runtime behavior changes), the change reuses the ORG-001 baseline rather than duplicating it, and legacy `vcpkg`-related entries remain narrowly grandfathered and documented to be removed by later ORG tasks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a97d788682883248ab9b6dc2d5a43b6)