### PR TITLE
ORG-020: extract CPack packaging configuration from root CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -314,44 +314,4 @@ endif()
 
 include(cmake/PerastageRuntimeStaging.cmake)
 
-set(CPACK_PACKAGE_NAME "Perastage")
-set(CPACK_PACKAGE_VENDOR "Perastage")
-set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Perastage lighting plot editor")
-set(CPACK_PACKAGE_VERSION "${PROJECT_VERSION}")
-
-if(WIN32)
-    set(CPACK_GENERATOR "NSIS")
-    set(CPACK_NSIS_ENABLE_UNINSTALL_BEFORE_INSTALL ON)
-    set(CPACK_NSIS_DISPLAY_NAME "Perastage")
-    set(CPACK_NSIS_PACKAGE_NAME "Perastage")
-    string(CONCAT CPACK_NSIS_EXTRA_INSTALL_COMMANDS
-        "WriteRegStr HKCR '.mvr' '' 'Perastage.MVR'\\n"
-        "WriteRegStr HKCR 'Perastage.MVR' '' 'MVR Scene'\\n"
-        "WriteRegStr HKCR 'Perastage.MVR\\\\DefaultIcon' '' '$INSTDIR\\\\Perastage.exe,0'\\n"
-        "WriteRegStr HKCR 'Perastage.MVR\\\\shell\\\\open\\\\command' '' '\\\"$INSTDIR\\\\Perastage.exe\\\" \\\"%1\\\"'\\n"
-    )
-    string(CONCAT CPACK_NSIS_EXTRA_UNINSTALL_COMMANDS
-        "DeleteRegKey HKCR 'Perastage.MVR'\\n"
-        "DeleteRegValue HKCR '.mvr' ''\\n"
-    )
-    if(PERASTAGE_ASSOCIATE_PSTG)
-        string(APPEND CPACK_NSIS_EXTRA_INSTALL_COMMANDS
-            "WriteRegStr HKCR '.pstg' '' 'Perastage.Project'\\n"
-            "WriteRegStr HKCR 'Perastage.Project' '' 'Perastage Project'\\n"
-            "WriteRegStr HKCR 'Perastage.Project\\\\DefaultIcon' '' '$INSTDIR\\\\Perastage.exe,0'\\n"
-            "WriteRegStr HKCR 'Perastage.Project\\\\shell\\\\open\\\\command' '' '\\\"$INSTDIR\\\\Perastage.exe\\\" \\\"%1\\\"'\\n"
-        )
-        string(APPEND CPACK_NSIS_EXTRA_UNINSTALL_COMMANDS
-            "DeleteRegKey HKCR 'Perastage.Project'\\n"
-            "DeleteRegValue HKCR '.pstg' ''\\n"
-        )
-    endif()
-endif()
-
-if(APPLE)
-    set(CPACK_GENERATOR "DragNDrop")
-    set(CPACK_DMG_VOLUME_NAME "Perastage")
-    set(CPACK_PACKAGE_FILE_NAME "Perastage-${PROJECT_VERSION}-macOS-arm64")
-endif()
-
-include(CPack)
+include(cmake/PerastagePackaging.cmake)

--- a/cmake/PerastagePackaging.cmake
+++ b/cmake/PerastagePackaging.cmake
@@ -1,0 +1,41 @@
+set(CPACK_PACKAGE_NAME "Perastage")
+set(CPACK_PACKAGE_VENDOR "Perastage")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Perastage lighting plot editor")
+set(CPACK_PACKAGE_VERSION "${PROJECT_VERSION}")
+
+if(WIN32)
+    set(CPACK_GENERATOR "NSIS")
+    set(CPACK_NSIS_ENABLE_UNINSTALL_BEFORE_INSTALL ON)
+    set(CPACK_NSIS_DISPLAY_NAME "Perastage")
+    set(CPACK_NSIS_PACKAGE_NAME "Perastage")
+    string(CONCAT CPACK_NSIS_EXTRA_INSTALL_COMMANDS
+        "WriteRegStr HKCR '.mvr' '' 'Perastage.MVR'\\n"
+        "WriteRegStr HKCR 'Perastage.MVR' '' 'MVR Scene'\\n"
+        "WriteRegStr HKCR 'Perastage.MVR\\\\DefaultIcon' '' '$INSTDIR\\\\Perastage.exe,0'\\n"
+        "WriteRegStr HKCR 'Perastage.MVR\\\\shell\\\\open\\\\command' '' '\\\"$INSTDIR\\\\Perastage.exe\\\" \\\"%1\\\"'\\n"
+    )
+    string(CONCAT CPACK_NSIS_EXTRA_UNINSTALL_COMMANDS
+        "DeleteRegKey HKCR 'Perastage.MVR'\\n"
+        "DeleteRegValue HKCR '.mvr' ''\\n"
+    )
+    if(PERASTAGE_ASSOCIATE_PSTG)
+        string(APPEND CPACK_NSIS_EXTRA_INSTALL_COMMANDS
+            "WriteRegStr HKCR '.pstg' '' 'Perastage.Project'\\n"
+            "WriteRegStr HKCR 'Perastage.Project' '' 'Perastage Project'\\n"
+            "WriteRegStr HKCR 'Perastage.Project\\\\DefaultIcon' '' '$INSTDIR\\\\Perastage.exe,0'\\n"
+            "WriteRegStr HKCR 'Perastage.Project\\\\shell\\\\open\\\\command' '' '\\\"$INSTDIR\\\\Perastage.exe\\\" \\\"%1\\\"'\\n"
+        )
+        string(APPEND CPACK_NSIS_EXTRA_UNINSTALL_COMMANDS
+            "DeleteRegKey HKCR 'Perastage.Project'\\n"
+            "DeleteRegValue HKCR '.pstg' ''\\n"
+        )
+    endif()
+endif()
+
+if(APPLE)
+    set(CPACK_GENERATOR "DragNDrop")
+    set(CPACK_DMG_VOLUME_NAME "Perastage")
+    set(CPACK_PACKAGE_FILE_NAME "Perastage-${PROJECT_VERSION}-macOS-arm64")
+endif()
+
+include(CPack)

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -21,7 +21,7 @@ This document defines the expected directory conventions for Perastage.
 
 ## CMake convention
 
-- Root `CMakeLists.txt` owns target creation, module orchestration, and CPack configuration; `cmake/PerastageDependencies.cmake` owns application dependency discovery and capability validation, `cmake/PerastageLocalization.cmake` owns gettext discovery, catalog compilation, and translation maintenance and validation targets, `cmake/PerastageRuntimeStaging.cmake` owns build-tree runtime asset staging, and `cmake/PerastageInstall.cmake` owns install-tree rules and the `perastage_stage` target. Further packaging extraction remains pending.
+- Root `CMakeLists.txt` owns target creation and module orchestration; `cmake/PerastageDependencies.cmake` owns application dependency discovery and capability validation, `cmake/PerastageLocalization.cmake` owns gettext discovery, catalog compilation, and translation maintenance and validation targets, `cmake/PerastageRuntimeStaging.cmake` owns build-tree runtime asset staging, `cmake/PerastageInstall.cmake` owns install-tree rules and the `perastage_stage` target, and `cmake/PerastagePackaging.cmake` owns CPack and package-generator compatibility configuration.
 - Every top-level application source module contributes its explicit source list using its local `CMakeLists.txt` and `target_sources(${PROJECT_NAME} ...)`.
 - `docs/developer/repository_structure_baseline.json` is the authoritative machine-readable contract for source-module classification and CMake registration.
 - Avoid recursive or wildcard project-source discovery; list files explicitly.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -24,6 +24,7 @@ Changes since **v1.6.0**.
 - Moved localization build configuration into a dedicated module while preserving existing catalog and platform behavior.
 - Moved build-tree runtime asset staging into a dedicated module while preserving existing cross-platform resource layouts.
 - Moved install-tree rules and packaging staging into a dedicated build module while preserving existing cross-platform installation layouts.
+- Moved CPack compatibility configuration into a dedicated build module while preserving existing package metadata and installer behavior.
 
 ## Downloads and installation
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -200,6 +200,9 @@ if(Python3_Interpreter_FOUND)
     add_repository_policy_test(InstallationOwnership ${Python3_EXECUTABLE}
                                ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_installation_ownership.py
                                LABELS standard-strict policy cmake)
+    add_repository_policy_test(PackagingOwnership ${Python3_EXECUTABLE}
+                               ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_packaging_ownership.py
+                               LABELS standard-strict policy cmake)
     add_repository_policy_test(DocsLinks ${Python3_EXECUTABLE}
                                ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_docs_links.py)
     add_repository_policy_test(TestTargetsNoSourceRootIncludes ${Python3_EXECUTABLE}

--- a/tests/check_packaging_ownership.py
+++ b/tests/check_packaging_ownership.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Validate ownership and boundaries of CPack packaging configuration."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ROOT_CMAKE = ROOT / "CMakeLists.txt"
+PACKAGING_MODULE = ROOT / "cmake" / "PerastagePackaging.cmake"
+
+
+def main() -> int:
+    """Reject CPack configuration outside its dedicated packaging module."""
+    root_cmake = ROOT_CMAKE.read_text(encoding="utf-8")
+    packaging_cmake = PACKAGING_MODULE.read_text(encoding="utf-8")
+    errors: list[str] = []
+
+    packaging_include = re.compile(
+        r"include\s*\(\s*(?:\"|')?cmake/PerastagePackaging\.cmake(?:\"|')?\s*\)",
+        re.IGNORECASE,
+    )
+    if len(packaging_include.findall(root_cmake)) != 1:
+        errors.append("root CMake must include PerastagePackaging.cmake exactly once")
+    elif (
+        root_cmake.index("include(cmake/PerastageInstall.cmake)")
+        > packaging_include.search(root_cmake).start()
+    ):
+        errors.append("root CMake must include packaging after installation configuration")
+
+    if re.search(r"\bset\s*\(\s*CPACK_", root_cmake, re.IGNORECASE):
+        errors.append("root CMake still owns CPack configuration")
+    if re.search(r"\binclude\s*\(\s*CPack\s*\)", root_cmake, re.IGNORECASE):
+        errors.append("root CMake still includes CPack directly")
+
+    contracts = (
+        'set(CPACK_PACKAGE_NAME "Perastage")',
+        'set(CPACK_PACKAGE_VENDOR "Perastage")',
+        'set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Perastage lighting plot editor")',
+        'set(CPACK_PACKAGE_VERSION "${PROJECT_VERSION}")',
+        'set(CPACK_GENERATOR "NSIS")',
+        "set(CPACK_NSIS_ENABLE_UNINSTALL_BEFORE_INSTALL ON)",
+        'set(CPACK_NSIS_DISPLAY_NAME "Perastage")',
+        'set(CPACK_NSIS_PACKAGE_NAME "Perastage")',
+        "string(CONCAT CPACK_NSIS_EXTRA_INSTALL_COMMANDS",
+        "string(CONCAT CPACK_NSIS_EXTRA_UNINSTALL_COMMANDS",
+        "WriteRegStr HKCR '.mvr' '' 'Perastage.MVR'",
+        "WriteRegStr HKCR 'Perastage.MVR' '' 'MVR Scene'",
+        r"WriteRegStr HKCR 'Perastage.MVR\\\\DefaultIcon' '' '$INSTDIR\\\\Perastage.exe,0'",
+        r"""WriteRegStr HKCR 'Perastage.MVR\\\\shell\\\\open\\\\command' '' '\\\"$INSTDIR\\\\Perastage.exe\\\" \\\"%1\\\"'""",
+        "DeleteRegKey HKCR 'Perastage.MVR'",
+        "DeleteRegValue HKCR '.mvr' ''",
+        "if(PERASTAGE_ASSOCIATE_PSTG)",
+        "string(APPEND CPACK_NSIS_EXTRA_INSTALL_COMMANDS",
+        "string(APPEND CPACK_NSIS_EXTRA_UNINSTALL_COMMANDS",
+        "WriteRegStr HKCR '.pstg' '' 'Perastage.Project'",
+        "WriteRegStr HKCR 'Perastage.Project' '' 'Perastage Project'",
+        r"WriteRegStr HKCR 'Perastage.Project\\\\DefaultIcon' '' '$INSTDIR\\\\Perastage.exe,0'",
+        r"""WriteRegStr HKCR 'Perastage.Project\\\\shell\\\\open\\\\command' '' '\\\"$INSTDIR\\\\Perastage.exe\\\" \\\"%1\\\"'""",
+        "DeleteRegKey HKCR 'Perastage.Project'",
+        "DeleteRegValue HKCR '.pstg' ''",
+        'set(CPACK_GENERATOR "DragNDrop")',
+        'set(CPACK_DMG_VOLUME_NAME "Perastage")',
+        'set(CPACK_PACKAGE_FILE_NAME "Perastage-${PROJECT_VERSION}-macOS-arm64")',
+    )
+    for contract in contracts:
+        if contract not in packaging_cmake:
+            errors.append(f"packaging module is missing contract: {contract}")
+
+    cpack_include = re.compile(r"\binclude\s*\(\s*CPack\s*\)", re.IGNORECASE)
+    if len(cpack_include.findall(packaging_cmake)) != 1:
+        errors.append("packaging module must include CPack exactly once")
+
+    forbidden_contracts = (
+        r"\binstall\s*\(",
+        r"\bperastage_stage\b",
+        r"\bPOST_BUILD\b",
+        r"\bfind_package\s*\(",
+        r"\bGettext\b",
+        r"PerastageCompileGettextCatalog\.cmake",
+        r"\bperastage_symbols\b",
+        r"\btarget_(?:sources|link_libraries|compile_options|compile_definitions|"
+        r"include_directories|link_options|link_directories|precompile_headers)\s*\(",
+        r"\bset_target_properties\s*\(",
+        r"PerastageInfo\.plist",
+    )
+    for pattern in forbidden_contracts:
+        if re.search(pattern, packaging_cmake, re.IGNORECASE):
+            errors.append(f"packaging module crosses an ownership boundary: {pattern}")
+
+    if errors:
+        print("Packaging ownership check failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    print("Packaging ownership check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Separate packaging/CPack responsibilities from the root CMake orchestration to keep packaging metadata and generator configuration isolated and maintainable while preserving existing installer behavior and artifact names.
- Preserve exact, behaviorally-sensitive packaging contracts (package name/vendor/description/version, Windows NSIS path including `.mvr` and optional `.pstg` associations and NSIS install/uninstall command escaping, macOS DragNDrop/DMG naming) so releases remain compatible.

### Description
- Added a dedicated packaging module `cmake/PerastagePackaging.cmake` that contains the extracted `CPACK_*` variables, NSIS registry commands, macOS DragNDrop configuration, and the final `include(CPack)` call, preserving the original packaging block byte-for-byte.
- Replaced the root packaging block in `CMakeLists.txt` with a single include: `include(cmake/PerastagePackaging.cmake)` placed after installation and runtime-staging includes so install rules remain owned by `PerastageInstall.cmake`.
- Added a focused ownership test `tests/check_packaging_ownership.py` that verifies the root includes the packaging module once, root no longer owns `CPACK_*` or `include(CPack)`, the packaging module provides the required contracts (Windows NSIS, `.mvr` and optional `.pstg` behavior, macOS DragNDrop naming), and that the packaging module does not cross other module boundaries.
- Registered the new test in `tests/CMakeLists.txt` and updated `docs/developer/architecture.md` and `docs/release-notes-draft.md` to reflect the new `cmake/PerastagePackaging.cmake` ownership.

### Testing
- Ran the new packaging guard: `python3 tests/check_packaging_ownership.py` and it passed.
- Executed repository policy and ownership checks: `tests/check_perastage_tree_modules.sh`, `tests/check_no_configmanager_get_in_gui.sh`, `python3 tests/check_dependency_discovery_ownership.py`, `python3 tests/check_localization_build_ownership.py`, `python3 tests/check_runtime_resource_staging_ownership.py`, `python3 tests/check_installation_ownership.py`, `python3 tests/check_repository_structure_baseline.py`, and `python3 tests/check_repository_structure_baseline_fixtures.py -v`, all of which passed in this branch.
- Generated focused CMake+CPack outputs and validated `CPackConfig.cmake` for platforms: for Windows with `PERASTAGE_ASSOCIATE_PSTG=ON` and `OFF` confirmed `CPACK_GENERATOR = NSIS`, `CPACK_NSIS_ENABLE_UNINSTALL_BEFORE_INSTALL = ON`, `CPACK_NSIS_DISPLAY_NAME = Perastage`, `CPACK_NSIS_PACKAGE_NAME = Perastage`, `.mvr` commands appear exactly once, `.pstg` commands follow the option, and the installer open-command quoting `"$INSTDIR\Perastage.exe" "%1"` is preserved; for macOS confirmed `CPACK_GENERATOR = DragNDrop`, `CPACK_DMG_VOLUME_NAME = Perastage`, and `CPACK_PACKAGE_FILE_NAME = Perastage-${PROJECT_VERSION}-macOS-arm64`; and for Linux confirmed no unintended generator was introduced.
- Performed `git diff --check` and byte-for-byte comparison of the extracted packaging block against the original root block to confirm no functional changes were made to the packaging content.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9c3fd0cf64832486b4f9bd58b7576b)