### PR TITLE
ORG-035–037: enforce repository architecture and local-config boundaries

### DIFF
--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -7,6 +7,12 @@ the canonical human-readable map of repository paths and root-file roles, see
 
 ## Top-level layout
 
+<!-- repository-source-module-responsibilities: app=application lifecycle and startup composition; core=shared business logic and services; gui=wxWidgets UI and workflows; models=scene data structures; mvr=MVR interchange; viewer2d=2D rendering and export; viewer3d=3D rendering and loading; viewer_common=shared viewer utilities -->
+
+This stable marker is checked against the canonical source-module inventory in
+`repository_structure_baseline.json`; the descriptions below define each
+module's architectural responsibility.
+
 - `app/`: wxWidgets application lifecycle and startup composition.
 - `core/`: shared business logic and services.
 - `gui/`: wxWidgets UI and main window workflows.
@@ -32,6 +38,17 @@ the canonical human-readable map of repository paths and root-file roles, see
 - `docs/developer/repository_structure_baseline.json` is the authoritative machine-readable contract for source-module classification and CMake registration.
 - Avoid recursive or wildcard project-source discovery; list files explicitly.
 - Keep include directories close to the module that owns them.
+- Root C/C++ sources are restricted to explicitly approved architectural entry
+  points. `main.cpp` is the sole current exception; approving another requires
+  aligned baseline root-source and root-role contracts plus architecture and
+  repository-layout documentation.
+
+Introducing a top-level production source module requires one coordinated
+change: baseline classification and guard-set alignment, a local
+`CMakeLists.txt` with explicit `target_sources(...)` ownership, root
+`add_subdirectory(...)` registration, and descriptions in both this document
+and the repository layout. Dependency directions remain separately reviewed;
+the guard never adds an accepted edge for a new module automatically.
 
 ### Application include-directory ownership
 

--- a/docs/developer/perastage_tree.md
+++ b/docs/developer/perastage_tree.md
@@ -92,3 +92,5 @@ Perastage/
 - If a new top-level source module is introduced, update the architecture guard scripts under `tests/` when appropriate.
 - Every top-level application source module owns an explicit local CMake source list; the root does not normally register feature implementations, and no recursive source discovery is used.
 - `repository_structure_baseline.json` is the authoritative machine-readable contract for source-module classification and root module registration.
+- New source modules must align that contract, explicit module and root CMake registration, architecture/layout documentation, and required guard inventories.
+- Root project sources are limited to documented entry-point exceptions, and developer-local presets, build trees, and IDE state must remain untracked.

--- a/docs/developer/repository_layout.md
+++ b/docs/developer/repository_layout.md
@@ -31,6 +31,13 @@ Repository documentation has one owner for each kind of structural fact:
 
 ## Top-level structure
 
+<!-- repository-source-modules: app, core, gui, models, mvr, viewer2d, viewer3d, viewer_common -->
+<!-- repository-root-source-roles: main.cpp=application_entry_point -->
+
+The marker above provides the deterministic layout mapping for the canonical
+source-module inventory; the table below provides the human-readable path role
+for every listed module.
+
 | Path | Purpose |
 |------|---------|
 | `main.cpp` | Minimal wxWidgets application-entry wiring; it includes the App-owned declaration and invokes `wxIMPLEMENT_APP(MyApp)`. |
@@ -65,7 +72,8 @@ The root CMake file explicitly registers every application source module with
 machine-readable `repository_structure_baseline.json` is the authoritative
 module-classification and registration list. The repository-structure guard
 keeps that classification, local module CMake ownership, and root registration
-from silently diverging.
+from silently diverging. Required architecture guard inventories and stable
+documentation markers are validated against the same canonical module list.
 
 The source-registration arrangement is decentralized. The root `CMakeLists.txt`
 creates the application target and registers only its entry point and generated
@@ -117,6 +125,16 @@ protects four invariants:
 
 The check uses no branch name or checkout-path assumption and accepts an
 explicit tracked-file manifest for isolated fixtures.
+
+Tracked developer-local configuration is rejected even if it is force-added:
+this includes root `CMakeUserPresets.json`, canonical local build directories,
+CMake build-tree metadata, and Visual Studio `.vs/` state. Critical ignore
+rules for local presets and the canonical `build/` directory are also part of
+the structural contract. `CMakeUserPresets.json` remains the supported,
+untracked mechanism for machine-specific preset overrides. Shared build and
+development configuration must use portable project or environment variables;
+literal developer-home paths are prohibited unless an exact, justified
+contract exception is recorded, and stale exceptions fail validation.
 
 Intentional architecture changes should update the declarative baseline,
 document the new module's responsibility in the architecture and repository

--- a/docs/developer/repository_structure_baseline.json
+++ b/docs/developer/repository_structure_baseline.json
@@ -52,7 +52,44 @@
     "generated_sources": ["generated/build_info.cpp"],
     "conditional_subdirectories": ["tests"]
   },
+  "documentation_contract": {
+    "architecture_source_modules_marker": "repository-source-module-responsibilities",
+    "repository_layout_source_modules_marker": "repository-source-modules",
+    "repository_layout_root_source_roles_marker": "repository-root-source-roles",
+    "root_source_roles": {
+      "main.cpp": "application_entry_point"
+    }
+  },
+  "module_guard_sets": {
+    "dependency_directions": [
+      "app", "core", "gui", "models", "mvr", "viewer2d", "viewer3d", "viewer_common"
+    ],
+    "application_bootstrap_lower_level": [
+      "core", "gui", "models", "mvr", "viewer2d", "viewer3d", "viewer_common"
+    ]
+  },
   "structural_guard": {
+    "local_configuration": {
+      "prohibited_root_files": [
+        "CMakeUserPresets.json",
+        "CMakeCache.txt",
+        "cmake_install.cmake",
+        "CTestTestfile.cmake",
+        "compile_commands.json",
+        "build.ninja",
+        ".ninja_deps",
+        ".ninja_log",
+        "Makefile"
+      ],
+      "prohibited_directory_prefixes": ["build/", "out/", "Debug/", "Release/", ".vs/"],
+      "prohibited_paths": [
+        ".vscode/extensions.json",
+        ".vscode/launch.json",
+        ".vscode/settings.json"
+      ],
+      "prohibited_build_tree_components": ["CMakeFiles", "Testing"],
+      "required_gitignore_patterns": ["build/", "CMakeUserPresets.json"]
+    },
     "third_party_ownership": {
       "owned_directory": "third_party",
       "vendor_directory_names": ["external", "externals", "thirdparty", "vendor", "vendors"],

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -33,6 +33,7 @@ Changes since **v1.6.0**.
 - Kept the Windows setup command stable while moving Visual Studio, dependency validation, and build orchestration into dedicated platform scripts and aligning setup documentation.
 - Moved application startup and lifecycle composition into a dedicated module while preserving launch, open-file, localization, diagnostics, splash, and shutdown behavior, leaving the root entry point minimal.
 - Reconciled developer documentation with the current modular repository layout and clarified the authoritative references for architecture, paths, and structural policy.
+- Enforced repository architecture boundaries for root entry points and source-module registration, and prevented developer-local build, preset, IDE, and machine-path configuration from being committed.
 
 ## Downloads and installation
 

--- a/tests/check_application_bootstrap_ownership.py
+++ b/tests/check_application_bootstrap_ownership.py
@@ -3,12 +3,16 @@
 
 from __future__ import annotations
 
+import json
 import re
 import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
-LOWER_LEVEL_MODULES = ("core", "gui", "models", "mvr", "viewer2d", "viewer3d", "viewer_common")
+BASELINE = json.loads(
+    (ROOT / "docs/developer/repository_structure_baseline.json").read_text(encoding="utf-8")
+)
+LOWER_LEVEL_MODULES = tuple(BASELINE["module_guard_sets"]["application_bootstrap_lower_level"])
 SOURCE_SUFFIXES = {".c", ".cc", ".cpp", ".cxx", ".h", ".hh", ".hpp", ".hxx"}
 
 

--- a/tests/check_module_dependency_directions.py
+++ b/tests/check_module_dependency_directions.py
@@ -4,13 +4,18 @@
 from __future__ import annotations
 
 import argparse
+import json
 import re
 import sys
 from collections import Counter, defaultdict
 from dataclasses import dataclass
 from pathlib import Path
 
-MODULES = ("app", "core", "models", "mvr", "gui", "viewer_common", "viewer2d", "viewer3d")
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+BASELINE = json.loads(
+    (REPOSITORY_ROOT / "docs/developer/repository_structure_baseline.json").read_text(encoding="utf-8")
+)
+MODULES = tuple(BASELINE["module_guard_sets"]["dependency_directions"])
 SOURCE_SUFFIXES = {".h", ".hpp", ".hh", ".hxx", ".c", ".cc", ".cpp", ".cxx"}
 # This is a reviewed contract, not a graph generated or rewritten by this check.
 ACCEPTED_DIRECTIONS: frozenset[tuple[str, str]] = frozenset({
@@ -206,7 +211,10 @@ def documentation_contract_errors(root: Path) -> list[str]:
                 documented.add((consumer, provider))
     errors: list[str] = []
     if consumers != set(MODULES):
-        errors.append("Architecture dependency table must contain exactly the eight production modules")
+        errors.append(
+            "Architecture dependency table must contain exactly the canonical production modules "
+            "from repository_structure_baseline.json"
+        )
     if documented != set(ACCEPTED_DIRECTIONS):
         errors.append(
             "Architecture dependency table and ACCEPTED_DIRECTIONS differ: "

--- a/tests/check_repository_structure_baseline.py
+++ b/tests/check_repository_structure_baseline.py
@@ -126,6 +126,143 @@ def audit_top_level_source_modules(files: set[str], baseline: dict) -> list[str]
     ]
 
 
+def documented_modules(root: Path, relative: str, marker: str) -> set[str] | None:
+    """Read a deliberately parseable source-module marker from documentation."""
+    path = root / relative
+    if not path.is_file():
+        return None
+    match = re.search(
+        rf"<!--\s*{re.escape(marker)}\s*:\s*([^>]+?)\s*-->",
+        path.read_text(encoding="utf-8"),
+    )
+    if match is None:
+        return None
+    separator = ";" if "=" in match.group(1) else ","
+    items = [item.strip() for item in match.group(1).split(separator) if item.strip()]
+    if "=" in match.group(1) and any(not item.partition("=")[2].strip() for item in items):
+        return None
+    return {item.partition("=")[0].strip() for item in items}
+
+
+def audit_documentation_contract(root: Path, baseline: dict) -> list[str]:
+    """Keep stable architecture and layout markers aligned with the canonical inventory."""
+    policy = baseline["documentation_contract"]
+    source_modules = set(baseline["top_level_directories"]["source_modules"])
+    errors: list[str] = []
+    documents = (
+        ("docs/developer/architecture.md", policy["architecture_source_modules_marker"]),
+        ("docs/developer/repository_layout.md", policy["repository_layout_source_modules_marker"]),
+    )
+    for relative, marker in documents:
+        documented = documented_modules(root, relative, marker)
+        if documented is None:
+            errors.append(
+                f"{relative} is missing the parseable '<!-- {marker}: ... -->' source-module "
+                "inventory required by repository_structure_baseline.json"
+            )
+        elif documented != source_modules:
+            errors.append(
+                f"{relative} source-module documentation is not aligned with the canonical baseline: "
+                f"missing {sorted(source_modules - documented)}, unexpected {sorted(documented - source_modules)}; "
+                f"update its '<!-- {marker}: ... -->' marker and module description"
+            )
+
+    root_roles = policy["root_source_roles"]
+    allowed_sources = set(baseline["source_registration"]["root_project_sources"])
+    if set(root_roles) != allowed_sources:
+        errors.append(
+            "documented root-source roles differ from source_registration.root_project_sources: "
+            f"missing roles {sorted(allowed_sources - set(root_roles))}, stale roles "
+            f"{sorted(set(root_roles) - allowed_sources)}; align documentation_contract.root_source_roles"
+        )
+    for source, role in sorted(root_roles.items()):
+        if source not in baseline["root_file_roles"].get(role, []):
+            errors.append(
+                f"approved root source {source} has undocumented role {role!r}; add it to the matching "
+                "root_file_roles entry and document that role in docs/developer/repository_layout.md"
+            )
+    layout = root / "docs/developer/repository_layout.md"
+    role_marker = policy["repository_layout_root_source_roles_marker"]
+    role_match = re.search(
+        rf"<!--\s*{re.escape(role_marker)}\s*:\s*([^>]+?)\s*-->",
+        layout.read_text(encoding="utf-8") if layout.is_file() else "",
+    )
+    documented_roles = {}
+    if role_match:
+        for item in role_match.group(1).split(","):
+            source, separator, role = item.strip().partition("=")
+            if separator and source and role:
+                documented_roles[source] = role
+    if documented_roles != root_roles:
+        errors.append(
+            f"docs/developer/repository_layout.md root-source role marker is not aligned: "
+            f"expected {root_roles}, found {documented_roles}; update '<!-- {role_marker}: file=role -->' "
+            "with the corresponding human-readable root-file role"
+        )
+    return errors
+
+
+def audit_module_guard_sets(baseline: dict) -> list[str]:
+    """Validate full and intentionally reduced guard inventories against source modules."""
+    modules = set(baseline["top_level_directories"]["source_modules"])
+    guards = baseline["module_guard_sets"]
+    errors: list[str] = []
+    dependency_modules = set(guards["dependency_directions"])
+    if dependency_modules != modules:
+        errors.append(
+            "required dependency-direction module guard list is stale: "
+            f"missing {sorted(modules - dependency_modules)}, unexpected {sorted(dependency_modules - modules)}; "
+            "align module_guard_sets.dependency_directions without changing ACCEPTED_DIRECTIONS automatically"
+        )
+    expected_lower = modules - {"app"}
+    lower_modules = set(guards["application_bootstrap_lower_level"])
+    if lower_modules != expected_lower:
+        errors.append(
+            "application-bootstrap lower-level module guard list is stale: "
+            f"missing {sorted(expected_lower - lower_modules)}, unexpected {sorted(lower_modules - expected_lower)}; "
+            "align module_guard_sets.application_bootstrap_lower_level (the intentional source_modules minus app subset)"
+        )
+    return errors
+
+
+def audit_local_configuration(root: Path, files: set[str], policy: dict) -> list[str]:
+    """Reject tracked local build and IDE state and require critical ignore rules."""
+    errors: list[str] = []
+    prohibited_roots = set(policy["prohibited_root_files"])
+    prohibited_paths = set(policy["prohibited_paths"])
+    prefixes = tuple(policy["prohibited_directory_prefixes"])
+    components = set(policy["prohibited_build_tree_components"])
+    for relative in sorted(files):
+        parts = relative.split("/")
+        reason = None
+        if "/" not in relative and relative in prohibited_roots:
+            reason = "developer-local/generated root configuration"
+        elif relative in prohibited_paths:
+            reason = "project-local editor configuration intentionally kept untracked"
+        elif relative.startswith(prefixes):
+            reason = "repository-local build or IDE output"
+        elif any(part in components for part in parts[:-1]):
+            reason = "generated CMake/build-tree state"
+        if reason:
+            errors.append(
+                f"tracked local configuration is prohibited: {relative} ({reason}); remove it from Git "
+                "and keep local overrides/build output untracked"
+            )
+
+    gitignore = root / ".gitignore"
+    lines = {
+        line.strip() for line in gitignore.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    } if gitignore.is_file() else set()
+    for pattern in policy["required_gitignore_patterns"]:
+        if pattern not in lines:
+            errors.append(
+                f"critical local-only pattern is missing from .gitignore: {pattern}; restore it so "
+                "ordinary Git usage does not stage architecture-prohibited local state"
+            )
+    return errors
+
+
 def audit_third_party_ownership(root: Path, files: set[str], policy: dict) -> list[str]:
     """Reject conservative evidence of vendored C/C++ code outside its owned directory."""
     owned_directory = policy["owned_directory"]
@@ -217,7 +354,9 @@ def audit_repository(root: Path, baseline: dict, files: set[str]) -> list[str]:
     for relative in sorted(actual_root_sources - allowed_root_sources):
         errors.append(
             f"unexpected root project source: {relative}; root-level C/C++ files must be "
-            "recorded architectural entry points in repository_structure_baseline.json"
+            "restricted to explicit entry points so feature ownership remains modular; if a new "
+            "entry point is intentional, align repository_structure_baseline.json root source and "
+            "role contracts plus docs/developer/architecture.md and repository_layout.md"
         )
     for relative in sorted(allowed_root_sources - actual_root_sources):
         errors.append(f"recorded root project source is missing: {relative}")
@@ -236,7 +375,15 @@ def audit_repository(root: Path, baseline: dict, files: set[str]) -> list[str]:
         for module in baseline["source_registration"]["module_cmake_directories"]:
             module_cmake = root / module / "CMakeLists.txt"
             if not module_cmake.is_file():
-                errors.append(f"module source-registration file is missing: {module}/CMakeLists.txt")
+                errors.append(
+                    f"module source-registration file is missing: {module}/CMakeLists.txt; add explicit "
+                    "module-level target_sources ownership in the same architecture change"
+                )
+            elif not re.search(r"\btarget_sources\s*\(", module_cmake.read_text(encoding="utf-8"), re.IGNORECASE):
+                errors.append(
+                    f"module source-registration file lacks explicit target_sources ownership: "
+                    f"{module}/CMakeLists.txt"
+                )
         executable_match = re.search(r"add_executable\s*\(([^)]*)\)", cmake, re.DOTALL)
         executable_sources = executable_match.group(1) if executable_match else ""
         for entry_point in baseline["source_registration"]["root_compiled_entry_points"]:
@@ -259,7 +406,10 @@ def audit_repository(root: Path, baseline: dict, files: set[str]) -> list[str]:
                 )
 
     guard = baseline["structural_guard"]
+    errors.extend(audit_documentation_contract(root, baseline))
+    errors.extend(audit_module_guard_sets(baseline))
     errors.extend(audit_top_level_source_modules(files, baseline))
+    errors.extend(audit_local_configuration(root, files, guard["local_configuration"]))
     errors.extend(audit_third_party_ownership(root, files, guard["third_party_ownership"]))
     errors.extend(audit_machine_paths(root, files, guard["machine_path_scan"]))
     errors.extend(audit_source_discovery(root, files))

--- a/tests/check_repository_structure_baseline_fixtures.py
+++ b/tests/check_repository_structure_baseline_fixtures.py
@@ -55,10 +55,22 @@ class RepositoryStructureBaselineTests(unittest.TestCase):
                 path.parent.mkdir(parents=True, exist_ok=True)
                 path.touch()
         registration = baseline["source_registration"]
+        marker = ", ".join(baseline["top_level_directories"]["source_modules"])
+        responsibilities = "; ".join(
+            f"{module}=fixture responsibility" for module in baseline["top_level_directories"]["source_modules"])
+        (root / "docs/developer").mkdir(parents=True, exist_ok=True)
+        (root / "docs/developer/architecture.md").write_text(
+            f"<!-- repository-source-module-responsibilities: {responsibilities} -->\n", encoding="utf-8")
+        (root / "docs/developer/repository_layout.md").write_text(
+            f"<!-- repository-source-modules: {marker} -->\n"
+            "<!-- repository-root-source-roles: main.cpp=application_entry_point -->\n",
+            encoding="utf-8")
+        (root / ".gitignore").write_text("build/\nCMakeUserPresets.json\n", encoding="utf-8")
         root_groups = " ".join(f"{group}/placeholder.cpp" for group in registration["root_registered_source_groups"])
         cmake_lines = [f"add_executable(Perastage main.cpp {root_groups})"]
         for directory in registration["module_cmake_directories"]:
-            (root / directory / "CMakeLists.txt").touch()
+            (root / directory / "CMakeLists.txt").write_text(
+                "target_sources(${PROJECT_NAME} PRIVATE placeholder.cpp)\n", encoding="utf-8")
             cmake_lines.append(f"add_subdirectory({directory})")
         for directory in registration["conditional_subdirectories"]:
             cmake_lines.append(f"add_subdirectory({directory})")
@@ -68,6 +80,37 @@ class RepositoryStructureBaselineTests(unittest.TestCase):
             existing = path.read_text(encoding="utf-8") if path.is_file() else ""
             occurrences = (item["value"] + "\n") * item["count"]
             path.write_text(existing + occurrences, encoding="utf-8")
+
+    def align_documented_modules(self, root: Path, baseline: dict) -> None:
+        """Align both parseable documentation inventories with a fixture baseline."""
+        modules = ", ".join(baseline["top_level_directories"]["source_modules"])
+        for relative in ("docs/developer/architecture.md", "docs/developer/repository_layout.md"):
+            suffix = (
+                "<!-- repository-root-source-roles: main.cpp=application_entry_point -->\n"
+                if relative.endswith("repository_layout.md") else ""
+            )
+            marker = (
+                "<!-- repository-source-module-responsibilities: "
+                + "; ".join(f"{module}=fixture responsibility" for module in baseline["top_level_directories"]["source_modules"])
+                + " -->\n"
+                if relative.endswith("architecture.md")
+                else f"<!-- repository-source-modules: {modules} -->\n"
+            )
+            (root / relative).write_text(f"{marker}{suffix}", encoding="utf-8")
+
+    def add_aligned_module(self, root: Path, baseline: dict, module: str) -> None:
+        """Add every contract surface needed by a hypothetical source module."""
+        baseline["top_level_directories"]["source_modules"].append(module)
+        baseline["source_registration"]["module_cmake_directories"].append(module)
+        baseline["module_guard_sets"]["dependency_directions"].append(module)
+        baseline["module_guard_sets"]["application_bootstrap_lower_level"].append(module)
+        (root / module).mkdir(exist_ok=True)
+        (root / module / "module.cpp").touch()
+        (root / module / "CMakeLists.txt").write_text(
+            "target_sources(${PROJECT_NAME} PRIVATE module.cpp)\n", encoding="utf-8")
+        with (root / "CMakeLists.txt").open("a", encoding="utf-8") as stream:
+            stream.write(f"\nadd_subdirectory({module})\n")
+        self.align_documented_modules(root, baseline)
 
     def write_baseline(self, root: Path, baseline: dict) -> Path:
         """Write a fixture-specific declarative baseline outside the tracked manifest."""
@@ -119,6 +162,26 @@ class RepositoryStructureBaselineTests(unittest.TestCase):
             result = self.run_audit(root)
         self.assertEqual(result.returncode, 0, result.stderr)
 
+    def test_main_cpp_is_the_documented_allowed_root_entry_point(self) -> None:
+        """Accept main.cpp through aligned source and root-role contracts."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.create_fixture(root)
+            result = self.run_audit(root)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_root_source_allowlist_without_documented_role_is_rejected(self) -> None:
+        """Reject an attempted exception that updates only the loose source list."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.create_fixture(root)
+            (root / "alternate.cpp").touch()
+            baseline = json.loads(BASELINE.read_text(encoding="utf-8"))
+            baseline["source_registration"]["root_project_sources"].append("alternate.cpp")
+            result = self.run_audit(root, self.write_baseline(root, baseline))
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("documented root-source roles differ", result.stderr)
+
     def test_declared_modules_tests_third_party_and_support_data_pass(self) -> None:
         """Accept classified source trees and source-free unclassified support data."""
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -163,16 +226,79 @@ class RepositoryStructureBaselineTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)
             self.create_fixture(root)
-            (root / "network/foo.cpp").parent.mkdir()
-            (root / "network/foo.cpp").touch()
             baseline = json.loads(BASELINE.read_text(encoding="utf-8"))
-            baseline["top_level_directories"]["source_modules"].append("network")
-            baseline["source_registration"]["module_cmake_directories"].append("network")
-            (root / "network/CMakeLists.txt").touch()
-            with (root / "CMakeLists.txt").open("a", encoding="utf-8") as stream:
-                stream.write("\nadd_subdirectory(network)\n")
+            self.add_aligned_module(root, baseline, "network")
             result = self.run_audit(root, self.write_baseline(root, baseline))
         self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_source_module_without_root_registration_is_rejected(self) -> None:
+        """Reject a module whose otherwise aligned contract omits root orchestration."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.create_fixture(root)
+            baseline = json.loads(BASELINE.read_text(encoding="utf-8"))
+            self.add_aligned_module(root, baseline, "network")
+            cmake = root / "CMakeLists.txt"
+            cmake.write_text(cmake.read_text(encoding="utf-8").replace("\nadd_subdirectory(network)\n", "\n"), encoding="utf-8")
+            result = self.run_audit(root, self.write_baseline(root, baseline))
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("root add_subdirectory registrations differ", result.stderr)
+
+    def test_source_module_without_module_cmake_is_rejected(self) -> None:
+        """Reject an otherwise aligned module without explicit local source ownership."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.create_fixture(root)
+            baseline = json.loads(BASELINE.read_text(encoding="utf-8"))
+            self.add_aligned_module(root, baseline, "network")
+            (root / "network/CMakeLists.txt").unlink()
+            result = self.run_audit(root, self.write_baseline(root, baseline))
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("module source-registration file is missing: network/CMakeLists.txt", result.stderr)
+
+    def test_source_module_without_architecture_documentation_is_rejected(self) -> None:
+        """Reject a module missing from the stable architecture marker."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.create_fixture(root)
+            baseline = json.loads(BASELINE.read_text(encoding="utf-8"))
+            self.add_aligned_module(root, baseline, "network")
+            (root / "docs/developer/architecture.md").write_text(
+                "<!-- repository-source-module-responsibilities: "
+                + "; ".join(f"{module}=fixture responsibility" for module in baseline["top_level_directories"]["source_modules"][:-1])
+                + " -->\n",
+                encoding="utf-8")
+            result = self.run_audit(root, self.write_baseline(root, baseline))
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("architecture.md source-module documentation is not aligned", result.stderr)
+
+    def test_source_module_without_layout_documentation_is_rejected(self) -> None:
+        """Reject a module missing from the stable repository-layout marker."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.create_fixture(root)
+            baseline = json.loads(BASELINE.read_text(encoding="utf-8"))
+            self.add_aligned_module(root, baseline, "network")
+            original = ", ".join(baseline["top_level_directories"]["source_modules"][:-1])
+            (root / "docs/developer/repository_layout.md").write_text(
+                f"<!-- repository-source-modules: {original} -->\n"
+                "<!-- repository-root-source-roles: main.cpp=application_entry_point -->\n",
+                encoding="utf-8")
+            result = self.run_audit(root, self.write_baseline(root, baseline))
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("repository_layout.md source-module documentation is not aligned", result.stderr)
+
+    def test_source_module_with_stale_required_guard_list_is_rejected(self) -> None:
+        """Reject a newly classified module omitted from a required architecture guard."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.create_fixture(root)
+            baseline = json.loads(BASELINE.read_text(encoding="utf-8"))
+            self.add_aligned_module(root, baseline, "network")
+            baseline["module_guard_sets"]["dependency_directions"].remove("network")
+            result = self.run_audit(root, self.write_baseline(root, baseline))
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("dependency-direction module guard list is stale", result.stderr)
 
     def test_documented_source_module_without_cmake_ownership_is_rejected(self) -> None:
         """Reject a documented source module that lacks module CMake ownership."""
@@ -262,6 +388,48 @@ class RepositoryStructureBaselineTests(unittest.TestCase):
         self.assertEqual(result.returncode, 1)
         self.assertIn("scripts/new-build-config.json:1 contains machine-specific absolute path", result.stderr)
         self.assertIn(repr(value), result.stderr)
+
+    def assert_tracked_local_path_rejected(self, relative: str) -> None:
+        """Verify tracked local state is rejected by its normalized repository path."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.create_fixture(root)
+            path = root / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.touch()
+            result = self.run_audit(root)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn(f"tracked local configuration is prohibited: {relative}", result.stderr)
+
+    def test_tracked_cmake_user_presets_are_rejected(self) -> None:
+        """Keep supported local preset overrides out of repository control."""
+        self.assert_tracked_local_path_rejected("CMakeUserPresets.json")
+
+    def test_tracked_local_build_tree_file_is_rejected(self) -> None:
+        """Reject generated files beneath the canonical local build directory."""
+        self.assert_tracked_local_path_rejected("build/debug/CMakeFiles/state.txt")
+
+    def test_tracked_root_cmake_cache_is_rejected(self) -> None:
+        """Reject generated CMake cache state at repository root."""
+        self.assert_tracked_local_path_rejected("CMakeCache.txt")
+
+    def test_tracked_visual_studio_local_state_is_rejected(self) -> None:
+        """Reject developer-machine Visual Studio state."""
+        self.assert_tracked_local_path_rejected(".vs/Perastage/v17/.suo")
+
+    def test_tracked_local_vscode_settings_are_rejected(self) -> None:
+        """Reject only the VS Code files that repository policy keeps developer-local."""
+        self.assert_tracked_local_path_rejected(".vscode/settings.json")
+
+    def test_missing_critical_gitignore_rule_is_rejected(self) -> None:
+        """Require critical local-only policy patterns to remain ignored."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.create_fixture(root)
+            (root / ".gitignore").write_text("build/\n", encoding="utf-8")
+            result = self.run_audit(root)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("critical local-only pattern is missing from .gitignore: CMakeUserPresets.json", result.stderr)
 
     def test_windows_machine_path_is_rejected(self) -> None:
         """Reject a new Windows drive-based development path."""


### PR DESCRIPTION
### Motivation
- Finish Phase 7 by enforcing the remaining ORG-035/036/037 repository-architecture contracts discovered during the audit of the existing baseline and guard infrastructure. 
- The audit found gaps: documentation markers were not machine-checked, the canonical module inventory was not validated against stable guard sets, root-level source approval was not tied to a documented role, and tracked developer-local build/preset/IDE files were not rejected deterministically. 
- Keep the enforcement deterministic, cross-platform, based on tracked files, and integrated with the existing baseline rather than creating a parallel registry.

### Description
- Extend `docs/developer/repository_structure_baseline.json` with `documentation_contract`, `module_guard_sets`, and a `local_configuration` subsection that enumerates documented root-source roles, required guard lists, prohibited local files/paths, and critical `.gitignore` patterns. 
- Harden the baseline checker in `tests/check_repository_structure_baseline.py` by adding `audit_documentation_contract`, `audit_module_guard_sets`, and `audit_local_configuration`, by requiring explicit `target_sources(...)` in module `CMakeLists.txt`, and by improving root-source diagnostics to point to the baseline and documentation to request intentional changes. 
- Add and extend fixtures in `tests/check_repository_structure_baseline_fixtures.py` to exercise the new behaviours (parseable doc markers, aligned module registration, root-role contracts, tracked `CMakeUserPresets.json`, local build-tree files, IDE state, portable vs machine paths, and stale-exception handling), and add helper routines to produce fully aligned hypothetical modules. 
- Make dependent checks consume the canonical guard lists by reading the new baseline in `tests/check_module_dependency_directions.py` and `tests/check_application_bootstrap_ownership.py` instead of hard-coded lists, and update human-facing docs in `docs/developer/architecture.md`, `docs/developer/repository_layout.md`, and `docs/developer/perastage_tree.md` to document the required markers and the root-source / local-config policy; add a release-note entry in `docs/release-notes-draft.md` describing the enforcement. 
- No production C/C++ sources, application behavior, module ownership in CMake for existing modules, startup paths, UI, CLI, file formats, packaging, or canonical presets were changed by this work.

### Testing
- Ran focused repository policy and guard checks locally: `python3 tests/check_repository_structure_baseline.py` passed. 
- Exercised deterministic fixtures: `python3 tests/check_repository_structure_baseline_fixtures.py -v` passed (fixture suite exercised unregistered modules, root-source cases, module registration/documentation/guard mismatches, machine-paths, and local-config cases). 
- Ran module dependency & fixture checks: `python3 tests/check_module_dependency_directions.py` and `python3 tests/check_module_dependency_directions_fixtures.py -v` passed, and `python3 tests/check_application_bootstrap_ownership.py` passed. 
- Ran the repository helper checks: `PERASTAGE_TEST_PYTHON="$(command -v python3)" PERASTAGE_TEST_BASH="$(command -v bash)" tests/check_perastage_tree_modules.sh`, `tests/check_no_configmanager_get_in_gui.sh`, and `python3 tests/check_docs_links.py` and verified `git diff --check` and `python3 -m py_compile` for modified scripts; all passed locally. 
- CI / push note: creating a PR / triggering the authoritative GitHub Actions matrix was not possible from this execution environment due to missing remote authentication and outbound network restrictions, so the GitHub Linux/Windows/macOS matrix and remote PR checks have not yet been run; local cross-platform portable Python fixtures and checks passed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9e0f32e77083248a6f00c7016244c7)