### PR TITLE
ORG-030: audit main.cpp bootstrap responsibilities

### DIFF
--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -88,6 +88,99 @@ new direction requires architectural review and a coordinated update to this
 section and the check's explicit `ACCEPTED_DIRECTIONS`; the check never blesses
 new edges automatically.
 
+## Application bootstrap ownership audit (ORG-030)
+
+ORG-030 audits the current root `main.cpp`; it does **not** move bootstrap code,
+create a module, change `MyApp`/`wxIMPLEMENT_APP`, or begin ORG-031, ORG-032, or
+ORG-033. The intended owner for a later extraction is a top-level `app/` module.
+Bootstrap is application composition: it may depend on Core services and GUI
+types, whereas neither `core/` nor other GUI-independent modules may depend on
+`app/` or acquire wxWidgets application-lifecycle responsibilities. This makes
+`app/` a clearer owner than `core/` or `gui/`.
+
+### Current responsibilities and future owners
+
+The following classification is based on the current implementation and records
+the ordering, platform, and repository constraints that a later change must
+preserve. "App" means the proposed `app/` module, not an existing directory.
+
+| Responsibility | Current owner and dependencies | Intended owner | Constraints and later references |
+|---|---|---|---|
+| Process/application entry wiring | `wxIMPLEMENT_APP(MyApp)` supplies the wxWidgets-generated process entry point. | Minimal root `main.cpp`. | Keep exactly one compiled root entry point and preserve wxWidgets platform entry semantics. Root `CMakeLists.txt`, the structure baseline and its fixture tests currently require this path. |
+| `wxApp` type and lifecycle declarations | The `MyApp : wxApp` declaration lists `OnInit`, `OnExit`, event/exception hooks, macOS callbacks, and private startup methods/state. | App, in a focused public `app/perastage_app.h`; implementations belong in App `.cpp` files. | The root should include the header solely to instantiate the application. Non-macOS compatibility declarations must remain so callback logic stays buildable/testable on all platforms. |
+| Startup sequencing | `MyApp::OnInit` creates metrics, configures debug behavior and process locale, captures the launch CWD, publishes app/vendor names, changes to the executable directory, initializes images/appearance, diagnostics, preferences/localization, splash/library bootstrap, and the main window before scheduling startup-open resolution. | App bootstrap implementation. | Preserve the exact sequence, especially capturing launch CWD before changing it; diagnostics before user-facing windows; configuration before localization; splash before library bootstrap; and deferred open resolution after window construction. |
+| Startup project/MVR resolution | `GetStartupPathFromArgs` accepts the first `.pstg` (via `ProjectUtils::PROJECT_EXTENSION`) or `.mvr` argument, resolves a relative argument against the captured launch CWD, and `FinalizeStartupOpenResolution` selects macOS explicit open, then CLI, then last project, then empty project. | App; path parsing/selection should become a separate, narrowly testable App helper because it is policy rather than UI presentation. | Preserve extension case folding, quote removal, UTF-8/filesystem conversions, precedence, `clearLastProject` values, two nested `CallAfter` calls that allow a macOS event to arrive, and the single queued `EVT_PROJECT_LOADED`. Packaging associations feed this input but do not depend on the source path. |
+| External-open routing | `HandleExternalOpenPath`, `StorePendingStartupExternalOpenPath`, `ConsumePendingStartupExternalOpenPath`, `ConsumePendingExternalOpenPath`, and `QueueProjectLoadedEvent` capture startup requests, queue requests while no top window exists, prevent duplicate initial loads, and later delegate to `MainWindow::EnqueueExternalOpenPath`. | App owns pre-window/lifecycle routing and state; GUI continues to own the ready-state/deferred-open pipeline in `MainWindow`. | Preserve GUI-thread `CallAfter`/`wxQueueEvent`, weak-window lifetime checks, request order, most-recent startup request semantics, and the atomic startup/load gates. Audit note: `ConsumePendingExternalOpenPath` currently has no caller; later work must not silently invent draining behavior during a move. |
+| macOS open callbacks | `MacOpenFile`, `MacOpenFiles`, and `MacOpenURL` convert wx strings, log safely, normalize, and enter the shared external-open route. | App lifecycle implementation. | Overrides apply only on `__WXOSX__`; declarations remain available elsewhere. Preserve ordered multi-file dispatch and LaunchServices/Finder timing. macOS bundle configuration is in `cmake/platform`, but does not name `main.cpp`. |
+| URI/path bootstrap helpers | `DecodeFileUriToPath`, `NormalizeExternalOpenPath`, `ToLowerAscii`, and the local UTF-8 conversion in `GetStartupPathFromArgs` decode `file://`, normalize separators/absolute paths, and compare extensions. | Initially private App implementation; extract pure parsing/selection portions into a testable App helper when useful. Shared encoding primitives may use existing Core `filesystem_path_utils`, but wx URI and launch policy must not move into Core. | Preserve macOS authority/slash handling, deliberate Windows avoidance of `wxFileName::Normalize`, filename-only diagnostics, and error fallbacks. |
+| Localization startup | `OnInit` calls `platform::EnsureProcessTextLocale`, reads `ui_language` from `ConfigManager`, initializes `LocalizationManager`, records timing and logs fallback; `ShowLocalizationFallbackWarningIfNeeded` schedules one Spanish-catalog warning after window creation. | App orchestration; locale and localization implementations remain in Core, warning presentation remains an App concern. | Preserve process-locale-before-config ordering, locale-independent numeric behavior, one-shot warning timing and exact translatable messages. The localization scanner and POT/complete PO source references currently name `main.cpp`. |
+| Diagnostic logging and crash handling | `OnInit` initializes `DiagnosticLogger` then `CrashHandler` and logs build/locale data. `OnExit` logs shutdown, calls `ShutdownGdtfCache`, marks runtime teardown, invokes `wxApp::OnExit`, then closes the logger. | App orchestration; implementations remain `core/diagnostics` and the Viewer3D GDTF cache owner. | Initialization must precede window construction and exception reporting. Teardown order must remain cache, crash-handler teardown marker, wx shutdown, final logger shutdown. |
+| Exception handling and event context | `FilterEvent` stores the last wx event summary. `LogExceptionWithStack`, `OnExceptionInMainLoop`, and `OnUnhandledException` log/report standard, allocation, and unknown exceptions; recoverable standard main-loop exceptions return `true`. | App lifecycle implementation; stack formatting can be a private diagnostics adapter, while logger/crash report mechanics remain Core diagnostics. | Preserve return behavior and last-event reporting. The `wxStackWalker` trace is Windows-only and exception hooks must retain wx lifecycle signatures. |
+| Application startup state | `MyApp` stores last-event text, atomic load/resolution gates, the explicit startup path, FIFO later-open paths, localization-warning state, shared metrics, and resolution start time. | App, preferably split by responsibility into bootstrap/open-routing state rather than exposed globally. | State must live for the wx application lifetime. Keep atomics where callbacks can cross delivery boundaries and keep `startup::Metrics` shared with `MainWindow`. |
+| Splash interaction | `OnInit` calls `SplashScreen::Show` and sets the library-bootstrap, main-window, and last-project messages. Final hiding/publication is driven by `MainWindow` startup composition. | App owns startup progress sequencing; GUI retains splash rendering and final publication. | Do not show/maximize the window from App. `tests/check_startup_window_publication.sh` inspects root `main.cpp` directly and must follow the implementation path later. |
+| Main-window creation and top-window publication | `OnInit` constructs `MainWindow(app::kName, nullptr, startup_metrics_)` and immediately calls `SetTopWindow`; `MainWindow::PublishInitialMainWindow` later updates layout, maximizes, and shows it. | App composes/sets the wx top window; GUI owns construction internals and authoritative visible publication. | Preserve top-window availability for external-open routing, weak references, and the hidden-until-composed invariant. |
+| Last-project loading | `OnInit` reads `ProjectUtils::LoadLastProjectPath`; `FinalizeStartupOpenResolution` uses it only if no explicit startup request wins and emits an empty-load event otherwise. | App selection policy; persistence remains Core `ProjectUtils`. | Read at the current point, preserve precedence and whether last-project state is cleared. Do not merge this with `MainWindow`'s separate user workflow. |
+| Startup metrics | `OnInit` creates `startup::Metrics` and records user-config/localization and main-window construction durations; finalization records delayed path-resolution duration. | App records orchestration spans; the neutral metrics data type remains Core and is passed to GUI consumers. | Preserve clock boundaries and shared ownership; extraction must not alter what time is included. |
+| Platform startup and debug behavior | `OnInit` uses `ConfigureWindowsDebugHeapLeakCheck` under MSVC Debug, sets wx dark-mode options, and changes CWD; `OnExit` optionally resets `ConfigManager` for leak reporting. | App, with platform-only helpers private to its implementation. | Preserve `PERASTAGE_CRT_LEAK_CHECK=1`, compile guards, MSVC CRT calls, wx version guard, all-platform system option, and shutdown reset timing. Platform CMake retains subsystem/bundle/resource ownership. |
+| Library bootstrap and cache teardown | `OnInit` invokes `ProjectUtils::RunStartupLibraryBootstrap`; `OnExit` invokes Viewer3D's `ShutdownGdtfCache`. | App coordinates calls; Core `ProjectUtils` and Viewer3D retain the underlying responsibilities. | Calls stay inside the established splash/diagnostic lifetime. This existing Viewer3D dependency is composition debt and must not be pushed into Core. |
+
+### Target boundary and dependency shape
+
+After the later extraction, root `main.cpp` should contain only the include of
+the App-owned `wxApp` declaration and `wxIMPLEMENT_APP(MyApp)` (plus the license
+header). `MyApp` needs its own header because the registration macro requires a
+complete named type at the root entry point; its state and non-override helpers
+remain private. App implementation files may depend downward on wxWidgets,
+`core/` configuration, filesystem, localization, platform-locale, startup
+metrics and diagnostics services, `gui/` (`MainWindow` and `SplashScreen`), and
+the existing Viewer3D cache shutdown API. GUI-independent modules must not
+include the App header or depend upward on bootstrap policy.
+
+Startup argument/path selection is the strongest candidate for a separate
+testable App helper: its inputs and precedence can be explicit without owning a
+window. wx event dispatch, lifecycle callbacks, diagnostic event capture, and
+the fallback dialog should remain private implementation details. A later
+design may narrow the direct Viewer3D teardown dependency through an
+owner-provided lifecycle interface, but ORG-030 neither introduces that
+interface nor changes behavior.
+
+When `app/` is actually created, it must have an explicit `app/CMakeLists.txt`
+using `target_sources`; root CMake must add the subdirectory while retaining
+only `main.cpp` and generated build information in `add_executable`. No globbing
+or broadened include path is warranted. The module-direction contract must add
+App as a composition-layer consumer, not as a provider to Core/GUI/viewers.
+
+### References that later implementation must update
+
+- Root `CMakeLists.txt` explicitly compiles `main.cpp`. The structure baseline
+  classifies it as the only root application source and compiled entry point;
+  `tests/check_repository_structure_baseline.py` enforces those lists and local
+  module registration, while its fixture suite embeds `main.cpp` and the
+  current module set. The minimal root file remains valid, but adding `app/`
+  requires coordinated baseline, fixture, root-registration, and module-CMake
+  updates rather than weakening the guard.
+- `tests/check_startup_window_publication.sh` reads `main.cpp` to reject direct
+  `Show`/`Maximize` calls and reads `gui/mainwindow_startup_splash.cpp` for the
+  authoritative publication sequence. It must inspect the App implementation
+  after the move while continuing to protect the same invariant.
+- `scripts/localization_catalog.py` explicitly includes `main.cpp` in its audit
+  set and identifies a representative root splash message. The POT and Spanish
+  and Simplified Chinese complete catalogs carry `#: main.cpp` locations for
+  the three splash messages and two fallback-warning strings. Source scanning,
+  representative wording, catalog regeneration, and COMPLETE-catalog checks
+  must be updated together after the strings move.
+- `docs/developer/repository_layout.md` and `perastage_tree.md` call `main.cpp`
+  the bootstrap/entry point. This architecture section, the machine-readable
+  baseline, and the GDTF editor architecture audit also mention its open-file
+  routing. Later documentation must distinguish the minimal root entry from the
+  App owner.
+- Windows installer file associations invoke the executable with one `.pstg`
+  or `.mvr` argument; Linux MIME/desktop integration and macOS bundle/
+  LaunchServices configuration likewise constrain observable open behavior.
+  They do not inspect or constrain the `main.cpp` path. Current GitHub Actions
+  and installer workflows impose executable, bundle, resource, and association
+  behavior but contain no direct source-path reference that needs changing.
+
 ## Library convention
 
 - Scene-object presets live in `library/scene_objects/`.

--- a/docs/developer/perastage_tree.md
+++ b/docs/developer/perastage_tree.md
@@ -8,7 +8,7 @@ This map is aligned with the terminology used in `README.md` and `docs/developer
 
 ```text
 Perastage/
-|-- main.cpp                     # wxWidgets application entry point.
+|-- main.cpp                     # Current wxWidgets entry point and bootstrap; planned to become entry-only.
 |-- CMakeLists.txt               # Root target creation, build orchestration, and module registration.
 |-- CMakePresets.json            # Supported local configure/build presets.
 |-- README.md                    # Product overview, features, and entry links.
@@ -61,7 +61,10 @@ Perastage/
 
 ## Critical files (explicit exception to high-level granularity)
 
-- `main.cpp`: application bootstrap.
+- `main.cpp`: current application bootstrap and sole root C/C++ entry point.
+  ORG-030 selects a future `app/` module for bootstrap composition, but does not
+  create it or move any code; see the ownership audit in
+  `docs/developer/architecture.md`.
 - `CMakeLists.txt`: primary build orchestration.
 - `CMakePresets.json`: supported local configure/build presets.
 - `README.md`: functional/documentation reference.

--- a/docs/developer/repository_layout.md
+++ b/docs/developer/repository_layout.md
@@ -13,7 +13,7 @@ this page remains its human-readable architectural counterpart.
 
 | Path | Purpose |
 |------|---------|
-| `main.cpp` | wxWidgets application entry point and top-level initialization. |
+| `main.cpp` | Current wxWidgets application entry point and bootstrap; ORG-030 plans a later minimal entry boundary with bootstrap owned by `app/`. |
 | `CMakeLists.txt` | Project options, principal target creation, shared target configuration, and build-module orchestration. |
 | `CMakePresets.json` | Canonical tracked configure/build presets for supported local development workflows. |
 | `cmake/` | Dependency discovery, CMake helper scripts, generated configuration templates, and platform metadata templates. |
@@ -52,6 +52,14 @@ bootstrap source. Every module above contributes its explicit application source
 list through its own `CMakeLists.txt`. `tests/` is added
 conditionally when testing is enabled. No recursive project-source discovery is
 used.
+
+The ORG-030 dependency audit in [Architecture](architecture.md#application-bootstrap-ownership-audit-org-030)
+selects a future top-level `app/` composition module for the wx application
+lifecycle and startup orchestration. That module does not exist yet: `main.cpp`
+still owns all current bootstrap behavior and remains the sole accepted root
+C/C++ source. A later implementation will leave only wx application entry
+wiring at the root and will add explicit App source registration; it must update
+the repository baseline and focused guards in the same change.
 
 Target-level operating-system configuration is dispatched once through
 `cmake/platform/PerastagePlatform.cmake`. The Windows owner configures the

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -31,6 +31,7 @@ Changes since **v1.6.0**.
 - Established a cross-platform, machine-checked contract for current internal module dependency directions, making accidental new coupling visible with consistent diagnostics on every supported operating system.
 - Kept the Linux/WSL setup command stable while moving its detailed bootstrap workflow into a dedicated platform script with portable cross-platform compatibility checks.
 - Kept the Windows setup command stable while moving Visual Studio, dependency validation, and build orchestration into dedicated platform scripts and aligning setup documentation.
+- Documented the application bootstrap's current responsibilities, dependencies, and lifecycle constraints to guide a later behavior-preserving modularization.
 
 ## Downloads and installation
 


### PR DESCRIPTION
### Motivation
- Capture a complete, code-grounded classification of every meaningful responsibility currently implemented in `main.cpp` so later extraction work can proceed without re-auditing ownership or breaking startup behavior.
- Preserve existing runtime behavior and platform semantics while documenting clear extraction targets and lifecycle constraints for a future bootstrap module.
- Record all repository references (CMake, tests, localization tooling, and docs) that must be updated together when the bootstrap is actually moved.

### Description
- Added a focused `ORG-030` audit section to `docs/developer/architecture.md` that enumerates the responsibilities currently in `main.cpp`, maps each responsibility to the owning functions/types, records dependencies and ordering/platform constraints, and recommends the intended future owner `app/` while explaining the rationale and boundary shape.
- Updated `docs/developer/repository_layout.md` and `docs/developer/perastage_tree.md` to note that `main.cpp` remains the current bootstrap and that ORG-030 selects a future `app/` composition module (with a clear statement that no code movement has occurred).
- Added a single-line release-note entry in `docs/release-notes-draft.md` summarizing that the bootstrap responsibilities were audited to guide a later behavior-preserving modularization; no production code was changed and `MyApp`/`wxIMPLEMENT_APP` were not modified.
- Recorded specific target decisions: the minimal root entry should remain a single compiled root file containing only the `MyApp` include and `wxIMPLEMENT_APP(MyApp)`, while the proposed `app/` module would own bootstrap implementation files, keep `MyApp` header separation, and preserve downward dependencies on `core`, `gui`, localization, diagnostics, and selective Viewer3D teardown hooks; also documented the test/tooling/docs/CMake items that later changes must update (for example `CMakeLists.txt`, `docs/developer/repository_structure_baseline.json`, `scripts/localization_catalog.py`, `tests/check_startup_window_publication.sh`, and POT/PO references to `main.cpp`).
- No bootstrap code was moved, no behavior or startup order was changed, and ORG-031 / ORG-032 / ORG-033 were not begun in this PR.

### Testing
- Ran `python3 tests/check_repository_structure_baseline.py` and it passed.
- Ran `python3 tests/check_repository_structure_baseline_fixtures.py -v` and it passed, and `tests/check_startup_window_publication.sh` passed as expected.
- Ran `PERASTAGE_TEST_PYTHON=$(command -v python3) tests/check_perastage_tree_modules.sh` and `PERASTAGE_TEST_PYTHON=$(command -v python3) tests/check_no_configmanager_get_in_gui.sh` and both passed, and `python3 tests/check_docs_links.py` passed as well.
- Ran `git diff --check` and no whitespace or index issues were reported; local commits were created on branch `codex/org-030-audit-main-bootstrap-responsibilities` (commit `c674407`).
- Note: pushing the branch and opening a GitHub pull request could not be completed from this environment because the checkout has no configured Git remote and `gh auth status` is not authenticated; the branch and commit exist locally for a maintainer or CI runner to push and open the PR for cross-platform CI validation.

Explicit statement: this PR is documentation-only, does not move or modify any bootstrap production code, and does not start ORG-031/ORG-032/ORG-033.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9df6fd0adc83248ec5a5d46a73614a)