### PR TITLE
ORG-025: validate internal module dependency directions

### DIFF
--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -56,6 +56,38 @@ coupling, but does not create source-local compiler isolation or a new target
 boundary. Stronger compile-time isolation would require a future target-level
 architecture change.
 
+### Internal module dependency directions
+
+The following contract records the current production source-level includes.
+It is not a target-level link graph: all seven modules still contribute to the
+single application target. Counts are evidence occurrences from the ORG-025
+audit; same-module includes and test sources are excluded.
+
+| Consumer | Accepted providers (evidence count) | Architectural rationale |
+|---|---|---|
+| `core` | `models` (46), `mvr` (5), `viewer2d` (4), `viewer3d` (7) | Application services coordinate scene data, interchange, and existing symbol/geometry implementations. |
+| `models` | None | Scene data does not include another audited application module. |
+| `mvr` | `core` (55), `gui` (3), `models` (9), `viewer2d` (1), `viewer3d` (2) | Interchange uses shared services and scene data plus existing import presentation, label, and geometry facilities. |
+| `gui` | `core` (411), `models` (42), `mvr` (15), `viewer2d` (77), `viewer3d` (45), `viewer_common` (5) | UI workflows orchestrate application services, interchange, both viewers, and shared GL utilities. |
+| `viewer_common` | `core` (4) | Shared viewer utilities use central preferences and diagnostics. |
+| `viewer2d` | `core` (26), `gui` (12), `models` (5), `viewer3d` (8), `viewer_common` (7) | 2D rendering consumes scene/services, shared GL support, existing 3D types, and UI command identifiers. |
+| `viewer3d` | `core` (70), `gui` (13), `models` (24), `viewer2d` (13), `viewer_common` (6) | 3D rendering consumes scene/services, shared GL support, 2D render interfaces, and existing UI status facilities. |
+
+The current graph contains intentional-for-current-architecture cycles between
+`core` and each of `mvr`, `viewer2d`, and `viewer3d`; between `gui` and each of
+`mvr`, `viewer2d`, and `viewer3d`; and between `viewer2d` and `viewer3d`.
+In particular, renderer-to-GUI includes, `mvr -> gui`, and Core's viewer
+includes are visible technical-debt directions rather than a proposed layering
+model. ORG-025 accepts them because they exist; removing them requires a
+separate behavior-preserving architecture change.
+
+`tests/check_module_dependency_directions.py` resolves quoted includes through
+source-relative paths and the application's ordered include roots, then rejects
+ambiguous project headers and directions outside this reviewed set. A legitimate
+new direction requires architectural review and a coordinated update to this
+section and the check's explicit `ACCEPTED_DIRECTIONS`; the check never blesses
+new edges automatically.
+
 ## Library convention
 
 - Scene-object presets live in `library/scene_objects/`.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -27,7 +27,7 @@ Changes since **v1.6.0**.
 - Moved CPack compatibility configuration into a dedicated build module while preserving existing package metadata and installer behavior.
 - Completed the build-system modularization by isolating platform target configuration and simplifying the root CMake file to project orchestration.
 - Localized application include-directory ownership to feature modules while retaining shared and dependency-provided build requirements at the project level.
-- Established a machine-checked contract for current internal module dependency directions, making accidental new coupling visible during repository validation.
+- Established a cross-platform, machine-checked contract for current internal module dependency directions, making accidental new coupling visible with consistent diagnostics on every supported operating system.
 
 ## Downloads and installation
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -27,6 +27,7 @@ Changes since **v1.6.0**.
 - Moved CPack compatibility configuration into a dedicated build module while preserving existing package metadata and installer behavior.
 - Completed the build-system modularization by isolating platform target configuration and simplifying the root CMake file to project orchestration.
 - Localized application include-directory ownership to feature modules while retaining shared and dependency-provided build requirements at the project level.
+- Established a machine-checked contract for current internal module dependency directions, making accidental new coupling visible during repository validation.
 
 ## Downloads and installation
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -212,6 +212,12 @@ if(Python3_Interpreter_FOUND)
     add_repository_policy_test(IncludeDirectoryOwnership ${Python3_EXECUTABLE}
                                ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_include_directory_ownership.py
                                LABELS standard-strict policy cmake)
+    add_repository_policy_test(ModuleDependencyDirections ${Python3_EXECUTABLE}
+                               ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_module_dependency_directions.py
+                               LABELS standard-strict policy architecture)
+    add_repository_policy_test(ModuleDependencyDirectionFixtures ${Python3_EXECUTABLE}
+                               ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_module_dependency_directions_fixtures.py -v
+                               LABELS standard-strict policy architecture)
     add_repository_policy_test(DocsLinks ${Python3_EXECUTABLE}
                                ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_docs_links.py)
     add_repository_policy_test(TestTargetsNoSourceRootIncludes ${Python3_EXECUTABLE}

--- a/tests/check_module_dependency_directions.py
+++ b/tests/check_module_dependency_directions.py
@@ -94,10 +94,19 @@ def owner(root: Path, path: Path) -> str | None:
     return first if first in MODULES else None
 
 
+def repository_relative_path(root: Path, path: Path) -> Path:
+    """Return a path relative to consistently resolved repository roots."""
+    return path.resolve().relative_to(root.resolve())
+
+
 def repository_path_for_display(root: Path, path: Path) -> str:
     """Render a repository-relative path consistently on every platform."""
-    relative = path.relative_to(root) if path.is_absolute() else path
-    return relative.as_posix()
+    if not path.is_absolute():
+        return path.as_posix()
+    try:
+        return repository_relative_path(root, path).as_posix()
+    except ValueError:
+        return path.resolve().as_posix()
 
 
 def resolve_include(root: Path, source: Path, spelling: str) -> tuple[Path | None, list[Path]]:
@@ -128,10 +137,12 @@ def resolve_include(root: Path, source: Path, spelling: str) -> tuple[Path | Non
 
 def audit(root: Path) -> tuple[list[Evidence], list[str]]:
     """Build the current cross-module include inventory and resolution errors."""
+    root = root.resolve()
     evidence: list[Evidence] = []
     errors: list[str] = []
     for source in production_files(root):
-        consumer = source.relative_to(root).parts[0]
+        source_relative = repository_relative_path(root, source)
+        consumer = source_relative.parts[0]
         for spelling in quoted_includes(source.read_text(encoding="utf-8", errors="replace")):
             resolved, conflicts = resolve_include(root, source, spelling)
             if conflicts:
@@ -146,7 +157,9 @@ def audit(root: Path) -> tuple[list[Evidence], list[str]]:
                 continue
             provider = owner(root, resolved)
             if provider and provider != consumer:
-                evidence.append(Evidence(consumer, provider, source.relative_to(root), spelling, resolved.relative_to(root)))
+                evidence.append(
+                    Evidence(consumer, provider, source_relative, spelling, repository_relative_path(root, resolved))
+                )
     return evidence, errors
 
 

--- a/tests/check_module_dependency_directions.py
+++ b/tests/check_module_dependency_directions.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Enforce the accepted source-level dependency directions between modules."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+
+MODULES = ("core", "models", "mvr", "gui", "viewer_common", "viewer2d", "viewer3d")
+SOURCE_SUFFIXES = {".h", ".hpp", ".hh", ".hxx", ".c", ".cc", ".cpp", ".cxx"}
+# This is a reviewed contract, not a graph generated or rewritten by this check.
+ACCEPTED_DIRECTIONS: frozenset[tuple[str, str]] = frozenset({
+    ("core", "models"), ("core", "mvr"), ("core", "viewer2d"), ("core", "viewer3d"),
+    ("gui", "core"), ("gui", "models"), ("gui", "mvr"), ("gui", "viewer2d"),
+    ("gui", "viewer3d"), ("gui", "viewer_common"),
+    ("mvr", "core"), ("mvr", "gui"), ("mvr", "models"), ("mvr", "viewer2d"),
+    ("mvr", "viewer3d"),
+    ("viewer2d", "core"), ("viewer2d", "gui"), ("viewer2d", "models"),
+    ("viewer2d", "viewer3d"), ("viewer2d", "viewer_common"),
+    ("viewer3d", "core"), ("viewer3d", "gui"), ("viewer3d", "models"),
+    ("viewer3d", "viewer2d"), ("viewer3d", "viewer_common"),
+    ("viewer_common", "core"),
+})
+# Keep this order aligned with application target include-directory accumulation.
+INCLUDE_ROOTS = (
+    "core", "core/diagnostics", "core/layouts", "core/print",
+    "gui", "gui/mainwindow/controllers", "gui/mainwindow/ids",
+    "models", "mvr", "viewer2d", "viewer2d/pdf", "viewer3d",
+    "viewer3d/interfaces", "viewer3d/resources", "viewer3d/culling",
+    "viewer3d/labels", "viewer3d/picking", "viewer3d/render", "viewer_common",
+)
+INCLUDE_RE = re.compile(r'^\s*#\s*include\s*"([^"\r\n]+)"', re.MULTILINE)
+
+
+@dataclass(frozen=True)
+class Evidence:
+    consumer: str
+    provider: str
+    source: Path
+    spelling: str
+    resolved: Path
+
+
+def production_files(root: Path) -> list[Path]:
+    """Return audited C and C++ files owned by the seven production modules."""
+    return sorted(
+        path
+        for module in MODULES
+        for path in (root / module).rglob("*")
+        if path.is_file() and path.suffix.lower() in SOURCE_SUFFIXES
+        and "tests" not in path.relative_to(root / module).parts
+    )
+
+
+def quoted_includes(text: str) -> list[str]:
+    """Extract quoted preprocessor includes while ignoring commented directives."""
+    cleaned: list[str] = []
+    index = 0
+    in_block = False
+    while index < len(text):
+        if in_block:
+            end = text.find("*/", index)
+            if end < 0:
+                cleaned.append("\n" * text[index:].count("\n"))
+                break
+            cleaned.append("\n" * text[index:end + 2].count("\n"))
+            index = end + 2
+            in_block = False
+        elif text.startswith("/*", index):
+            in_block = True
+            index += 2
+        elif text.startswith("//", index):
+            end = text.find("\n", index)
+            if end < 0:
+                break
+            cleaned.append("\n")
+            index = end + 1
+        else:
+            cleaned.append(text[index])
+            index += 1
+    return INCLUDE_RE.findall("".join(cleaned))
+
+
+def owner(root: Path, path: Path) -> str | None:
+    """Map a resolved repository path to its top-level production owner."""
+    try:
+        first = path.resolve().relative_to(root.resolve()).parts[0]
+    except (ValueError, IndexError):
+        return None
+    return first if first in MODULES else None
+
+
+def resolve_include(root: Path, source: Path, spelling: str) -> tuple[Path | None, list[Path]]:
+    """Resolve an include using source-relative and ordered application include roots."""
+    relative = (source.parent / spelling).resolve()
+    if relative.is_file():
+        return relative, []
+
+    candidates: list[Path] = []
+    for include_root in INCLUDE_ROOTS:
+        candidate = (root / include_root / spelling).resolve()
+        if candidate.is_file() and owner(root, candidate):
+            candidates.append(candidate)
+    unique = list(dict.fromkeys(candidates))
+    if len(unique) == 1:
+        return unique[0], []
+    if len(unique) > 1:
+        return None, unique
+
+    parts = Path(spelling).parts
+    if parts and parts[0] in MODULES:
+        qualified = (root / spelling).resolve()
+        if qualified.is_file():
+            return qualified, []
+        return None, [qualified]
+    return None, []
+
+
+def audit(root: Path) -> tuple[list[Evidence], list[str]]:
+    """Build the current cross-module include inventory and resolution errors."""
+    evidence: list[Evidence] = []
+    errors: list[str] = []
+    for source in production_files(root):
+        consumer = source.relative_to(root).parts[0]
+        for spelling in quoted_includes(source.read_text(encoding="utf-8", errors="replace")):
+            resolved, conflicts = resolve_include(root, source, spelling)
+            if conflicts:
+                label = "Ambiguous" if len(conflicts) > 1 else "Unresolved project-local"
+                rendered = ", ".join(str(path.relative_to(root)) for path in conflicts)
+                errors.append(
+                    f'{label} include:\n  source: {source.relative_to(root)}\n'
+                    f'  include: "{spelling}"\n  candidates: {rendered}'
+                )
+                continue
+            if resolved is None:
+                continue
+            provider = owner(root, resolved)
+            if provider and provider != consumer:
+                evidence.append(Evidence(consumer, provider, source.relative_to(root), spelling, resolved.relative_to(root)))
+    return evidence, errors
+
+
+def validate(root: Path, accepted: frozenset[tuple[str, str]]) -> tuple[list[Evidence], list[str]]:
+    """Compare the audited graph with the explicitly reviewed direction contract."""
+    evidence, errors = audit(root)
+    by_edge: dict[tuple[str, str], list[Evidence]] = defaultdict(list)
+    for item in evidence:
+        by_edge[(item.consumer, item.provider)].append(item)
+    for edge in sorted(set(by_edge) - accepted):
+        item = by_edge[edge][0]
+        errors.append(
+            f"Unexpected module dependency:\n  {item.consumer} -> {item.provider}\n"
+            f"  introduced by: {item.source}\n  include: \"{item.spelling}\"\n"
+            f"  resolved to: {item.resolved}\nUpdate architecture documentation and the accepted "
+            "dependency contract only if this direction is intentional."
+        )
+    missing = sorted(accepted - set(by_edge))
+    for consumer, provider in missing:
+        errors.append(
+            f"Stale accepted module dependency: {consumer} -> {provider}\n"
+            "Remove it from the contract and architecture documentation after review."
+        )
+    return evidence, errors
+
+
+def documentation_contract_errors(root: Path) -> list[str]:
+    """Require architecture documentation to describe the checked-in edge set."""
+    path = root / "docs/developer/architecture.md"
+    if not path.is_file():
+        return ["Missing module dependency contract in docs/developer/architecture.md"]
+    documented: set[tuple[str, str]] = set()
+    rows = re.findall(r"^\| `([^`]+)` \| ([^|]+) \|", path.read_text(encoding="utf-8"), re.MULTILINE)
+    consumers = {consumer for consumer, _ in rows if consumer in MODULES}
+    for consumer, providers in rows:
+        if consumer not in MODULES:
+            continue
+        for provider in re.findall(r"`([^`]+)`\s*\(\d+\)", providers):
+            if provider in MODULES:
+                documented.add((consumer, provider))
+    errors: list[str] = []
+    if consumers != set(MODULES):
+        errors.append("Architecture dependency table must contain exactly the seven production modules")
+    if documented != set(ACCEPTED_DIRECTIONS):
+        errors.append(
+            "Architecture dependency table and ACCEPTED_DIRECTIONS differ: "
+            f"documented-only={sorted(documented - set(ACCEPTED_DIRECTIONS))}, "
+            f"checker-only={sorted(set(ACCEPTED_DIRECTIONS) - documented)}"
+        )
+    return errors
+
+
+def main() -> int:
+    """Run the module direction policy check for a repository root."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[1])
+    parser.add_argument("--inventory", action="store_true", help="print the discovered edge counts")
+    args = parser.parse_args()
+    evidence, errors = validate(args.root.resolve(), ACCEPTED_DIRECTIONS)
+    errors.extend(documentation_contract_errors(args.root.resolve()))
+    if args.inventory:
+        counts = Counter((item.consumer, item.provider) for item in evidence)
+        for (consumer, provider), count in sorted(counts.items()):
+            print(f"{consumer} -> {provider}: {count}")
+    if errors:
+        print("Module dependency direction check failed:", file=sys.stderr)
+        for error in errors:
+            print(f"\n{error}", file=sys.stderr)
+        return 1
+    print("Module dependency direction check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/check_module_dependency_directions.py
+++ b/tests/check_module_dependency_directions.py
@@ -94,6 +94,12 @@ def owner(root: Path, path: Path) -> str | None:
     return first if first in MODULES else None
 
 
+def repository_path_for_display(root: Path, path: Path) -> str:
+    """Render a repository-relative path consistently on every platform."""
+    relative = path.relative_to(root) if path.is_absolute() else path
+    return relative.as_posix()
+
+
 def resolve_include(root: Path, source: Path, spelling: str) -> tuple[Path | None, list[Path]]:
     """Resolve an include using source-relative and ordered application include roots."""
     relative = (source.parent / spelling).resolve()
@@ -130,9 +136,9 @@ def audit(root: Path) -> tuple[list[Evidence], list[str]]:
             resolved, conflicts = resolve_include(root, source, spelling)
             if conflicts:
                 label = "Ambiguous" if len(conflicts) > 1 else "Unresolved project-local"
-                rendered = ", ".join(str(path.relative_to(root)) for path in conflicts)
+                rendered = ", ".join(repository_path_for_display(root, path) for path in conflicts)
                 errors.append(
-                    f'{label} include:\n  source: {source.relative_to(root)}\n'
+                    f'{label} include:\n  source: {repository_path_for_display(root, source)}\n'
                     f'  include: "{spelling}"\n  candidates: {rendered}'
                 )
                 continue
@@ -154,8 +160,10 @@ def validate(root: Path, accepted: frozenset[tuple[str, str]]) -> tuple[list[Evi
         item = by_edge[edge][0]
         errors.append(
             f"Unexpected module dependency:\n  {item.consumer} -> {item.provider}\n"
-            f"  introduced by: {item.source}\n  include: \"{item.spelling}\"\n"
-            f"  resolved to: {item.resolved}\nUpdate architecture documentation and the accepted "
+            f"  introduced by: {repository_path_for_display(root, item.source)}\n"
+            f"  include: \"{item.spelling}\"\n"
+            f"  resolved to: {repository_path_for_display(root, item.resolved)}\n"
+            "Update architecture documentation and the accepted "
             "dependency contract only if this direction is intentional."
         )
     missing = sorted(accepted - set(by_edge))

--- a/tests/check_module_dependency_directions_fixtures.py
+++ b/tests/check_module_dependency_directions_fixtures.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Exercise the module dependency direction checker with synthetic trees."""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import sys
+import unittest
+from pathlib import Path
+
+CHECK_PATH = Path(__file__).with_name("check_module_dependency_directions.py")
+SPEC = importlib.util.spec_from_file_location("module_directions", CHECK_PATH)
+assert SPEC and SPEC.loader
+checker = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = checker
+SPEC.loader.exec_module(checker)
+
+
+class ModuleDependencyDirectionFixtures(unittest.TestCase):
+    """Verify resolution, graph enforcement, and production-file scope."""
+
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        for module in checker.MODULES:
+            (self.root / module).mkdir()
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def write(self, relative: str, contents: str = "") -> None:
+        path = self.root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(contents, encoding="utf-8")
+
+    def test_accepted_direction_passes(self) -> None:
+        self.write("models/model.h")
+        self.write("core/use.cpp", '#include "model.h"\n')
+        _, errors = checker.validate(self.root, frozenset({("core", "models")}))
+        self.assertEqual(errors, [])
+
+    def test_unaccepted_direction_fails_with_evidence(self) -> None:
+        self.write("models/model.h")
+        self.write("core/use.cpp", '#include "model.h"\n')
+        _, errors = checker.validate(self.root, frozenset())
+        message = "\n".join(errors)
+        self.assertIn("core -> models", message)
+        self.assertIn('include: "model.h"', message)
+        self.assertIn("resolved to: models/model.h", message)
+
+    def test_same_module_include_does_not_create_an_edge(self) -> None:
+        self.write("core/local.h")
+        self.write("core/use.cpp", '#include "local.h"\n')
+        evidence, errors = checker.validate(self.root, frozenset())
+        self.assertEqual((evidence, errors), ([], []))
+
+    def test_relative_cross_module_include_is_detected(self) -> None:
+        self.write("models/model.h")
+        self.write("core/use.cpp", '#include "../models/model.h"\n')
+        evidence, _ = checker.audit(self.root)
+        self.assertEqual((evidence[0].consumer, evidence[0].provider), ("core", "models"))
+
+    def test_unqualified_include_root_is_resolved(self) -> None:
+        self.write("viewer_common/shared.h")
+        self.write("gui/use.cpp", '#include "shared.h"\n')
+        evidence, _ = checker.audit(self.root)
+        self.assertEqual(evidence[0].resolved, Path("viewer_common/shared.h"))
+
+    def test_external_and_commented_includes_are_ignored(self) -> None:
+        self.write("core/use.cpp", '#include <vector>\n#include "external_api.h"\n// #include "models/missing.h"\n')
+        evidence, errors = checker.audit(self.root)
+        self.assertEqual((evidence, errors), ([], []))
+
+    def test_ambiguous_project_include_fails_clearly(self) -> None:
+        self.write("core/shared.h")
+        self.write("models/shared.h")
+        self.write("gui/use.cpp", '#include "shared.h"\n')
+        _, errors = checker.audit(self.root)
+        self.assertIn("Ambiguous include", errors[0])
+        self.assertIn("core/shared.h, models/shared.h", errors[0])
+
+    def test_test_only_source_is_excluded(self) -> None:
+        self.write("models/model.h")
+        self.write("core/tests/use.cpp", '#include "model.h"\n')
+        evidence, errors = checker.audit(self.root)
+        self.assertEqual((evidence, errors), ([], []))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/check_module_dependency_directions_fixtures.py
+++ b/tests/check_module_dependency_directions_fixtures.py
@@ -69,6 +69,18 @@ class ModuleDependencyDirectionFixtures(unittest.TestCase):
         evidence, _ = checker.audit(self.root)
         self.assertEqual(evidence[0].resolved, Path("viewer_common/shared.h"))
 
+    def test_display_path_normalizes_root_before_relativizing(self) -> None:
+        self.write("models/model.h")
+        lexical_root = self.root / "core" / ".."
+        resolved_path = (self.root / "models/model.h").resolve()
+        self.assertEqual(checker.repository_path_for_display(lexical_root, resolved_path), "models/model.h")
+
+    def test_outside_display_path_uses_a_normalized_fallback(self) -> None:
+        outside = self.root.parent / "outside.h"
+        rendered = checker.repository_path_for_display(self.root, outside)
+        self.assertTrue(rendered.endswith("/outside.h"))
+        self.assertNotIn("\\", rendered)
+
     def test_external_and_commented_includes_are_ignored(self) -> None:
         self.write("core/use.cpp", '#include <vector>\n#include "external_api.h"\n// #include "models/missing.h"\n')
         evidence, errors = checker.audit(self.root)

--- a/tests/check_module_dependency_directions_fixtures.py
+++ b/tests/check_module_dependency_directions_fixtures.py
@@ -47,7 +47,9 @@ class ModuleDependencyDirectionFixtures(unittest.TestCase):
         message = "\n".join(errors)
         self.assertIn("core -> models", message)
         self.assertIn('include: "model.h"', message)
+        self.assertIn("introduced by: core/use.cpp", message)
         self.assertIn("resolved to: models/model.h", message)
+        self.assertNotIn("\\", message)
 
     def test_same_module_include_does_not_create_an_edge(self) -> None:
         self.write("core/local.h")
@@ -79,6 +81,7 @@ class ModuleDependencyDirectionFixtures(unittest.TestCase):
         _, errors = checker.audit(self.root)
         self.assertIn("Ambiguous include", errors[0])
         self.assertIn("core/shared.h, models/shared.h", errors[0])
+        self.assertNotIn("\\", errors[0])
 
     def test_test_only_source_is_excluded(self) -> None:
         self.write("models/model.h")


### PR DESCRIPTION
### Motivation

- Add a deterministic, source-level guard that documents and enforces the actual module-to-module include directions after the include-directory ownership cleanup. 
- Derive the contract from the real repository tree (resolve source-relative, qualified, and unqualified quoted includes) and make ambiguous/resolution failures actionable. 
- Detect and fail on newly introduced cross-module directions that are not in the reviewed contract while preserving the current application build and behavior.

### Description

- Added a new policy checker `tests/check_module_dependency_directions.py` that scans production sources in the seven modules, resolves quoted includes using source-relative lookup and ordered application include roots, records cross-module edges, rejects ambiguous/unresolved project-local includes, and compares the discovered edges against an explicit reviewed `ACCEPTED_DIRECTIONS` set. 
- Added lightweight fixture tests in `tests/check_module_dependency_directions_fixtures.py` exercising accepted directions, unexpected directions, same-module includes, relative and unqualified resolution, external/commented includes, ambiguity detection, and test-only-source exclusion. 
- Registered the guard and its fixture test in `tests/CMakeLists.txt` and documented the factual dependency matrix and rationale in `docs/developer/architecture.md`, and added a short release-note entry in `docs/release-notes-draft.md`; no production C/C++ sources or include-directory declarations were changed. 
- Discovered/accepted directed edges (evidence counts from the audit): `core->models:46`, `core->mvr:5`, `core->viewer2d:4`, `core->viewer3d:7`, `gui->core:411`, `gui->models:42`, `gui->mvr:15`, `gui->viewer2d:77`, `gui->viewer3d:45`, `gui->viewer_common:5`, `mvr->core:55`, `mvr->gui:3`, `mvr->models:9`, `mvr->viewer2d:1`, `mvr->viewer3d:2`, `viewer2d->core:26`, `viewer2d->gui:12`, `viewer2d->models:5`, `viewer2d->viewer3d:8`, `viewer2d->viewer_common:7`, `viewer3d->core:70`, `viewer3d->gui:13`, `viewer3d->models:24`, `viewer3d->viewer2d:13`, `viewer3d->viewer_common:6`, `viewer_common->core:4`.

### Testing

- Ran the new checker inventory: `python3 tests/check_module_dependency_directions.py --inventory` and it produced the audited edge counts; the checker itself runs and exits cleanly against the current tree. 
- Ran the fixture suite: `python3 tests/check_module_dependency_directions_fixtures.py -v` (8 tests) and all fixture cases passed locally. 
- Ran the repository policy/ownership checks that interact with the new guard and surrounding policy (including `check_dependency_discovery_ownership.py`, `check_include_directory_ownership.py`, `check_repository_structure_baseline.py`, and the listed shell policy checks) and observed they passed in the local validation run. 
- Performed `git diff --check` and Python compile checks for the new tests; these validations passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9c71e634548324bdc067e94adeaa5a)