### PR TITLE
CH-002: Add tracked repository hygiene guard

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,12 @@
 * text=auto
 *.pdf binary
 *.PDF binary
+*.3ds -text
+*.gdtf -text
+*.icns -text
+*.ico -text
+*.png -text
+*.ttf -text
 tests/data/*.txt text eol=lf
 tests/fixtures/fixture_symbols/*.txt text eol=lf
 

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -333,6 +333,8 @@ jobs:
           export PERASTAGE_TEST_PYTHON="$(command -v python3)"
           python3 tests/check_source_file_size.py
           python3 tests/check_source_file_size_test.py
+          python3 tests/check_repository_hygiene.py
+          python3 tests/check_repository_hygiene_test.py
           bash tests/check_perastage_tree_modules.sh
           bash tests/check_no_configmanager_get_in_gui.sh
           bash tests/check_ci_cmake_language_policy.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ Keep Perastage clean and modular while continuing to deliver new features, follo
      - `tests/check_perastage_tree_modules.sh`
      - `tests/check_no_configmanager_get_in_gui.sh`
      - `python3 tests/check_source_file_size.py`
+     - `python3 tests/check_repository_hygiene.py`
    - If a new architectural boundary is introduced, add a small `tests/check_*.sh` script in the same PR.
 
 5. **Refactoring strategy**
@@ -70,6 +71,13 @@ Keep Perastage clean and modular while continuing to deliver new features, follo
 - `gui/fixtureeditdialog.cpp`
 
 The versioned policy file is authoritative for exact maximum line counts and also records any oversized maintained test source.
+
+## Repository hygiene policy
+
+- `tests/check_repository_hygiene.py` rejects tracked build outputs, compiled artifacts, caches, temporary archives, and files beyond the reviewable limits in `tests/repository_hygiene_policy.json`.
+- Bundled GDTFs are intentional normal-Git assets only under the configured `library/fixtures/` and `library/trusses/` scopes, with bounded per-file limits. This policy does not require Git LFS.
+- The guard evaluates the current tracked tree, not historical Git objects. History cleanup, including removal of old binary objects, requires a separate explicit migration decision.
+- A legitimate new binary class or exceptional file requires a narrow, documented policy rule and review of its path, format, purpose, and maximum size; never regenerate policy allowances automatically.
 
 ## Change quality
 - Keep changes small, focused, and explicit in responsibility naming.

--- a/docs/developer/code_health_review_2026-02-13.md
+++ b/docs/developer/code_health_review_2026-02-13.md
@@ -2,6 +2,8 @@
 
 > **Historical snapshot:** This review describes the repository as it existed on 2026-02-13; its line counts are not the current policy. The authoritative limits and current hotspot baselines are in `tests/source_file_size_policy.json` and are enforced by `tests/check_source_file_size.py`.
 
+> **Current repository hygiene guard:** `tests/check_repository_hygiene.py` separately owns tracked-artifact and tracked-file byte limits through `tests/repository_hygiene_policy.json`. It blocks accidental build products and repository weight while preserving bounded bundled GDTFs in normal Git. It does not inspect or rewrite historical Git objects and does not introduce Git LFS. New intentional binary classes or exact exceptions require a narrow, documented policy update reviewed with the asset's ownership and size limit.
+
 ## Scope
 
 This review checks whether Perastage is now in a solid state of cleanliness/order to continue feature work.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -12,6 +12,7 @@ Changes since **v1.6.0**.
 
 ## Technical and packaging changes
 
+- Added a cross-platform repository hygiene guard that blocks accidentally tracked build artifacts and unexpectedly large files while preserving the bounded bundled GDTF library as normal Git assets.
 - Added an automated, cross-platform source-size guardrail that prevents existing C/C++ hotspots from growing beyond reviewable baselines and limits new source files to a maintainable default size.
 - Validated the native Linux, Windows, WSL, and Apple Silicon macOS clean-checkout developer workflows, corrected Linux/WSL prerequisite installation order and Debug test dependencies, prevented Windows-only PowerShell tests from registering on Linux hosts, completed Linux system dependency and locale setup, fixed external mDNS header discovery, corrected Windows wxWidgets secure-store and Debug test-tool validation, made restricted-path policy tests use canonical directories across macOS and Windows environments, and kept local test artifacts out of the source tree.
 - Prevented compatible macOS dependency caches from being discarded because binary contents were misread as SDK metadata, and migrated CI away from an immutable stale cache snapshot so repaired dependencies can persist across runs.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -189,6 +189,12 @@ if(Python3_Interpreter_FOUND)
     add_repository_policy_test(SourceFileSizeFixtures ${Python3_EXECUTABLE}
                                ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_source_file_size_test.py -v
                                LABELS standard-strict policy architecture)
+    add_repository_policy_test(RepositoryHygiene ${Python3_EXECUTABLE}
+                               ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_repository_hygiene.py
+                               LABELS standard-strict policy architecture)
+    add_repository_policy_test(RepositoryHygieneFixtures ${Python3_EXECUTABLE}
+                               ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_repository_hygiene_test.py -v
+                               LABELS standard-strict policy architecture)
     add_repository_policy_test(WindowsSetupEntrypoint ${Python3_EXECUTABLE}
                                ARGS ${CMAKE_CURRENT_SOURCE_DIR}/check_windows_setup_entrypoint.py
                                LABELS windows cmake policy)

--- a/tests/check_repository_hygiene.py
+++ b/tests/check_repository_hygiene.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Reject prohibited artifacts and unexpectedly large files tracked by Git."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+
+DEFAULT_POLICY = Path(__file__).with_name("repository_hygiene_policy.json")
+POLICY_KEYS = {
+    "schema_version", "default_max_bytes", "prohibited_suffixes",
+    "prohibited_filename_patterns", "prohibited_path_components",
+    "restricted_asset_suffixes", "asset_classes", "exact_exceptions",
+}
+ASSET_KEYS = {"name", "path_prefix", "suffixes", "max_bytes"}
+
+
+def _positive_integer(value: object, field: str) -> int:
+    """Validate and return a positive byte limit."""
+    if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+        raise ValueError(f"{field} must be a positive integer")
+    return value
+
+
+def _normalized_path(value: object, field: str, *, prefix: bool = False) -> str:
+    """Validate a normalized repository-relative path or directory prefix."""
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{field} must be a non-empty string")
+    candidate = value[:-1] if prefix and value.endswith("/") else value
+    path = PurePosixPath(candidate)
+    if (prefix and not value.endswith("/")) or path.is_absolute() or ".." in path.parts or "\\" in value or path.as_posix() != candidate:
+        kind = "directory prefix ending in '/'" if prefix else "path"
+        raise ValueError(f"{field} must be a normalized repository-relative {kind}")
+    return value
+
+
+def _suffixes(value: object, field: str) -> list[str]:
+    """Validate a unique, lowercase extension list."""
+    if not isinstance(value, list) or not value:
+        raise ValueError(f"{field} must be a non-empty list")
+    if any(not isinstance(item, str) or not re.fullmatch(r"\.[a-z0-9]+", item) for item in value):
+        raise ValueError(f"{field} must contain lowercase extensions beginning with '.'")
+    if len(value) != len(set(value)):
+        raise ValueError(f"{field} contains duplicate extensions")
+    return value
+
+
+def load_policy(path: Path) -> dict[str, Any]:
+    """Load and strictly validate the versioned hygiene policy."""
+    try:
+        policy = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError(f"cannot read valid JSON from {path}: {error}") from error
+    if not isinstance(policy, dict) or set(policy) != POLICY_KEYS:
+        raise ValueError(f"{path} must contain exactly these keys: {sorted(POLICY_KEYS)}")
+    if policy["schema_version"] != 1:
+        raise ValueError(f"{path} has unsupported schema_version {policy['schema_version']!r}")
+    _positive_integer(policy["default_max_bytes"], "default_max_bytes")
+    _suffixes(policy["prohibited_suffixes"], "prohibited_suffixes")
+
+    patterns = policy["prohibited_filename_patterns"]
+    if not isinstance(patterns, list) or not patterns or any(not isinstance(item, str) or not item for item in patterns):
+        raise ValueError("prohibited_filename_patterns must be a non-empty string list")
+    if len(patterns) != len(set(patterns)):
+        raise ValueError("prohibited_filename_patterns contains duplicates")
+    try:
+        policy["_compiled_patterns"] = [re.compile(item, re.IGNORECASE) for item in patterns]
+    except re.error as error:
+        raise ValueError(f"invalid prohibited filename pattern: {error}") from error
+
+    components = policy["prohibited_path_components"]
+    if not isinstance(components, list) or not components or any(not isinstance(item, str) or not item or "/" in item or "\\" in item or item != item.lower() for item in components):
+        raise ValueError("prohibited_path_components must contain unique lowercase path components")
+    if len(components) != len(set(components)):
+        raise ValueError("prohibited_path_components contains duplicates")
+    restricted_suffixes = _suffixes(policy["restricted_asset_suffixes"], "restricted_asset_suffixes")
+    overlap = set(restricted_suffixes) & set(policy["prohibited_suffixes"])
+    if overlap:
+        raise ValueError(f"suffixes cannot be both prohibited and restricted assets: {sorted(overlap)}")
+
+    classes = policy["asset_classes"]
+    if not isinstance(classes, list) or not classes:
+        raise ValueError("asset_classes must be a non-empty list")
+    seen_names: set[str] = set()
+    seen_scopes: set[tuple[str, str]] = set()
+    for index, rule in enumerate(classes):
+        field = f"asset_classes[{index}]"
+        if not isinstance(rule, dict) or set(rule) != ASSET_KEYS:
+            raise ValueError(f"{field} must contain exactly these keys: {sorted(ASSET_KEYS)}")
+        if not isinstance(rule["name"], str) or not rule["name"] or rule["name"] in seen_names:
+            raise ValueError(f"{field}.name must be non-empty and unique")
+        seen_names.add(rule["name"])
+        _normalized_path(rule["path_prefix"], f"{field}.path_prefix", prefix=True)
+        _positive_integer(rule["max_bytes"], f"{field}.max_bytes")
+        for suffix in _suffixes(rule["suffixes"], f"{field}.suffixes"):
+            scope = (rule["path_prefix"], suffix)
+            if scope in seen_scopes:
+                raise ValueError(f"duplicate asset-class scope for {scope[0]}*{scope[1]}")
+            seen_scopes.add(scope)
+
+    exceptions = policy["exact_exceptions"]
+    if not isinstance(exceptions, dict):
+        raise ValueError("exact_exceptions must map paths to positive byte limits")
+    for relative, maximum in exceptions.items():
+        _normalized_path(relative, "exact exception path")
+        _positive_integer(maximum, f"exact exception {relative!r}")
+    return policy
+
+
+def tracked_files(root: Path, manifest: Path | None = None) -> list[str]:
+    """Return deterministic repository-relative tracked paths."""
+    if manifest is not None:
+        paths = [line.strip() for line in manifest.read_text(encoding="utf-8").splitlines() if line.strip()]
+        for relative in paths:
+            _normalized_path(relative, "tracked manifest entry")
+        return sorted(set(paths))
+    result = subprocess.run(["git", "-C", str(root), "ls-files", "-z"], check=False, capture_output=True)
+    if result.returncode != 0:
+        diagnostic = result.stderr.decode(errors="replace").strip()
+        raise OSError(f"cannot enumerate tracked files with git ls-files: {diagnostic}")
+    return sorted(path.decode(errors="surrogateescape") for path in result.stdout.split(b"\0") if path)
+
+
+def _asset_rule(relative: str, policy: dict[str, Any]) -> dict[str, Any] | None:
+    """Return the single narrowly scoped asset rule matching a path."""
+    suffix = PurePosixPath(relative).suffix.lower()
+    return next((rule for rule in policy["asset_classes"] if relative.startswith(rule["path_prefix"]) and suffix in rule["suffixes"]), None)
+
+
+def audit(root: Path, files: list[str], policy: dict[str, Any]) -> tuple[list[str], int]:
+    """Return hygiene violations and the number of tracked files inspected."""
+    errors: list[str] = []
+    inspected: set[str] = set()
+    exceptions = policy["exact_exceptions"]
+    prohibited_suffixes = set(policy["prohibited_suffixes"])
+    restricted_suffixes = set(policy["restricted_asset_suffixes"])
+    components = set(policy["prohibited_path_components"])
+    for relative in files:
+        path = root / PurePosixPath(relative)
+        if not path.is_file():
+            errors.append(f"tracked file is missing from the worktree: {relative}")
+            continue
+        inspected.add(relative)
+        name = PurePosixPath(relative).name
+        suffix = PurePosixPath(relative).suffix.lower()
+        lowered_parts = {part.lower() for part in PurePosixPath(relative).parts[:-1]}
+        reason = None
+        rule = _asset_rule(relative, policy)
+        if suffix in prohibited_suffixes:
+            reason = f"prohibited artifact extension {suffix}"
+        elif suffix in restricted_suffixes and rule is None:
+            reason = f"intentional asset extension {suffix} is outside its approved path scope"
+        elif any(pattern.fullmatch(name) for pattern in policy["_compiled_patterns"]):
+            reason = "generated build filename"
+        elif lowered_parts & components:
+            reason = f"prohibited build/cache path component {sorted(lowered_parts & components)[0]!r}"
+        if reason:
+            errors.append(f"{relative}: tracked repository artifact is prohibited ({reason}); remove it from Git and keep generated output untracked")
+            continue
+
+        maximum = exceptions.get(relative, rule["max_bytes"] if rule else policy["default_max_bytes"])
+        size = path.stat().st_size
+        if size > maximum:
+            scope = "exact exception" if relative in exceptions else rule["name"] if rule else "default tracked-file limit"
+            errors.append(f"{relative}: {size} bytes exceeds the {scope} maximum of {maximum} bytes; reduce the file or review an explicit narrow policy change")
+    for relative in sorted(set(exceptions) - inspected):
+        errors.append(f"stale exact exception references a missing or untracked file: {relative}; remove or correct the policy entry")
+    return errors, len(inspected)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the tracked-file hygiene check from any working directory."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[1])
+    parser.add_argument("--policy", type=Path, default=DEFAULT_POLICY)
+    parser.add_argument("--tracked-manifest", type=Path)
+    args = parser.parse_args(argv)
+    try:
+        policy = load_policy(args.policy.resolve())
+        files = tracked_files(args.root.resolve(), args.tracked_manifest.resolve() if args.tracked_manifest else None)
+        errors, inspected = audit(args.root.resolve(), files, policy)
+    except (OSError, ValueError) as error:
+        print(f"Repository hygiene policy error: {error}", file=sys.stderr)
+        return 2
+    if errors:
+        print("Repository hygiene policy violations:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+    print(f"Repository hygiene policy passed: inspected {inspected} tracked files (default maximum {policy['default_max_bytes']} bytes; {len(policy['asset_classes'])} asset classes; {len(policy['exact_exceptions'])} exact exceptions).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/check_repository_hygiene_test.py
+++ b/tests/check_repository_hygiene_test.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Exercise tracked-artifact and tracked-file size policy behavior."""
+
+from __future__ import annotations
+
+import json
+import re
+import tempfile
+import unittest
+from pathlib import Path
+
+import check_repository_hygiene as guard
+
+
+class RepositoryHygienePolicyTest(unittest.TestCase):
+    """Validate artifact, asset, size, and policy configuration cases."""
+
+    def setUp(self) -> None:
+        """Create an isolated repository and valid compact policy."""
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary_directory.name)
+        self.policy = {
+            "schema_version": 1,
+            "default_max_bytes": 10,
+            "prohibited_suffixes": [".dll", ".o", ".zip"],
+            "prohibited_filename_patterns": [r"^CMakeCache\.txt$", r"^.+\.so(?:\.[0-9]+)+$"],
+            "prohibited_path_components": [".cache", "__pycache__", "cmakefiles"],
+            "restricted_asset_suffixes": [".gdtf"],
+            "asset_classes": [
+                {"name": "fixture GDTFs", "path_prefix": "library/fixtures/", "suffixes": [".gdtf"], "max_bytes": 20}
+            ],
+            "exact_exceptions": {},
+        }
+        # Tests exercise audit directly, so compile the same configured patterns as load_policy.
+        self.policy["_compiled_patterns"] = [re.compile(item, re.IGNORECASE) for item in self.policy["prohibited_filename_patterns"]]
+
+    def tearDown(self) -> None:
+        """Remove the isolated repository after each test."""
+        self.temporary_directory.cleanup()
+
+    def write(self, relative: str, size: int) -> None:
+        """Write a fixture with an exact byte size."""
+        path = self.root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"x" * size)
+
+    def errors_for(self, relative: str, size: int) -> list[str]:
+        """Audit one tracked fixture and return its diagnostics."""
+        self.write(relative, size)
+        errors, _ = guard.audit(self.root, [relative], self.policy)
+        return errors
+
+    def test_prohibited_compiled_artifact_fails(self) -> None:
+        """Reject a tracked compiled library regardless of its size."""
+        self.assertIn("prohibited artifact extension .dll", "\n".join(self.errors_for("bin/app.dll", 1)))
+
+    def test_prohibited_build_or_cache_path_fails(self) -> None:
+        """Reject generated files nested in known build/cache components."""
+        self.assertIn("prohibited build/cache path", "\n".join(self.errors_for("build/CMakeFiles/state.dat", 1)))
+
+    def test_generated_build_filename_fails(self) -> None:
+        """Reject a generated CMake filename outside a conventional build directory."""
+        self.assertIn("generated build filename", "\n".join(self.errors_for("scratch/CMakeCache.txt", 1)))
+
+    def test_ordinary_source_and_small_binary_resource_pass(self) -> None:
+        """Accept ordinary small tracked content independent of binary encoding."""
+        self.write("src/main.cpp", 5)
+        self.write("resources/icon.png", 9)
+        errors, inspected = guard.audit(self.root, ["resources/icon.png", "src/main.cpp"], self.policy)
+        self.assertEqual([], errors)
+        self.assertEqual(2, inspected)
+
+    def test_approved_bundled_gdtf_passes(self) -> None:
+        """Accept a bounded GDTF only in its configured bundled-library scope."""
+        self.assertEqual([], self.errors_for("library/fixtures/demo.gdtf", 20))
+
+    def test_oversized_approved_gdtf_fails(self) -> None:
+        """Reject growth beyond the approved GDTF class limit."""
+        self.assertIn("fixture GDTFs maximum of 20", "\n".join(self.errors_for("library/fixtures/demo.gdtf", 21)))
+
+    def test_gdtf_outside_approved_scope_fails(self) -> None:
+        """Reject even a small GDTF outside the explicit bundled-library scope."""
+        self.assertIn("outside its approved path scope", "\n".join(self.errors_for("misc/demo.gdtf", 1)))
+
+    def test_unexpected_oversized_binary_fails(self) -> None:
+        """Reject an unclassified binary payload beyond the ordinary limit."""
+        self.assertIn("default tracked-file limit", "\n".join(self.errors_for("misc/payload.bin", 11)))
+
+    def test_exact_exception_passes_and_stale_exception_fails(self) -> None:
+        """Accept a bounded exact exception and diagnose it when stale."""
+        self.policy["exact_exceptions"] = {"docs/intentional.bin": 30}
+        self.assertEqual([], self.errors_for("docs/intentional.bin", 30))
+        errors, _ = guard.audit(self.root, [], self.policy)
+        self.assertIn("stale exact exception", "\n".join(errors))
+
+    def test_malformed_policy_fails(self) -> None:
+        """Reject unknown configuration keys and invalid byte limits."""
+        policy_path = self.root / "policy.json"
+        malformed = {key: value for key, value in self.policy.items() if not key.startswith("_")}
+        malformed["default_max_bytes"] = 0
+        policy_path.write_text(json.dumps(malformed), encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "positive integer"):
+            guard.load_policy(policy_path)
+
+    def test_path_normalization_and_traversal_fail(self) -> None:
+        """Reject traversal and platform-dependent separators in configured paths."""
+        for relative in ("../outside.bin", "docs\\asset.bin"):
+            policy_path = self.root / "policy.json"
+            malformed = {key: value for key, value in self.policy.items() if not key.startswith("_")}
+            malformed["exact_exceptions"] = {relative: 20}
+            policy_path.write_text(json.dumps(malformed), encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "normalized repository-relative"):
+                guard.load_policy(policy_path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/repository_hygiene_policy.json
+++ b/tests/repository_hygiene_policy.json
@@ -1,0 +1,42 @@
+{
+  "schema_version": 1,
+  "default_max_bytes": 2097152,
+  "prohibited_suffixes": [
+    ".7z", ".a", ".appimage", ".appx", ".bz2", ".class", ".d", ".deb",
+    ".dll", ".dmg", ".dylib", ".exe", ".exp", ".gcda", ".gcno", ".gz",
+    ".idb", ".ilk", ".ipdb", ".iobj", ".jar", ".lib", ".msi", ".nupkg",
+    ".o", ".obj", ".pch", ".pdb", ".pkg", ".profraw", ".pyc", ".rar",
+    ".rpm", ".so", ".suo", ".tar", ".tgz", ".user", ".whl", ".xz",
+    ".zip", ".zst"
+  ],
+  "prohibited_filename_patterns": [
+    "^CMakeCache\\.txt$",
+    "^CTestTestfile\\.cmake$",
+    "^cmake_install\\.cmake$",
+    "^compile_commands\\.json$",
+    "^install_manifest\\.txt$",
+    "^build\\.ninja$",
+    "^\\.DS_Store$",
+    "^\\.ninja_(?:deps|log)$",
+    "^.+\\.so(?:\\.[0-9]+)+$"
+  ],
+  "prohibited_path_components": [
+    ".cache", ".pytest_cache", ".vs", "__pycache__", "cmakefiles"
+  ],
+  "restricted_asset_suffixes": [".gdtf"],
+  "asset_classes": [
+    {
+      "name": "bundled fixture GDTFs",
+      "path_prefix": "library/fixtures/",
+      "suffixes": [".gdtf"],
+      "max_bytes": 6291456
+    },
+    {
+      "name": "bundled truss GDTFs",
+      "path_prefix": "library/trusses/",
+      "suffixes": [".gdtf"],
+      "max_bytes": 1048576
+    }
+  ],
+  "exact_exceptions": {}
+}


### PR DESCRIPTION
### Motivation

- Prevent accidental tracked build outputs, compiled binaries, caches, temporary archives, and unexpectedly large files from entering the repository while preserving intentional runtime assets. 
- Keep the policy deterministic, auditable, and repository-tree focused so historical Git objects and history rewriting are out of scope. 
- Integrate the guard with existing policy infrastructure and CI so repository-policy checks remain centralized and repeatable.

### Description

- Add a deterministic tracked-file hygiene checker `tests/check_repository_hygiene.py` and a strict versioned policy `tests/repository_hygiene_policy.json` that validate schema, normalized paths, extension lists, compiled filename patterns, exact exceptions, and per-class byte limits. 
- Add isolated unit tests `tests/check_repository_hygiene_test.py` that cover prohibited artifacts, generated/cache paths, ordinary sources, approved/misplaced GDTFs, oversized assets, malformed policy data, path normalization, and stale exact exceptions. 
- Register the new guard and its fixture tests in `tests/CMakeLists.txt` and run them from the existing repository-policy CI stage by updating `.github/workflows/ci-tests.yml`. 
- Mark intentional binary asset formats found in the tree as non-text in `.gitattributes` (`*.gdtf`, `*.3ds`, `*.icns`, `*.ico`, `*.png`, `*.ttf`) and add concise documentation notes to `AGENTS.md`, `docs/developer/code_health_review_2026-02-13.md`, and `docs/release-notes-draft.md` explaining policy scope and exception process. 
- Policy decisions: default per-file tracked limit is `2 MiB` (`default_max_bytes`); bundled fixture GDTFs under `library/fixtures/` are allowed up to `6 MiB`; bundled truss GDTFs under `library/trusses/` are allowed up to `1 MiB`; a curated list of clearly prohibited suffixes and filename patterns blocks common build outputs and installer payloads; exact exceptions are supported but must be explicit and reviewable.

### Testing

- Ran `python3 tests/check_repository_hygiene.py` which passed against the current tracked tree and reported: "Repository hygiene policy passed: inspected N tracked files (default maximum 2097152 bytes; 2 asset classes; 0 exact exceptions)." 
- Ran the new unit tests with `python3 tests/check_repository_hygiene_test.py -v` and they all passed (11 tests), and `python3 -m py_compile` succeeded for the new and related policy scripts. 
- Executed existing policy test suites and checks including `tests/check_source_file_size.py` and its fixtures, `tests/check_repository_structure_baseline.py` and fixtures, `tests/check_docs_links.py`, `tests/check_perastage_tree_modules.sh`, and other repository-policy scripts; these passed in the local validation run. 
- Attempted a local CMake configure (`cmake -S . -B /tmp/perastage-ch002 -DBUILD_TESTING=ON`), which reached dependency discovery but could not complete locally because wxWidgets development libraries are unavailable in the environment; GitHub Actions remains authoritative for full cross-platform CTest validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6aa279fb03148324968cfb1a57e71066)