### PR TITLE
docs: consolidate CH-003 main-branch protection into single administrative handoff

### DIFF
--- a/docs/developer/github_actions_workflows.md
+++ b/docs/developer/github_actions_workflows.md
@@ -78,8 +78,8 @@ before enablement. It requests the same permission, queries the token's accessib
 installation repositories, requires the sole result to be the current repository,
 and summarizes only the App slug, installation ID, repository, permission, and
 result. It performs no checkout, push, tag, Release, or branch mutation. See the
-[main branch protection contract](main_branch_protection.md) for provisioning and
-CH-003B2 prerequisites.
+[main branch protection contract](main_branch_protection.md) for the single
+remaining administrative activation and verification handoff.
 
 ## Weekly and manual compatibility packages
 

--- a/docs/developer/main_branch_protection.md
+++ b/docs/developer/main_branch_protection.md
@@ -1,23 +1,95 @@
 # Main branch protection contract
 
-This document records the CH-003A audit, the CH-003B1 release-App preparation,
-and the proposed configuration for a later CH-003B2. It complements, rather than repeats, the
+This document records the CH-003 audit, the release-App preparation, and the
+single administrative handoff required to activate the final contract. It complements, rather than repeats, the
 [GitHub Actions workflow architecture](github_actions_workflows.md).
 
-> **Preparation-only status:** CH-003B1 does not create, edit, disable, or delete
+> **Administrative handoff required (verified 2026-09-10):** the available
+> environment has no authenticated GitHub session and cannot create or install a
+> GitHub App, configure Actions credentials, dispatch the validation workflow, or
+> administer repository rules. No live setting was partially changed. The public
+> API still reports ruleset `20119238` as active with only deletion and
+> non-fast-forward rules. Complete the one-pass handoff below to close CH-003.
+>
+> Repository preparation does not create, edit, disable, or delete
 > a ruleset or classic branch-protection rule. Required pull requests and status
 > checks must not be activated until the dedicated App is installed, validated,
 > enabled, and proven on an intended publication path.
 
+## One-pass administrative handoff
+
+Perform this sequence as a repository/account administrator; do not enable only
+part of the final protection contract.
+
+1. In the owning GitHub account, open **Settings > Developer settings > GitHub
+   Apps > New GitHub App**. Register **Perastage Release Automation**, disable the
+   webhook if it is not used, subscribe to no events, grant only repository
+   **Contents: Read and write**, and allow installation only on the owning account.
+2. On the App's **Install App** page, install it with **Only select repositories**
+   and select only `PeramatoG/Perastage`. Generate a private key and copy the
+   displayed Client ID. Do not copy the App ID, installation ID, bot user ID, or
+   ruleset actor ID into the Client ID variable.
+3. In **PeramatoG/Perastage > Settings > Secrets and variables > Actions**, create
+   repository variable `PERASTAGE_RELEASE_APP_CLIENT_ID` with that Client ID and
+   repository secret `PERASTAGE_RELEASE_APP_PRIVATE_KEY` with the complete private
+   key. Keep `PERASTAGE_RELEASE_APP_ENABLED` unset or `false`.
+4. In **Actions**, run **Validate Release Automation App**. Require a successful
+   summary naming the expected App slug, a nonempty installation ID,
+   `PeramatoG/Perastage`, `contents: write`, and current-repository-only access.
+   The workflow performs no Git or GitHub write. Correct installation or credential
+   configuration rather than weakening its validation if it fails.
+5. Set repository variable `PERASTAGE_RELEASE_APP_ENABLED` to `true`, then safely
+   dispatch **Main Patch Release Artifacts**. Require its authentication summary to
+   name the dedicated App and installation, the patch bump commit to reach `main`,
+   and the resulting `[skip version-bump]` push not to recurse. Confirm that no tag,
+   Release, or unexpected ref was created and that no `GITHUB_TOKEN` fallback was
+   used.
+6. Before changing protection, inspect **Settings > Rules > Rulesets** and
+   **Settings > Branches**. Record any classic `main` protection. If one exists,
+   reconcile or remove only its conflicting duplicate requirements while retaining
+   effective safety; do not leave contradictory overlapping policies.
+7. Inspect the successful platform check runs on recent PRs to `main` and confirm
+   `linux-debug`, `macos-debug`, and `windows-debug` are produced by **GitHub
+   Actions** integration ID `15368`. Do not separately require `resolve-source`.
+8. Edit existing ruleset **Protect main** (`20119238`), rather than creating a new
+   ruleset. Keep it active for `~DEFAULT_BRANCH` with no exclusions. Retain
+   **Restrict deletions** and **Block force pushes**. Enable **Require a pull request
+   before merging** with zero approvals, stale-review dismissal off, code-owner
+   review off, last-push approval off, conversation resolution on, and every merge
+   method that the repository intentionally enables.
+9. Enable required status checks for exactly `linux-debug`, `macos-debug`, and
+   `windows-debug`, selecting GitHub Actions as each expected source (integration
+   ID `15368`). Leave **Require branches to be up to date before merging** off.
+10. Retain the repository administrator role (`RepositoryRole`, actor ID `5`) in
+    **Pull requests only** bypass mode. Add only **Perastage Release Automation** as
+    an Integration in **Always allow** mode. Record the Integration actor ID
+    returned by the ruleset after saving. Do not add the built-in GitHub Actions
+    App, a user/PAT, a deploy key, or any other actor.
+11. Save, re-fetch the full ruleset, and compare every condition, rule, parameter,
+    and bypass with steps 8-10. Use ruleset inspection and successful PR evidence to
+    verify the scenario matrix below; do not test deletion or force-push
+    destructively. Confirm the patch publisher can still write as the dedicated App
+    and that the minor publisher still uses the same App only for its final atomic
+    main/tag publication.
+12. Update this document's status with the activation date, App name/slug,
+    installation ID, Integration actor ID, classic-protection result, and exact
+    server-returned configuration. Also change the transition wording in
+    `github_actions_workflows.md` to state that dedicated-App mode is active.
+
+If activation unexpectedly blocks an intended operation, restore the complete
+pre-change ruleset captured below, diagnose the exact App/check mismatch, and make
+no broad bypass, PAT, force-push, or protection-disable workaround.
+
 ## Audit basis and access limits
 
-The audit was performed on 2026-09-10 at `origin/main` commit
-`93adfc05b63e420ae37672295eaf5efc5a760ab3`, after CH-002 was merged as PR
-#2344. Current authenticated ruleset detail, the public GitHub REST API, and the
-checked-out workflows were inspected. This environment had no authenticated
+The closure audit was repeated on 2026-09-10 at `main` commit
+`674f29c920c2fb696cbbeaedcaebe3444b1f7a1b` (`VERSION` `1.6.31`). Merge commit
+`fb3b5d6b374d7ab84f2aa729e069f05c5820e49e` for PR #2346 is its parent, so the
+release-App preparation is present. The public GitHub REST API and checked-out
+workflows were inspected. This environment had no authenticated
 GitHub CLI session and could neither administer nor modify repository settings.
 Classic branch protection was not accessible with the current integration, so an
-administrator must determine its state in the Settings UI before CH-003B.
+administrator must determine its state in the Settings UI before activation.
 
 ## Current protection of `main`
 
@@ -39,13 +111,13 @@ The current admin-role bypass applies only in the pull-request context. It is no
 an unrestricted direct-push bypass to `main` and therefore cannot authorize the
 direct main writes required by `Main Patch Release Artifacts` and `Minor Draft
 Release`. It is nevertheless part of the active ruleset and must be retained or
-deliberately reconsidered in CH-003B.
+deliberately reconsidered during activation.
 
 No other repository or organization ruleset appeared in the effective rules for
 `main`; the only effective rules returned were deletion and non-fast-forward.
 This is strong evidence that no overlapping ruleset currently applies. It does
 not prove that classic branch protection is absent because that setting was not
-accessible with the current integration. Before applying CH-003B, an
+accessible with the current integration. Before activating the final contract, an
 administrator must inspect **Settings > Rules > Rulesets** and **Settings >
 Branches**, record any classic rule, and reconcile it rather than creating an
 accidentally layered policy.
@@ -113,7 +185,7 @@ token.
 7. Manually run **Validate Release Automation App** and verify its App slug, installation ID, repository, and current-repository-only result.
 8. Set `PERASTAGE_RELEASE_APP_ENABLED=true`.
 9. Prove that a normal intended version bump or minor publication authenticates with the dedicated App.
-10. Only then, in CH-003B2, add that installed App to `Protect main` as an **Always allow** bypass actor and activate the planned PR/check rules.
+10. Only then add that installed App to `Protect main` as an **Always allow** bypass actor and activate the planned PR/check rules.
 11. Do **not** add the built-in GitHub Actions App as an Always-allow bypass.
 
 ## Pull-request check contract
@@ -132,7 +204,7 @@ The smallest complete gate is therefore the three platform checks. Their job IDs
 are literal workflow keys, were stable across the sampled PRs, and each validates
 the exact head SHA emitted by `resolve-source`. Requiring `resolve-source` too
 would be redundant and would add another name that can block merging without
-adding platform coverage. CH-003B should bind each required context to the
+adding platform coverage. The final ruleset should bind each required context to the
 expected GitHub Actions App (ID `15368`) if the ruleset UI/API offers expected
 source selection.
 
@@ -144,12 +216,12 @@ Loose mode accepts the residual risk that a passing head can interact badly with
 a newer `main`; the maintainer should update and rerun when a concurrent change
 touches the same behavior or build surface.
 
-## Proposed CH-003B ruleset
+## Final CH-003 ruleset
 
-Subject to the unresolved bypass and classic-rule prerequisites below, edit the
+After satisfying the App and classic-rule prerequisites above, edit the
 existing ruleset rather than layer a second one:
 
-| Setting | Proposed value and reason |
+| Setting | Final value and reason |
 |---|---|
 | Name | Keep `Protect main` |
 | Target / enforcement | Branches matching `~DEFAULT_BRANCH`, no exclusions; Active |
@@ -170,9 +242,9 @@ do not add deployment, code-scanning, code-owner, merge-queue, branch-name,
 metadata, file-path, file-size, or restricted-push rules because they are not
 needed for this contract. Do not give recovery a main-ruleset bypass: its tag and
 Release writes do not target the protected branch. Tags can receive a separate
-future policy, but that is outside CH-003B.
+future policy, but that is outside CH-003.
 
-### Bypass decision and unresolved prerequisite
+### Bypass decision and administrative prerequisite
 
 Ruleset bypass modes are actor-wide, not workflow-wide. **Pull requests only** is
 insufficient because both trusted publishers directly update `main`. Adding the
@@ -180,7 +252,7 @@ built-in GitHub Actions App with **Always allow** would let any present or futur
 workflow holding a write-capable `GITHUB_TOKEN` bypass the PR and status-check
 rules on `main`; GitHub cannot narrow that actor entry to two workflow files.
 That would fail scenario J and is an explicit, broad-authority security tradeoff,
-not the safe proposed configuration.
+not the safe final configuration.
 
 The narrower design is a dedicated GitHub App installed only on this repository,
 granted only the minimum repository-contents write permission, selected in the
@@ -189,9 +261,9 @@ the two intended publication workflows from protected App credentials. Ordinary
 workflows retain the built-in `GITHUB_TOKEN` and therefore cannot use the bypass.
 App private-key access and workflow modification remain sensitive administrative
 boundaries. An administrator must confirm that this dedicated installed App is
-selectable in this repository's bypass UI before CH-003B; it does not currently
+selectable in this repository's bypass UI before activation; it does not currently
 exist in the audited tree or visible public settings. Until that confirmation,
-the safe exact bypass identity remains unresolved and CH-003B is not ready.
+the safe exact bypass identity remains unavailable until the App is provisioned.
 `Always allow` necessarily lets that dedicated identity bypass every rule in this
 main-targeting ruleset, including deletion and non-fast-forward rules; narrowing
 which workflows can mint its token and preserving the workflows' explicit
@@ -221,4 +293,4 @@ current ruleset.
 | G. Automatic post-merge `VERSION` bump | Allowed only when its main push uses the dedicated App; serialization, validation, and recursion suppression remain unchanged. |
 | H. Minor Draft Release | Its temp ref remains outside the target; after package/asset validation and the `origin/main == BASE_SHA` check, the dedicated App can retain the atomic fast-forward-main/tag push. |
 | I. Recovery workflow | No main bypass is needed or granted; it remains limited to a release commit already reachable from `main`, a tag, and a draft Release. |
-| J. Unrelated workflow using `GITHUB_TOKEN` | Cannot bypass because the built-in GitHub Actions App is not a bypass actor. This guarantee is lost if CH-003B instead grants that App Always allow. |
+| J. Unrelated workflow using `GITHUB_TOKEN` | Cannot bypass because the built-in GitHub Actions App is not a bypass actor. This guarantee is lost if the final ruleset instead grants that App Always allow. |

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -12,6 +12,7 @@ Changes since **v1.6.0**.
 
 ## Technical and packaging changes
 
+- Consolidated the final main-branch protection activation, dedicated release-App validation, and rollback requirements into one administrator-ready closure procedure.
 - Prepared narrowly scoped, fail-closed GitHub App authentication for trusted release publication while preserving the existing automation path until maintainers enable it.
 - Documented the audited main-branch protection contract and the narrow automation identity required before stronger protection can be safely activated.
 - Added a cross-platform repository hygiene guard that blocks accidentally tracked build artifacts and unexpectedly large files while preserving the bounded bundled GDTF library as normal Git assets.


### PR DESCRIPTION
### Motivation

- Close roadmap item CH-003 safely by converting the phased follow-up plan into a single administrator-ready activation sequence because the current environment had no authenticated GitHub admin access. 
- Preserve the existing release automation design and safety constraints while making the remaining manual steps explicit and verifiable before any live ruleset mutation.

### Description

- Rewrote `docs/developer/main_branch_protection.md` to record the re-audit against current `main` (SHA `674f29c...`, `VERSION` `1.6.31`), and replaced the multi-phase CH-003B language with a single, numbered one-pass administrative handoff (12 clear steps) that covers GitHub App creation, installation, secret/variable configuration, validation run, publication proof, classic-protection inspection, ruleset activation, verification, and rollback procedure.
- Updated `docs/developer/github_actions_workflows.md` to point to the single remaining administrative activation handoff and to keep the workflow documentation truthful about dedicated-App mode being pending until activation.
- Added a concise internal release-note line to `docs/release-notes-draft.md` documenting the consolidation of the final activation, App validation, and rollback procedure.
- Only documentation was changed; no source code or behavioral logic was modified and no live repository ruleset or secrets were altered because the environment lacked administrative credentials.

### Testing

- Ran focused repository checks and CI-focused tests: `python3 tests/check_ci_workflow_architecture.py` (OK), `python3 -m pytest -q tests/ci/test_release_workflow_publication.py` (5 passed), `python3 tests/check_docs_links.py` (OK), `python3 tests/check_repository_hygiene.py` (OK), `python3 tests/check_source_file_size.py` (OK), `PERASTAGE_TEST_PYTHON="$(command -v python3)" tests/check_perastage_tree_modules.sh` (OK), and `PERASTAGE_TEST_PYTHON="$(command -v python3)" tests/check_no_configmanager_get_in_gui.sh` (OK). 
- Performed `git diff --check` and repository hygiene/source-size verifications (OK) and confirmed the changes are limited to documentation files.
- Noted environmental limitations that prevented live administrative operations: `gh auth status` reported no authenticated host and the classic branch-protection API returned HTTP 401, so no App provisioning, validation runs, or ruleset mutations were attempted in this change; these constraints are explicitly documented in the handoff steps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6aa309fef180832496cefce17bd643d9)