### PR TITLE
CH-001: Add source-size baseline and ratchet guardrail

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -331,6 +331,8 @@ jobs:
       - name: Run repository policy tests
         run: |
           export PERASTAGE_TEST_PYTHON="$(command -v python3)"
+          python3 tests/check_source_file_size.py
+          python3 tests/check_source_file_size_test.py
           bash tests/check_perastage_tree_modules.sh
           bash tests/check_no_configmanager_get_in_gui.sh
           bash tests/check_ci_cmake_language_policy.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,8 +10,10 @@ Keep Perastage clean and modular while continuing to deliver new features, follo
    - If a change introduces a new responsibility, create/use adjacent files organized by responsibility.
 
 2. **File-size guardrail (soft limit)**
-   - When touching a file near **1200–1500 LOC**, prioritize extraction before adding major features.
-   - If extraction is not feasible in the same PR, include a short technical note in the PR description with the next recommended split.
+   - `tests/check_source_file_size.py` automatically enforces a default maximum of **1500 physical lines** for tracked project C/C++ files.
+   - Existing files above that limit are explicitly grandfathered in `tests/source_file_size_policy.json` at their current maximum. They may stay the same size or shrink, but any growth above the recorded maximum fails the guard.
+   - Baseline reductions are intentional, reviewable changes: the guard never rewrites the policy when a hotspot shrinks.
+   - When touching a file near the limit, prioritize responsibility extraction before adding major features. If extraction is not feasible in the same PR, include a short technical note in the PR description with the next recommended split.
 
 3. **Architecture and build conventions**
    - Keep explicit source ownership in CMake (no `GLOB_RECURSE` for project source registration).
@@ -21,6 +23,7 @@ Keep Perastage clean and modular while continuing to deliver new features, follo
    - Run and keep green:
      - `tests/check_perastage_tree_modules.sh`
      - `tests/check_no_configmanager_get_in_gui.sh`
+     - `python3 tests/check_source_file_size.py`
    - If a new architectural boundary is introduced, add a small `tests/check_*.sh` script in the same PR.
 
 5. **Refactoring strategy**
@@ -48,13 +51,25 @@ Keep Perastage clean and modular while continuing to deliver new features, follo
    - This is required for meaningful feature changes, and not required for minor internal refactors, small bug fixes, formatting-only changes, build-system maintenance, or invisible technical changes that do not affect user experience.
 
 ## Current hotspots (watch for growth)
-- `gui/layoutviewerpanel.cpp`
-- `viewer2d/viewer2dpanel.cpp`
-- `viewer2d/pdf/layout_pdf_exporter.cpp`
-- `viewer3d/viewer3dcontroller.cpp`
+- `mvr/mvrimporter.cpp`
 - `mvr/mvrexporter.cpp`
+- `viewer3d/viewer3dpanel.cpp`
+- `viewer2d/viewer2dpanel.cpp`
+- `core/riderimporter.cpp`
+- `gui/layoutviewerpanel.cpp`
+- `gui/dictionaryeditdialog.cpp`
+- `viewer3d/gdtfloader.cpp`
+- `viewer3d/viewer3dcontroller.cpp`
+- `viewer2d/pdf/layout_pdf_exporter.cpp`
 - `gui/mainwindow_menu.cpp`
 - `gui/fixturetablepanel.cpp`
+- `gui/mainwindow.cpp`
+- `gui/hoisttablepanel.cpp`
+- `gui/layoutviewerpanel_legend.cpp`
+- `gui/trusstablepanel.cpp`
+- `gui/fixtureeditdialog.cpp`
+
+The versioned policy file is authoritative for exact maximum line counts and also records any oversized maintained test source.
 
 ## Change quality
 - Keep changes small, focused, and explicit in responsibility naming.

--- a/docs/developer/code_health_review_2026-02-13.md
+++ b/docs/developer/code_health_review_2026-02-13.md
@@ -1,5 +1,7 @@
 # Code health review (2026-02-13)
 
+> **Historical snapshot:** This review describes the repository as it existed on 2026-02-13; its line counts are not the current policy. The authoritative limits and current hotspot baselines are in `tests/source_file_size_policy.json` and are enforced by `tests/check_source_file_size.py`.
+
 ## Scope
 
 This review checks whether Perastage is now in a solid state of cleanliness/order to continue feature work.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -12,6 +12,7 @@ Changes since **v1.6.0**.
 
 ## Technical and packaging changes
 
+- Added an automated, cross-platform source-size guardrail that prevents existing C/C++ hotspots from growing beyond reviewable baselines and limits new source files to a maintainable default size.
 - Validated the native Linux, Windows, WSL, and Apple Silicon macOS clean-checkout developer workflows, corrected Linux/WSL prerequisite installation order and Debug test dependencies, prevented Windows-only PowerShell tests from registering on Linux hosts, completed Linux system dependency and locale setup, fixed external mDNS header discovery, corrected Windows wxWidgets secure-store and Debug test-tool validation, made restricted-path policy tests use canonical directories across macOS and Windows environments, and kept local test artifacts out of the source tree.
 - Prevented compatible macOS dependency caches from being discarded because binary contents were misread as SDK metadata, and migrated CI away from an immutable stale cache snapshot so repaired dependencies can persist across runs.
 - Added a reproducible repository-structure baseline and policy validation to protect current module and build ownership during future organization work.

--- a/mvr/AGENTS.md
+++ b/mvr/AGENTS.md
@@ -4,8 +4,8 @@
 These rules apply to everything under `mvr/`.
 
 ## Rules
-1. **Primary hotspot**
-   - `mvrexporter.cpp` should evolve through responsibility extraction.
+1. **Hotspots**
+   - `mvrimporter.cpp` and `mvrexporter.cpp` are covered by the repository source-size ratchet and should evolve through responsibility extraction.
 
 2. **Recommended separation when extending exporter logic**
    - Keep decoupled:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -183,6 +183,12 @@ if(BASH_EXECUTABLE)
 endif()
 
 if(Python3_Interpreter_FOUND)
+    add_repository_policy_test(SourceFileSize ${Python3_EXECUTABLE}
+                               ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_source_file_size.py
+                               LABELS standard-strict policy architecture)
+    add_repository_policy_test(SourceFileSizeFixtures ${Python3_EXECUTABLE}
+                               ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_source_file_size_test.py -v
+                               LABELS standard-strict policy architecture)
     add_repository_policy_test(WindowsSetupEntrypoint ${Python3_EXECUTABLE}
                                ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_windows_setup_entrypoint.py
                                LABELS windows cmake policy)

--- a/tests/check_source_file_size.py
+++ b/tests/check_source_file_size.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Enforce the tracked C/C++ source-size baseline and hotspot ratchet."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+
+DEFAULT_POLICY = Path(__file__).with_name("source_file_size_policy.json")
+
+
+def load_policy(path: Path) -> dict[str, Any]:
+    """Load and validate the source-size policy document."""
+    try:
+        policy = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError(f"cannot read valid JSON from {path}: {error}") from error
+    required = {"schema_version", "default_max_lines", "source_suffixes", "excluded_prefixes", "hotspots"}
+    if not isinstance(policy, dict) or set(policy) != required:
+        raise ValueError(f"{path} must contain exactly these keys: {sorted(required)}")
+    if policy["schema_version"] != 1:
+        raise ValueError(f"{path} has unsupported schema_version {policy['schema_version']!r}")
+    if not isinstance(policy["default_max_lines"], int) or isinstance(policy["default_max_lines"], bool) or policy["default_max_lines"] < 1:
+        raise ValueError(f"{path}: default_max_lines must be a positive integer")
+    suffixes = policy["source_suffixes"]
+    if not isinstance(suffixes, list) or not suffixes or any(not isinstance(item, str) or not item.startswith(".") for item in suffixes):
+        raise ValueError(f"{path}: source_suffixes must be a non-empty list of extensions")
+    prefixes = policy["excluded_prefixes"]
+    if not isinstance(prefixes, list) or any(not isinstance(item, str) or not item.endswith("/") for item in prefixes):
+        raise ValueError(f"{path}: excluded_prefixes must contain directory prefixes ending in '/'")
+    hotspots = policy["hotspots"]
+    if not isinstance(hotspots, dict):
+        raise ValueError(f"{path}: hotspots must be an object mapping paths to line limits")
+    for relative, maximum in hotspots.items():
+        normalized = PurePosixPath(relative)
+        if normalized.is_absolute() or ".." in normalized.parts or "\\" in relative or relative != normalized.as_posix():
+            raise ValueError(f"{path}: hotspot path {relative!r} must be a normalized repository-relative path")
+        if normalized.suffix.lower() not in suffixes:
+            raise ValueError(f"{path}: hotspot {relative!r} is not a configured C/C++ source file")
+        if not isinstance(maximum, int) or isinstance(maximum, bool) or maximum <= policy["default_max_lines"]:
+            raise ValueError(f"{path}: hotspot {relative!r} must have an integer limit above default_max_lines")
+    return policy
+
+
+def tracked_files(root: Path, manifest: Path | None = None) -> list[str]:
+    """Return deterministic repository-relative tracked paths."""
+    if manifest is not None:
+        return sorted({line.strip().replace("\\", "/") for line in manifest.read_text(encoding="utf-8").splitlines() if line.strip()})
+    result = subprocess.run(
+        ["git", "-C", str(root), "ls-files", "-z"], check=False, capture_output=True
+    )
+    if result.returncode != 0:
+        diagnostic = result.stderr.decode(errors="replace").strip()
+        raise OSError(f"cannot enumerate tracked files with git ls-files: {diagnostic}")
+    return sorted(path.decode(errors="surrogateescape") for path in result.stdout.split(b"\0") if path)
+
+
+def is_project_source(relative: str, policy: dict[str, Any]) -> bool:
+    """Identify tracked project C/C++ files covered by the policy."""
+    normalized = relative.replace("\\", "/")
+    return PurePosixPath(normalized).suffix.lower() in policy["source_suffixes"] and not any(
+        normalized.startswith(prefix) for prefix in policy["excluded_prefixes"]
+    )
+
+
+def physical_line_count(path: Path) -> int:
+    """Count physical lines, including a final line without a newline."""
+    content = path.read_bytes()
+    return content.count(b"\n") + (1 if content and not content.endswith(b"\n") else 0)
+
+
+def audit(root: Path, files: list[str], policy: dict[str, Any]) -> tuple[list[str], int]:
+    """Return source-size violations and the number of inspected files."""
+    errors: list[str] = []
+    inspected: set[str] = set()
+    hotspots = policy["hotspots"]
+    for relative in files:
+        normalized = relative.replace("\\", "/")
+        if not is_project_source(normalized, policy):
+            continue
+        path = root / PurePosixPath(normalized)
+        if not path.is_file():
+            errors.append(f"tracked source file is missing from the worktree: {normalized}")
+            continue
+        inspected.add(normalized)
+        line_count = physical_line_count(path)
+        maximum = hotspots.get(normalized, policy["default_max_lines"])
+        if line_count > maximum:
+            rule = "hotspot baseline" if normalized in hotspots else "default limit"
+            errors.append(
+                f"{normalized}: {line_count} physical lines exceeds its {rule} of {maximum}; "
+                "extract responsibility or explicitly review and update tests/source_file_size_policy.json"
+            )
+    for relative in sorted(set(hotspots) - inspected):
+        errors.append(f"hotspot baseline references a missing, excluded, or untracked source file: {relative}; remove or correct the stale entry")
+    return errors, len(inspected)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the source-size policy check from any working directory."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[1])
+    parser.add_argument("--policy", type=Path, default=DEFAULT_POLICY)
+    parser.add_argument("--tracked-manifest", type=Path, help="newline-separated tracked paths for isolated tests")
+    args = parser.parse_args(argv)
+    root = args.root.resolve()
+    try:
+        policy = load_policy(args.policy.resolve())
+        files = tracked_files(root, args.tracked_manifest.resolve() if args.tracked_manifest else None)
+        errors, inspected = audit(root, files, policy)
+    except (OSError, ValueError) as error:
+        print(f"Source-size policy error: {error}", file=sys.stderr)
+        return 2
+    if errors:
+        print("Source-size policy violations:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+    print(f"Source-size policy passed: inspected {inspected} tracked project C/C++ files (default maximum {policy['default_max_lines']} lines; {len(policy['hotspots'])} hotspot baselines).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/check_source_file_size_test.py
+++ b/tests/check_source_file_size_test.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Exercise source-size limit and hotspot ratchet behavior."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import check_source_file_size as guard
+
+
+class SourceFileSizePolicyTest(unittest.TestCase):
+    """Validate ordinary, grandfathered, excluded, and malformed policy cases."""
+
+    def setUp(self) -> None:
+        """Create a minimal isolated repository and policy for each test."""
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary_directory.name)
+        self.policy = {
+            "schema_version": 1,
+            "default_max_lines": 5,
+            "source_suffixes": [".cpp", ".h"],
+            "excluded_prefixes": ["third_party/", "tests/fixtures/"],
+            "hotspots": {"src/hotspot.cpp": 8},
+        }
+
+    def tearDown(self) -> None:
+        """Remove the isolated repository after each test."""
+        self.temporary_directory.cleanup()
+
+    def write_lines(self, relative: str, count: int) -> None:
+        """Write a source fixture with the requested physical line count."""
+        path = self.root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("line\n" * count, encoding="utf-8")
+
+    def errors_for(self, relative: str, count: int) -> list[str]:
+        """Audit one source fixture and return its diagnostics."""
+        self.write_lines(relative, count)
+        if relative != "src/hotspot.cpp":
+            self.write_lines("src/hotspot.cpp", 8)
+        errors, _ = guard.audit(self.root, sorted({relative, "src/hotspot.cpp"}), self.policy)
+        return errors
+
+    def test_ordinary_file_below_threshold_passes(self) -> None:
+        """Accept an ordinary source below the default maximum."""
+        self.assertEqual([], self.errors_for("src/ordinary.cpp", 4))
+
+    def test_ordinary_file_above_threshold_fails(self) -> None:
+        """Reject an ordinary source above the default maximum."""
+        self.assertIn("default limit of 5", "\n".join(self.errors_for("src/ordinary.cpp", 6)))
+
+    def test_hotspot_at_baseline_passes(self) -> None:
+        """Accept a hotspot exactly at its recorded baseline."""
+        self.assertEqual([], self.errors_for("src/hotspot.cpp", 8))
+
+    def test_hotspot_below_baseline_passes(self) -> None:
+        """Accept a hotspot that has shrunk without changing its baseline."""
+        self.assertEqual([], self.errors_for("src/hotspot.cpp", 7))
+
+    def test_hotspot_above_baseline_fails(self) -> None:
+        """Reject growth beyond a hotspot's recorded baseline."""
+        self.assertIn("hotspot baseline of 8", "\n".join(self.errors_for("src/hotspot.cpp", 9)))
+
+    def test_excluded_and_non_source_paths_are_ignored(self) -> None:
+        """Ignore vendor, fixture, and non-C/C++ tracked paths."""
+        files = ["third_party/vendor.cpp", "tests/fixtures/large.cpp", "docs/large.md", "src/hotspot.cpp"]
+        for relative in files:
+            self.write_lines(relative, 20 if relative != "src/hotspot.cpp" else 8)
+        errors, inspected = guard.audit(self.root, files, self.policy)
+        self.assertEqual([], errors)
+        self.assertEqual(1, inspected)
+
+    def test_malformed_policy_is_rejected(self) -> None:
+        """Reject invalid hotspot limits in the versioned policy data."""
+        policy_path = self.root / "policy.json"
+        malformed = dict(self.policy)
+        malformed["hotspots"] = {"src/hotspot.cpp": "eight"}
+        policy_path.write_text(json.dumps(malformed), encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "integer limit above"):
+            guard.load_policy(policy_path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/source_file_size_policy.json
+++ b/tests/source_file_size_policy.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": 1,
+  "default_max_lines": 1500,
+  "source_suffixes": [
+    ".c",
+    ".cc",
+    ".cpp",
+    ".cxx",
+    ".h",
+    ".hh",
+    ".hpp",
+    ".hxx"
+  ],
+  "excluded_prefixes": [
+    "build/",
+    "generated/",
+    "third_party/",
+    "tests/fixtures/"
+  ],
+  "hotspots": {
+    "core/riderimporter.cpp": 4015,
+    "gui/dictionaryeditdialog.cpp": 2814,
+    "gui/fixtureeditdialog.cpp": 1522,
+    "gui/fixturetablepanel.cpp": 2007,
+    "gui/hoisttablepanel.cpp": 1660,
+    "gui/layoutviewerpanel.cpp": 3595,
+    "gui/layoutviewerpanel_legend.cpp": 1595,
+    "gui/mainwindow.cpp": 1852,
+    "gui/mainwindow_menu.cpp": 2082,
+    "gui/trusstablepanel.cpp": 1528,
+    "mvr/mvrexporter.cpp": 4911,
+    "mvr/mvrimporter.cpp": 5172,
+    "tests/mvr_exporter_compliance_test.cpp": 1664,
+    "viewer2d/pdf/layout_pdf_exporter.cpp": 2352,
+    "viewer2d/viewer2dpanel.cpp": 4550,
+    "viewer3d/gdtfloader.cpp": 2537,
+    "viewer3d/viewer3dcontroller.cpp": 2402,
+    "viewer3d/viewer3dpanel.cpp": 4556
+  }
+}


### PR DESCRIPTION
### Motivation

- Implement an automated, repository-policy guard that prevents tracked C/C++ source files from silently growing while allowing the current codebase to remain green. 
- Establish a simple default size limit and an explicit ratchet for existing oversized files so debt can shrink but not expand silently. 
- Keep the solution cross-platform, GUI-independent, reviewable, and CI-enforced without changing runtime/application behavior.

### Description

- Add a portable, standard-library Python check `tests/check_source_file_size.py` that derives the file set from `git ls-files`, excludes generated/vendor/fixture paths, counts physical lines deterministically, and enforces a ratcheted hotspot policy. 
- Add `tests/source_file_size_policy.json` to record a default maximum of `1500` physical lines and explicit per-file hotspot maxima for existing oversized sources. 
- Add focused regression tests `tests/check_source_file_size_test.py` covering ordinary-limit, hotspot-at/below/above-baseline, exclusions, and malformed policy data. 
- Wire the guard into the repository policy layer by registering the check and its fixtures in `tests/CMakeLists.txt` and invoking them from the existing PR Debug repository-policy stage in `.github/workflows/ci-tests.yml`, and update `AGENTS.md`, `mvr/AGENTS.md`, `docs/developer/code_health_review_2026-02-13.md`, and `docs/release-notes-draft.md` to reflect the new automated policy and current hotspots.

### Testing

- `python3 -m py_compile tests/check_source_file_size.py tests/check_source_file_size_test.py` succeeded without syntax errors. 
- `python3 tests/check_source_file_size.py` passed and reported successful inspection (inspected tracked project C/C++ files and applied 18 hotspot baselines). 
- `python3 tests/check_source_file_size_test.py -v` ran seven unit tests and all passed. 
- Repository policy and CI-related checks were exercised locally and passed: `bash tests/check_perastage_tree_modules.sh`, `bash tests/check_no_configmanager_get_in_gui.sh`, `bash tests/check_ci_cmake_language_policy.sh`, `python3 tests/check_docs_links.py`, `python3 tests/check_ci_workflow_architecture.py`, and `python3 tests/check_bash_test_registration.py` all reported OK; a local `cmake` configure was attempted but stopped on this host due to missing system `wxWidgets` dev libraries and is expected to be validated by GitHub Actions in a full clean environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6aa2673473508324bbafad53691c33b7)