### PR TITLE
Establish Core/MVR coverage baseline and add MVR importer characterization tests

### DIFF
--- a/.github/scripts/generate_core_mvr_coverage.py
+++ b/.github/scripts/generate_core_mvr_coverage.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Generate informational gcovr reports scoped to Core and MVR production code."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--build-dir", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--commit", default="local")
+    parser.add_argument("--summary", type=Path)
+    return parser.parse_args()
+
+
+def totals(report: dict, prefix: str | None = None) -> tuple[int, int]:
+    covered = total = 0
+    for entry in report["files"]:
+        name = entry["file"].replace("\\", "/")
+        if prefix is not None and not name.startswith(prefix):
+            continue
+        for line in entry["lines"]:
+            if line.get("gcovr/noncode"):
+                continue
+            total += 1
+            if line["count"] > 0:
+                covered += 1
+    return covered, total
+
+
+def percent(values: tuple[int, int]) -> str:
+    covered, total = values
+    return f"{covered * 100.0 / total:.2f}%" if total else "n/a"
+
+
+def main() -> int:
+    args = parse_args()
+    root = Path(__file__).resolve().parents[2]
+    output = args.output_dir.resolve()
+    output.mkdir(parents=True, exist_ok=True)
+    base = [
+        sys.executable,
+        "-m",
+        "gcovr",
+        "--root",
+        str(root),
+        "--filter",
+        r"^(core|mvr)/",
+        "--exclude-unreachable-branches",
+        "--gcov-ignore-parse-errors=negative_hits.warn_once_per_file",
+        str(args.build_dir.resolve()),
+    ]
+    subprocess.run(
+        base
+        + [
+            "--txt",
+            str(output / "coverage.txt"),
+            "--html-details",
+            str(output / "index.html"),
+            "--html-title",
+            "Perastage Core/MVR coverage",
+            "--json",
+            str(output / "coverage.json"),
+            "--xml-pretty",
+            "--xml",
+            str(output / "coverage.xml"),
+        ],
+        check=True,
+    )
+
+    report = json.loads((output / "coverage.json").read_text(encoding="utf-8"))
+    core = totals(report, "core/")
+    mvr = totals(report, "mvr/")
+    combined = (core[0] + mvr[0], core[1] + mvr[1])
+    gaps = sorted(
+        ((totals({"files": [entry]}), entry["file"]) for entry in report["files"]),
+        key=lambda item: item[0][1] - item[0][0],
+        reverse=True,
+    )[:5]
+    summary = [
+        "## Core/MVR coverage",
+        "",
+        f"Tested commit: `{args.commit}`",
+        "",
+        "| Scope | Covered / total lines | Line coverage |",
+        "|---|---:|---:|",
+        f"| `core/` | {core[0]} / {core[1]} | {percent(core)} |",
+        f"| `mvr/` | {mvr[0]} / {mvr[1]} | {percent(mvr)} |",
+        f"| Combined | {combined[0]} / {combined[1]} | {percent(combined)} |",
+        "",
+        "Largest uncovered files:",
+    ]
+    summary.extend(
+        f"- `{name}`: {values[1] - values[0]} uncovered lines"
+        for values, name in gaps
+    )
+    summary.append("\nCoverage is informational; no percentage threshold is enforced.\n")
+    rendered = "\n".join(summary)
+    (output / "summary.md").write_text(rendered, encoding="utf-8")
+    if args.summary:
+        args.summary.parent.mkdir(parents=True, exist_ok=True)
+        args.summary.write_text(rendered, encoding="utf-8")
+    github_summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if github_summary:
+        with open(github_summary, "a", encoding="utf-8") as stream:
+            stream.write(rendered)
+    print(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/core-mvr-coverage.yml
+++ b/.github/workflows/core-mvr-coverage.yml
@@ -1,0 +1,97 @@
+name: Core MVR Coverage
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "core/**"
+      - "mvr/**"
+      - "models/**"
+      - "tests/**"
+      - "cmake/**"
+      - "CMakeLists.txt"
+      - "vcpkg.json"
+      - "vcpkg-configuration.json"
+      - ".github/workflows/core-mvr-coverage.yml"
+      - ".github/scripts/generate_core_mvr_coverage.py"
+
+permissions:
+  contents: read
+
+jobs:
+  core-mvr-coverage:
+    runs-on: ubuntu-latest
+    env:
+      VCPKG_ROOT: ${{ github.workspace }}/vcpkg
+      VCPKG_INSTALLED: ${{ github.workspace }}/.vcpkg-cache/installed
+      VCPKG_DOWNLOADS: ${{ github.workspace }}/.vcpkg-cache/downloads
+      VCPKG_PACKAGES: ${{ github.workspace }}/.vcpkg-cache/packages
+      VCPKG_BINARY_CACHE: ${{ github.workspace }}/.vcpkg-cache/binary
+      VCPKG_BINARY_SOURCES: clear;files,${{ github.workspace }}/.vcpkg-cache/binary,readwrite
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Install build and coverage prerequisites
+        run: |
+          .github/scripts/install_vcpkg_build_prerequisites.sh linux
+          python3 -m pip install --disable-pip-version-check gcovr==8.3
+      - name: Read pinned vcpkg baseline
+        id: vcpkg-baseline
+        run: |
+          set -euo pipefail
+          baseline="$(python3 .github/scripts/get_vcpkg_baseline.py vcpkg.json)"
+          echo "baseline=$baseline" >> "$GITHUB_OUTPUT"
+      - name: Restore vcpkg downloads
+        uses: actions/cache@v5
+        with:
+          path: .vcpkg-cache/downloads
+          key: vcpkg-downloads-v3-${{ runner.os }}-${{ runner.arch }}-x64-linux-default-${{ steps.vcpkg-baseline.outputs.baseline }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
+          restore-keys: vcpkg-downloads-v3-${{ runner.os }}-${{ runner.arch }}-x64-linux-default-${{ steps.vcpkg-baseline.outputs.baseline }}-
+      - name: Restore vcpkg installed packages and binary archives
+        uses: actions/cache@v5
+        with:
+          path: |
+            .vcpkg-cache/installed
+            .vcpkg-cache/packages
+            .vcpkg-cache/binary
+          key: vcpkg-compiled-v3-${{ runner.os }}-${{ runner.arch }}-x64-linux-default-${{ steps.vcpkg-baseline.outputs.baseline }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
+          restore-keys: vcpkg-compiled-v3-${{ runner.os }}-${{ runner.arch }}-x64-linux-default-${{ steps.vcpkg-baseline.outputs.baseline }}-
+      - name: Bootstrap pinned vcpkg baseline
+        run: |
+          set -euo pipefail
+          baseline="${{ steps.vcpkg-baseline.outputs.baseline }}"
+          git clone https://github.com/microsoft/vcpkg.git "$VCPKG_ROOT"
+          git -C "$VCPKG_ROOT" checkout --force "$baseline"
+          "$VCPKG_ROOT/bootstrap-vcpkg.sh" -disableMetrics
+          mkdir -p "$VCPKG_INSTALLED" "$VCPKG_DOWNLOADS" "$VCPKG_PACKAGES" "$VCPKG_BINARY_CACHE"
+      - name: Install dependencies
+        run: |
+          python3 .github/scripts/vcpkg_install_retry.py --vcpkg "$VCPKG_ROOT/vcpkg" \
+            --triplet x64-linux --manifest-root "$GITHUB_WORKSPACE" \
+            --install-root "$VCPKG_INSTALLED" --packages-root "$VCPKG_PACKAGES" \
+            --downloads-root "$VCPKG_DOWNLOADS" --attempts 4 \
+            --initial-delay-seconds 30 --max-delay-seconds 120
+      - name: Configure dedicated GCC coverage build
+        run: |
+          cmake -S . -B build/linux-coverage -G Ninja \
+            -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON \
+            -DPERASTAGE_ENABLE_COVERAGE=ON -DPERASTAGE_ENABLE_COMPILER_CACHE=OFF \
+            -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" \
+            -DVCPKG_TARGET_TRIPLET=x64-linux -DVCPKG_INSTALLED_DIR="$VCPKG_INSTALLED"
+      - name: Build all production and test targets
+        run: cmake --build build/linux-coverage --target all --parallel 2
+      - name: Run registered tests
+        run: xvfb-run -a ctest --test-dir build/linux-coverage --output-on-failure
+      - name: Generate informational reports
+        run: |
+          python3 .github/scripts/generate_core_mvr_coverage.py \
+            --build-dir build/linux-coverage --output-dir out/core-mvr-coverage \
+            --commit "$GITHUB_SHA"
+      - name: Upload Core/MVR coverage report
+        uses: actions/upload-artifact@v6
+        with:
+          name: core-mvr-coverage-report
+          path: out/core-mvr-coverage
+          if-no-files-found: error

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,17 @@ if(PERASTAGE_ENABLE_COMPILER_CACHE)
     endif()
 endif()
 
+option(PERASTAGE_ENABLE_COVERAGE
+       "Enable informational gcov instrumentation for Core/MVR coverage" OFF)
+if(PERASTAGE_ENABLE_COVERAGE)
+    if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        message(FATAL_ERROR
+            "PERASTAGE_ENABLE_COVERAGE currently supports GCC builds only.")
+    endif()
+    add_compile_options(--coverage -O0 -g)
+    add_link_options(--coverage)
+endif()
+
 option(PERASTAGE_FORCE_WXDEBUG "Force linking wxWidgets debug libs" OFF)
 
 get_property(_perastage_build_testing_set CACHE BUILD_TESTING PROPERTY VALUE SET)

--- a/docs/developer/core_mvr_coverage.md
+++ b/docs/developer/core_mvr_coverage.md
@@ -1,0 +1,54 @@
+# Core and MVR coverage
+
+Perastage maintains an informational Linux/GCC coverage baseline for production code
+under `core/` and `mvr/`. Tests, generated code, dependencies, GUI, and viewer modules
+are outside the reported denominator. There is no line, function, or branch percentage
+gate; failures indicate a broken build, test, or report collection rather than a low
+percentage.
+
+The dedicated `Core MVR Coverage` workflow runs on manual dispatch and on relevant
+pushes to `main`. It does not run for pull requests or pure documentation and version
+changes, and it is not one of the required `Protect main` checks. The workflow disables
+compiler caching for instrumented project objects while retaining vcpkg dependency
+caches. It builds the complete production and test target set, runs registered tests,
+and uploads `core-mvr-coverage-report` with:
+
+- `coverage.txt`, a human-readable summary;
+- `index.html` and per-file HTML pages;
+- `coverage.json` and `coverage.xml`, machine-readable reports;
+- `summary.md`, the concise Core, MVR, and combined result plus largest file gaps.
+
+## Local reproduction
+
+From an already provisioned Linux build environment, install the pinned report tool
+and run:
+
+```bash
+python3 -m pip install gcovr==8.3
+cmake -S . -B build/linux-coverage -G Ninja \
+  -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON \
+  -DPERASTAGE_ENABLE_COVERAGE=ON \
+  -DPERASTAGE_ENABLE_COMPILER_CACHE=OFF \
+  -DPERASTAGE_ENABLE_MVR_XCHANGE_MDNS=OFF
+cmake --build build/linux-coverage --target all
+xvfb-run -a ctest --test-dir build/linux-coverage --output-on-failure
+python3 .github/scripts/generate_core_mvr_coverage.py \
+  --build-dir build/linux-coverage \
+  --output-dir out/core-mvr-coverage \
+  --commit "$(git rev-parse HEAD)"
+```
+
+The first local smoke baseline is recorded below. It includes the complete production denominator and the three new importer archive scenarios; the dedicated workflow runs the complete registered suite and its artifact/job summary is authoritative for the full-suite baseline. It was produced with GCC gcov
+instrumentation (`--coverage -O0 -g`) and gcovr 8.3 from a working tree based on commit `a38ddd3b1af3fc9cd99882753e423450da53e815` on
+2026-09-10.
+
+| Scope | Line coverage |
+|---|---:|
+| `core/` | `0.83%` |
+| `mvr/` | `4.06%` |
+| Combined | `1.80%` |
+
+The normative MVR archive assertions in the characterization suite use the official
+[MVR 1.6 file format and archive rules](https://github.com/mvrdevelopment/spec/blob/main/mvr-spec.md#file-format),
+[GeneralSceneDescription node](https://github.com/mvrdevelopment/spec/blob/main/mvr-spec.md#generalscenedescription-node),
+and [UUID type](https://github.com/mvrdevelopment/spec/blob/main/mvr-spec.md#attribute-type-uuid).

--- a/docs/developer/github_actions_workflows.md
+++ b/docs/developer/github_actions_workflows.md
@@ -53,33 +53,18 @@ It does not rerun Debug CI, and it does not build macOS 15 or Arch Linux compati
 
 ### Release publication authentication
 
-The repository is prepared for a dedicated release-automation GitHub App without
-requiring its credentials during the transition. If
-`PERASTAGE_RELEASE_APP_ENABLED` is absent or not exactly `true`, `bump-version`
-and `publish-release` continue to authenticate with `GITHUB_TOKEN`. If it is
-exactly `true`, those jobs must successfully mint a token with
-`actions/create-github-app-token@v3`, repository variable
-`PERASTAGE_RELEASE_APP_CLIENT_ID`, Actions secret
-`PERASTAGE_RELEASE_APP_PRIVATE_KEY`, and only `contents: write`; failure stops
-the job without a `GITHUB_TOKEN` fallback.
+Dedicated-App mode is active. The patch `bump-version` and minor-release
+`publish-release` jobs mint a current-repository token for the **Perastage Release
+Automation** GitHub App using `actions/create-github-app-token@v3`. The App is
+installed only on `PeramatoG/Perastage`, requests only `contents: write`, and is the
+sole Integration with `always` bypass in the active `Protect main` ruleset.
 
-The action receives neither `owner` nor `repositories`, which scopes its token to
-the current repository, and default end-of-job revocation remains enabled. Only
-the patch `bump-version` job and final minor `publish-release` job can mint the
-token. Their mutually exclusive checkout steps persist the selected credential
-before any protected-main push. The minor publisher also uses that same selected
-token for its existing draft Release operations. Reusable package builders,
-minor temp-ref staging and cleanup, and recovery continue using ordinary tokens.
-Commit/tag author configuration remains `github-actions[bot]`; it is the checkout
-credential, rather than that attribution, that authenticates a push.
-
-Maintainers can run the manual-only **Validate Release Automation App** workflow
-before enablement. It requests the same permission, queries the token's accessible
-installation repositories, requires the sole result to be the current repository,
-and summarizes only the App slug, installation ID, repository, permission, and
-result. It performs no checkout, push, tag, Release, or branch mutation. See the
-[main branch protection contract](main_branch_protection.md) for the single
-remaining administrative activation and verification handoff.
+Token creation is fail-closed: enabled App mode never falls back to `GITHUB_TOKEN`.
+Only the two protected-main publishers can mint the token; package builders,
+temporary-reference staging and cleanup, and recovery cannot access it. The manual
+validation workflow verifies the installation and permission scope without a Git
+write. See the [main branch protection contract](main_branch_protection.md) for the
+verified live ruleset, security rationale, and rollback procedure.
 
 ## Weekly and manual compatibility packages
 

--- a/docs/developer/main_branch_protection.md
+++ b/docs/developer/main_branch_protection.md
@@ -1,296 +1,101 @@
 # Main branch protection contract
 
-This document records the CH-003 audit, the release-App preparation, and the
-single administrative handoff required to activate the final contract. It complements, rather than repeats, the
-[GitHub Actions workflow architecture](github_actions_workflows.md).
+CH-003 is operationally complete. The `Protect main` repository ruleset is active,
+the dedicated release App has been validated and used by a real patch-version run,
+and classic branch protection is not configured. This document records the live
+contract and its security/rollback rationale; it is not an activation checklist.
 
-> **Administrative handoff required (verified 2026-09-10):** the available
-> environment has no authenticated GitHub session and cannot create or install a
-> GitHub App, configure Actions credentials, dispatch the validation workflow, or
-> administer repository rules. No live setting was partially changed. The public
-> API still reports ruleset `20119238` as active with only deletion and
-> non-fast-forward rules. Complete the one-pass handoff below to close CH-003.
->
-> Repository preparation does not create, edit, disable, or delete
-> a ruleset or classic branch-protection rule. Required pull requests and status
-> checks must not be activated until the dedicated App is installed, validated,
-> enabled, and proven on an intended publication path.
+## Active ruleset
 
-## One-pass administrative handoff
+The live repository ruleset is:
 
-Perform this sequence as a repository/account administrator; do not enable only
-part of the final protection contract.
-
-1. In the owning GitHub account, open **Settings > Developer settings > GitHub
-   Apps > New GitHub App**. Register **Perastage Release Automation**, disable the
-   webhook if it is not used, subscribe to no events, grant only repository
-   **Contents: Read and write**, and allow installation only on the owning account.
-2. On the App's **Install App** page, install it with **Only select repositories**
-   and select only `PeramatoG/Perastage`. Generate a private key and copy the
-   displayed Client ID. Do not copy the App ID, installation ID, bot user ID, or
-   ruleset actor ID into the Client ID variable.
-3. In **PeramatoG/Perastage > Settings > Secrets and variables > Actions**, create
-   repository variable `PERASTAGE_RELEASE_APP_CLIENT_ID` with that Client ID and
-   repository secret `PERASTAGE_RELEASE_APP_PRIVATE_KEY` with the complete private
-   key. Keep `PERASTAGE_RELEASE_APP_ENABLED` unset or `false`.
-4. In **Actions**, run **Validate Release Automation App**. Require a successful
-   summary naming the expected App slug, a nonempty installation ID,
-   `PeramatoG/Perastage`, `contents: write`, and current-repository-only access.
-   The workflow performs no Git or GitHub write. Correct installation or credential
-   configuration rather than weakening its validation if it fails.
-5. Set repository variable `PERASTAGE_RELEASE_APP_ENABLED` to `true`, then safely
-   dispatch **Main Patch Release Artifacts**. Require its authentication summary to
-   name the dedicated App and installation, the patch bump commit to reach `main`,
-   and the resulting `[skip version-bump]` push not to recurse. Confirm that no tag,
-   Release, or unexpected ref was created and that no `GITHUB_TOKEN` fallback was
-   used.
-6. Before changing protection, inspect **Settings > Rules > Rulesets** and
-   **Settings > Branches**. Record any classic `main` protection. If one exists,
-   reconcile or remove only its conflicting duplicate requirements while retaining
-   effective safety; do not leave contradictory overlapping policies.
-7. Inspect the successful platform check runs on recent PRs to `main` and confirm
-   `linux-debug`, `macos-debug`, and `windows-debug` are produced by **GitHub
-   Actions** integration ID `15368`. Do not separately require `resolve-source`.
-8. Edit existing ruleset **Protect main** (`20119238`), rather than creating a new
-   ruleset. Keep it active for `~DEFAULT_BRANCH` with no exclusions. Retain
-   **Restrict deletions** and **Block force pushes**. Enable **Require a pull request
-   before merging** with zero approvals, stale-review dismissal off, code-owner
-   review off, last-push approval off, conversation resolution on, and every merge
-   method that the repository intentionally enables.
-9. Enable required status checks for exactly `linux-debug`, `macos-debug`, and
-   `windows-debug`, selecting GitHub Actions as each expected source (integration
-   ID `15368`). Leave **Require branches to be up to date before merging** off.
-10. Retain the repository administrator role (`RepositoryRole`, actor ID `5`) in
-    **Pull requests only** bypass mode. Add only **Perastage Release Automation** as
-    an Integration in **Always allow** mode. Record the Integration actor ID
-    returned by the ruleset after saving. Do not add the built-in GitHub Actions
-    App, a user/PAT, a deploy key, or any other actor.
-11. Save, re-fetch the full ruleset, and compare every condition, rule, parameter,
-    and bypass with steps 8-10. Use ruleset inspection and successful PR evidence to
-    verify the scenario matrix below; do not test deletion or force-push
-    destructively. Confirm the patch publisher can still write as the dedicated App
-    and that the minor publisher still uses the same App only for its final atomic
-    main/tag publication.
-12. Update this document's status with the activation date, App name/slug,
-    installation ID, Integration actor ID, classic-protection result, and exact
-    server-returned configuration. Also change the transition wording in
-    `github_actions_workflows.md` to state that dedicated-App mode is active.
-
-If activation unexpectedly blocks an intended operation, restore the complete
-pre-change ruleset captured below, diagnose the exact App/check mismatch, and make
-no broad bypass, PAT, force-push, or protection-disable workaround.
-
-## Audit basis and access limits
-
-The closure audit was repeated on 2026-09-10 at `main` commit
-`674f29c920c2fb696cbbeaedcaebe3444b1f7a1b` (`VERSION` `1.6.31`). Merge commit
-`fb3b5d6b374d7ab84f2aa729e069f05c5820e49e` for PR #2346 is its parent, so the
-release-App preparation is present. The public GitHub REST API and checked-out
-workflows were inspected. This environment had no authenticated
-GitHub CLI session and could neither administer nor modify repository settings.
-Classic branch protection was not accessible with the current integration, so an
-administrator must determine its state in the Settings UI before activation.
-
-## Current protection of `main`
-
-The public ruleset list and the effective-rules endpoint showed one active,
-repository-level branch ruleset affecting `main`:
-
-| Setting | Current value |
+| Setting | Active value |
 |---|---|
 | Name / ID | `Protect main` / `20119238` |
-| Enforcement | Active |
-| Target condition | Include `~DEFAULT_BRANCH`; exclude nothing |
-| Deletion | Blocked |
-| Non-fast-forward updates | Blocked |
-| Pull request required | No |
-| Required status checks | None |
-| Bypass actors | Repository admin role (`RepositoryRole`, actor ID `5`), `pull_request` mode; `current_user_can_bypass` was `pull_requests_only` |
+| Enforcement / target | Active on `~DEFAULT_BRANCH`, with no exclusions |
+| Deletion / non-fast-forward | Both blocked |
+| Pull request | Required, with `0` approvals and conversation resolution required |
+| Merge methods | Merge, squash, and rebase allowed |
+| Required checks | `linux-debug`, `macos-debug`, and `windows-debug`, each from GitHub Actions Integration ID `15368` |
+| Strict status checks | Disabled (`strict_required_status_checks_policy = false`) |
+| Admin bypass | Repository role actor ID `5`, `pull_request` mode |
+| Automation bypass | Perastage Release Automation, Integration actor ID `4902198`, `always` mode |
 
-The current admin-role bypass applies only in the pull-request context. It is not
-an unrestricted direct-push bypass to `main` and therefore cannot authorize the
-direct main writes required by `Main Patch Release Artifacts` and `Minor Draft
-Release`. It is nevertheless part of the active ruleset and must be retained or
-deliberately reconsidered during activation.
+Classic branch protection is not configured. The ruleset above is therefore the
+single branch-protection policy affecting `main`, rather than one layer of two
+potentially conflicting mechanisms. Coverage and other informational workflows are
+not required checks.
 
-No other repository or organization ruleset appeared in the effective rules for
-`main`; the only effective rules returned were deletion and non-fast-forward.
-This is strong evidence that no overlapping ruleset currently applies. It does
-not prove that classic branch protection is absent because that setting was not
-accessible with the current integration. Before activating the final contract, an
-administrator must inspect **Settings > Rules > Rulesets** and **Settings >
-Branches**, record any classic rule, and reconcile it rather than creating an
-accidentally layered policy.
+The three required contexts are the platform job IDs in `CI Debug Tests`. They test
+the exact SHA produced by `resolve-source`; requiring `resolve-source` separately
+would be redundant. Loose checks avoid repeating three expensive platform builds
+after every unrelated main update. A maintainer should still refresh a branch when
+a concurrent change touches the same build or behavior.
 
-## Git-state writer inventory
+## Dedicated release identity
 
-Only three current workflows request `contents: write`. Their Git/GitHub writes
-are inline workflow commands; the asset assembly and validation scripts invoked
-by them only prepare or validate runner-local files.
+The sole Integration with `always` bypass is the dedicated GitHub App:
 
-| Workflow | Trigger and permissions | Remote writes and identity | Preconditions and architectural need |
-|---|---|---|---|
-| `Main Patch Release Artifacts` (`main-patch-test-build.yml`) | Push to `main` or manual dispatch; `contents: write`, `actions: read`, `packages: read`; serialized by `main-patch-version-bump` with cancellation disabled | Only `bump-version` can mint the dedicated App token. Its checkout explicitly persists either that token in enabled mode or `GITHUB_TOKEN` in transitional mode before pushing `HEAD:main`. It writes no tag, temporary ref, or Release. | Validates numeric `VERSION`, makes one patch increment, marks the commit to avoid recursion, and excludes bot-triggered push runs. The direct main write is required by the current automatic post-merge version/artifact architecture. |
-| `Minor Draft Release` (`minor-draft-release.yml`) | Manual dispatch; `contents: write`, `actions: read`, `packages: read`; serialized by `perastage-minor-draft-release` | Temporary-ref staging and cleanup retain `GITHUB_TOKEN`. Only `publish-release` can mint the dedicated App token and explicitly checks out with it in enabled mode before the atomic main/tag push and draft Release operations. | Validates version/tag state and the artifact contract, builds all packages from the exact staged SHA, validates the assembled assets and provenance, refetches and requires `origin/main == BASE_SHA`, and normally publishes main plus tag with `git push --atomic`. Retry states are explicitly constrained. Every write is part of the stabilized minor-publication transaction or exact temp-ref cleanup. |
-| `Recover Validated Minor Release` (`recover-minor-release.yml`) | Manual dispatch; `contents: write`, `actions: read`; serialized by `perastage-minor-release-recovery` | The checkout-provided `GITHUB_TOKEN` may create only the requested `refs/tags/v<version>` and may create/edit a draft GitHub Release and upload assets. It never updates `main` or a temporary branch. | Requires a full SHA and semantic version, requires that SHA to be reachable from current `origin/main`, verifies `VERSION`, the completed source `Minor Draft Release` run, the single unexpired validated artifact, checksums, and provenance. Dry run defaults to true. These restricted writes recover publication without rebuilding or moving main. |
-
-`CI Debug Tests` (`ci-tests.yml`) runs on pushes and pull requests to `main`, on
-manual dispatch, and as a reusable workflow. It has only `contents: read` and
-`packages: read`; it fetches refs and tests an exact resolved SHA but performs no
-repository, tag, or Release write. No other workflow currently requests
-`contents: write` or contains a Git/GitHub remote-publication command.
-
-The visible commit author configuration is not the authorization boundary.
-`git config user.name github-actions[bot]` controls commit/tag attribution, while
-the credential persisted by `actions/checkout` is the repository's
-`GITHUB_TOKEN`: an installation access token for the GitHub Actions App. Ruleset
-bypass must therefore address the App/integration that authenticates the push,
-not the configured Git author.
-
-## Dedicated release-App transition
-
-The two main-writing jobs use `actions/create-github-app-token@v3` only when the
-repository variable `PERASTAGE_RELEASE_APP_ENABLED` is exactly `true`. They read
-the Client ID from repository variable `PERASTAGE_RELEASE_APP_CLIENT_ID`, read
-the private key from Actions secret `PERASTAGE_RELEASE_APP_PRIVATE_KEY`, and
-request only `permission-contents: write`. Omitting both `owner` and
-`repositories` uses the action's current-repository scope. Token revocation is
-left at its default, so the post step revokes the token at job completion.
-
-When enablement is absent or has any value other than `true`, the two jobs use
-their existing `GITHUB_TOKEN` path. This transitional default preserves current
-publication until manual provisioning is complete. When enablement is exactly
-`true`, token creation and a nonempty token are mandatory; a missing Client ID,
-missing or invalid private key, unavailable installation or permission, or token
-creation failure stops the publication job. The enabled path never selects
-`GITHUB_TOKEN` as a fallback.
-
-The selected authentication credential, not the configured Git author, controls
-ruleset authorization. Each publisher uses mutually exclusive checkout steps
-and passes the selected token directly to `actions/checkout@v6`, whose persisted
-credential is then used by `git push`. `publish-release` also assigns the same
-selected credential to `GH_TOKEN` for its existing Release transaction. Tokens
-are neither job outputs nor reusable-workflow inputs. Builders, temp-ref staging,
-cleanup, and `Recover Validated Minor Release` cannot access the dedicated App
-token.
-
-### Manual provisioning checklist
-
-1. Register a dedicated GitHub App for Perastage release automation.
-2. Grant only repository **Contents: Read and write**; request no unrelated organization or account permissions.
-3. Install the App only on `PeramatoG/Perastage`.
-4. Store its Client ID in repository variable `PERASTAGE_RELEASE_APP_CLIENT_ID`.
-5. Store its private key in Actions secret `PERASTAGE_RELEASE_APP_PRIVATE_KEY`.
-6. Keep `PERASTAGE_RELEASE_APP_ENABLED` unset or false initially.
-7. Manually run **Validate Release Automation App** and verify its App slug, installation ID, repository, and current-repository-only result.
-8. Set `PERASTAGE_RELEASE_APP_ENABLED=true`.
-9. Prove that a normal intended version bump or minor publication authenticates with the dedicated App.
-10. Only then add that installed App to `Protect main` as an **Always allow** bypass actor and activate the planned PR/check rules.
-11. Do **not** add the built-in GitHub Actions App as an Always-allow bypass.
-
-## Pull-request check contract
-
-The head SHAs of five consecutive successful PRs targeting `main` (#2340–#2344)
-all reported the same four check-run names and producer:
-
-| Check name | Producer | Gate classification |
-|---|---|---|
-| `linux-debug` | GitHub Actions, App ID `15368` | Required: complete Linux Debug validation |
-| `macos-debug` | GitHub Actions, App ID `15368` | Required: complete macOS Debug validation |
-| `windows-debug` | GitHub Actions, App ID `15368` | Required: complete Windows Debug validation |
-| `resolve-source` | GitHub Actions, App ID `15368` | Prerequisite only: resolves the exact SHA and cache trust; the three platform jobs already depend on it |
-
-The smallest complete gate is therefore the three platform checks. Their job IDs
-are literal workflow keys, were stable across the sampled PRs, and each validates
-the exact head SHA emitted by `resolve-source`. Requiring `resolve-source` too
-would be redundant and would add another name that can block merging without
-adding platform coverage. The final ruleset should bind each required context to the
-expected GitHub Actions App (ID `15368`) if the ruleset UI/API offers expected
-source selection.
-
-Use **loose** status checks: do not require the PR branch to be up to date before
-merging. The checks validate the exact proposed head SHA, while strict mode would
-re-run relatively expensive Windows and macOS jobs after every intervening main
-change. For this single-maintainer repository, that cost is disproportionate.
-Loose mode accepts the residual risk that a passing head can interact badly with
-a newer `main`; the maintainer should update and rerun when a concurrent change
-touches the same behavior or build surface.
-
-## Final CH-003 ruleset
-
-After satisfying the App and classic-rule prerequisites above, edit the
-existing ruleset rather than layer a second one:
-
-| Setting | Final value and reason |
+| Property | Verified value |
 |---|---|
-| Name | Keep `Protect main` |
-| Target / enforcement | Branches matching `~DEFAULT_BRANCH`, no exclusions; Active |
-| Require a pull request before merging | Enabled, so ordinary human changes use the reviewed PR path |
-| Required approvals | `0`; there is one primary maintainer, so an invented second reviewer would impede rather than improve the real process |
-| Dismiss stale approvals / code-owner approval / last-push approval | Disabled; none adds value with zero required approvals |
-| Require conversation resolution | Enabled; unresolved review findings should not be merged, without requiring another person to approve |
-| Required status checks | `linux-debug`, `macos-debug`, `windows-debug`, each expected from GitHub Actions App ID `15368` |
-| Require branches to be up to date | Disabled (loose), for the cost/risk balance above |
-| Block deletions | Enabled (retain current rule) |
-| Block force pushes / non-fast-forward updates | Enabled (retain current rule) |
-| Existing admin bypass | Retain repository admin role (`RepositoryRole`, actor ID `5`) in Pull requests only mode; it does not authorize direct pushes |
-| Automation bypass | A **dedicated release-automation GitHub App**, Always allow, used only by the main-writing steps in `Main Patch Release Artifacts` and `Minor Draft Release` |
+| Name | Perastage Release Automation |
+| Slug | `perastage-release-automation` |
+| Integration actor ID | `4902198` |
+| Installation ID observed during validation | `160710316` |
+| Installation scope | `PeramatoG/Perastage` only |
+| Requested repository permission | `contents: write` |
 
-Do not enable signed commits until the automation signing design is established;
-do not enable linear history because normal merge commits are current practice;
-do not add deployment, code-scanning, code-owner, merge-queue, branch-name,
-metadata, file-path, file-size, or restricted-push rules because they are not
-needed for this contract. Do not give recovery a main-ruleset bypass: its tag and
-Release writes do not target the protected branch. Tags can receive a separate
-future policy, but that is outside CH-003.
+The manual validation workflow confirmed this scope without performing a Git write.
+A subsequent real `Main Patch Release Artifacts` `bump-version` run authenticated as
+the App and advanced `VERSION` to `1.6.32`.
 
-### Bypass decision and administrative prerequisite
+Only the patch `bump-version` and minor-release `publish-release` jobs can mint the
+App token. They request only repository contents write access and fail closed when
+App mode is enabled but token creation fails. Builders, temporary-reference staging,
+cleanup, and recovery do not receive this credential. Commit attribution does not
+control authorization; the checkout credential authenticating the push does.
 
-Ruleset bypass modes are actor-wide, not workflow-wide. **Pull requests only** is
-insufficient because both trusted publishers directly update `main`. Adding the
-built-in GitHub Actions App with **Always allow** would let any present or future
-workflow holding a write-capable `GITHUB_TOKEN` bypass the PR and status-check
-rules on `main`; GitHub cannot narrow that actor entry to two workflow files.
-That would fail scenario J and is an explicit, broad-authority security tradeoff,
-not the safe final configuration.
+The built-in GitHub Actions App must not receive `always` bypass. Such a bypass would
+apply actor-wide and would let any present or future workflow with a write-capable
+`GITHUB_TOKEN` bypass the pull-request and check rules. The dedicated, repository-only
+App confines that authority to credentials available to the two intended publishers.
+The admin-role bypass remains pull-request-only and cannot authorize direct main
+writes.
 
-The narrower design is a dedicated GitHub App installed only on this repository,
-granted only the minimum repository-contents write permission, selected in the
-ruleset as an Integration bypass actor with **Always allow**, and minted only in
-the two intended publication workflows from protected App credentials. Ordinary
-workflows retain the built-in `GITHUB_TOKEN` and therefore cannot use the bypass.
-App private-key access and workflow modification remain sensitive administrative
-boundaries. An administrator must confirm that this dedicated installed App is
-selectable in this repository's bypass UI before activation; it does not currently
-exist in the audited tree or visible public settings. Until that confirmation,
-the safe exact bypass identity remains unavailable until the App is provisioned.
-`Always allow` necessarily lets that dedicated identity bypass every rule in this
-main-targeting ruleset, including deletion and non-fast-forward rules; narrowing
-which workflows can mint its token and preserving the workflows' explicit
-fast-forward-only commands are therefore essential parts of the trust boundary.
+## Git-state writers
 
-If a dedicated App is not acceptable, the least-disruptive alternative is to
-restructure the patch bump as an automatically opened PR and merge it only after
-the required checks. The minor release could similarly stage a protected PR and
-publish the tag/Release after merge, but that changes the current atomic
-main-and-tag guarantee and must not be adopted casually. A personal access token
-or broad built-in Actions bypass is not a narrower substitute. No normal process
-should require temporarily disabling protection.
+Three workflows request `contents: write`:
 
-## Scenario matrix
+- `Main Patch Release Artifacts` may advance `main` by one validated patch increment.
+  Its `bump-version` job uses the dedicated App in active App mode.
+- `Minor Draft Release` stages and validates all release outputs, then its final
+  publisher uses the dedicated App for the atomic main/tag push and draft Release.
+- `Recover Validated Minor Release` may recover a validated tag and draft Release
+  reachable from current `main`; it cannot update `main` and has no main bypass.
 
-These results describe the proposed dedicated-App design, not the unchanged
-current ruleset.
+`CI Debug Tests` has read-only repository access. It runs on pull requests, pushes,
+manual dispatch, and reusable-workflow calls, but performs no repository, tag, or
+Release write.
 
-| Scenario | Expected result |
-|---|---|
-| A. Normal PR; all three platform Debug checks pass | Allowed once conversations are resolved; no approval is mandatory. |
-| B. Normal PR; `windows-debug` fails | Blocked by the required check. |
-| C. Normal PR; a required check is missing | Blocked until the exact expected check reports success. |
-| D. Direct human push to `main` | Blocked by the PR requirement. |
-| E. Force push to `main` | Blocked for humans and non-bypass automation. The dedicated App is technically exempt under Always allow, so its token confinement and unchanged fast-forward-only commands are required. |
-| F. Delete `main` | Blocked for non-bypass actors. The release App could technically bypass this rule but no intended workflow issues a main deletion. |
-| G. Automatic post-merge `VERSION` bump | Allowed only when its main push uses the dedicated App; serialization, validation, and recursion suppression remain unchanged. |
-| H. Minor Draft Release | Its temp ref remains outside the target; after package/asset validation and the `origin/main == BASE_SHA` check, the dedicated App can retain the atomic fast-forward-main/tag push. |
-| I. Recovery workflow | No main bypass is needed or granted; it remains limited to a release commit already reachable from `main`, a tag, and a draft Release. |
-| J. Unrelated workflow using `GITHUB_TOKEN` | Cannot bypass because the built-in GitHub Actions App is not a bypass actor. This guarantee is lost if the final ruleset instead grants that App Always allow. |
+## Rollback and incident response
+
+If release-App authentication or publication behaves unexpectedly:
+
+1. Disable `PERASTAGE_RELEASE_APP_ENABLED` to stop selecting the App credential.
+2. Disable or suspend the App installation if its key or installation is suspect.
+3. Remove Integration actor `4902198` from the ruleset before investigating any
+   possibility of unintended branch access.
+4. Keep pull-request, required-check, deletion, and non-fast-forward rules active.
+5. Rotate the App private key before re-enabling it after a credential incident.
+6. Re-run the no-write validation workflow and verify repository-only scope before a
+   controlled publisher validation.
+
+Removing the App bypass intentionally prevents the automated direct main writers; it
+does not require weakening ordinary branch protection. If emergency repository work
+is unavoidable, use the existing administrator pull-request path and retain an audit
+trail rather than granting the built-in Actions App broad bypass.
+
+Do not add signed-commit, linear-history, deployment, code-scanning, code-owner,
+merge-queue, branch-name, metadata, path, or file-size rules without a separate design
+and validation. Tags may receive a separate future policy; recovery does not justify a
+main-branch bypass.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -12,9 +12,9 @@ Changes since **v1.6.0**.
 
 ## Technical and packaging changes
 
-- Consolidated the final main-branch protection activation, dedicated release-App validation, and rollback requirements into one administrator-ready closure procedure.
-- Prepared narrowly scoped, fail-closed GitHub App authentication for trusted release publication while preserving the existing automation path until maintainers enable it.
-- Documented the audited main-branch protection contract and the narrow automation identity required before stronger protection can be safely activated.
+- Established informational Linux coverage reporting for Core and MVR production code and expanded deterministic MVR import/export characterization ahead of future internal refactoring.
+- Reconciled maintainer documentation with the active main-branch ruleset and dedicated release-App configuration.
+
 - Added a cross-platform repository hygiene guard that blocks accidentally tracked build artifacts and unexpectedly large files while preserving the bounded bundled GDTF library as normal Git assets.
 - Added an automated, cross-platform source-size guardrail that prevents existing C/C++ hotspots from growing beyond reviewable baselines and limits new source files to a maintainable default size.
 - Validated the native Linux, Windows, WSL, and Apple Silicon macOS clean-checkout developer workflows, corrected Linux/WSL prerequisite installation order and Debug test dependencies, prevented Windows-only PowerShell tests from registering on Linux hosts, completed Linux system dependency and locale setup, fixed external mDNS header discovery, corrected Windows wxWidgets secure-store and Debug test-tool validation, made restricted-path policy tests use canonical directories across macOS and Windows environments, and kept local test artifacts out of the source tree.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1190,6 +1190,7 @@ add_executable(mvr_gdtf_import_matching_test mvr_gdtf_import_matching_test.cpp
                ${PERASTAGE_TEST_MVR_CATALOG_SOURCES})
 target_include_directories(mvr_gdtf_import_matching_test PRIVATE ../mvr ../third_party)
 add_test(NAME MvrGdtfImportMatching COMMAND mvr_gdtf_import_matching_test)
+set_perastage_test_labels(MvrGdtfImportMatching LAYER perastage-extension DOMAINS mvr gdtf)
 
 add_executable(mvr_dmx_address_test mvr_dmx_address_test.cpp
                build_info_stub.cpp
@@ -1231,6 +1232,7 @@ target_include_directories(mvr_dmx_address_test PRIVATE
 target_link_libraries(mvr_dmx_address_test PRIVATE
                       ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
 add_test(NAME MvrDmxAddressConversion COMMAND mvr_dmx_address_test)
+set_perastage_test_labels(MvrDmxAddressConversion LAYER perastage-extension DOMAINS mvr)
 set_library_env(MvrDmxAddressConversion)
 
 
@@ -1275,6 +1277,7 @@ target_include_directories(mvr_support_userdata_roundtrip_test PRIVATE
 target_link_libraries(mvr_support_userdata_roundtrip_test PRIVATE
                       ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
 add_test(NAME MvrSupportUserDataRoundtrip COMMAND mvr_support_userdata_roundtrip_test)
+set_perastage_test_labels(MvrSupportUserDataRoundtrip LAYER perastage-extension DOMAINS mvr project)
 set_library_env(MvrSupportUserDataRoundtrip)
 
 add_executable(mvr_perastage_metadata_recovery_test
@@ -1356,6 +1359,7 @@ target_include_directories(mvr_layer_appearance_userdata_test PRIVATE
 target_link_libraries(mvr_layer_appearance_userdata_test PRIVATE
                       ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
 add_test(NAME MvrLayerAppearanceUserData COMMAND mvr_layer_appearance_userdata_test)
+set_perastage_test_labels(MvrLayerAppearanceUserData LAYER perastage-extension DOMAINS mvr project)
 set_library_env(MvrLayerAppearanceUserData)
 
 
@@ -1400,6 +1404,7 @@ target_include_directories(mvr_fixture_category_roundtrip_test PRIVATE
 target_link_libraries(mvr_fixture_category_roundtrip_test PRIVATE
                       ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
 add_test(NAME MvrFixtureCategoryRoundtrip COMMAND mvr_fixture_category_roundtrip_test)
+set_perastage_test_labels(MvrFixtureCategoryRoundtrip LAYER perastage-extension DOMAINS mvr gdtf)
 set_library_env(MvrFixtureCategoryRoundtrip)
 
 add_executable(mvr_sceneobject_symbol_identity_test mvr_sceneobject_symbol_identity_test.cpp
@@ -1447,6 +1452,7 @@ target_include_directories(mvr_sceneobject_symbol_identity_test PRIVATE
 target_link_libraries(mvr_sceneobject_symbol_identity_test PRIVATE
                       ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
 add_test(NAME MvrSceneObjectSymbolIdentity COMMAND mvr_sceneobject_symbol_identity_test)
+set_perastage_test_labels(MvrSceneObjectSymbolIdentity LAYER legacy-compatibility DOMAINS mvr zip)
 set_library_env(MvrSceneObjectSymbolIdentity)
 
 add_executable(mvr_truss_roundtrip_structure_test mvr_truss_roundtrip_structure_test.cpp
@@ -1533,7 +1539,46 @@ target_include_directories(mvr_exporter_compliance_test PRIVATE
 target_link_libraries(mvr_exporter_compliance_test PRIVATE
                       ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
 add_test(NAME MvrExporterCompliance COMMAND mvr_exporter_compliance_test)
+set_perastage_test_labels(MvrExporterCompliance LAYER standard-strict DOMAINS mvr gdtf zip)
 set_library_env(MvrExporterCompliance)
+
+add_executable(mvr_importer_archive_characterization_test
+               mvr_importer_archive_characterization_test.cpp
+               build_info_stub.cpp
+               ../core/configmanager.cpp ../core/configservices.cpp
+               ../core/projectutils.cpp ../core/library/library_bootstrap.cpp
+               ../core/gdtfdictionary.cpp ../core/gdtf_fixture_category.cpp
+               ../core/layer_service.cpp ../core/scene_grouping.cpp
+               ../core/scene_node_operations.cpp ../core/utf8_utils.cpp
+               ../core/trussdictionary.cpp ../core/trussloader.cpp
+               ../core/wx_path_utils.cpp ../core/runtime_storage.cpp
+               ../core/truss_gdtf_builder.cpp ../core/dummyprofilelibrary.cpp
+               ../mvr/mvrimporter.cpp ../core/fixture_visual_color.cpp
+               ${PERASTAGE_TEST_MVR_CATALOG_SOURCES}
+               ../viewer2d/fixture_label_overrides.cpp
+               ../mvr/mvrexporter.cpp ../core/scene_transform_integrity.cpp
+               ../core/mvr_identity_recovery.cpp
+               ../mvr/primitive_model_resources.cpp
+               ../core/gdtf_canonicalizer.cpp ../core/gdtf_mutation_audit.cpp
+               ../core/logger.cpp gdtfloader_stub.cpp consolepanel_stub.cpp
+               ../models/mvrscene.cpp ../models/fixture.cpp ../models/truss.cpp
+               ../models/sceneobject.cpp ../models/layer.cpp ${LAYOUT_SOURCES})
+target_include_directories(mvr_importer_archive_characterization_test PRIVATE
+                           . ../core ../models ../mvr ../gui ../third_party)
+target_link_libraries(mvr_importer_archive_characterization_test PRIVATE
+                      ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
+add_test(NAME MvrImporterArchiveStrict
+         COMMAND mvr_importer_archive_characterization_test strict)
+set_perastage_test_labels(MvrImporterArchiveStrict LAYER standard-strict DOMAINS mvr zip)
+add_test(NAME MvrImporterArchiveLegacy
+         COMMAND mvr_importer_archive_characterization_test legacy)
+set_perastage_test_labels(MvrImporterArchiveLegacy LAYER legacy-compatibility DOMAINS mvr zip)
+add_test(NAME MvrImporterArchiveRecovery
+         COMMAND mvr_importer_archive_characterization_test recovery)
+set_perastage_test_labels(MvrImporterArchiveRecovery LAYER tolerant-recovery DOMAINS mvr zip)
+set_library_env(MvrImporterArchiveStrict)
+set_library_env(MvrImporterArchiveLegacy)
+set_library_env(MvrImporterArchiveRecovery)
 
 add_executable(rider_save_roundtrip_test rider_save_roundtrip_test.cpp
                build_info_stub.cpp
@@ -2313,6 +2358,7 @@ target_include_directories(mvr_patched_gdtf_export_test PRIVATE
                            . ../core ../models ../mvr ../gui ../viewer3d ../third_party)
 target_link_libraries(mvr_patched_gdtf_export_test PRIVATE ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2 perastage_test_gdtf_archive_reader)
 add_test(NAME MvrPatchedGdtfExportMutation COMMAND mvr_patched_gdtf_export_test)
+set_perastage_test_labels(MvrPatchedGdtfExportMutation LAYER perastage-extension DOMAINS mvr gdtf zip)
 set_library_env(MvrPatchedGdtfExportMutation)
 
 
@@ -2762,6 +2808,7 @@ add_executable(mvr_identity_recovery_test mvr_identity_recovery_test.cpp
                ../core/mvr_identity_recovery.cpp)
 target_include_directories(mvr_identity_recovery_test PRIVATE ../core ../models)
 add_test(NAME MvrIdentityRecovery COMMAND mvr_identity_recovery_test)
+set_perastage_test_labels(MvrIdentityRecovery LAYER perastage-extension DOMAINS mvr project)
 
 # Supplies the shared UUID implementation to every standalone test executable.
 get_property(perastage_test_targets DIRECTORY PROPERTY BUILDSYSTEM_TARGETS)

--- a/tests/mvr_importer_archive_characterization_test.cpp
+++ b/tests/mvr_importer_archive_characterization_test.cpp
@@ -1,0 +1,102 @@
+/*
+ * This file is part of Perastage.
+ */
+#include <cassert>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include <wx/init.h>
+#include <wx/mstream.h>
+#include <wx/zipstrm.h>
+
+#include "mvrimporter.h"
+
+// Builds an in-memory MVR archive with entries in deterministic order.
+static std::vector<std::uint8_t> BuildArchive(
+    const std::vector<std::pair<std::string, std::string>> &entries) {
+  wxMemoryOutputStream memory;
+  {
+    wxZipOutputStream zip(memory);
+    for (const auto &[name, payload] : entries) {
+      assert(zip.PutNextEntry(name));
+      zip.Write(payload.data(), payload.size());
+    }
+    zip.Close();
+  }
+  std::vector<std::uint8_t> bytes(memory.GetSize());
+  memory.CopyTo(bytes.data(), bytes.size());
+  return bytes;
+}
+
+// Imports bytes through the isolated parse-only seam.
+static bool Import(const std::vector<std::uint8_t> &bytes,
+                   MvrImportResult &result) {
+  MvrImportOptions options;
+  options.promptConflicts = false;
+  options.applyDictionary = false;
+  options.allowDummyFallback = false;
+  MvrImporter importer;
+  return importer.ImportFromBuffer(bytes, result, MvrImportMode::ParseOnly,
+                                   options);
+}
+
+// Verifies mandatory root scene-description failures remain deterministic.
+static void TestStrictArchiveRejection() {
+  MvrImportResult result;
+  assert(!Import(BuildArchive({{"resource.txt", "payload"}}), result));
+  assert(!Import(BuildArchive({{"GeneralSceneDescription.xml", "<broken"}}),
+                 result));
+}
+
+// Verifies the documented legacy case-insensitive root-name compatibility path.
+static void TestLegacyRootNameCompatibility() {
+  const std::string xml =
+      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+      "<GeneralSceneDescription verMajor=\"1\" verMinor=\"5\" provider=\"Legacy\" providerVersion=\"1\">"
+      "<Scene><Layers/></Scene></GeneralSceneDescription>";
+  MvrImportResult result;
+  assert(Import(BuildArchive({{"generalscenedescription.xml", xml}}), result));
+  assert(result.scene.versionMajor == 1);
+  assert(result.scene.versionMinor == 5);
+  assert(result.scene.provider == "Legacy");
+}
+
+// Verifies recoverable extension defects produce stable structured diagnostics.
+static void TestRecoverableUserDataDiagnostics() {
+  const std::string xml =
+      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+      "<GeneralSceneDescription verMajor=\"1\" verMinor=\"6\" provider=\"Test\" providerVersion=\"1\">"
+      "<UserData><Unknown/><Data ver=\"1\"><Value/></Data></UserData>"
+      "<UserData><Data provider=\"Ignored\"/></UserData>"
+      "<Scene><Layers/></Scene></GeneralSceneDescription>";
+  MvrImportResult result;
+  assert(Import(BuildArchive({{"GeneralSceneDescription.xml", xml}}), result));
+  const auto hasCode = [&](const std::string &code) {
+    for (const MvrImportDiagnostic &diagnostic : result.diagnostics) {
+      if (diagnostic.code == code)
+        return true;
+    }
+    return false;
+  };
+  assert(hasCode("multiple_root_userdata"));
+  assert(hasCode("invalid_root_userdata_child"));
+  assert(hasCode("missing_userdata_provider"));
+}
+
+// Runs one independently labeled importer characterization scenario.
+int main(int argc, char **argv) {
+  wxInitializer initializer;
+  assert(initializer.IsOk());
+  assert(argc == 2);
+  const std::string scenario = argv[1];
+  if (scenario == "strict")
+    TestStrictArchiveRejection();
+  else if (scenario == "legacy")
+    TestLegacyRootNameCompatibility();
+  else if (scenario == "recovery")
+    TestRecoverableUserDataDiagnostics();
+  else
+    assert(false);
+  return 0;
+}


### PR DESCRIPTION
### Motivation

- Provide an informational Linux/GCC coverage baseline for the production `core/` and `mvr/` code paths without introducing any gating thresholds or changing normal Debug/Release builds.
- Improve MVR importer/exporter behavior characterization by adding small deterministic parse-only tests that document current strict, legacy-compatibility, and tolerant-recovery behavior domains.

### Description

- Add an opt-in CMake option `PERASTAGE_ENABLE_COVERAGE` that is OFF by default, only allowed for GNU compilers, and centrally applies `--coverage -O0 -g` and the coverage link option when enabled. (edited `CMakeLists.txt`)
- Add an informational GitHub Actions workflow `.github/workflows/core-mvr-coverage.yml` that: installs pinned `gcovr` (8.3), reuses vcpkg caches, configures a dedicated coverage build with `PERASTAGE_ENABLE_COVERAGE=ON` while disabling project compiler caching, builds production+tests, runs CTest, generates text/HTML/JSON/XML reports, and uploads a single artifact `core-mvr-coverage-report`.
- Add a reporting helper script `.github/scripts/generate_core_mvr_coverage.py` that invokes `gcovr` scoped to files under `core/` and `mvr/`, computes separate Core/MVR/combined line totals, lists the largest uncovered files, and writes `summary.md` into the report directory and optionally the GitHub job summary.
- Add a small, deterministic parse-only characterization test `tests/mvr_importer_archive_characterization_test.cpp` that builds in-memory MVR ZIP fixtures and exercises three labeled scenarios: strict missing/malformed root rejection (`standard-strict`), legacy case-insensitive root compatibility (`legacy-compatibility`), and tolerant UserData diagnostics (`tolerant-recovery`). Tests are registered in `tests/CMakeLists.txt` with appropriate `set_perastage_test_labels` and linked into the test harness without growing the oversized `mvr_exporter_compliance_test.cpp`.
- Add documentation: `docs/developer/core_mvr_coverage.md` (how to run/interpret coverage), update `docs/developer/github_actions_workflows.md` and `docs/developer/main_branch_protection.md` to reflect the verified active CH-003 ruleset and dedicated release-App facts, and add a short internal release-note entry to `docs/release-notes-draft.md`.

### Testing

- Built focused test targets and ran imported-characterization tests in a local Linux build:
  - `cmake --preset wsl-x64-debug -DPERASTAGE_ENABLE_COMPILER_CACHE=OFF -DPERASTAGE_ENABLE_MVR_XCHANGE_MDNS=OFF` (configure) succeeded.
  - Built and ran the new importer archive characterization tests: `mvr_importer_archive_characterization_test` and executed CTest label-filtered runs; the three scenarios passed (3/3).
- Performed a local coverage smoke run on Linux with `PERASTAGE_ENABLE_COVERAGE=ON`: configured and built an instrumented `build/linux-coverage`, ran the registered CTest subset, generated reports with gcovr 8.3, and validated generated outputs exist (`coverage.txt`, `index.html`, `coverage.json`, `coverage.xml`, `summary.md`). The local smoke baseline recorded Core 0.83%, MVR 4.06%, combined 1.80% (informational). All generated coverage files were scoped to `core/` and `mvr/` only.
- Ran repository validation scripts and policy checks: `tests/check_source_file_size.py`, `tests/check_repository_hygiene.py`, `tests/check_docs_links.py`, `tests/check_ci_workflow_architecture.py`, `tests/check_perastage_tree_modules.sh`, and `tests/check_no_configmanager_get_in_gui.sh`; these checks passed for the modified tree.
- Confirmed `tests/mvr_exporter_compliance_test.cpp` was not changed and remains at its recorded baseline; the new characterization file is small (~102 lines).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6aa324cb84b48324a07508bb7ed5c673)