### PR TITLE
ORG-019: extract installation rules from root CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,46 +234,6 @@ endif()
 # Mark as GUI application (no console)
 set_target_properties(${PROJECT_NAME} PROPERTIES WIN32_EXECUTABLE TRUE)
 
-if(APPLE)
-    install(TARGETS ${PROJECT_NAME}
-        BUNDLE DESTINATION .
-        RUNTIME DESTINATION .
-    )
-else()
-    install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION .)
-endif()
-
-if(UNIX AND NOT APPLE)
-    configure_file(
-        "${CMAKE_SOURCE_DIR}/packaging/linux/perastage.desktop.in"
-        "${CMAKE_BINARY_DIR}/perastage.desktop"
-        @ONLY
-    )
-    install(FILES "${CMAKE_BINARY_DIR}/perastage.desktop"
-        DESTINATION share/applications
-    )
-    install(FILES "${CMAKE_SOURCE_DIR}/packaging/linux/perastage-mime.xml"
-        DESTINATION share/mime/packages
-    )
-    install(FILES "${CMAKE_SOURCE_DIR}/resources/Perastage_logo_1024.png"
-        DESTINATION share/icons/hicolor/1024x1024/apps
-        RENAME perastage.png
-    )
-    install(CODE [[
-        execute_process(
-            COMMAND update-mime-database "${CMAKE_INSTALL_PREFIX}/share/mime"
-            RESULT_VARIABLE perastage_mime_result
-            OUTPUT_QUIET
-            ERROR_QUIET
-        )
-        execute_process(
-            COMMAND update-desktop-database "${CMAKE_INSTALL_PREFIX}/share/applications"
-            RESULT_VARIABLE perastage_desktop_result
-            OUTPUT_QUIET
-            ERROR_QUIET
-        )
-    ]])
-endif()
 
 # Include project directories
 target_include_directories(${PROJECT_NAME} PRIVATE
@@ -330,176 +290,17 @@ if(BUILD_TESTING)
     add_subdirectory(tests)
 endif()
 
-if(APPLE)
-    # Keep runtime assets inside the app bundle so packaged macOS builds resolve resources correctly.
-    set(PERASTAGE_INSTALL_ASSET_DEST "${PROJECT_NAME}.app/Contents/Resources")
-    set(PERASTAGE_INSTALL_RESOURCE_DEST "${PROJECT_NAME}.app/Contents/Resources")
-else()
-    # Keep runtime assets next to the executable on non-macOS platforms.
-    set(PERASTAGE_INSTALL_ASSET_DEST ".")
-    set(PERASTAGE_INSTALL_RESOURCE_DEST "${PERASTAGE_INSTALL_ASSET_DEST}")
-endif()
-
-install(DIRECTORY ${CMAKE_SOURCE_DIR}/resources DESTINATION ${PERASTAGE_INSTALL_RESOURCE_DEST})
-if(PERASTAGE_ENABLE_LOCALIZATION)
-    foreach(PERASTAGE_TRANSLATION_LANGUAGE IN LISTS PERASTAGE_TRANSLATION_LANGUAGES)
-        if(APPLE)
-            set(PERASTAGE_INSTALL_LOCALE_DEST "${PERASTAGE_INSTALL_RESOURCE_DEST}/locale/${PERASTAGE_TRANSLATION_LANGUAGE}/LC_MESSAGES")
-        else()
-            set(PERASTAGE_INSTALL_LOCALE_DEST "${PERASTAGE_INSTALL_RESOURCE_DEST}/resources/locale/${PERASTAGE_TRANSLATION_LANGUAGE}/LC_MESSAGES")
-        endif()
-        install(FILES "${PERASTAGE_GENERATED_LOCALE_DIR}/${PERASTAGE_TRANSLATION_LANGUAGE}/LC_MESSAGES/perastage.mo" DESTINATION "${PERASTAGE_INSTALL_LOCALE_DEST}")
-    endforeach()
-endif()
-if(EXISTS "${CMAKE_SOURCE_DIR}/library")
-    install(DIRECTORY ${CMAKE_SOURCE_DIR}/library DESTINATION ${PERASTAGE_INSTALL_ASSET_DEST})
-endif()
-install(FILES "${PERASTAGE_GENERATED_DUMMY_GDTF_ARCHIVE}"
-        DESTINATION "${PERASTAGE_INSTALL_ASSET_DEST}/library/fixtures")
-if(EXISTS "${CMAKE_SOURCE_DIR}/licenses")
-    install(DIRECTORY ${CMAKE_SOURCE_DIR}/licenses DESTINATION ${PERASTAGE_INSTALL_ASSET_DEST})
-endif()
-
-install(FILES
-    ${CMAKE_SOURCE_DIR}/LICENSE.txt
-    ${CMAKE_SOURCE_DIR}/THIRD_PARTY_LICENSES.md
-    ${CMAKE_SOURCE_DIR}/help.md
-    DESTINATION ${PERASTAGE_INSTALL_ASSET_DEST}
-    OPTIONAL
-)
-
-if(WIN32)
-    set(CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP TRUE)
-    include(InstallRequiredSystemLibraries)
-
-    # Collect vcpkg release and debug bin directories.
-    set(PERASTAGE_VCPKG_BIN_DIRS "")
-    set(PERASTAGE_VCPKG_DEBUG_BIN_DIRS "")
-    if(DEFINED VCPKG_INSTALLED_DIR AND DEFINED VCPKG_TARGET_TRIPLET)
-        set(_perastage_vcpkg_bin "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin")
-        if(EXISTS "${_perastage_vcpkg_bin}")
-            list(APPEND PERASTAGE_VCPKG_BIN_DIRS "${_perastage_vcpkg_bin}")
-        endif()
-        set(_perastage_vcpkg_debug_bin "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug/bin")
-        if(EXISTS "${_perastage_vcpkg_debug_bin}")
-            list(APPEND PERASTAGE_VCPKG_DEBUG_BIN_DIRS "${_perastage_vcpkg_debug_bin}")
-        endif()
-    endif()
-    list(REMOVE_DUPLICATES PERASTAGE_VCPKG_BIN_DIRS)
-    list(REMOVE_DUPLICATES PERASTAGE_VCPKG_DEBUG_BIN_DIRS)
-
-    # Stage all DLLs from vcpkg/bin directly via glob.
-    # This is simpler and more reliable than file(GET_RUNTIME_DEPENDENCIES),
-    # which struggles with virtual Windows API-set DLLs that have no physical
-    # file on disk. vcpkg/bin contains only the third-party runtime DLLs we
-    # need — no Windows system DLLs — so a plain glob is safe here.
-    set(PERASTAGE_VCPKG_RELEASE_DLLS "")
-    set(PERASTAGE_VCPKG_DEBUG_DLLS "")
-    foreach(_vcpkg_bin IN LISTS PERASTAGE_VCPKG_BIN_DIRS)
-        file(GLOB _vcpkg_bin_dlls "${_vcpkg_bin}/*.dll")
-        list(APPEND PERASTAGE_VCPKG_RELEASE_DLLS ${_vcpkg_bin_dlls})
-    endforeach()
-    foreach(_vcpkg_debug_bin IN LISTS PERASTAGE_VCPKG_DEBUG_BIN_DIRS)
-        file(GLOB _vcpkg_debug_bin_dlls "${_vcpkg_debug_bin}/*.dll")
-        list(APPEND PERASTAGE_VCPKG_DEBUG_DLLS ${_vcpkg_debug_bin_dlls})
-    endforeach()
-    list(REMOVE_DUPLICATES PERASTAGE_VCPKG_RELEASE_DLLS)
-    list(REMOVE_DUPLICATES PERASTAGE_VCPKG_DEBUG_DLLS)
-
-    if(PERASTAGE_VCPKG_RELEASE_DLLS)
-        if(CMAKE_CONFIGURATION_TYPES)
-            install(FILES ${PERASTAGE_VCPKG_RELEASE_DLLS} DESTINATION . CONFIGURATIONS Release RelWithDebInfo MinSizeRel)
-            install(FILES ${PERASTAGE_VCPKG_DEBUG_DLLS}   DESTINATION . CONFIGURATIONS Debug)
-        elseif(CMAKE_BUILD_TYPE STREQUAL "Debug")
-            install(FILES ${PERASTAGE_VCPKG_DEBUG_DLLS} DESTINATION .)
-        else()
-            install(FILES ${PERASTAGE_VCPKG_RELEASE_DLLS} DESTINATION .)
-        endif()
-    endif()
-
-    # wxWidgets libraries may not appear in TARGET_RUNTIME_DLLS when discovered
-    # via wxWidgets_USE_FILE, so derive DLL locations from linked libraries too.
-    set(PERASTAGE_WX_SEARCH_DIRS "")
-    foreach(wx_dir IN LISTS wxWidgets_LIBRARY_DIRS)
-        if(wx_dir AND IS_DIRECTORY "${wx_dir}")
-            list(APPEND PERASTAGE_WX_SEARCH_DIRS "${wx_dir}")
-        endif()
-    endforeach()
-    foreach(wx_lib IN LISTS wxWidgets_LIBRARIES)
-        if(EXISTS "${wx_lib}")
-            get_filename_component(wx_lib_dir "${wx_lib}" DIRECTORY)
-            if(IS_DIRECTORY "${wx_lib_dir}")
-                list(APPEND PERASTAGE_WX_SEARCH_DIRS "${wx_lib_dir}")
-            endif()
-        endif()
-    endforeach()
-    list(REMOVE_DUPLICATES PERASTAGE_WX_SEARCH_DIRS)
-
-    set(PERASTAGE_WX_DLL_PATTERNS "")
-    foreach(wx_dir IN LISTS PERASTAGE_WX_SEARCH_DIRS)
-        list(APPEND PERASTAGE_WX_DLL_PATTERNS
-            "${wx_dir}/wxmsw*.dll"
-            "${wx_dir}/wxbase*.dll"
-            "${wx_dir}/nwxmsw*.dll"
-            "${wx_dir}/nwxbase*.dll")
-        get_filename_component(wx_bin_dir "${wx_dir}/../bin" ABSOLUTE)
-        list(APPEND PERASTAGE_WX_DLL_PATTERNS
-            "${wx_bin_dir}/wxmsw*.dll"
-            "${wx_bin_dir}/wxbase*.dll"
-            "${wx_bin_dir}/nwxmsw*.dll"
-            "${wx_bin_dir}/nwxbase*.dll")
-    endforeach()
-    list(REMOVE_ITEM PERASTAGE_WX_DLL_PATTERNS "")
-    list(REMOVE_DUPLICATES PERASTAGE_WX_DLL_PATTERNS)
-
-    set(PERASTAGE_WX_RUNTIME_DLLS "")
-    foreach(wx_pattern IN LISTS PERASTAGE_WX_DLL_PATTERNS)
-        file(GLOB PERASTAGE_WX_GLOB "${wx_pattern}")
-        list(APPEND PERASTAGE_WX_RUNTIME_DLLS ${PERASTAGE_WX_GLOB})
-    endforeach()
-    list(REMOVE_DUPLICATES PERASTAGE_WX_RUNTIME_DLLS)
-
-    if(PERASTAGE_WX_RUNTIME_DLLS)
-        set(PERASTAGE_WX_DEBUG_DLLS ${PERASTAGE_WX_RUNTIME_DLLS})
-        set(PERASTAGE_WX_RELEASE_DLLS ${PERASTAGE_WX_RUNTIME_DLLS})
-        list(FILTER PERASTAGE_WX_DEBUG_DLLS INCLUDE REGEX ".*(d_vc_|ud_vc_).*\\.dll$")
-        list(FILTER PERASTAGE_WX_RELEASE_DLLS EXCLUDE REGEX ".*(d_vc_|ud_vc_).*\\.dll$")
-        list(FILTER PERASTAGE_WX_RELEASE_DLLS EXCLUDE REGEX ".*ud_.*\\.dll$")
-        list(FILTER PERASTAGE_WX_RELEASE_DLLS EXCLUDE REGEX ".*d_.*\\.dll$")
-        list(FILTER PERASTAGE_WX_RELEASE_DLLS EXCLUDE REGEX ".*d\\.dll$")
-
-        if(CMAKE_CONFIGURATION_TYPES)
-            install(FILES ${PERASTAGE_WX_DEBUG_DLLS} DESTINATION . CONFIGURATIONS Debug)
-            install(FILES ${PERASTAGE_WX_RELEASE_DLLS} DESTINATION . CONFIGURATIONS Release RelWithDebInfo MinSizeRel)
-        elseif(wxWidgets_USE_DEBUG)
-            install(FILES ${PERASTAGE_WX_DEBUG_DLLS} DESTINATION .)
-        else()
-            install(FILES ${PERASTAGE_WX_RELEASE_DLLS} DESTINATION .)
-        endif()
-    endif()
-
-endif()
+include(cmake/PerastageInstall.cmake)
 
 if(CMAKE_CONFIGURATION_TYPES)
-    set(PERASTAGE_STAGE_PREFIX "${CMAKE_SOURCE_DIR}/out/install/$<CONFIG>")
-    set(PERASTAGE_STAGE_CONFIG --config $<CONFIG>)
     set(PERASTAGE_SYMBOLS_DIR "${CMAKE_SOURCE_DIR}/out/symbols/windows")
 else()
     if(CMAKE_BUILD_TYPE)
-        set(PERASTAGE_STAGE_PREFIX "${CMAKE_SOURCE_DIR}/out/install/${CMAKE_BUILD_TYPE}")
         set(PERASTAGE_SYMBOLS_DIR "${CMAKE_SOURCE_DIR}/out/symbols/windows")
     else()
-        set(PERASTAGE_STAGE_PREFIX "${CMAKE_SOURCE_DIR}/out/install")
         set(PERASTAGE_SYMBOLS_DIR "${CMAKE_SOURCE_DIR}/out/symbols/windows")
     endif()
-    set(PERASTAGE_STAGE_CONFIG)
 endif()
-
-add_custom_target(perastage_stage
-    COMMAND ${CMAKE_COMMAND} -E rm -rf "${PERASTAGE_STAGE_PREFIX}"
-    COMMAND ${CMAKE_COMMAND} --install "${CMAKE_BINARY_DIR}" --prefix "${PERASTAGE_STAGE_PREFIX}" ${PERASTAGE_STAGE_CONFIG}
-    DEPENDS ${PROJECT_NAME}
-)
 
 if(WIN32 AND MSVC)
     add_custom_target(perastage_symbols

--- a/cmake/PerastageInstall.cmake
+++ b/cmake/PerastageInstall.cmake
@@ -1,0 +1,208 @@
+if(APPLE)
+    install(TARGETS ${PROJECT_NAME}
+        BUNDLE DESTINATION .
+        RUNTIME DESTINATION .
+    )
+else()
+    install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION .)
+endif()
+
+if(UNIX AND NOT APPLE)
+    configure_file(
+        "${CMAKE_SOURCE_DIR}/packaging/linux/perastage.desktop.in"
+        "${CMAKE_BINARY_DIR}/perastage.desktop"
+        @ONLY
+    )
+    install(FILES "${CMAKE_BINARY_DIR}/perastage.desktop"
+        DESTINATION share/applications
+    )
+    install(FILES "${CMAKE_SOURCE_DIR}/packaging/linux/perastage-mime.xml"
+        DESTINATION share/mime/packages
+    )
+    install(FILES "${CMAKE_SOURCE_DIR}/resources/Perastage_logo_1024.png"
+        DESTINATION share/icons/hicolor/1024x1024/apps
+        RENAME perastage.png
+    )
+    install(CODE [[
+        execute_process(
+            COMMAND update-mime-database "${CMAKE_INSTALL_PREFIX}/share/mime"
+            RESULT_VARIABLE perastage_mime_result
+            OUTPUT_QUIET
+            ERROR_QUIET
+        )
+        execute_process(
+            COMMAND update-desktop-database "${CMAKE_INSTALL_PREFIX}/share/applications"
+            RESULT_VARIABLE perastage_desktop_result
+            OUTPUT_QUIET
+            ERROR_QUIET
+        )
+    ]])
+endif()
+
+if(APPLE)
+    # Keep runtime assets inside the app bundle so packaged macOS builds resolve resources correctly.
+    set(PERASTAGE_INSTALL_ASSET_DEST "${PROJECT_NAME}.app/Contents/Resources")
+    set(PERASTAGE_INSTALL_RESOURCE_DEST "${PROJECT_NAME}.app/Contents/Resources")
+else()
+    # Keep runtime assets next to the executable on non-macOS platforms.
+    set(PERASTAGE_INSTALL_ASSET_DEST ".")
+    set(PERASTAGE_INSTALL_RESOURCE_DEST "${PERASTAGE_INSTALL_ASSET_DEST}")
+endif()
+
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/resources DESTINATION ${PERASTAGE_INSTALL_RESOURCE_DEST})
+if(PERASTAGE_ENABLE_LOCALIZATION)
+    foreach(PERASTAGE_TRANSLATION_LANGUAGE IN LISTS PERASTAGE_TRANSLATION_LANGUAGES)
+        if(APPLE)
+            set(PERASTAGE_INSTALL_LOCALE_DEST "${PERASTAGE_INSTALL_RESOURCE_DEST}/locale/${PERASTAGE_TRANSLATION_LANGUAGE}/LC_MESSAGES")
+        else()
+            set(PERASTAGE_INSTALL_LOCALE_DEST "${PERASTAGE_INSTALL_RESOURCE_DEST}/resources/locale/${PERASTAGE_TRANSLATION_LANGUAGE}/LC_MESSAGES")
+        endif()
+        install(FILES "${PERASTAGE_GENERATED_LOCALE_DIR}/${PERASTAGE_TRANSLATION_LANGUAGE}/LC_MESSAGES/perastage.mo" DESTINATION "${PERASTAGE_INSTALL_LOCALE_DEST}")
+    endforeach()
+endif()
+if(EXISTS "${CMAKE_SOURCE_DIR}/library")
+    install(DIRECTORY ${CMAKE_SOURCE_DIR}/library DESTINATION ${PERASTAGE_INSTALL_ASSET_DEST})
+endif()
+install(FILES "${PERASTAGE_GENERATED_DUMMY_GDTF_ARCHIVE}"
+        DESTINATION "${PERASTAGE_INSTALL_ASSET_DEST}/library/fixtures")
+if(EXISTS "${CMAKE_SOURCE_DIR}/licenses")
+    install(DIRECTORY ${CMAKE_SOURCE_DIR}/licenses DESTINATION ${PERASTAGE_INSTALL_ASSET_DEST})
+endif()
+
+install(FILES
+    ${CMAKE_SOURCE_DIR}/LICENSE.txt
+    ${CMAKE_SOURCE_DIR}/THIRD_PARTY_LICENSES.md
+    ${CMAKE_SOURCE_DIR}/help.md
+    DESTINATION ${PERASTAGE_INSTALL_ASSET_DEST}
+    OPTIONAL
+)
+
+if(WIN32)
+    set(CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP TRUE)
+    include(InstallRequiredSystemLibraries)
+
+    # Collect vcpkg release and debug bin directories.
+    set(PERASTAGE_VCPKG_BIN_DIRS "")
+    set(PERASTAGE_VCPKG_DEBUG_BIN_DIRS "")
+    if(DEFINED VCPKG_INSTALLED_DIR AND DEFINED VCPKG_TARGET_TRIPLET)
+        set(_perastage_vcpkg_bin "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin")
+        if(EXISTS "${_perastage_vcpkg_bin}")
+            list(APPEND PERASTAGE_VCPKG_BIN_DIRS "${_perastage_vcpkg_bin}")
+        endif()
+        set(_perastage_vcpkg_debug_bin "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug/bin")
+        if(EXISTS "${_perastage_vcpkg_debug_bin}")
+            list(APPEND PERASTAGE_VCPKG_DEBUG_BIN_DIRS "${_perastage_vcpkg_debug_bin}")
+        endif()
+    endif()
+    list(REMOVE_DUPLICATES PERASTAGE_VCPKG_BIN_DIRS)
+    list(REMOVE_DUPLICATES PERASTAGE_VCPKG_DEBUG_BIN_DIRS)
+
+    # Stage all DLLs from vcpkg/bin directly via glob.
+    # This is simpler and more reliable than file(GET_RUNTIME_DEPENDENCIES),
+    # which struggles with virtual Windows API-set DLLs that have no physical
+    # file on disk. vcpkg/bin contains only the third-party runtime DLLs we
+    # need — no Windows system DLLs — so a plain glob is safe here.
+    set(PERASTAGE_VCPKG_RELEASE_DLLS "")
+    set(PERASTAGE_VCPKG_DEBUG_DLLS "")
+    foreach(_vcpkg_bin IN LISTS PERASTAGE_VCPKG_BIN_DIRS)
+        file(GLOB _vcpkg_bin_dlls "${_vcpkg_bin}/*.dll")
+        list(APPEND PERASTAGE_VCPKG_RELEASE_DLLS ${_vcpkg_bin_dlls})
+    endforeach()
+    foreach(_vcpkg_debug_bin IN LISTS PERASTAGE_VCPKG_DEBUG_BIN_DIRS)
+        file(GLOB _vcpkg_debug_bin_dlls "${_vcpkg_debug_bin}/*.dll")
+        list(APPEND PERASTAGE_VCPKG_DEBUG_DLLS ${_vcpkg_debug_bin_dlls})
+    endforeach()
+    list(REMOVE_DUPLICATES PERASTAGE_VCPKG_RELEASE_DLLS)
+    list(REMOVE_DUPLICATES PERASTAGE_VCPKG_DEBUG_DLLS)
+
+    if(PERASTAGE_VCPKG_RELEASE_DLLS)
+        if(CMAKE_CONFIGURATION_TYPES)
+            install(FILES ${PERASTAGE_VCPKG_RELEASE_DLLS} DESTINATION . CONFIGURATIONS Release RelWithDebInfo MinSizeRel)
+            install(FILES ${PERASTAGE_VCPKG_DEBUG_DLLS}   DESTINATION . CONFIGURATIONS Debug)
+        elseif(CMAKE_BUILD_TYPE STREQUAL "Debug")
+            install(FILES ${PERASTAGE_VCPKG_DEBUG_DLLS} DESTINATION .)
+        else()
+            install(FILES ${PERASTAGE_VCPKG_RELEASE_DLLS} DESTINATION .)
+        endif()
+    endif()
+
+    # wxWidgets libraries may not appear in TARGET_RUNTIME_DLLS when discovered
+    # via wxWidgets_USE_FILE, so derive DLL locations from linked libraries too.
+    set(PERASTAGE_WX_SEARCH_DIRS "")
+    foreach(wx_dir IN LISTS wxWidgets_LIBRARY_DIRS)
+        if(wx_dir AND IS_DIRECTORY "${wx_dir}")
+            list(APPEND PERASTAGE_WX_SEARCH_DIRS "${wx_dir}")
+        endif()
+    endforeach()
+    foreach(wx_lib IN LISTS wxWidgets_LIBRARIES)
+        if(EXISTS "${wx_lib}")
+            get_filename_component(wx_lib_dir "${wx_lib}" DIRECTORY)
+            if(IS_DIRECTORY "${wx_lib_dir}")
+                list(APPEND PERASTAGE_WX_SEARCH_DIRS "${wx_lib_dir}")
+            endif()
+        endif()
+    endforeach()
+    list(REMOVE_DUPLICATES PERASTAGE_WX_SEARCH_DIRS)
+
+    set(PERASTAGE_WX_DLL_PATTERNS "")
+    foreach(wx_dir IN LISTS PERASTAGE_WX_SEARCH_DIRS)
+        list(APPEND PERASTAGE_WX_DLL_PATTERNS
+            "${wx_dir}/wxmsw*.dll"
+            "${wx_dir}/wxbase*.dll"
+            "${wx_dir}/nwxmsw*.dll"
+            "${wx_dir}/nwxbase*.dll")
+        get_filename_component(wx_bin_dir "${wx_dir}/../bin" ABSOLUTE)
+        list(APPEND PERASTAGE_WX_DLL_PATTERNS
+            "${wx_bin_dir}/wxmsw*.dll"
+            "${wx_bin_dir}/wxbase*.dll"
+            "${wx_bin_dir}/nwxmsw*.dll"
+            "${wx_bin_dir}/nwxbase*.dll")
+    endforeach()
+    list(REMOVE_ITEM PERASTAGE_WX_DLL_PATTERNS "")
+    list(REMOVE_DUPLICATES PERASTAGE_WX_DLL_PATTERNS)
+
+    set(PERASTAGE_WX_RUNTIME_DLLS "")
+    foreach(wx_pattern IN LISTS PERASTAGE_WX_DLL_PATTERNS)
+        file(GLOB PERASTAGE_WX_GLOB "${wx_pattern}")
+        list(APPEND PERASTAGE_WX_RUNTIME_DLLS ${PERASTAGE_WX_GLOB})
+    endforeach()
+    list(REMOVE_DUPLICATES PERASTAGE_WX_RUNTIME_DLLS)
+
+    if(PERASTAGE_WX_RUNTIME_DLLS)
+        set(PERASTAGE_WX_DEBUG_DLLS ${PERASTAGE_WX_RUNTIME_DLLS})
+        set(PERASTAGE_WX_RELEASE_DLLS ${PERASTAGE_WX_RUNTIME_DLLS})
+        list(FILTER PERASTAGE_WX_DEBUG_DLLS INCLUDE REGEX ".*(d_vc_|ud_vc_).*\\.dll$")
+        list(FILTER PERASTAGE_WX_RELEASE_DLLS EXCLUDE REGEX ".*(d_vc_|ud_vc_).*\\.dll$")
+        list(FILTER PERASTAGE_WX_RELEASE_DLLS EXCLUDE REGEX ".*ud_.*\\.dll$")
+        list(FILTER PERASTAGE_WX_RELEASE_DLLS EXCLUDE REGEX ".*d_.*\\.dll$")
+        list(FILTER PERASTAGE_WX_RELEASE_DLLS EXCLUDE REGEX ".*d\\.dll$")
+
+        if(CMAKE_CONFIGURATION_TYPES)
+            install(FILES ${PERASTAGE_WX_DEBUG_DLLS} DESTINATION . CONFIGURATIONS Debug)
+            install(FILES ${PERASTAGE_WX_RELEASE_DLLS} DESTINATION . CONFIGURATIONS Release RelWithDebInfo MinSizeRel)
+        elseif(wxWidgets_USE_DEBUG)
+            install(FILES ${PERASTAGE_WX_DEBUG_DLLS} DESTINATION .)
+        else()
+            install(FILES ${PERASTAGE_WX_RELEASE_DLLS} DESTINATION .)
+        endif()
+    endif()
+
+endif()
+
+if(CMAKE_CONFIGURATION_TYPES)
+    set(PERASTAGE_STAGE_PREFIX "${CMAKE_SOURCE_DIR}/out/install/$<CONFIG>")
+    set(PERASTAGE_STAGE_CONFIG --config $<CONFIG>)
+else()
+    if(CMAKE_BUILD_TYPE)
+        set(PERASTAGE_STAGE_PREFIX "${CMAKE_SOURCE_DIR}/out/install/${CMAKE_BUILD_TYPE}")
+    else()
+        set(PERASTAGE_STAGE_PREFIX "${CMAKE_SOURCE_DIR}/out/install")
+    endif()
+    set(PERASTAGE_STAGE_CONFIG)
+endif()
+
+add_custom_target(perastage_stage
+    COMMAND ${CMAKE_COMMAND} -E rm -rf "${PERASTAGE_STAGE_PREFIX}"
+    COMMAND ${CMAKE_COMMAND} --install "${CMAKE_BINARY_DIR}" --prefix "${PERASTAGE_STAGE_PREFIX}" ${PERASTAGE_STAGE_CONFIG}
+    DEPENDS ${PROJECT_NAME}
+)

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -21,7 +21,7 @@ This document defines the expected directory conventions for Perastage.
 
 ## CMake convention
 
-- Root `CMakeLists.txt` owns target creation and module orchestration; `cmake/PerastageDependencies.cmake` owns application dependency discovery and capability validation, `cmake/PerastageLocalization.cmake` owns gettext discovery, catalog compilation, and translation maintenance and validation targets, and `cmake/PerastageRuntimeStaging.cmake` owns build-tree runtime asset staging. Installation and packaging remain root responsibilities pending their dedicated extraction.
+- Root `CMakeLists.txt` owns target creation, module orchestration, and CPack configuration; `cmake/PerastageDependencies.cmake` owns application dependency discovery and capability validation, `cmake/PerastageLocalization.cmake` owns gettext discovery, catalog compilation, and translation maintenance and validation targets, `cmake/PerastageRuntimeStaging.cmake` owns build-tree runtime asset staging, and `cmake/PerastageInstall.cmake` owns install-tree rules and the `perastage_stage` target. Further packaging extraction remains pending.
 - Every top-level application source module contributes its explicit source list using its local `CMakeLists.txt` and `target_sources(${PROJECT_NAME} ...)`.
 - `docs/developer/repository_structure_baseline.json` is the authoritative machine-readable contract for source-module classification and CMake registration.
 - Avoid recursive or wildcard project-source discovery; list files explicitly.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -23,6 +23,7 @@ Changes since **v1.6.0**.
 - Moved application dependency discovery into a dedicated build module while preserving existing package-manager and platform behavior.
 - Moved localization build configuration into a dedicated module while preserving existing catalog and platform behavior.
 - Moved build-tree runtime asset staging into a dedicated module while preserving existing cross-platform resource layouts.
+- Moved install-tree rules and packaging staging into a dedicated build module while preserving existing cross-platform installation layouts.
 
 ## Downloads and installation
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -197,6 +197,9 @@ if(Python3_Interpreter_FOUND)
     add_repository_policy_test(RuntimeResourceStagingOwnership ${Python3_EXECUTABLE}
                                ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_runtime_resource_staging_ownership.py
                                LABELS standard-strict policy cmake)
+    add_repository_policy_test(InstallationOwnership ${Python3_EXECUTABLE}
+                               ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_installation_ownership.py
+                               LABELS standard-strict policy cmake)
     add_repository_policy_test(DocsLinks ${Python3_EXECUTABLE}
                                ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_docs_links.py)
     add_repository_policy_test(TestTargetsNoSourceRootIncludes ${Python3_EXECUTABLE}

--- a/tests/check_installation_ownership.py
+++ b/tests/check_installation_ownership.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Validate ownership and boundaries of install-tree configuration."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ROOT_CMAKE = ROOT / "CMakeLists.txt"
+INSTALL_MODULE = ROOT / "cmake" / "PerastageInstall.cmake"
+
+
+def main() -> int:
+    """Reject installation rules outside their dedicated CMake module."""
+    root_cmake = ROOT_CMAKE.read_text(encoding="utf-8")
+    install_cmake = INSTALL_MODULE.read_text(encoding="utf-8")
+    errors: list[str] = []
+
+    install_include = re.compile(
+        r"include\s*\(\s*(?:\"|')?cmake/PerastageInstall\.cmake(?:\"|')?\s*\)",
+        re.IGNORECASE,
+    )
+    if len(install_include.findall(root_cmake)) != 1:
+        errors.append("root CMake must include PerastageInstall.cmake exactly once")
+
+    if re.search(r"\binstall\s*\(", root_cmake, re.IGNORECASE):
+        errors.append("root CMake still owns install rules")
+    if re.search(r"add_custom_target\s*\(\s*perastage_stage\b", root_cmake,
+                 re.IGNORECASE):
+        errors.append("root CMake still defines perastage_stage")
+
+    contracts = (
+        "install(TARGETS ${PROJECT_NAME}",
+        "BUNDLE DESTINATION .",
+        "install(DIRECTORY ${CMAKE_SOURCE_DIR}/resources DESTINATION ${PERASTAGE_INSTALL_RESOURCE_DEST})",
+        "PERASTAGE_GENERATED_LOCALE_DIR",
+        "PERASTAGE_TRANSLATION_LANGUAGES",
+        "${PERASTAGE_INSTALL_RESOURCE_DEST}/locale/${PERASTAGE_TRANSLATION_LANGUAGE}/LC_MESSAGES",
+        "${PERASTAGE_INSTALL_RESOURCE_DEST}/resources/locale/${PERASTAGE_TRANSLATION_LANGUAGE}/LC_MESSAGES",
+        "${CMAKE_SOURCE_DIR}/library",
+        "${PERASTAGE_GENERATED_DUMMY_GDTF_ARCHIVE}",
+        "${CMAKE_SOURCE_DIR}/licenses",
+        "${CMAKE_SOURCE_DIR}/LICENSE.txt",
+        "${CMAKE_SOURCE_DIR}/THIRD_PARTY_LICENSES.md",
+        "${CMAKE_SOURCE_DIR}/help.md",
+        "OPTIONAL",
+        "share/applications",
+        "share/mime/packages",
+        "share/icons/hicolor/1024x1024/apps",
+        "RENAME perastage.png",
+        "update-mime-database",
+        "update-desktop-database",
+        "include(InstallRequiredSystemLibraries)",
+        "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin",
+        "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug/bin",
+        "file(GLOB _vcpkg_bin_dlls",
+        "CONFIGURATIONS Release RelWithDebInfo MinSizeRel",
+        "CONFIGURATIONS Debug",
+        "CMAKE_BUILD_TYPE STREQUAL \"Debug\"",
+        "wxWidgets_LIBRARY_DIRS",
+        "wxWidgets_LIBRARIES",
+        "${wx_dir}/../bin",
+        "${wx_dir}/wxmsw*.dll",
+        "${wx_dir}/wxbase*.dll",
+        "${wx_dir}/nwxmsw*.dll",
+        "${wx_dir}/nwxbase*.dll",
+        "wxWidgets_USE_DEBUG",
+        ".*(d_vc_|ud_vc_).*\\\\.dll$",
+        "add_custom_target(perastage_stage",
+        "${CMAKE_SOURCE_DIR}/out/install/$<CONFIG>",
+        "${CMAKE_SOURCE_DIR}/out/install/${CMAKE_BUILD_TYPE}",
+        "${CMAKE_SOURCE_DIR}/out/install",
+        "${CMAKE_COMMAND} -E rm -rf",
+        "${CMAKE_COMMAND} --install",
+    )
+    for contract in contracts:
+        if contract not in install_cmake:
+            errors.append(f"install module is missing contract: {contract}")
+
+    forbidden_contracts = (
+        r"\bPOST_BUILD\b",
+        r"\bfind_package\s*\(\s*Gettext\b",
+        r"PerastageCompileGettextCatalog\.cmake",
+        r"\binclude\s*\(\s*CPack\b",
+        r"\bset\s*\(\s*CPACK_",
+        r"\bperastage_symbols\b",
+        r"\btarget_(?:sources|link_libraries|compile_options|link_options)\s*\(",
+        r"\bset_target_properties\s*\(",
+    )
+    for pattern in forbidden_contracts:
+        if re.search(pattern, install_cmake, re.IGNORECASE):
+            errors.append(f"install module crosses an ownership boundary: {pattern}")
+
+    if not re.search(
+        r"if\s*\(\s*PERASTAGE_ENABLE_LOCALIZATION\s*\).*?install\s*\(\s*FILES\s+"
+        r"\"\$\{PERASTAGE_GENERATED_LOCALE_DIR\}",
+        install_cmake,
+        re.IGNORECASE | re.DOTALL,
+    ):
+        errors.append("generated locale installation must remain gated by localization")
+
+    if errors:
+        print("Installation ownership check failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    print("Installation ownership check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation

- Extract install-tree ownership from the root `CMakeLists.txt` into a dedicated module so installation rules, platform-specific install behavior, and the staging target are owned and testable in one place. 
- Preserve exact cross-platform install semantics (macOS bundle installs, non-macOS runtime destination, resource and library layout, localization install gating, Linux desktop/mime/icon integration, and Windows vcpkg/wx DLL staging). 
- Keep POST_BUILD runtime staging, gettext/catalog build, and CPack configuration in their existing modules to maintain clear ownership boundaries.

### Description

- Added `cmake/PerastageInstall.cmake` and moved all normal `install(...)` targets, resource installs, localization install wiring, bundled `library` install, generated dummy GDTF install, licenses/help installs, Linux desktop/mime/icon installation, Windows vcpkg and wx DLL collection/installation, and the `perastage_stage` staging target into this module. 
- Replaced the root install logic with a single `include(cmake/PerastageInstall.cmake)` in `CMakeLists.txt` and left `perastage_symbols`, runtime staging include, and CPack settings in the root as before. 
- Added a focused ownership guard `tests/check_installation_ownership.py` and registered it in `tests/CMakeLists.txt` to verify the module owns the listed install contracts and that the root no longer contains normal `install(...)` or `perastage_stage`. 
- Updated developer docs to reflect the new ownership (`docs/developer/architecture.md`) and added a concise release-note entry (`docs/release-notes-draft.md`).

### Testing

- Ran `git diff --check` and the repository policy/ownership checks: `python3 tests/check_installation_ownership.py`, `python3 tests/check_dependency_discovery_ownership.py`, `python3 tests/check_localization_build_ownership.py`, `python3 tests/check_runtime_resource_staging_ownership.py`, `python3 tests/check_repository_structure_baseline.py`, and `python3 tests/check_repository_structure_baseline_fixtures.py -v`, all of which passed. 
- Ran bash policy checks and repository scripts (`check_cmake_preset_policy.sh`, `check_localization_contract_boundaries.sh`, `check_perastage_tree_modules.sh`, `check_no_configmanager_get_in_gui.sh`) under the harness and they passed once the required harness env vars were set. 
- Performed a focused CMake/Ninja staging harness run that exercised `perastage_stage` with `PERASTAGE_ENABLE_LOCALIZATION=OFF` and `ON` and verified staged paths (executable, resources, library, `library/fixtures/Dummy 1ch.gdtf`, help/LICENSE/THIRD_PARTY_LICENSES, licenses/, Linux desktop/mime/icon, and presence/absence of `.mo` files according to the localization flag), which passed. 
- Verified the new `cmake/PerastageInstall.cmake` mechanically matches the extracted installation logic from the pre-refactor root CMake (apart from a separating blank line) to ensure behavior preservation; note that a full configure in this environment failed due to missing wxWidgets development packages, which is an environment limitation not related to the refactor.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9c341fe67083249552c08e20c669d3)