### PR TITLE
ci: add opt-in GitHub App authentication for release publication (CH-003B1)

### DIFF
--- a/.github/workflows/main-patch-test-build.yml
+++ b/.github/workflows/main-patch-test-build.yml
@@ -30,10 +30,44 @@ jobs:
       previous_version: ${{ steps.bump.outputs.previous_version }}
       new_version: ${{ steps.bump.outputs.new_version }}
     steps:
-      - uses: actions/checkout@v6
+      - name: Create dedicated release App token
+        id: release-app-token
+        if: ${{ vars.PERASTAGE_RELEASE_APP_ENABLED == 'true' }}
+        uses: actions/create-github-app-token@v3
         with:
+          client-id: ${{ vars.PERASTAGE_RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.PERASTAGE_RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+      - name: Validate dedicated release App token
+        if: ${{ vars.PERASTAGE_RELEASE_APP_ENABLED == 'true' }}
+        env:
+          RELEASE_APP_TOKEN: ${{ steps.release-app-token.outputs.token }}
+        run: test -n "$RELEASE_APP_TOKEN"
+      - name: Check out main with the dedicated release App
+        if: ${{ vars.PERASTAGE_RELEASE_APP_ENABLED == 'true' }}
+        uses: actions/checkout@v6
+        with:
+          token: ${{ steps.release-app-token.outputs.token }}
           ref: main
           fetch-depth: 0
+      - name: Check out main with GITHUB_TOKEN
+        if: ${{ vars.PERASTAGE_RELEASE_APP_ENABLED != 'true' }}
+        uses: actions/checkout@v6
+        with:
+          token: ${{ github.token }}
+          ref: main
+          fetch-depth: 0
+      - name: Summarize publication authentication
+        env:
+          RELEASE_APP_ENABLED: ${{ vars.PERASTAGE_RELEASE_APP_ENABLED == 'true' }}
+          RELEASE_APP_SLUG: ${{ steps.release-app-token.outputs.app-slug }}
+          RELEASE_APP_INSTALLATION_ID: ${{ steps.release-app-token.outputs.installation-id }}
+        run: |
+          if [ "$RELEASE_APP_ENABLED" = true ]; then
+            echo "Publication authentication: dedicated GitHub App (${RELEASE_APP_SLUG}, installation ${RELEASE_APP_INSTALLATION_ID})." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Publication authentication: GITHUB_TOKEN." >> "$GITHUB_STEP_SUMMARY"
+          fi
       - name: Bump patch version in VERSION
         id: bump
         run: |

--- a/.github/workflows/minor-draft-release.yml
+++ b/.github/workflows/minor-draft-release.yml
@@ -190,17 +190,53 @@ jobs:
     needs: [resolve-release, stage-release-commit, validate-release-assets]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - name: Create dedicated release App token
+        id: release-app-token
+        if: ${{ vars.PERASTAGE_RELEASE_APP_ENABLED == 'true' }}
+        uses: actions/create-github-app-token@v3
         with:
+          client-id: ${{ vars.PERASTAGE_RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.PERASTAGE_RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+      - name: Validate dedicated release App token
+        if: ${{ vars.PERASTAGE_RELEASE_APP_ENABLED == 'true' }}
+        env:
+          RELEASE_APP_TOKEN: ${{ steps.release-app-token.outputs.token }}
+        run: test -n "$RELEASE_APP_TOKEN"
+      - name: Check out release commit with the dedicated release App
+        if: ${{ vars.PERASTAGE_RELEASE_APP_ENABLED == 'true' }}
+        uses: actions/checkout@v6
+        with:
+          token: ${{ steps.release-app-token.outputs.token }}
           ref: ${{ needs.stage-release-commit.outputs.release_sha }}
           fetch-depth: 0
+      - name: Check out release commit with GITHUB_TOKEN
+        if: ${{ vars.PERASTAGE_RELEASE_APP_ENABLED != 'true' }}
+        uses: actions/checkout@v6
+        with:
+          token: ${{ github.token }}
+          ref: ${{ needs.stage-release-commit.outputs.release_sha }}
+          fetch-depth: 0
+      - name: Summarize publication authentication
+        env:
+          RELEASE_APP_ENABLED: ${{ vars.PERASTAGE_RELEASE_APP_ENABLED == 'true' }}
+          RELEASE_APP_SLUG: ${{ steps.release-app-token.outputs.app-slug }}
+          RELEASE_APP_INSTALLATION_ID: ${{ steps.release-app-token.outputs.installation-id }}
+        run: |
+          if [ "$RELEASE_APP_ENABLED" = true ]; then
+            echo "Publication authentication: dedicated GitHub App (${RELEASE_APP_SLUG}, installation ${RELEASE_APP_INSTALLATION_ID})." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Publication authentication: GITHUB_TOKEN." >> "$GITHUB_STEP_SUMMARY"
+          fi
       - uses: actions/download-artifact@v8
         with:
           name: Perastage-validated-release-assets
           path: release-assets/final
       - name: Publish main, tag, and draft release after validation
         env:
-          GH_TOKEN: ${{ github.token }}
+          RELEASE_APP_ENABLED: ${{ vars.PERASTAGE_RELEASE_APP_ENABLED == 'true' }}
+          RELEASE_APP_TOKEN: ${{ steps.release-app-token.outputs.token }}
+          BUILT_IN_TOKEN: ${{ github.token }}
           BASE_SHA: ${{ needs.resolve-release.outputs.base_sha }}
           RELEASE_SHA: ${{ needs.stage-release-commit.outputs.release_sha }}
           NEW_TAG: ${{ needs.resolve-release.outputs.new_tag }}
@@ -209,6 +245,12 @@ jobs:
           PRERELEASE: ${{ needs.resolve-release.outputs.prerelease }}
         run: |
           set -euo pipefail
+          if [ "$RELEASE_APP_ENABLED" = true ]; then
+            test -n "$RELEASE_APP_TOKEN"
+            export GH_TOKEN="$RELEASE_APP_TOKEN"
+          else
+            export GH_TOKEN="$BUILT_IN_TOKEN"
+          fi
           git fetch origin main --tags
           CURRENT_MAIN="$(git rev-parse origin/main)"
           TAG_TARGET=""

--- a/.github/workflows/validate-release-automation-app.yml
+++ b/.github/workflows/validate-release-automation-app.yml
@@ -1,0 +1,58 @@
+name: Validate Release Automation App
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-release-app:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require dedicated release App configuration
+        env:
+          RELEASE_APP_CLIENT_ID: ${{ vars.PERASTAGE_RELEASE_APP_CLIENT_ID }}
+        run: |
+          set -euo pipefail
+          [ -n "$RELEASE_APP_CLIENT_ID" ] || { echo "PERASTAGE_RELEASE_APP_CLIENT_ID is not configured."; exit 1; }
+      - name: Create dedicated release App token
+        id: release-app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.PERASTAGE_RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.PERASTAGE_RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+      - name: Verify installation repository scope
+        env:
+          GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
+          EXPECTED_REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          installation_repositories="$(mktemp)"
+          gh api "/installation/repositories?per_page=100" > "$installation_repositories"
+          python3 - "$installation_repositories" "$EXPECTED_REPOSITORY" <<'PY'
+          import json
+          import sys
+
+          payload = json.load(open(sys.argv[1], encoding="utf-8"))
+          repositories = [repository["full_name"] for repository in payload["repositories"]]
+          if payload["total_count"] != 1 or repositories != [sys.argv[2]]:
+              raise SystemExit(
+                  f"Expected installation token access only to {sys.argv[2]}, got {repositories}"
+              )
+          PY
+      - name: Summarize validated identity
+        env:
+          RELEASE_APP_SLUG: ${{ steps.release-app-token.outputs.app-slug }}
+          RELEASE_APP_INSTALLATION_ID: ${{ steps.release-app-token.outputs.installation-id }}
+          EXPECTED_REPOSITORY: ${{ github.repository }}
+        run: |
+          {
+            echo "# Release automation App validation"
+            echo "App: ${RELEASE_APP_SLUG}"
+            echo "Installation ID: ${RELEASE_APP_INSTALLATION_ID}"
+            echo "Repository: ${EXPECTED_REPOSITORY}"
+            echo "Requested permission: contents: write"
+            echo "Result: token creation and current-repository-only access validated without a Git write."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/developer/github_actions_workflows.md
+++ b/docs/developer/github_actions_workflows.md
@@ -51,6 +51,36 @@ The workflow serializes version mutation, increments only the patch component in
 
 It does not rerun Debug CI, and it does not build macOS 15 or Arch Linux compatibility packages. These artifacts are intended for manual testing and continuous verification of current hosted packaging runners. Automatic patch artifacts use GitHub Actions artifact retention and are not permanent release assets.
 
+### Release publication authentication
+
+The repository is prepared for a dedicated release-automation GitHub App without
+requiring its credentials during the transition. If
+`PERASTAGE_RELEASE_APP_ENABLED` is absent or not exactly `true`, `bump-version`
+and `publish-release` continue to authenticate with `GITHUB_TOKEN`. If it is
+exactly `true`, those jobs must successfully mint a token with
+`actions/create-github-app-token@v3`, repository variable
+`PERASTAGE_RELEASE_APP_CLIENT_ID`, Actions secret
+`PERASTAGE_RELEASE_APP_PRIVATE_KEY`, and only `contents: write`; failure stops
+the job without a `GITHUB_TOKEN` fallback.
+
+The action receives neither `owner` nor `repositories`, which scopes its token to
+the current repository, and default end-of-job revocation remains enabled. Only
+the patch `bump-version` job and final minor `publish-release` job can mint the
+token. Their mutually exclusive checkout steps persist the selected credential
+before any protected-main push. The minor publisher also uses that same selected
+token for its existing draft Release operations. Reusable package builders,
+minor temp-ref staging and cleanup, and recovery continue using ordinary tokens.
+Commit/tag author configuration remains `github-actions[bot]`; it is the checkout
+credential, rather than that attribution, that authenticates a push.
+
+Maintainers can run the manual-only **Validate Release Automation App** workflow
+before enablement. It requests the same permission, queries the token's accessible
+installation repositories, requires the sole result to be the current repository,
+and summarizes only the App slug, installation ID, repository, permission, and
+result. It performs no checkout, push, tag, Release, or branch mutation. See the
+[main branch protection contract](main_branch_protection.md) for provisioning and
+CH-003B2 prerequisites.
+
 ## Weekly and manual compatibility packages
 
 `Weekly Compatibility Packages` in `.github/workflows/compatibility-builds.yml` runs weekly at `03:27 UTC` on Tuesday and supports `workflow_dispatch` with an optional `source_ref`.

--- a/docs/developer/main_branch_protection.md
+++ b/docs/developer/main_branch_protection.md
@@ -1,14 +1,13 @@
 # Main branch protection contract
 
-This document records the CH-003A audit of GitHub protection and proposes the
-configuration for a later CH-003B. It complements, rather than repeats, the
+This document records the CH-003A audit, the CH-003B1 release-App preparation,
+and the proposed configuration for a later CH-003B2. It complements, rather than repeats, the
 [GitHub Actions workflow architecture](github_actions_workflows.md).
 
-> **Audit-only status:** CH-003A did not create, edit, disable, or delete a
-> ruleset or classic branch-protection rule. It did not change any release or
-> versioning workflow. CH-003B is **not ready to apply** until an administrator
-> verifies classic protection and provisions or identifies a narrowly scoped
-> automation identity.
+> **Preparation-only status:** CH-003B1 does not create, edit, disable, or delete
+> a ruleset or classic branch-protection rule. Required pull requests and status
+> checks must not be activated until the dedicated App is installed, validated,
+> enabled, and proven on an intended publication path.
 
 ## Audit basis and access limits
 
@@ -59,8 +58,8 @@ by them only prepare or validate runner-local files.
 
 | Workflow | Trigger and permissions | Remote writes and identity | Preconditions and architectural need |
 |---|---|---|---|
-| `Main Patch Release Artifacts` (`main-patch-test-build.yml`) | Push to `main` or manual dispatch; `contents: write`, `actions: read`, `packages: read`; serialized by `main-patch-version-bump` with cancellation disabled | The checkout-provided `GITHUB_TOKEN` pushes `HEAD:main` as the GitHub Actions installation (`github-actions[bot]`). It writes no tag, temporary ref, or Release. | Validates numeric `VERSION`, makes one patch increment, marks the commit to avoid recursion, and excludes bot-triggered push runs. The direct main write is required by the current automatic post-merge version/artifact architecture. |
-| `Minor Draft Release` (`minor-draft-release.yml`) | Manual dispatch; `contents: write`, `actions: read`, `packages: read`; serialized by `perastage-minor-draft-release` | The checkout-provided `GITHUB_TOKEN` creates and deletes exactly `refs/heads/automation/release-v<version>-<run-id>`, then may atomically fast-forward `refs/heads/main` and create `refs/tags/v<version>`. `github.token` is also passed to `gh` to create/edit a draft GitHub Release and upload assets. | Validates version/tag state and the artifact contract, builds all packages from the exact staged SHA, validates the assembled assets and provenance, refetches and requires `origin/main == BASE_SHA`, and normally publishes main plus tag with `git push --atomic`. Retry states are explicitly constrained. Every write is part of the stabilized minor-publication transaction or exact temp-ref cleanup. |
+| `Main Patch Release Artifacts` (`main-patch-test-build.yml`) | Push to `main` or manual dispatch; `contents: write`, `actions: read`, `packages: read`; serialized by `main-patch-version-bump` with cancellation disabled | Only `bump-version` can mint the dedicated App token. Its checkout explicitly persists either that token in enabled mode or `GITHUB_TOKEN` in transitional mode before pushing `HEAD:main`. It writes no tag, temporary ref, or Release. | Validates numeric `VERSION`, makes one patch increment, marks the commit to avoid recursion, and excludes bot-triggered push runs. The direct main write is required by the current automatic post-merge version/artifact architecture. |
+| `Minor Draft Release` (`minor-draft-release.yml`) | Manual dispatch; `contents: write`, `actions: read`, `packages: read`; serialized by `perastage-minor-draft-release` | Temporary-ref staging and cleanup retain `GITHUB_TOKEN`. Only `publish-release` can mint the dedicated App token and explicitly checks out with it in enabled mode before the atomic main/tag push and draft Release operations. | Validates version/tag state and the artifact contract, builds all packages from the exact staged SHA, validates the assembled assets and provenance, refetches and requires `origin/main == BASE_SHA`, and normally publishes main plus tag with `git push --atomic`. Retry states are explicitly constrained. Every write is part of the stabilized minor-publication transaction or exact temp-ref cleanup. |
 | `Recover Validated Minor Release` (`recover-minor-release.yml`) | Manual dispatch; `contents: write`, `actions: read`; serialized by `perastage-minor-release-recovery` | The checkout-provided `GITHUB_TOKEN` may create only the requested `refs/tags/v<version>` and may create/edit a draft GitHub Release and upload assets. It never updates `main` or a temporary branch. | Requires a full SHA and semantic version, requires that SHA to be reachable from current `origin/main`, verifies `VERSION`, the completed source `Minor Draft Release` run, the single unexpired validated artifact, checksums, and provenance. Dry run defaults to true. These restricted writes recover publication without rebuilding or moving main. |
 
 `CI Debug Tests` (`ci-tests.yml`) runs on pushes and pull requests to `main`, on
@@ -75,6 +74,47 @@ the credential persisted by `actions/checkout` is the repository's
 `GITHUB_TOKEN`: an installation access token for the GitHub Actions App. Ruleset
 bypass must therefore address the App/integration that authenticates the push,
 not the configured Git author.
+
+## Dedicated release-App transition
+
+The two main-writing jobs use `actions/create-github-app-token@v3` only when the
+repository variable `PERASTAGE_RELEASE_APP_ENABLED` is exactly `true`. They read
+the Client ID from repository variable `PERASTAGE_RELEASE_APP_CLIENT_ID`, read
+the private key from Actions secret `PERASTAGE_RELEASE_APP_PRIVATE_KEY`, and
+request only `permission-contents: write`. Omitting both `owner` and
+`repositories` uses the action's current-repository scope. Token revocation is
+left at its default, so the post step revokes the token at job completion.
+
+When enablement is absent or has any value other than `true`, the two jobs use
+their existing `GITHUB_TOKEN` path. This transitional default preserves current
+publication until manual provisioning is complete. When enablement is exactly
+`true`, token creation and a nonempty token are mandatory; a missing Client ID,
+missing or invalid private key, unavailable installation or permission, or token
+creation failure stops the publication job. The enabled path never selects
+`GITHUB_TOKEN` as a fallback.
+
+The selected authentication credential, not the configured Git author, controls
+ruleset authorization. Each publisher uses mutually exclusive checkout steps
+and passes the selected token directly to `actions/checkout@v6`, whose persisted
+credential is then used by `git push`. `publish-release` also assigns the same
+selected credential to `GH_TOKEN` for its existing Release transaction. Tokens
+are neither job outputs nor reusable-workflow inputs. Builders, temp-ref staging,
+cleanup, and `Recover Validated Minor Release` cannot access the dedicated App
+token.
+
+### Manual provisioning checklist
+
+1. Register a dedicated GitHub App for Perastage release automation.
+2. Grant only repository **Contents: Read and write**; request no unrelated organization or account permissions.
+3. Install the App only on `PeramatoG/Perastage`.
+4. Store its Client ID in repository variable `PERASTAGE_RELEASE_APP_CLIENT_ID`.
+5. Store its private key in Actions secret `PERASTAGE_RELEASE_APP_PRIVATE_KEY`.
+6. Keep `PERASTAGE_RELEASE_APP_ENABLED` unset or false initially.
+7. Manually run **Validate Release Automation App** and verify its App slug, installation ID, repository, and current-repository-only result.
+8. Set `PERASTAGE_RELEASE_APP_ENABLED=true`.
+9. Prove that a normal intended version bump or minor publication authenticates with the dedicated App.
+10. Only then, in CH-003B2, add that installed App to `Protect main` as an **Always allow** bypass actor and activate the planned PR/check rules.
+11. Do **not** add the built-in GitHub Actions App as an Always-allow bypass.
 
 ## Pull-request check contract
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -12,6 +12,7 @@ Changes since **v1.6.0**.
 
 ## Technical and packaging changes
 
+- Prepared narrowly scoped, fail-closed GitHub App authentication for trusted release publication while preserving the existing automation path until maintainers enable it.
 - Documented the audited main-branch protection contract and the narrow automation identity required before stronger protection can be safely activated.
 - Added a cross-platform repository hygiene guard that blocks accidentally tracked build artifacts and unexpectedly large files while preserving the bounded bundled GDTF library as normal Git assets.
 - Added an automated, cross-platform source-size guardrail that prevents existing C/C++ hotspots from growing beyond reviewable baselines and limits new source files to a maintainable default size.

--- a/tests/ci/test_release_workflow_publication.py
+++ b/tests/ci/test_release_workflow_publication.py
@@ -40,6 +40,67 @@ def test_workflows_encode_safe_publication_and_recovery_guards() -> None:
     assert recover.find("if [ \"$DRY_RUN\" = true ]; then") < recover.find("git tag -a \"$TAG\"")
 
 
+def test_release_app_credentials_are_confined_and_fail_closed() -> None:
+    workflows = {path.name: path.read_text() for path in WORKFLOWS.glob("*.yml")}
+    action = "actions/create-github-app-token@v3"
+    expected_users = {
+        "main-patch-test-build.yml": "  bump-version:",
+        "minor-draft-release.yml": "  publish-release:",
+        "validate-release-automation-app.yml": "  validate-release-app:",
+    }
+
+    assert {name for name, text in workflows.items() if action in text} == set(expected_users)
+    for name, job_marker in expected_users.items():
+        text = workflows[name]
+        assert text.count(action) == 1
+        assert text.index(action) > text.index(job_marker)
+        token_block = text[text.index(action) : text.index(action) + 400]
+        assert "permission-contents: write" in token_block
+        assert "owner:" not in token_block and "repositories:" not in token_block
+        assert "skip-token-revoke" not in text
+
+    patch = workflows["main-patch-test-build.yml"]
+    minor = workflows["minor-draft-release.yml"]
+    recovery = workflows["recover-minor-release.yml"]
+    for publisher in (patch, minor):
+        assert "vars.PERASTAGE_RELEASE_APP_ENABLED == 'true'" in publisher
+        assert "vars.PERASTAGE_RELEASE_APP_ENABLED != 'true'" in publisher
+        assert 'run: test -n "$RELEASE_APP_TOKEN"' in publisher
+        assert "token: ${{ steps.release-app-token.outputs.token }}" in publisher
+        assert "token: ${{ github.token }}" in publisher
+    assert patch.index("token: ${{ steps.release-app-token.outputs.token }}") < patch.index("git push origin HEAD:main")
+    publish_job = minor[minor.index("  publish-release:") : minor.index("  cleanup-temp-ref:")]
+    assert 'test -n "$RELEASE_APP_TOKEN"' in publish_job
+    assert 'export GH_TOKEN="$RELEASE_APP_TOKEN"' in publish_job
+    assert 'export GH_TOKEN="$BUILT_IN_TOKEN"' in publish_job
+    assert publish_job.index("token: ${{ steps.release-app-token.outputs.token }}") < publish_job.index("git push --atomic origin")
+    assert action not in recovery
+    assert "PERASTAGE_RELEASE_APP_" not in recovery
+
+    reusable_builders = [
+        "windows-installer.yml",
+        "linux-installer.yml",
+        "macos-installer.yml",
+        "macos-15-manual-installer.yml",
+        "arch-package.yml",
+    ]
+    for name in reusable_builders:
+        assert "PERASTAGE_RELEASE_APP_" not in workflows[name]
+        assert "release-app-token" not in workflows[name]
+
+
+def test_release_app_validation_is_read_only_and_repository_scoped() -> None:
+    validation = (WORKFLOWS / "validate-release-automation-app.yml").read_text()
+    assert "workflow_dispatch:" in validation
+    assert "push:" not in validation and "pull_request:" not in validation
+    assert "contents: read" in validation
+    assert 'gh api "/installation/repositories?per_page=100"' in validation
+    assert 'payload["total_count"] != 1' in validation
+    assert "git push" not in validation
+    assert "git tag" not in validation
+    assert "gh release" not in validation
+
+
 def test_atomic_branch_and_tag_push_succeeds_against_local_bare_remote(tmp_path: Path) -> None:
     remote = tmp_path / "remote.git"
     run(["git", "init", "--bare", str(remote)], tmp_path)


### PR DESCRIPTION
### Motivation

- Prepare the repository-side GitHub Actions plumbing so a dedicated release-automation GitHub App can be used for protected `main` publication without changing release semantics now. 
- Preserve the existing `GITHUB_TOKEN` publication path unless maintainers explicitly enable the dedicated App, and ensure the enabled path is fail-closed. 
- Confine the dedicated App token to exactly the jobs that must write `main` and provide a manual read-only validation path for maintainers to verify installation before enabling stronger rules.

### Description

- Add opt-in App-token creation to the two main-writing jobs: `bump-version` in `Main Patch Release Artifacts` and `publish-release` in `Minor Draft Release`, using `actions/create-github-app-token@v3` and requesting only `permission-contents: write`.
- Make checkout and credential selection explicit and mutually exclusive by passing the selected token directly to `actions/checkout@v6`, and ensure the same selected credential is used for `git push` and `gh` operations (minor publisher sets `GH_TOKEN` from the selected token when enabled).
- Introduce a manual `workflow_dispatch` read-only validation workflow, `validate-release-automation-app.yml`, which mints the same repository-scoped token, queries the installation repositories, verifies the token only has access to the expected repository, and reports `app-slug`/`installation-id` without performing any Git writes.
- Add static tests asserting the expected placement and constraints of `actions/create-github-app-token@v3`, update `tests/ci/test_release_workflow_publication.py` with checks for transitional and fail-closed behavior, and keep token use confined (builders, staging, cleanup, and recovery do not receive the App token).
- Update documentation to record the transitional architecture and the maintainer provisioning checklist in `docs/developer/main_branch_protection.md` and `docs/developer/github_actions_workflows.md`, and add a short internal entry to `docs/release-notes-draft.md` describing the preparation.
- Configuration names and action details used: repository variable `PERASTAGE_RELEASE_APP_ENABLED`, repository variable `PERASTAGE_RELEASE_APP_CLIENT_ID`, Actions secret `PERASTAGE_RELEASE_APP_PRIVATE_KEY`, and `actions/create-github-app-token@v3` with `permission-contents: write`; `owner`/`repositories` inputs are omitted so token scope defaults to the current repository and default post-job revocation is preserved.

### Testing

- Ran `python3 tests/check_ci_workflow_architecture.py` and it passed.
- Ran `python3 -m pytest -q tests/ci/test_release_workflow_publication.py` and all tests passed.
- Ran `python3 tests/check_docs_links.py`, `python3 tests/check_repository_hygiene.py`, `python3 tests/check_source_file_size.py`, `PERASTAGE_TEST_PYTHON=$(command -v python3) bash tests/check_perastage_tree_modules.sh`, and `PERASTAGE_TEST_PYTHON=$(command -v python3) bash tests/check_no_configmanager_get_in_gui.sh` and they succeeded.
- Note: end-to-end minting and push verification that exercise a real App installation and remote push authorization cannot be executed in this environment because App credentials and a writable upstream remote are not present; the workflows and static tests are designed so the PR can merge without those credentials and so that enabling `PERASTAGE_RELEASE_APP_ENABLED=true` will be fail-closed until maintainers provision the App and secrets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6aa29bc963488324977a15d49f329377)