### PR TITLE
ORG-021–022: isolate platform CMake and complete root orchestration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,38 +164,6 @@ if(PERASTAGE_MACOS15_LEGACY_THREAD_COMPAT)
         PERASTAGE_MACOS15_LEGACY_THREAD_COMPAT=1)
 endif()
 
-if(APPLE)
-    set(PERASTAGE_MACOS_INFO_PLIST "${CMAKE_BINARY_DIR}/PerastageInfo.plist")
-    set(EXECUTABLE_NAME "${PROJECT_NAME}")
-    set(PERASTAGE_VERSION "${PROJECT_VERSION}")
-
-    set(PERASTAGE_MACOS_RESOURCES
-        "${CMAKE_SOURCE_DIR}/resources/Perastage.icns"
-        "${CMAKE_SOURCE_DIR}/resources/PerastageProject.icns"
-        "${CMAKE_SOURCE_DIR}/resources/PerastageMVR.icns"
-    )
-
-    target_sources(${PROJECT_NAME} PRIVATE
-        ${PERASTAGE_MACOS_RESOURCES}
-    )
-
-    set_source_files_properties(${PERASTAGE_MACOS_RESOURCES} PROPERTIES
-        MACOSX_PACKAGE_LOCATION "Resources"
-    )
-
-    configure_file(
-        "${CMAKE_SOURCE_DIR}/cmake/PerastageInfo.plist.in"
-        "${PERASTAGE_MACOS_INFO_PLIST}"
-        @ONLY
-    )
-
-    set_target_properties(${PROJECT_NAME} PROPERTIES
-        MACOSX_BUNDLE TRUE
-        MACOSX_BUNDLE_INFO_PLIST "${PERASTAGE_MACOS_INFO_PLIST}"
-        RESOURCE "${PERASTAGE_MACOS_RESOURCES}"
-    )
-endif()
-
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)
 target_compile_definitions(${PROJECT_NAME} PRIVATE
     PERASTAGE_ENABLE_MVR_GDTF_DOWNLOAD_API=1
@@ -209,15 +177,7 @@ set_source_files_properties("${PERASTAGE_GENERATED_BUILD_INFO_CPP}" PROPERTIES
     COMPILE_DEFINITIONS "PERASTAGE_BUILD_CONFIGURATION=\"$<CONFIG>\""
 )
 
-if(MSVC)
-    target_compile_options(${PROJECT_NAME} PRIVATE /Zc:__cplusplus)
-    target_compile_options(${PROJECT_NAME} PRIVATE "$<$<CONFIG:Release>:/Zi>")
-    target_link_options(${PROJECT_NAME} PRIVATE
-        "$<$<CONFIG:Release>:/DEBUG>"
-        "$<$<CONFIG:Release>:/OPT:REF>"
-        "$<$<CONFIG:Release>:/OPT:ICF>"
-    )
-endif()
+include(cmake/platform/PerastagePlatform.cmake)
 
 add_subdirectory(core)
 add_subdirectory(gui)
@@ -227,15 +187,7 @@ add_subdirectory(viewer2d)
 add_subdirectory(viewer3d)
 add_subdirectory(viewer_common)
 
-if(WIN32)
-    target_sources(${PROJECT_NAME} PRIVATE resources/Perastage.rc)
-endif()
-
-# Mark as GUI application (no console)
-set_target_properties(${PROJECT_NAME} PROPERTIES WIN32_EXECUTABLE TRUE)
-
-
-# Include project directories
+# Include project directories pending the ORG-023/024 ownership audit.
 target_include_directories(${PROJECT_NAME} PRIVATE
     ${CMAKE_SOURCE_DIR}/gui
     ${CMAKE_SOURCE_DIR}/gui/mainwindow/controllers
@@ -276,42 +228,10 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
     ${_wx_libs}
 )
 
-if(WIN32)
-    target_link_libraries(${PROJECT_NAME} PRIVATE Dbghelp)
-endif()
-
-
-
-
-
-
-
 if(BUILD_TESTING)
     add_subdirectory(tests)
 endif()
 
 include(cmake/PerastageInstall.cmake)
-
-if(CMAKE_CONFIGURATION_TYPES)
-    set(PERASTAGE_SYMBOLS_DIR "${CMAKE_SOURCE_DIR}/out/symbols/windows")
-else()
-    if(CMAKE_BUILD_TYPE)
-        set(PERASTAGE_SYMBOLS_DIR "${CMAKE_SOURCE_DIR}/out/symbols/windows")
-    else()
-        set(PERASTAGE_SYMBOLS_DIR "${CMAKE_SOURCE_DIR}/out/symbols/windows")
-    endif()
-endif()
-
-if(WIN32 AND MSVC)
-    add_custom_target(perastage_symbols
-        COMMAND ${CMAKE_COMMAND}
-            "-DPDB_SOURCE=$<TARGET_PDB_FILE:${PROJECT_NAME}>"
-            "-DPDB_DESTINATION=${PERASTAGE_SYMBOLS_DIR}"
-            -P "${CMAKE_SOURCE_DIR}/cmake/PerastageCopySymbols.cmake"
-        DEPENDS ${PROJECT_NAME}
-    )
-endif()
-
 include(cmake/PerastageRuntimeStaging.cmake)
-
 include(cmake/PerastagePackaging.cmake)

--- a/cmake/platform/PerastageLinux.cmake
+++ b/cmake/platform/PerastageLinux.cmake
@@ -1,0 +1,2 @@
+# Linux currently requires no additional target-level build configuration.
+# Desktop, MIME, and icon integration remains owned by PerastageInstall.cmake.

--- a/cmake/platform/PerastageMacOS.cmake
+++ b/cmake/platform/PerastageMacOS.cmake
@@ -1,0 +1,29 @@
+# Configure the macOS application bundle and its document icon resources.
+set(PERASTAGE_MACOS_INFO_PLIST "${CMAKE_BINARY_DIR}/PerastageInfo.plist")
+set(EXECUTABLE_NAME "${PROJECT_NAME}")
+set(PERASTAGE_VERSION "${PROJECT_VERSION}")
+
+set(PERASTAGE_MACOS_RESOURCES
+    "${CMAKE_SOURCE_DIR}/resources/Perastage.icns"
+    "${CMAKE_SOURCE_DIR}/resources/PerastageProject.icns"
+    "${CMAKE_SOURCE_DIR}/resources/PerastageMVR.icns"
+)
+
+target_sources(${PROJECT_NAME} PRIVATE
+    ${PERASTAGE_MACOS_RESOURCES}
+)
+set_source_files_properties(${PERASTAGE_MACOS_RESOURCES} PROPERTIES
+    MACOSX_PACKAGE_LOCATION "Resources"
+)
+
+configure_file(
+    "${CMAKE_SOURCE_DIR}/cmake/PerastageInfo.plist.in"
+    "${PERASTAGE_MACOS_INFO_PLIST}"
+    @ONLY
+)
+
+set_target_properties(${PROJECT_NAME} PROPERTIES
+    MACOSX_BUNDLE TRUE
+    MACOSX_BUNDLE_INFO_PLIST "${PERASTAGE_MACOS_INFO_PLIST}"
+    RESOURCE "${PERASTAGE_MACOS_RESOURCES}"
+)

--- a/cmake/platform/PerastagePlatform.cmake
+++ b/cmake/platform/PerastagePlatform.cmake
@@ -1,0 +1,8 @@
+# Dispatch target-level build configuration to the active platform owner.
+if(WIN32)
+    include("${CMAKE_CURRENT_LIST_DIR}/PerastageWindows.cmake")
+elseif(APPLE)
+    include("${CMAKE_CURRENT_LIST_DIR}/PerastageMacOS.cmake")
+elseif(UNIX)
+    include("${CMAKE_CURRENT_LIST_DIR}/PerastageLinux.cmake")
+endif()

--- a/cmake/platform/PerastageWindows.cmake
+++ b/cmake/platform/PerastageWindows.cmake
@@ -1,0 +1,34 @@
+# Configure Windows application resources and GUI subsystem behavior.
+target_sources(${PROJECT_NAME} PRIVATE
+    resources/Perastage.rc
+)
+set_target_properties(${PROJECT_NAME} PROPERTIES
+    WIN32_EXECUTABLE TRUE
+)
+
+# Preserve MSVC language conformance and Release symbol/link optimization settings.
+if(MSVC)
+    target_compile_options(${PROJECT_NAME} PRIVATE
+        /Zc:__cplusplus
+        "$<$<CONFIG:Release>:/Zi>"
+    )
+    target_link_options(${PROJECT_NAME} PRIVATE
+        "$<$<CONFIG:Release>:/DEBUG>"
+        "$<$<CONFIG:Release>:/OPT:REF>"
+        "$<$<CONFIG:Release>:/OPT:ICF>"
+    )
+endif()
+
+target_link_libraries(${PROJECT_NAME} PRIVATE Dbghelp)
+
+# Collect the application PDB in the release-support symbols directory.
+if(MSVC)
+    set(PERASTAGE_SYMBOLS_DIR "${CMAKE_SOURCE_DIR}/out/symbols/windows")
+    add_custom_target(perastage_symbols
+        COMMAND ${CMAKE_COMMAND}
+            "-DPDB_SOURCE=$<TARGET_PDB_FILE:${PROJECT_NAME}>"
+            "-DPDB_DESTINATION=${PERASTAGE_SYMBOLS_DIR}"
+            -P "${CMAKE_SOURCE_DIR}/cmake/PerastageCopySymbols.cmake"
+        DEPENDS ${PROJECT_NAME}
+    )
+endif()

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -21,7 +21,8 @@ This document defines the expected directory conventions for Perastage.
 
 ## CMake convention
 
-- Root `CMakeLists.txt` owns target creation and module orchestration; `cmake/PerastageDependencies.cmake` owns application dependency discovery and capability validation, `cmake/PerastageLocalization.cmake` owns gettext discovery, catalog compilation, and translation maintenance and validation targets, `cmake/PerastageRuntimeStaging.cmake` owns build-tree runtime asset staging, `cmake/PerastageInstall.cmake` owns install-tree rules and the `perastage_stage` target, and `cmake/PerastagePackaging.cmake` owns CPack and package-generator compatibility configuration.
+- Root `CMakeLists.txt` owns project options, principal target creation, shared target configuration, and module orchestration. Focused modules own dependency discovery (`PerastageDependencies.cmake`), localization (`PerastageLocalization.cmake`), runtime staging (`PerastageRuntimeStaging.cmake`), installation (`PerastageInstall.cmake`), and packaging (`PerastagePackaging.cmake`).
+- `cmake/platform/PerastagePlatform.cmake` dispatches target-level platform configuration to separate Windows, macOS, and Linux owners after the application target exists. Linux desktop, MIME, and icon integration remains installation configuration rather than target configuration.
 - Every top-level application source module contributes its explicit source list using its local `CMakeLists.txt` and `target_sources(${PROJECT_NAME} ...)`.
 - `docs/developer/repository_structure_baseline.json` is the authoritative machine-readable contract for source-module classification and CMake registration.
 - Avoid recursive or wildcard project-source discovery; list files explicitly.

--- a/docs/developer/perastage_tree.md
+++ b/docs/developer/perastage_tree.md
@@ -16,7 +16,8 @@ Perastage/
 |-- docs/                        # User documentation, architecture notes, repository map, and docs website assets.
 |-- AGENTS.md                    # Repository guidance for automated coding agents.
 |-- VERSION                      # Single project version source.
-|-- cmake/                       # Dependency, localization, and runtime-staging build modules, templates, and helper scripts.
+|-- cmake/                       # Focused build modules, templates, and helper scripts.
+|   `-- platform/                # Platform target-configuration dispatcher and OS-specific owners.
 |-- core/                        # Shared business logic and cross-cutting services.
 |   |-- layouts/                 # Printable layout/page management.
 |   `-- print/                   # Printing and PDF/table export helpers.
@@ -56,6 +57,7 @@ Perastage/
 - **`models/`**: core scene model (fixtures, trusses, hoists/supports, objects, layers).
 - **`mvr/`**: inbound/outbound integration with the MVR ecosystem, including MVR-xchange support.
 - **`packaging/`**: platform packaging metadata, installer scripts, and desktop integration files.
+- **`cmake/platform/`**: Windows and macOS target/build configuration plus the explicit Linux target-configuration boundary, selected through one dispatcher.
 
 ## Critical files (explicit exception to high-level granularity)
 

--- a/docs/developer/repository_layout.md
+++ b/docs/developer/repository_layout.md
@@ -14,7 +14,7 @@ this page remains its human-readable architectural counterpart.
 | Path | Purpose |
 |------|---------|
 | `main.cpp` | wxWidgets application entry point and top-level initialization. |
-| `CMakeLists.txt` | Root build orchestration, platform options, install rules, and module registration. |
+| `CMakeLists.txt` | Project options, principal target creation, shared target configuration, and build-module orchestration. |
 | `CMakePresets.json` | Canonical tracked configure/build presets for supported local development workflows. |
 | `cmake/` | Dependency discovery, CMake helper scripts, generated configuration templates, and platform metadata templates. |
 | `core/` | Core logic, import helpers, dictionaries, patching, layouts, printing, persistence, and shared services. |
@@ -52,6 +52,14 @@ bootstrap source. Every module above contributes its explicit application source
 list through its own `CMakeLists.txt`. `tests/` is added
 conditionally when testing is enabled. No recursive project-source discovery is
 used.
+
+Target-level operating-system configuration is dispatched once through
+`cmake/platform/PerastagePlatform.cmake`. The Windows owner configures the
+application resource, GUI subsystem, MSVC release symbols, and `Dbghelp`; the
+macOS owner configures the application bundle, plist, and icon resources. The
+Linux owner documents that no additional target configuration is currently
+required, while desktop, MIME, and icon installation remains in
+`cmake/PerastageInstall.cmake`.
 
 Cross-cutting viewport interaction preference policy is owned by `core/`, next
 to the existing shared selection movement settings. GUI, 2D viewer, and 3D

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -25,6 +25,7 @@ Changes since **v1.6.0**.
 - Moved build-tree runtime asset staging into a dedicated module while preserving existing cross-platform resource layouts.
 - Moved install-tree rules and packaging staging into a dedicated build module while preserving existing cross-platform installation layouts.
 - Moved CPack compatibility configuration into a dedicated build module while preserving existing package metadata and installer behavior.
+- Completed the build-system modularization by isolating platform target configuration and simplifying the root CMake file to project orchestration.
 
 ## Downloads and installation
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -203,6 +203,12 @@ if(Python3_Interpreter_FOUND)
     add_repository_policy_test(PackagingOwnership ${Python3_EXECUTABLE}
                                ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_packaging_ownership.py
                                LABELS standard-strict policy cmake)
+    add_repository_policy_test(PlatformCMakeOwnership ${Python3_EXECUTABLE}
+                               ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_platform_cmake_ownership.py
+                               LABELS standard-strict policy cmake)
+    add_repository_policy_test(RootCMakeOrchestration ${Python3_EXECUTABLE}
+                               ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_root_cmake_orchestration.py
+                               LABELS standard-strict policy cmake)
     add_repository_policy_test(DocsLinks ${Python3_EXECUTABLE}
                                ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_docs_links.py)
     add_repository_policy_test(TestTargetsNoSourceRootIncludes ${Python3_EXECUTABLE}

--- a/tests/check_platform_cmake_ownership.py
+++ b/tests/check_platform_cmake_ownership.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Validate ownership boundaries for platform-specific target configuration."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ROOT_CMAKE = ROOT / "CMakeLists.txt"
+PLATFORM_DIR = ROOT / "cmake" / "platform"
+
+
+def require_contracts(text: str, contracts: tuple[str, ...], owner: str, errors: list[str]) -> None:
+    """Record contracts that are missing from their expected owner."""
+    for contract in contracts:
+        if contract not in text:
+            errors.append(f"{owner} is missing contract: {contract}")
+
+
+def main() -> int:
+    """Reject misplaced or incomplete platform target configuration."""
+    root = ROOT_CMAKE.read_text(encoding="utf-8")
+    dispatcher = (PLATFORM_DIR / "PerastagePlatform.cmake").read_text(encoding="utf-8")
+    windows = (PLATFORM_DIR / "PerastageWindows.cmake").read_text(encoding="utf-8")
+    macos = (PLATFORM_DIR / "PerastageMacOS.cmake").read_text(encoding="utf-8")
+    linux = (PLATFORM_DIR / "PerastageLinux.cmake").read_text(encoding="utf-8")
+    errors: list[str] = []
+
+    dispatcher_include = "include(cmake/platform/PerastagePlatform.cmake)"
+    if root.count(dispatcher_include) != 1:
+        errors.append("root CMake must include the platform dispatcher exactly once")
+    elif root.index(dispatcher_include) < root.index("add_executable(${PROJECT_NAME}"):
+        errors.append("root CMake must dispatch platform configuration after target creation")
+
+    require_contracts(
+        dispatcher,
+        (
+            "if(WIN32)",
+            "PerastageWindows.cmake",
+            "elseif(APPLE)",
+            "PerastageMacOS.cmake",
+            "elseif(UNIX)",
+            "PerastageLinux.cmake",
+        ),
+        "platform dispatcher",
+        errors,
+    )
+    require_contracts(
+        windows,
+        (
+            "resources/Perastage.rc",
+            "WIN32_EXECUTABLE TRUE",
+            "/Zc:__cplusplus",
+            '"$<$<CONFIG:Release>:/Zi>"',
+            '"$<$<CONFIG:Release>:/DEBUG>"',
+            '"$<$<CONFIG:Release>:/OPT:REF>"',
+            '"$<$<CONFIG:Release>:/OPT:ICF>"',
+            "target_link_libraries(${PROJECT_NAME} PRIVATE Dbghelp)",
+            "add_custom_target(perastage_symbols",
+            "${CMAKE_SOURCE_DIR}/out/symbols/windows",
+            "PDB_SOURCE=$<TARGET_PDB_FILE:${PROJECT_NAME}>",
+            "cmake/PerastageCopySymbols.cmake",
+        ),
+        "Windows platform module",
+        errors,
+    )
+    require_contracts(
+        macos,
+        (
+            "resources/Perastage.icns",
+            "resources/PerastageProject.icns",
+            "resources/PerastageMVR.icns",
+            'MACOSX_PACKAGE_LOCATION "Resources"',
+            "cmake/PerastageInfo.plist.in",
+            "MACOSX_BUNDLE TRUE",
+            "MACOSX_BUNDLE_INFO_PLIST",
+            'RESOURCE "${PERASTAGE_MACOS_RESOURCES}"',
+        ),
+        "macOS platform module",
+        errors,
+    )
+    if "no additional target-level build configuration" not in linux:
+        errors.append("Linux platform module must document its intentionally empty boundary")
+
+    platform_contracts = (
+        "resources/Perastage.rc",
+        "WIN32_EXECUTABLE",
+        "/Zc:__cplusplus",
+        "Dbghelp",
+        "perastage_symbols",
+        "PERASTAGE_SYMBOLS_DIR",
+        "resources/Perastage.icns",
+        "MACOSX_PACKAGE_LOCATION",
+        "PerastageInfo.plist.in",
+        "MACOSX_BUNDLE",
+    )
+    for contract in platform_contracts:
+        if contract in root:
+            errors.append(f"root CMake still owns platform contract: {contract}")
+
+    forbidden = {
+        "dependency discovery": r"\bfind_package\s*\(",
+        "localization": r"\b(?:Gettext|msgfmt|perastage_(?:translations|update_translations))\b",
+        "install rules": r"\binstall\s*\(",
+        "runtime staging": r"\bPOST_BUILD\b",
+        "packaging": r"\bCPACK_|\binclude\s*\(\s*CPack\s*\)",
+        "feature registration": r"\badd_subdirectory\s*\(",
+        "generic includes": r"\btarget_include_directories\s*\(",
+        "generic dependencies": r"\b(?:tinyxml2::tinyxml2|OpenGL::GL|CURL::libcurl|_wx_libs)\b",
+    }
+    for module_name, module_text in (("dispatcher", dispatcher), ("Windows", windows), ("macOS", macos), ("Linux", linux)):
+        for responsibility, pattern in forbidden.items():
+            if re.search(pattern, module_text, re.IGNORECASE):
+                errors.append(f"{module_name} platform module contains forbidden {responsibility}")
+
+    if errors:
+        print("Platform CMake ownership check failed:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+    print("Platform CMake ownership check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/check_root_cmake_orchestration.py
+++ b/tests/check_root_cmake_orchestration.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Validate that the root CMake file remains focused on project orchestration."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+ROOT_CMAKE = Path(__file__).resolve().parents[1] / "CMakeLists.txt"
+
+
+def main() -> int:
+    """Check representative root ownership and Phase 3 module boundaries."""
+    root = ROOT_CMAKE.read_text(encoding="utf-8")
+    errors: list[str] = []
+
+    required = (
+        "project(\n    Perastage",
+        "option(PERASTAGE_MACOS15_LEGACY_THREAD_COMPAT",
+        "add_library(perastage_uuid OBJECT)",
+        "add_executable(${PROJECT_NAME}",
+        "if(PERASTAGE_MACOS15_LEGACY_THREAD_COMPAT)",
+        "PERASTAGE_MACOS15_LEGACY_THREAD_COMPAT=1",
+        "target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)",
+        "target_include_directories(${PROJECT_NAME} PRIVATE",
+        "target_link_libraries(${PROJECT_NAME} PRIVATE",
+        "if(BUILD_TESTING)\n    add_subdirectory(tests)",
+    )
+    required += tuple(f"add_subdirectory({module})" for module in (
+        "core", "gui", "models", "mvr", "viewer2d", "viewer3d", "viewer_common"
+    ))
+    required += tuple(f"include({module})" for module in (
+        "cmake/PerastageDependencies.cmake",
+        "cmake/PerastageLocalization.cmake",
+        "cmake/platform/PerastagePlatform.cmake",
+        "cmake/PerastageInstall.cmake",
+        "cmake/PerastageRuntimeStaging.cmake",
+        "cmake/PerastagePackaging.cmake",
+    ))
+    for contract in required:
+        if contract not in root:
+            errors.append(f"root CMake is missing orchestration contract: {contract}")
+
+    include_entries = (
+        "${CMAKE_SOURCE_DIR}/gui",
+        "${CMAKE_SOURCE_DIR}/gui/mainwindow/controllers",
+        "${CMAKE_SOURCE_DIR}/gui/mainwindow/ids",
+        "${CMAKE_SOURCE_DIR}/models",
+        "${CMAKE_SOURCE_DIR}/core",
+        "${CMAKE_SOURCE_DIR}/core/layouts",
+        "${CMAKE_SOURCE_DIR}/core/print",
+        "${CMAKE_SOURCE_DIR}/mvr",
+        "${CMAKE_SOURCE_DIR}/third_party",
+        "${CMAKE_SOURCE_DIR}/viewer3d",
+        "${CMAKE_SOURCE_DIR}/viewer3d/interfaces",
+        "${CMAKE_SOURCE_DIR}/viewer3d/resources",
+        "${CMAKE_SOURCE_DIR}/viewer3d/culling",
+        "${CMAKE_SOURCE_DIR}/viewer3d/labels",
+        "${CMAKE_SOURCE_DIR}/viewer3d/picking",
+        "${CMAKE_SOURCE_DIR}/viewer3d/render",
+        "${CMAKE_SOURCE_DIR}/viewer2d",
+        "${CMAKE_SOURCE_DIR}/viewer2d/pdf",
+        "${CMAKE_SOURCE_DIR}/resources",
+        "${_wx_includes}",
+        "${NANOVG_INCLUDE_DIR}",
+    )
+    for entry in include_entries:
+        if len(re.findall(rf"^\s*{re.escape(entry)}\s*$", root, re.MULTILINE)) != 1:
+            errors.append(f"root generic include contract changed: {entry}")
+
+    forbidden = {
+        "dependency discovery": r"\bfind_package\s*\(",
+        "catalog generation": r"PerastageCompileGettextCatalog|\bGETTEXT_(?:MSGFMT|XGETTEXT)_EXECUTABLE\b",
+        "runtime staging": r"\bPOST_BUILD\b",
+        "installation": r"\binstall\s*\(",
+        "packaging": r"\bCPACK_|\binclude\s*\(\s*CPack\s*\)",
+        "platform implementation": r"\b(?:WIN32_EXECUTABLE|MACOSX_BUNDLE|Dbghelp|perastage_symbols|Perastage\.rc|PerastageInfo\.plist)\b",
+        "feature source list": r"\bset\s*\(\s*PERASTAGE_(?:CORE|GUI|MODELS|MVR|VIEWER2D|VIEWER3D)_SOURCES\b",
+    }
+    for responsibility, pattern in forbidden.items():
+        if re.search(pattern, root, re.IGNORECASE):
+            errors.append(f"root CMake regained {responsibility} ownership")
+
+    if root.index("add_executable(${PROJECT_NAME}") > root.index("include(cmake/platform/PerastagePlatform.cmake)"):
+        errors.append("platform dispatcher must follow principal target creation")
+    if root.index("include(cmake/platform/PerastagePlatform.cmake)") > root.index("include(cmake/PerastageInstall.cmake)"):
+        errors.append("platform target configuration must precede installation")
+
+    if errors:
+        print("Root CMake orchestration check failed:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+    print("Root CMake orchestration check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation

- Separate OS-specific target configuration from the root to make platform ownership explicit and avoid platform logic creeping back into the global orchestration.
- Preserve all existing platform behavior (Windows resources/flags, macOS bundle and plist, Linux boundary) while making the root `CMakeLists.txt` primarily an orchestrator.
- Add focused guards and documentation so Phase 3 ownership is verifiable and future Phase 4 work can proceed without regressions.

### Description

- Added a platform dispatcher and per-OS modules: `cmake/platform/PerastagePlatform.cmake`, `PerastageWindows.cmake`, `PerastageMacOS.cmake`, and `PerastageLinux.cmake`, and moved target-level platform configuration into those modules while avoiding duplication of shared configuration.
- Simplified `CMakeLists.txt` by removing the inline Windows/macOS platform blocks and including the new dispatcher; retained the `PERASTAGE_MACOS15_LEGACY_THREAD_COMPAT` option semantics and the global include/link/contracts required by later phases.
- Added ownership guards `tests/check_platform_cmake_ownership.py` and `tests/check_root_cmake_orchestration.py` and registered them in `tests/CMakeLists.txt` to enforce Phase 3 boundaries.
- Updated developer docs to reflect the new Phase 3 ownership: `docs/developer/architecture.md`, `docs/developer/perastage_tree.md`, `docs/developer/repository_layout.md`, and added a short entry to `docs/release-notes-draft.md`.

### Testing

- Ran repository policy and ownership checks: `python3 tests/check_dependency_discovery_ownership.py`, `python3 tests/check_localization_build_ownership.py`, `python3 tests/check_runtime_resource_staging_ownership.py`, `python3 tests/check_installation_ownership.py`, and `python3 tests/check_packaging_ownership.py`, all passed.
- Executed the new/updated guards: `python3 tests/check_platform_cmake_ownership.py` and `python3 tests/check_root_cmake_orchestration.py`, both passed.
- Ran repository baseline and policy fixtures: `python3 tests/check_repository_structure_baseline.py` and `python3 tests/check_repository_structure_baseline_fixtures.py -v`, plus the existing bash policy scripts such as `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, all passed in this environment.
- Verified Python compilation of new tests with `python3 -m py_compile`, and `git diff --check` succeeded, and `cmake --preset wsl-x64-debug -DBUILD_TESTING=ON` reached dependency discovery but stopped due to missing system `wxWidgets` headers in the local environment (local dependency issue, not a change-induced failure); full platform CI builds are still required to validate complete configure/build/test on each OS.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9c503cfc948324b1bd20d6e34d3620)