### PR TITLE
ORG-012: Move models/ source registration into module-owned CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,13 +275,6 @@ target_include_directories(perastage_uuid PUBLIC ${CMAKE_SOURCE_DIR}/core)
 
 add_executable(${PROJECT_NAME} main.cpp
     "${PERASTAGE_GENERATED_BUILD_INFO_CPP}"
-    models/fixture.cpp
-    models/continuous_placement_scene.cpp
-    models/continuous_placement_state.cpp
-    models/layer.cpp
-    models/mvrscene.cpp
-    models/sceneobject.cpp
-    models/truss.cpp
     core/runtime_storage.cpp
     core/fixture_gdtf_derivative_contract.cpp
     core/symbols/fixture_symbol_preparation_coordinator.cpp
@@ -538,6 +531,7 @@ endif()
 
 add_subdirectory(core)
 add_subdirectory(gui)
+add_subdirectory(models)
 add_subdirectory(viewer2d)
 add_subdirectory(viewer3d)
 add_subdirectory(viewer_common)

--- a/docs/developer/perastage_tree.md
+++ b/docs/developer/perastage_tree.md
@@ -34,6 +34,7 @@ Perastage/
 |   `-- interfaces/              # Render/selection context contracts.
 |-- viewer_common/               # Shared viewer utilities used across viewer modules.
 |-- models/                      # Scene data structures (fixtures/trusses/hoists/objects/layers).
+|   `-- CMakeLists.txt           # Explicit model source registration for the application target.
 |-- mvr/                         # MVR format import/export modules and MVR-xchange networking.
 |-- packaging/                   # Installer, desktop integration, and package metadata.
 |-- tests/                       # Automated tests and lightweight checks.

--- a/docs/developer/repository_layout.md
+++ b/docs/developer/repository_layout.md
@@ -40,6 +40,7 @@ The root CMake file explicitly registers the main source modules with `add_subdi
 ```text
 core/
 gui/
+models/
 viewer2d/
 viewer3d/
 viewer_common/
@@ -49,8 +50,8 @@ Keep this list aligned with `CMakeLists.txt` whenever a new top-level source mod
 
 The current arrangement is intentionally descriptive rather than fully
 decentralized. The root `CMakeLists.txt` creates the application target, directly
-registers `main.cpp`, generated `build_info.cpp`, and source groups from
-`models/`, `mvr/`, and `core/`. The five modules above contribute their explicit
+registers `main.cpp`, generated `build_info.cpp`, and source groups from `mvr/`
+and `core/`. The six modules above contribute their explicit
 source lists through their own `CMakeLists.txt` files. `tests/` is added
 conditionally when testing is enabled. No recursive project-source discovery is
 used.

--- a/docs/developer/repository_structure_baseline.json
+++ b/docs/developer/repository_structure_baseline.json
@@ -38,11 +38,12 @@
     "module_cmake_directories": [
       "core",
       "gui",
+      "models",
       "viewer2d",
       "viewer3d",
       "viewer_common"
     ],
-    "root_registered_source_groups": ["models", "mvr", "core"],
+    "root_registered_source_groups": ["mvr", "core"],
     "root_project_sources": ["main.cpp"],
     "root_compiled_entry_points": ["main.cpp"],
     "generated_sources": ["generated/build_info.cpp"],

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -18,6 +18,7 @@ Changes since **v1.6.0**.
 - Clarified Core ownership of the shared viewport interaction preference policy and removed its temporary repository-root compatibility exception.
 - Established the shared CMake presets as the canonical local build configuration and documented optional, untracked developer overrides across supported platforms.
 - Made the Windows classic-vcpkg workflow portable and reliable in Visual Studio through explicit or user-wide external checkout discovery, while ignoring the IDE's injected bundled dependency tree, keeping cross-platform validation reliable, and removing redundant legacy configuration files.
+- Gave the scene-model module explicit ownership of its application source registration while preserving existing build behavior.
 
 ## Downloads and installation
 

--- a/models/CMakeLists.txt
+++ b/models/CMakeLists.txt
@@ -1,0 +1,13 @@
+target_sources(${PROJECT_NAME} PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/continuous_placement_scene.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/continuous_placement_state.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/fixture.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/layer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/mvrscene.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/sceneobject.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/truss.cpp
+)
+
+target_include_directories(${PROJECT_NAME} PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/tests/check_repository_structure_baseline_fixtures.py
+++ b/tests/check_repository_structure_baseline_fixtures.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -104,7 +105,7 @@ class RepositoryStructureBaselineTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)
             self.create_fixture(root)
-            (root / "models").rmdir()
+            shutil.rmtree(root / "models")
             result = self.run_audit(root)
         self.assertEqual(result.returncode, 1)
         self.assertIn("required top-level directory is missing: models/", result.stderr)


### PR DESCRIPTION
### Motivation
- Give the `models/` top-level module ownership of its application-source registration so root CMake no longer directly lists production `models/*.cpp` files, following the established Perastage CMake convention for feature modules. 

### Description
- Added `models/CMakeLists.txt` which uses `target_sources(${PROJECT_NAME} PRIVATE ...)` to explicitly register the seven production model implementation files: `continuous_placement_scene.cpp`, `continuous_placement_state.cpp`, `fixture.cpp`, `layer.cpp`, `mvrscene.cpp`, `sceneobject.cpp`, and `truss.cpp`, and declared the local include with `target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})`.
- Updated the root `CMakeLists.txt` to add `add_subdirectory(models)` and removed the direct `models/*.cpp` entries from the `add_executable(${PROJECT_NAME} ...)` source list so the application target no longer enumerates production `models/` implementation files.
- Updated repository metadata and documentation to reflect the change by adding `models` to `source_registration.module_cmake_directories`, removing `models` from `source_registration.root_registered_source_groups` in `docs/developer/repository_structure_baseline.json`, and adjusting `docs/developer/repository_layout.md` and `docs/developer/perastage_tree.md` to describe the module-owned registration; also added a concise internal entry to `docs/release-notes-draft.md`.
- Made a small test-fixture fix in `tests/check_repository_structure_baseline_fixtures.py` to correctly remove the temporary `models/` fixture directory during the missing-directory test; preserved all test-target `../models/*.cpp` registrations in `tests/CMakeLists.txt` unchanged.

### Testing
- Ran `python3 tests/check_repository_structure_baseline.py` and `python3 tests/check_repository_structure_baseline_fixtures.py -v`, both passed locally (fixtures exercise updated accordingly).
- Ran repository policy checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both passed locally.
- Verified `git diff --check` produced no staged whitespace or error issues and confirmed with a parity check that `models/CMakeLists.txt` registers every `models/*.cpp` exactly once using a `comm`-style check.
- Attempted an out-of-tree CMake configure (`cmake -S . -B build/org012-debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON`); configure reached dependency discovery but could not complete in this environment because required `wxWidgets` headers/libraries are not available locally, so a full local build and CTest run were not possible and must be validated by CI.

Branch/commit: branch `codex/org-012-models-cmake-ownership`, commit `fc8d73e` (message: "ORG-012: give models CMake source ownership").

Notes: this PR implements only ORG-012; no model source files were moved or modified; no `file(GLOB...)` or recursive discovery was introduced; test-specific model registrations remain unchanged. Full platform CI (Windows/Linux/macOS) must validate the branch upstream.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9b2722d89c8324873b9a8261141286)