### PR TITLE
ORG-016: extract dependency discovery from root CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,20 +46,7 @@ if(PERASTAGE_ENABLE_COMPILER_CACHE)
     endif()
 endif()
 
-# wxWidgets chooses different binary sets based on wxWidgets_USE_DEBUG.
-# - Single-config: we can select debug libs based on CMAKE_BUILD_TYPE.
-# - Multi-config (Visual Studio): do not force wxWidgets_USE_DEBUG unless explicitly requested.
 option(PERASTAGE_FORCE_WXDEBUG "Force linking wxWidgets debug libs" OFF)
-if(PERASTAGE_FORCE_WXDEBUG)
-    set(wxWidgets_USE_DEBUG ON)
-elseif(NOT CMAKE_CONFIGURATION_TYPES)
-    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-        set(wxWidgets_USE_DEBUG ON)
-    else()
-        set(wxWidgets_USE_DEBUG OFF)
-    endif()
-endif()
-set(wxWidgets_USE_UNICODE ON)
 
 get_property(_perastage_build_testing_set CACHE BUILD_TESTING PROPERTY VALUE SET)
 if(NOT _perastage_build_testing_set)
@@ -77,68 +64,7 @@ if(BUILD_TESTING)
     enable_testing()
 endif()
 
-# Find required packages
-if(WIN32)
-    find_package(wxWidgets CONFIG REQUIRED COMPONENTS core base aui gl html richtext xml)
-    set(_wx_libs
-        wx::core
-        wx::base
-        wx::aui
-        wx::gl
-        wx::html
-        wx::richtext
-    )
-    if(TARGET wx::xml)
-        list(APPEND _wx_libs wx::xml)
-    endif()
-    set(_wx_includes "")
-    find_package(tinyxml2 CONFIG REQUIRED)
-else()
-    find_package(wxWidgets REQUIRED COMPONENTS core base aui gl html richtext xml)
-    include(${wxWidgets_USE_FILE})
-    set(_wx_libs ${wxWidgets_LIBRARIES})
-    set(_wx_includes ${wxWidgets_INCLUDE_DIRS})
-    find_package(tinyxml2 REQUIRED)
-endif()
-find_package(OpenGL REQUIRED)
-find_package(CURL REQUIRED)
-find_package(Python3 COMPONENTS Interpreter REQUIRED)
-find_package(GLEW REQUIRED)
-find_package(meshoptimizer CONFIG REQUIRED)
-if(WIN32)
-    find_package(nanovg CONFIG REQUIRED)
-    find_package(podofo CONFIG REQUIRED)
-else()
-    find_package(nanovg CONFIG QUIET)
-    if(NOT nanovg_FOUND)
-        find_path(NANOVG_INCLUDE_DIR nanovg.h)
-        find_library(NANOVG_LIBRARY nanovg)
-        if(NOT NANOVG_INCLUDE_DIR OR NOT NANOVG_LIBRARY)
-            message(FATAL_ERROR "nanovg not found. Install libnanovg-dev or provide nanovgConfig.cmake.")
-        endif()
-        add_library(nanovg::nanovg UNKNOWN IMPORTED)
-        set_target_properties(nanovg::nanovg PROPERTIES
-            IMPORTED_LOCATION "${NANOVG_LIBRARY}"
-            INTERFACE_INCLUDE_DIRECTORIES "${NANOVG_INCLUDE_DIR}"
-        )
-    endif()
-
-    find_package(podofo CONFIG QUIET)
-    if(NOT podofo_FOUND)
-        find_path(PODOFO_INCLUDE_DIR podofo/podofo.h)
-        find_library(PODOFO_LIBRARY podofo)
-        if(NOT PODOFO_INCLUDE_DIR OR NOT PODOFO_LIBRARY)
-            message(FATAL_ERROR "podofo not found. Install libpodofo-dev or provide podofoConfig.cmake.")
-        endif()
-        add_library(podofo::podofo UNKNOWN IMPORTED)
-        set_target_properties(podofo::podofo PROPERTIES
-            IMPORTED_LOCATION "${PODOFO_LIBRARY}"
-            INTERFACE_INCLUDE_DIRECTORIES "${PODOFO_INCLUDE_DIR}"
-        )
-    endif()
-endif()
-find_package(ZLIB REQUIRED)
-find_package(Backward CONFIG REQUIRED)
+include(cmake/PerastageDependencies.cmake)
 
 set(PERASTAGE_DUMMY_GDTF_DESCRIPTION "${CMAKE_SOURCE_DIR}/cmake/fixtures/Dummy1ch.description.xml")
 set(PERASTAGE_GENERATED_LIBRARY_DIR "${CMAKE_BINARY_DIR}/generated/library")
@@ -157,50 +83,6 @@ add_custom_command(
 add_custom_target(perastage_generated_dummy_gdtf ALL
     DEPENDS "${PERASTAGE_GENERATED_DUMMY_GDTF_ARCHIVE}"
 )
-
-if(PERASTAGE_ENABLE_MVR_XCHANGE_MDNS)
-    find_package(mdns CONFIG REQUIRED)
-    message(STATUS "MVR-xchange mDNS backend enabled: vcpkg mdns")
-else()
-    message(WARNING "MVR-xchange mDNS backend disabled by PERASTAGE_ENABLE_MVR_XCHANGE_MDNS=OFF.")
-endif()
-# Verifies that the configured wxWidgets build exposes wxSecretStore support.
-function(perastage_probe_wx_secretstore out_var)
-    include(CheckCXXSourceCompiles)
-    set(_previous_required_includes "${CMAKE_REQUIRED_INCLUDES}")
-    set(_probe_includes ${_wx_includes})
-    foreach(_wx_target wx::base wx::core)
-        if(TARGET ${_wx_target})
-            get_target_property(_target_includes ${_wx_target} INTERFACE_INCLUDE_DIRECTORIES)
-            if(_target_includes)
-                list(APPEND _probe_includes ${_target_includes})
-            endif()
-        endif()
-    endforeach()
-    list(REMOVE_DUPLICATES _probe_includes)
-    set(CMAKE_REQUIRED_INCLUDES ${_probe_includes})
-    check_cxx_source_compiles("#include <wx/setup.h>
-#if !defined(wxUSE_SECRETSTORE) || !wxUSE_SECRETSTORE
-#error wxSecretStore support is disabled
-#endif
-int main() { return 0; }
-" PERASTAGE_WX_SECRETSTORE_COMPILES)
-    set(CMAKE_REQUIRED_INCLUDES "${_previous_required_includes}")
-    set(${out_var} ${PERASTAGE_WX_SECRETSTORE_COMPILES} PARENT_SCOPE)
-endfunction()
-
-perastage_probe_wx_secretstore(PERASTAGE_WX_SECRETSTORE_ENABLED)
-message(STATUS "Perastage secure credential store requirement: ${PERASTAGE_REQUIRE_SECURE_CREDENTIAL_STORE}")
-message(STATUS "Perastage target platform: ${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}")
-message(STATUS "wxUSE_SECRETSTORE enabled: ${PERASTAGE_WX_SECRETSTORE_ENABLED}")
-if(PERASTAGE_REQUIRE_SECURE_CREDENTIAL_STORE AND NOT PERASTAGE_WX_SECRETSTORE_ENABLED)
-    message(FATAL_ERROR
-        "wxSecretStore support is missing from the configured wxWidgets build. "
-        "Official Perastage builds require native credential-store support. "
-        "When using vcpkg, install wxwidgets[secretstore] via the repository vcpkg manifest. "
-        "On Linux, wxWidgets also needs libsecret development support (for example libsecret-1-dev) when it is built."
-    )
-endif()
 
 # Reconfigure generated build identity when HEAD or its active branch ref moves.
 execute_process(

--- a/cmake/PerastageDependencies.cmake
+++ b/cmake/PerastageDependencies.cmake
@@ -1,0 +1,122 @@
+# Discover application dependencies and validate required package capabilities.
+
+# wxWidgets chooses different binary sets based on wxWidgets_USE_DEBUG.
+# - Single-config: we can select debug libs based on CMAKE_BUILD_TYPE.
+# - Multi-config (Visual Studio): do not force wxWidgets_USE_DEBUG unless explicitly requested.
+if(PERASTAGE_FORCE_WXDEBUG)
+    set(wxWidgets_USE_DEBUG ON)
+elseif(NOT CMAKE_CONFIGURATION_TYPES)
+    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+        set(wxWidgets_USE_DEBUG ON)
+    else()
+        set(wxWidgets_USE_DEBUG OFF)
+    endif()
+endif()
+set(wxWidgets_USE_UNICODE ON)
+
+if(WIN32)
+    find_package(wxWidgets CONFIG REQUIRED COMPONENTS core base aui gl html richtext xml)
+    set(_wx_libs
+        wx::core
+        wx::base
+        wx::aui
+        wx::gl
+        wx::html
+        wx::richtext
+    )
+    if(TARGET wx::xml)
+        list(APPEND _wx_libs wx::xml)
+    endif()
+    set(_wx_includes "")
+    find_package(tinyxml2 CONFIG REQUIRED)
+else()
+    find_package(wxWidgets REQUIRED COMPONENTS core base aui gl html richtext xml)
+    include(${wxWidgets_USE_FILE})
+    set(_wx_libs ${wxWidgets_LIBRARIES})
+    set(_wx_includes ${wxWidgets_INCLUDE_DIRS})
+    find_package(tinyxml2 REQUIRED)
+endif()
+find_package(OpenGL REQUIRED)
+find_package(CURL REQUIRED)
+find_package(Python3 COMPONENTS Interpreter REQUIRED)
+find_package(GLEW REQUIRED)
+find_package(meshoptimizer CONFIG REQUIRED)
+if(WIN32)
+    find_package(nanovg CONFIG REQUIRED)
+    find_package(podofo CONFIG REQUIRED)
+else()
+    find_package(nanovg CONFIG QUIET)
+    if(NOT nanovg_FOUND)
+        find_path(NANOVG_INCLUDE_DIR nanovg.h)
+        find_library(NANOVG_LIBRARY nanovg)
+        if(NOT NANOVG_INCLUDE_DIR OR NOT NANOVG_LIBRARY)
+            message(FATAL_ERROR "nanovg not found. Install libnanovg-dev or provide nanovgConfig.cmake.")
+        endif()
+        add_library(nanovg::nanovg UNKNOWN IMPORTED)
+        set_target_properties(nanovg::nanovg PROPERTIES
+            IMPORTED_LOCATION "${NANOVG_LIBRARY}"
+            INTERFACE_INCLUDE_DIRECTORIES "${NANOVG_INCLUDE_DIR}"
+        )
+    endif()
+
+    find_package(podofo CONFIG QUIET)
+    if(NOT podofo_FOUND)
+        find_path(PODOFO_INCLUDE_DIR podofo/podofo.h)
+        find_library(PODOFO_LIBRARY podofo)
+        if(NOT PODOFO_INCLUDE_DIR OR NOT PODOFO_LIBRARY)
+            message(FATAL_ERROR "podofo not found. Install libpodofo-dev or provide podofoConfig.cmake.")
+        endif()
+        add_library(podofo::podofo UNKNOWN IMPORTED)
+        set_target_properties(podofo::podofo PROPERTIES
+            IMPORTED_LOCATION "${PODOFO_LIBRARY}"
+            INTERFACE_INCLUDE_DIRECTORIES "${PODOFO_INCLUDE_DIR}"
+        )
+    endif()
+endif()
+find_package(ZLIB REQUIRED)
+find_package(Backward CONFIG REQUIRED)
+
+if(PERASTAGE_ENABLE_MVR_XCHANGE_MDNS)
+    find_package(mdns CONFIG REQUIRED)
+    message(STATUS "MVR-xchange mDNS backend enabled: vcpkg mdns")
+else()
+    message(WARNING "MVR-xchange mDNS backend disabled by PERASTAGE_ENABLE_MVR_XCHANGE_MDNS=OFF.")
+endif()
+
+# Verifies that the configured wxWidgets build exposes wxSecretStore support.
+function(perastage_probe_wx_secretstore out_var)
+    include(CheckCXXSourceCompiles)
+    set(_previous_required_includes "${CMAKE_REQUIRED_INCLUDES}")
+    set(_probe_includes ${_wx_includes})
+    foreach(_wx_target wx::base wx::core)
+        if(TARGET ${_wx_target})
+            get_target_property(_target_includes ${_wx_target} INTERFACE_INCLUDE_DIRECTORIES)
+            if(_target_includes)
+                list(APPEND _probe_includes ${_target_includes})
+            endif()
+        endif()
+    endforeach()
+    list(REMOVE_DUPLICATES _probe_includes)
+    set(CMAKE_REQUIRED_INCLUDES ${_probe_includes})
+    check_cxx_source_compiles("#include <wx/setup.h>
+#if !defined(wxUSE_SECRETSTORE) || !wxUSE_SECRETSTORE
+#error wxSecretStore support is disabled
+#endif
+int main() { return 0; }
+" PERASTAGE_WX_SECRETSTORE_COMPILES)
+    set(CMAKE_REQUIRED_INCLUDES "${_previous_required_includes}")
+    set(${out_var} ${PERASTAGE_WX_SECRETSTORE_COMPILES} PARENT_SCOPE)
+endfunction()
+
+perastage_probe_wx_secretstore(PERASTAGE_WX_SECRETSTORE_ENABLED)
+message(STATUS "Perastage secure credential store requirement: ${PERASTAGE_REQUIRE_SECURE_CREDENTIAL_STORE}")
+message(STATUS "Perastage target platform: ${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}")
+message(STATUS "wxUSE_SECRETSTORE enabled: ${PERASTAGE_WX_SECRETSTORE_ENABLED}")
+if(PERASTAGE_REQUIRE_SECURE_CREDENTIAL_STORE AND NOT PERASTAGE_WX_SECRETSTORE_ENABLED)
+    message(FATAL_ERROR
+        "wxSecretStore support is missing from the configured wxWidgets build. "
+        "Official Perastage builds require native credential-store support. "
+        "When using vcpkg, install wxwidgets[secretstore] via the repository vcpkg manifest. "
+        "On Linux, wxWidgets also needs libsecret development support (for example libsecret-1-dev) when it is built."
+    )
+endif()

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -21,7 +21,7 @@ This document defines the expected directory conventions for Perastage.
 
 ## CMake convention
 
-- Root `CMakeLists.txt` owns target creation, global dependencies, and module orchestration; it does not normally register feature-module implementation sources.
+- Root `CMakeLists.txt` owns target creation and module orchestration; `cmake/PerastageDependencies.cmake` owns application dependency discovery and capability validation.
 - Every top-level application source module contributes its explicit source list using its local `CMakeLists.txt` and `target_sources(${PROJECT_NAME} ...)`.
 - `docs/developer/repository_structure_baseline.json` is the authoritative machine-readable contract for source-module classification and CMake registration.
 - Avoid recursive or wildcard project-source discovery; list files explicitly.

--- a/docs/developer/perastage_tree.md
+++ b/docs/developer/perastage_tree.md
@@ -16,7 +16,7 @@ Perastage/
 |-- docs/                        # User documentation, architecture notes, repository map, and docs website assets.
 |-- AGENTS.md                    # Repository guidance for automated coding agents.
 |-- VERSION                      # Single project version source.
-|-- cmake/                       # CMake templates and helper scripts.
+|-- cmake/                       # Dependency discovery, CMake templates, and helper scripts.
 |-- core/                        # Shared business logic and cross-cutting services.
 |   |-- layouts/                 # Printable layout/page management.
 |   `-- print/                   # Printing and PDF/table export helpers.

--- a/docs/developer/repository_layout.md
+++ b/docs/developer/repository_layout.md
@@ -14,9 +14,9 @@ this page remains its human-readable architectural counterpart.
 | Path | Purpose |
 |------|---------|
 | `main.cpp` | wxWidgets application entry point and top-level initialization. |
-| `CMakeLists.txt` | Root build orchestration, global dependencies, platform options, install rules, and module registration. |
+| `CMakeLists.txt` | Root build orchestration, platform options, install rules, and module registration. |
 | `CMakePresets.json` | Canonical tracked configure/build presets for supported local development workflows. |
-| `cmake/` | CMake helper scripts, generated configuration templates, and platform metadata templates. |
+| `cmake/` | Dependency discovery, CMake helper scripts, generated configuration templates, and platform metadata templates. |
 | `core/` | Core logic, import helpers, dictionaries, patching, layouts, printing, persistence, and shared services. |
 | `gui/` | wxWidgets windows, dialogs, menus, panels, UI controllers, and user interaction workflows. |
 | `models/` | Scene data models for fixtures, trusses, hoists, objects, layers, and placement data. |
@@ -34,6 +34,10 @@ this page remains its human-readable architectural counterpart.
 | `.github/workflows/` | GitHub Actions workflows for CI, packaging, release assets, and platform builds. |
 
 ## Build module registration
+
+Application dependency discovery and dependency capability validation are owned
+by `cmake/PerastageDependencies.cmake`, which the root includes before creating
+or registering targets that consume the discovered packages.
 
 The root CMake file explicitly registers every application source module with
 `add_subdirectory(...)` instead of discovering project sources recursively. The

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -20,6 +20,7 @@ Changes since **v1.6.0**.
 - Made the Windows classic-vcpkg workflow portable and reliable in Visual Studio through explicit or user-wide external checkout discovery, while ignoring the IDE's injected bundled dependency tree, keeping cross-platform validation reliable, and removing redundant legacy configuration files.
 - Gave the scene-model module explicit ownership of its application source registration while preserving existing build behavior.
 - Completed explicit CMake source ownership across all application modules and strengthened cross-platform, harness-aware repository checks against architecture drift.
+- Moved application dependency discovery into a dedicated build module while preserving existing package-manager and platform behavior.
 
 ## Downloads and installation
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -188,6 +188,9 @@ if(Python3_Interpreter_FOUND)
     add_repository_policy_test(RepositoryStructureBaselineFixtures ${Python3_EXECUTABLE}
                                ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_repository_structure_baseline_fixtures.py
                                LABELS standard-strict policy cmake)
+    add_repository_policy_test(DependencyDiscoveryOwnership ${Python3_EXECUTABLE}
+                               ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_dependency_discovery_ownership.py
+                               LABELS standard-strict policy cmake)
     add_repository_policy_test(DocsLinks ${Python3_EXECUTABLE}
                                ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_docs_links.py)
     add_repository_policy_test(TestTargetsNoSourceRootIncludes ${Python3_EXECUTABLE}

--- a/tests/check_dependency_discovery_ownership.py
+++ b/tests/check_dependency_discovery_ownership.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Validate ownership of application dependency discovery in CMake."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ROOT_CMAKE = ROOT / "CMakeLists.txt"
+DEPENDENCY_MODULE = ROOT / "cmake" / "PerastageDependencies.cmake"
+
+
+def main() -> int:
+    """Reject dependency discovery that escapes its dedicated CMake module."""
+    root_cmake = ROOT_CMAKE.read_text(encoding="utf-8")
+    dependency_cmake = DEPENDENCY_MODULE.read_text(encoding="utf-8")
+    errors: list[str] = []
+
+    include_statement = "include(cmake/PerastageDependencies.cmake)"
+    if root_cmake.count(include_statement) != 1:
+        errors.append(f"root CMake must include {DEPENDENCY_MODULE.name} exactly once")
+
+    application_packages = (
+        "wxWidgets",
+        "tinyxml2",
+        "OpenGL",
+        "CURL",
+        "GLEW",
+        "meshoptimizer",
+        "nanovg",
+        "podofo",
+        "ZLIB",
+        "Backward",
+        "mdns",
+    )
+    for package in application_packages:
+        if re.search(rf"find_package\s*\(\s*{re.escape(package)}\b", root_cmake):
+            errors.append(f"root CMake still discovers application dependency {package}")
+        if not re.search(rf"find_package\s*\(\s*{re.escape(package)}\b", dependency_cmake):
+            errors.append(f"dependency module does not discover {package}")
+
+    required_contracts = (
+        "find_package(Python3 COMPONENTS Interpreter REQUIRED)",
+        "set(_wx_libs",
+        "set(_wx_includes",
+        "find_path(NANOVG_INCLUDE_DIR nanovg.h)",
+        "add_library(nanovg::nanovg UNKNOWN IMPORTED)",
+        "add_library(podofo::podofo UNKNOWN IMPORTED)",
+        "perastage_probe_wx_secretstore(PERASTAGE_WX_SECRETSTORE_ENABLED)",
+        "if(PERASTAGE_ENABLE_MVR_XCHANGE_MDNS)",
+    )
+    for contract in required_contracts:
+        if contract not in dependency_cmake:
+            errors.append(f"dependency module is missing contract: {contract}")
+
+    if "find_package(Gettext QUIET)" not in root_cmake:
+        errors.append("localization-specific Gettext discovery must remain in root CMake for ORG-017")
+
+    if errors:
+        print("Dependency discovery ownership check failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    print("Dependency discovery ownership check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Reduce root CMake file responsibility by moving third-party package discovery, platform-specific fallbacks, and capability probes into a single focused `cmake/` module to improve modularity and ease future maintenance.
- Preserve exact observable build behavior and package/target contracts across platforms, including wxWidgets debug selection, NanoVG/PoDoFo fallbacks, and the conditional mDNS backend.

### Description
- Added `cmake/PerastageDependencies.cmake` which centralizes discovery for `wxWidgets`, `tinyxml2`, `OpenGL`, `CURL`, `Python3` (Interpreter), `GLEW`, `meshoptimizer`, `nanovg` (with non-Windows `find_path`/`find_library` fallback and an imported `nanovg::nanovg` target), `podofo` (with equivalent fallback and `podofo::podofo`), `ZLIB`, `Backward`, and conditional `mdns`, plus the `perastage_probe_wx_secretstore` compile probe and associated diagnostics.
- Replaced the root discovery block with a single `include(cmake/PerastageDependencies.cmake)` so existing variables and imported targets remain available to downstream root/module CMake logic without changing semantics, and preserved `_wx_libs`, `_wx_includes`, `NANOVG_INCLUDE_DIR`, and `Python3_EXECUTABLE` usage sites.
- Added `tests/check_dependency_discovery_ownership.py` and registered it in `tests/CMakeLists.txt` to assert ownership of dependency discovery and the intentional Gettext boundary left in root, and updated `docs/developer/architecture.md`, `docs/developer/perastage_tree.md`, `docs/developer/repository_layout.md`, and `docs/release-notes-draft.md` to reflect the new ownership. 
- Dependency mapping (old root behavior -> new module behavior): `wxWidgets` retains Windows `find_package(... CONFIG REQUIRED ...)` and non-Windows `find_package(... REQUIRED)` with `_wx_libs`/`_wx_includes` preserved; `tinyxml2` remains `CONFIG REQUIRED` on Windows and `REQUIRED` elsewhere; `OpenGL`, `CURL`, `Python3 (Interpreter)`, `GLEW`, `meshoptimizer`, `ZLIB`, and `Backward` keep their required/config semantics; `nanovg` keeps Windows `CONFIG REQUIRED` and non-Windows `CONFIG QUIET` then system fallback with created `nanovg::nanovg`; `podofo` keeps Windows `CONFIG REQUIRED` and non-Windows `CONFIG QUIET` then system fallback with created `podofo::podofo`; `mdns` remains conditional on `PERASTAGE_ENABLE_MVR_XCHANGE_MDNS`. 

### Testing
- Ran `python3 tests/check_dependency_discovery_ownership.py` which passed and confirms the root includes the new module and the module contains the expected discovery contracts. 
- Ran repository structure and fixture checks `python3 tests/check_repository_structure_baseline.py` and `python3 tests/check_repository_structure_baseline_fixtures.py -v` which passed. 
- Executed representative policy and guard scripts (invoked via `PERASTAGE_TEST_PYTHON=$(command -v python3)`): `tests/check_perastage_tree_modules.sh`, `tests/check_no_configmanager_get_in_gui.sh`, `tests/check_securestore_build_policy.sh`, `tests/check_cmake_preset_policy.sh`, `tests/check_localization_contract_boundaries.sh`, and `python3 tests/check_unresolved_python_invocations.py`, all of which passed; also ran `python3 -m py_compile tests/check_dependency_discovery_ownership.py` and `python3 tests/check_docs_links.py` which passed, and `git diff --cached --check` which produced no issues. 
- Attempted a representative configure with `cmake --preset wsl-x64-debug -DPERASTAGE_ENABLE_MVR_XCHANGE_MDNS=OFF -DPERASTAGE_ENABLE_LOCALIZATION=OFF`, which reached the extracted module successfully but failed to complete configuration on this runner due to missing system wxWidgets development libraries (this is an environment limitation, not a behavioral regression).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9bd1217a048324bc2aa8bcb300c4ea)