### PR TITLE
ORG-013–015: complete source-module CMake ownership

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -270,42 +270,11 @@ configure_file(
     @ONLY
 )
 
-add_library(perastage_uuid OBJECT core/uuidutils.cpp)
-target_include_directories(perastage_uuid PUBLIC ${CMAKE_SOURCE_DIR}/core)
+add_library(perastage_uuid OBJECT)
 
-add_executable(${PROJECT_NAME} main.cpp
+add_executable(${PROJECT_NAME}
+    main.cpp
     "${PERASTAGE_GENERATED_BUILD_INFO_CPP}"
-    core/runtime_storage.cpp
-    core/fixture_gdtf_derivative_contract.cpp
-    core/symbols/fixture_symbol_preparation_coordinator.cpp
-    core/symbols/fixture_symbol_preparation_requests.cpp
-    core/fixture_gdtf_derivative_publication.cpp
-    core/mvr_identity_recovery.cpp
-    core/project_fixture_gdtf_consolidator.cpp
-    mvr/gdtf_catalog_matcher.cpp
-    mvr/gdtf_catalog_parser.cpp
-    mvr/mvrimporter.cpp
-    mvr/mvr_merge_analyzer.cpp
-    mvr/mvr_merge_applier.cpp
-    mvr/mvr_merge_resource_rewriter.cpp
-    mvr/mvrscenemerger.cpp
-    mvr/mvrexporter.cpp
-    mvr/primitive_model_resources.cpp
-    mvr/xchange/mvr_xchange_commit.cpp
-    mvr/xchange/mvr_xchange_dns_names.cpp
-    mvr/xchange/mvr_xchange_mdns_discovery.cpp
-    mvr/xchange/mvr_xchange_mdns_cache.cpp
-    mvr/xchange/mvr_xchange_mdns_service.cpp
-    mvr/xchange/mvr_xchange_network_interfaces.cpp
-    mvr/xchange/mvr_xchange_remote_station.cpp
-    mvr/xchange/mvr_xchange_station_registry.cpp
-    mvr/xchange/mvr_xchange_tcp_client.cpp
-    mvr/xchange/mvr_xchange_message.cpp
-    mvr/xchange/mvr_xchange_packet.cpp
-    mvr/xchange/mvr_xchange_publication_policy.cpp
-    mvr/xchange/mvr_xchange_service.cpp
-    mvr/xchange/mvr_xchange_settings.cpp
-    mvr/xchange/mvr_xchange_tcp_server.cpp
 )
 
 if(PERASTAGE_MACOS15_LEGACY_THREAD_COMPAT)
@@ -532,17 +501,13 @@ endif()
 add_subdirectory(core)
 add_subdirectory(gui)
 add_subdirectory(models)
+add_subdirectory(mvr)
 add_subdirectory(viewer2d)
 add_subdirectory(viewer3d)
 add_subdirectory(viewer_common)
 
 if(WIN32)
     target_sources(${PROJECT_NAME} PRIVATE resources/Perastage.rc)
-    target_link_libraries(${PROJECT_NAME} PRIVATE ws2_32 iphlpapi)
-endif()
-if(PERASTAGE_ENABLE_MVR_XCHANGE_MDNS)
-    target_compile_definitions(${PROJECT_NAME} PRIVATE PERASTAGE_MVR_XCHANGE_ENABLE_MDNS=1)
-    target_link_libraries(${PROJECT_NAME} PRIVATE mdns::mdns)
 endif()
 
 # Mark as GUI application (no console)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -16,6 +16,8 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/dummyprofilelibrary.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/file_import_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/filesystem_path_utils.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/fixture_gdtf_derivative_contract.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/fixture_gdtf_derivative_publication.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fixture_visual_color.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtfdictionary.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtf_archive_reader.cpp
@@ -63,6 +65,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/logger.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/markdown.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/magnet_snap.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/mvr_identity_recovery.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/truss_attachment_paths.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/patchmanager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/platform_locale.cpp
@@ -70,11 +73,13 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/print/PageSetup.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/print/Viewer2DPrintSettings.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/projectutils.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/project_fixture_gdtf_consolidator.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/startup_profile.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/rigging_extra_weight_settings.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/riderimporter.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/rider_fixture_resolution.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/rider_text_semantics.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/runtime_storage.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/scene_grouping.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/scene_clipboard.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/scene_node_operations.cpp
@@ -106,6 +111,14 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/wx_path_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/units/unit_label_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/units/units.cpp
+)
+
+target_sources(perastage_uuid PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/uuidutils.cpp
+)
+
+target_include_directories(perastage_uuid PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
 target_include_directories(${PROJECT_NAME} PRIVATE

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -21,9 +21,10 @@ This document defines the expected directory conventions for Perastage.
 
 ## CMake convention
 
-- Root `CMakeLists.txt` owns target creation and global dependencies.
-- Feature directories contribute sources using local `CMakeLists.txt` files and `target_sources(${PROJECT_NAME} ...)`.
-- Avoid `file(GLOB_RECURSE ...)` for project source registration; list files explicitly.
+- Root `CMakeLists.txt` owns target creation, global dependencies, and module orchestration; it does not normally register feature-module implementation sources.
+- Every top-level application source module contributes its explicit source list using its local `CMakeLists.txt` and `target_sources(${PROJECT_NAME} ...)`.
+- `docs/developer/repository_structure_baseline.json` is the authoritative machine-readable contract for source-module classification and CMake registration.
+- Avoid recursive or wildcard project-source discovery; list files explicitly.
 - Keep include directories close to the module that owns them.
 
 ## Library convention

--- a/docs/developer/perastage_tree.md
+++ b/docs/developer/perastage_tree.md
@@ -9,7 +9,7 @@ This map is aligned with the terminology used in `README.md` and `docs/developer
 ```text
 Perastage/
 |-- main.cpp                     # wxWidgets application entry point.
-|-- CMakeLists.txt               # Root build orchestration and global dependencies.
+|-- CMakeLists.txt               # Root target creation, build orchestration, and module registration.
 |-- CMakePresets.json            # Supported local configure/build presets.
 |-- README.md                    # Product overview, features, and entry links.
 |-- help.md                      # In-app help content.
@@ -36,6 +36,7 @@ Perastage/
 |-- models/                      # Scene data structures (fixtures/trusses/hoists/objects/layers).
 |   `-- CMakeLists.txt           # Explicit model source registration for the application target.
 |-- mvr/                         # MVR format import/export modules and MVR-xchange networking.
+|   `-- CMakeLists.txt           # Explicit MVR and MVR-xchange source registration.
 |-- packaging/                   # Installer, desktop integration, and package metadata.
 |-- tests/                       # Automated tests and lightweight checks.
 |-- library/                     # Packaged runtime content (fixtures, trusses, etc.).
@@ -71,3 +72,5 @@ Perastage/
 - Avoid listing all individual files except truly critical entry points.
 - If repository layout changes, update this document in the same PR.
 - If a new top-level source module is introduced, update the architecture guard scripts under `tests/` when appropriate.
+- Every top-level application source module owns an explicit local CMake source list; the root does not normally register feature implementations, and no recursive source discovery is used.
+- `repository_structure_baseline.json` is the authoritative machine-readable contract for source-module classification and root module registration.

--- a/docs/developer/repository_layout.md
+++ b/docs/developer/repository_layout.md
@@ -35,24 +35,17 @@ this page remains its human-readable architectural counterpart.
 
 ## Build module registration
 
-The root CMake file explicitly registers the main source modules with `add_subdirectory(...)` instead of discovering project sources recursively. The currently registered source modules are:
+The root CMake file explicitly registers every application source module with
+`add_subdirectory(...)` instead of discovering project sources recursively. The
+machine-readable `repository_structure_baseline.json` is the authoritative
+module-classification and registration list. The repository-structure guard
+keeps that classification, local module CMake ownership, and root registration
+from silently diverging.
 
-```text
-core/
-gui/
-models/
-viewer2d/
-viewer3d/
-viewer_common/
-```
-
-Keep this list aligned with `CMakeLists.txt` whenever a new top-level source module is introduced.
-
-The current arrangement is intentionally descriptive rather than fully
-decentralized. The root `CMakeLists.txt` creates the application target, directly
-registers `main.cpp`, generated `build_info.cpp`, and source groups from `mvr/`
-and `core/`. The six modules above contribute their explicit
-source lists through their own `CMakeLists.txt` files. `tests/` is added
+The source-registration arrangement is decentralized. The root `CMakeLists.txt`
+creates the application target and registers only its entry point and generated
+bootstrap source. Every module above contributes its explicit application source
+list through its own `CMakeLists.txt`. `tests/` is added
 conditionally when testing is enabled. No recursive project-source discovery is
 used.
 

--- a/docs/developer/repository_structure_baseline.json
+++ b/docs/developer/repository_structure_baseline.json
@@ -39,11 +39,12 @@
       "core",
       "gui",
       "models",
+      "mvr",
       "viewer2d",
       "viewer3d",
       "viewer_common"
     ],
-    "root_registered_source_groups": ["mvr", "core"],
+    "root_registered_source_groups": [],
     "root_project_sources": ["main.cpp"],
     "root_compiled_entry_points": ["main.cpp"],
     "generated_sources": ["generated/build_info.cpp"],

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -19,6 +19,7 @@ Changes since **v1.6.0**.
 - Established the shared CMake presets as the canonical local build configuration and documented optional, untracked developer overrides across supported platforms.
 - Made the Windows classic-vcpkg workflow portable and reliable in Visual Studio through explicit or user-wide external checkout discovery, while ignoring the IDE's injected bundled dependency tree, keeping cross-platform validation reliable, and removing redundant legacy configuration files.
 - Gave the scene-model module explicit ownership of its application source registration while preserving existing build behavior.
+- Completed explicit CMake source ownership across all application modules and strengthened repository checks against architecture drift.
 
 ## Downloads and installation
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -19,7 +19,7 @@ Changes since **v1.6.0**.
 - Established the shared CMake presets as the canonical local build configuration and documented optional, untracked developer overrides across supported platforms.
 - Made the Windows classic-vcpkg workflow portable and reliable in Visual Studio through explicit or user-wide external checkout discovery, while ignoring the IDE's injected bundled dependency tree, keeping cross-platform validation reliable, and removing redundant legacy configuration files.
 - Gave the scene-model module explicit ownership of its application source registration while preserving existing build behavior.
-- Completed explicit CMake source ownership across all application modules and strengthened cross-platform repository checks against architecture drift.
+- Completed explicit CMake source ownership across all application modules and strengthened cross-platform, harness-aware repository checks against architecture drift.
 
 ## Downloads and installation
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -19,7 +19,7 @@ Changes since **v1.6.0**.
 - Established the shared CMake presets as the canonical local build configuration and documented optional, untracked developer overrides across supported platforms.
 - Made the Windows classic-vcpkg workflow portable and reliable in Visual Studio through explicit or user-wide external checkout discovery, while ignoring the IDE's injected bundled dependency tree, keeping cross-platform validation reliable, and removing redundant legacy configuration files.
 - Gave the scene-model module explicit ownership of its application source registration while preserving existing build behavior.
-- Completed explicit CMake source ownership across all application modules and strengthened repository checks against architecture drift.
+- Completed explicit CMake source ownership across all application modules and strengthened cross-platform repository checks against architecture drift.
 
 ## Downloads and installation
 

--- a/mvr/CMakeLists.txt
+++ b/mvr/CMakeLists.txt
@@ -1,0 +1,41 @@
+target_sources(${PROJECT_NAME} PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/gdtf_catalog_matcher.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gdtf_catalog_parser.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/mvrimporter.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/mvr_merge_analyzer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/mvr_merge_applier.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/mvr_merge_resource_rewriter.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/mvrscenemerger.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/mvrexporter.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/primitive_model_resources.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/xchange/mvr_xchange_commit.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/xchange/mvr_xchange_dns_names.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/xchange/mvr_xchange_mdns_discovery.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/xchange/mvr_xchange_mdns_cache.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/xchange/mvr_xchange_mdns_service.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/xchange/mvr_xchange_network_interfaces.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/xchange/mvr_xchange_remote_station.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/xchange/mvr_xchange_station_registry.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/xchange/mvr_xchange_tcp_client.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/xchange/mvr_xchange_message.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/xchange/mvr_xchange_packet.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/xchange/mvr_xchange_publication_policy.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/xchange/mvr_xchange_service.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/xchange/mvr_xchange_settings.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/xchange/mvr_xchange_tcp_server.cpp
+)
+
+target_include_directories(${PROJECT_NAME} PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+if(WIN32)
+    target_link_libraries(${PROJECT_NAME} PRIVATE ws2_32 iphlpapi)
+endif()
+
+if(PERASTAGE_ENABLE_MVR_XCHANGE_MDNS)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE
+        PERASTAGE_MVR_XCHANGE_ENABLE_MDNS=1
+    )
+    target_link_libraries(${PROJECT_NAME} PRIVATE mdns::mdns)
+endif()

--- a/tests/check_perastage_tree_modules.sh
+++ b/tests/check_perastage_tree_modules.sh
@@ -8,7 +8,7 @@ TREE_DOC="$ROOT_DIR/docs/developer/perastage_tree.md"
 BASELINE="$ROOT_DIR/docs/developer/repository_structure_baseline.json"
 
 source_modules="$(
-  python3 - "$BASELINE" <<'PY'
+  run_test_python - "$BASELINE" <<'PY'
 import json
 import sys
 

--- a/tests/check_perastage_tree_modules.sh
+++ b/tests/check_perastage_tree_modules.sh
@@ -20,6 +20,7 @@ PY
 
 required_dirs=()
 while IFS= read -r dir; do
+  dir="${dir%$'\r'}"
   [[ -n "$dir" ]] && required_dirs+=("$dir")
 done <<< "$source_modules"
 required_dirs+=(packaging cmake library resources third_party tests docs)

--- a/tests/check_perastage_tree_modules.sh
+++ b/tests/check_perastage_tree_modules.sh
@@ -5,23 +5,19 @@ require_ripgrep
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TREE_DOC="$ROOT_DIR/docs/developer/perastage_tree.md"
+BASELINE="$ROOT_DIR/docs/developer/repository_structure_baseline.json"
 
-required_dirs=(
-  core
-  gui
-  viewer2d
-  viewer3d
-  viewer_common
-  models
-  mvr
-  packaging
-  cmake
-  library
-  resources
-  third_party
-  tests
-  docs
+mapfile -t required_dirs < <(
+  python3 - "$BASELINE" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as stream:
+    baseline = json.load(stream)
+print(*baseline["top_level_directories"]["source_modules"], sep="\n")
+PY
 )
+required_dirs+=(packaging cmake library resources third_party tests docs)
 
 missing_dirs=()
 for dir in "${required_dirs[@]}"; do

--- a/tests/check_perastage_tree_modules.sh
+++ b/tests/check_perastage_tree_modules.sh
@@ -7,7 +7,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TREE_DOC="$ROOT_DIR/docs/developer/perastage_tree.md"
 BASELINE="$ROOT_DIR/docs/developer/repository_structure_baseline.json"
 
-mapfile -t required_dirs < <(
+source_modules="$(
   python3 - "$BASELINE" <<'PY'
 import json
 import sys
@@ -16,7 +16,12 @@ with open(sys.argv[1], encoding="utf-8") as stream:
     baseline = json.load(stream)
 print(*baseline["top_level_directories"]["source_modules"], sep="\n")
 PY
-)
+)"
+
+required_dirs=()
+while IFS= read -r dir; do
+  [[ -n "$dir" ]] && required_dirs+=("$dir")
+done <<< "$source_modules"
 required_dirs+=(packaging cmake library resources third_party tests docs)
 
 missing_dirs=()

--- a/tests/check_repository_structure_baseline.py
+++ b/tests/check_repository_structure_baseline.py
@@ -190,6 +190,18 @@ def audit_repository(root: Path, baseline: dict, files: set[str]) -> list[str]:
     required_directories = flatten_groups(baseline["top_level_directories"])
     required_files = flatten_groups(baseline["root_file_roles"])
     entry_points = flatten_groups(baseline["development_entry_points"])
+    source_modules = set(baseline["top_level_directories"]["source_modules"])
+    module_cmake_directories = set(
+        baseline["source_registration"]["module_cmake_directories"]
+    )
+
+    if source_modules != module_cmake_directories:
+        errors.append(
+            "source-module classification differs from module CMake ownership: "
+            f"documented source modules {sorted(source_modules)}, module CMake directories "
+            f"{sorted(module_cmake_directories)}; every top-level source module must own its "
+            "application source registration"
+        )
 
     for relative in required_directories:
         if not (root / relative).is_dir():
@@ -233,6 +245,18 @@ def audit_repository(root: Path, baseline: dict, files: set[str]) -> list[str]:
         for group in baseline["source_registration"]["root_registered_source_groups"]:
             if not re.search(rf"(^|\s){re.escape(group)}/", executable_sources):
                 errors.append(f"root source group is not registered by add_executable: {group}/")
+        allowed_root_groups = set(
+            baseline["source_registration"]["root_registered_source_groups"]
+        )
+        for module in sorted(source_modules - allowed_root_groups):
+            feature_source_pattern = (
+                rf"(^|\s)[\"']?{re.escape(module)}/[^\s\)]*\.(?:c|cc|cpp|cxx)\b"
+            )
+            if re.search(feature_source_pattern, executable_sources, re.IGNORECASE):
+                errors.append(
+                    f"root add_executable retains feature source ownership for {module}/; "
+                    f"register application implementation sources in {module}/CMakeLists.txt"
+                )
 
     guard = baseline["structural_guard"]
     errors.extend(audit_top_level_source_modules(files, baseline))

--- a/tests/check_repository_structure_baseline_fixtures.py
+++ b/tests/check_repository_structure_baseline_fixtures.py
@@ -167,8 +167,53 @@ class RepositoryStructureBaselineTests(unittest.TestCase):
             (root / "network/foo.cpp").touch()
             baseline = json.loads(BASELINE.read_text(encoding="utf-8"))
             baseline["top_level_directories"]["source_modules"].append("network")
+            baseline["source_registration"]["module_cmake_directories"].append("network")
+            (root / "network/CMakeLists.txt").touch()
+            with (root / "CMakeLists.txt").open("a", encoding="utf-8") as stream:
+                stream.write("\nadd_subdirectory(network)\n")
             result = self.run_audit(root, self.write_baseline(root, baseline))
         self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_documented_source_module_without_cmake_ownership_is_rejected(self) -> None:
+        """Reject a documented source module that lacks module CMake ownership."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.create_fixture(root)
+            baseline = json.loads(BASELINE.read_text(encoding="utf-8"))
+            baseline["top_level_directories"]["source_modules"].append("network")
+            result = self.run_audit(root, self.write_baseline(root, baseline))
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("source-module classification differs from module CMake ownership", result.stderr)
+
+    def test_cmake_module_without_source_classification_is_rejected(self) -> None:
+        """Reject module CMake ownership without source-module classification."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.create_fixture(root)
+            baseline = json.loads(BASELINE.read_text(encoding="utf-8"))
+            baseline["source_registration"]["module_cmake_directories"].append("network")
+            result = self.run_audit(root, self.write_baseline(root, baseline))
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("source-module classification differs from module CMake ownership", result.stderr)
+
+    def test_root_owned_feature_source_is_rejected(self) -> None:
+        """Reject feature implementation ownership in the root application target."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.create_fixture(root)
+            cmake = root / "CMakeLists.txt"
+            cmake.write_text(
+                cmake.read_text(encoding="utf-8").replace(
+                    "main.cpp",
+                    "main.cpp core/feature.cpp",
+                    1,
+                ),
+                encoding="utf-8",
+            )
+            (root / "core/feature.cpp").touch()
+            result = self.run_audit(root)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("root add_executable retains feature source ownership for core/", result.stderr)
 
     def test_vendored_marker_in_first_party_module_is_rejected(self) -> None:
         """Reject conservative provenance evidence outside third_party ownership."""

--- a/tests/check_unresolved_python_invocations.py
+++ b/tests/check_unresolved_python_invocations.py
@@ -12,7 +12,7 @@ ALLOWED_FILES = {
     Path("tests/ci/test_vcpkg_install_retry.py"),
 }
 DIRECT_PYTHON = re.compile(
-    r"(?m)(?:^|[;&|`$()]\s*)(?P<cmd>python3?|/[^\s'\"]*/python3?)(?:\s|$)"
+    r"(?m)(?:^[ \t]*|[;&|`$()][ \t]*)(?P<cmd>python3?|/[^\s'\"]*/python3?)(?:\s|$)"
 )
 ALLOWED_CONTEXTS = (
     "#!/usr/bin/env python3",


### PR DESCRIPTION
### Motivation

- Finish Phase 2 CMake ownership work so each top-level application module owns its explicit application source registration and the root no longer enumerates feature-module implementation sources.
- Move MVR/MVR-xchange ownership into the `mvr/` module and relocate remaining Core implementation ownership into `core/` to match the documented architecture and avoid mixed root ownership.
- Strengthen the repository baseline and automated guards to prevent future silent divergence between documented modules and CMake registrations.

### Description

- Added `mvr/CMakeLists.txt` that explicitly registers all application `mvr/` and `mvr/xchange/` implementation sources, the module include dir, Windows socket link requirements, and conditional mDNS wiring under `PERASTAGE_ENABLE_MVR_XCHANGE_MDNS`.
- Removed all feature implementation paths from the root `add_executable(...)` and added `add_subdirectory(mvr)` so all top-level source modules follow the same `add_subdirectory(...)` ownership convention.
- Moved remaining Core implementation sources previously listed at root into `core/CMakeLists.txt`, and moved `uuidutils.cpp` into `core` ownership via `target_sources(perastage_uuid ...)` while preserving the `perastage_uuid` object-target identity and include visibility.
- Updated machine-readable baseline and enforcement logic: `docs/developer/repository_structure_baseline.json` now lists `mvr` among `module_cmake_directories` and clears `root_registered_source_groups`, `tests/check_repository_structure_baseline.py` was extended to assert parity between declared top-level source modules and module CMake directories and to reject retained root-owned feature sources, and fixture tests/scripts were updated accordingly; also updated `tests/check_perastage_tree_modules.sh`, `docs/developer/{architecture.md,repository_layout.md,perastage_tree.md}`, and `docs/release-notes-draft.md` to reflect the completed Phase 2 state.

### Testing

- Ran the repository structure audit: `python3 tests/check_repository_structure_baseline.py` and the fixtures: `python3 tests/check_repository_structure_baseline_fixtures.py -v`, both completed OK.
- Ran repository module checks and policy scripts: `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both completed OK.
- Performed an explicit source-registration audit (Python inspection) confirming every production `.cpp` in `core`, `gui`, `models`, `mvr`, `viewer2d`, `viewer3d`, and `viewer_common` is registered exactly once and the root `add_executable(...)` no longer contains feature-module implementation paths; `core/uuidutils.cpp` is no longer listed from the root.
- Ran local CMake configure presets to validate MVR-xchange wiring in both modes, but full configuration could not complete in this environment due to missing platform `wxWidgets` packages; the mDNS conditional compile/link logic was validated in the module-level CMake changes.  
- Verified `git diff --check` and Python syntax checks for modified test scripts; no `file(GLOB ...)` or recursive discovery was introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9b352f31a083248c4fd07857ccbced)