### PR TITLE
Fix Core/MVR coverage vcpkg install logging

### DIFF
--- a/.github/workflows/core-mvr-coverage.yml
+++ b/.github/workflows/core-mvr-coverage.yml
@@ -23,6 +23,7 @@ jobs:
   core-mvr-coverage:
     runs-on: ubuntu-latest
     env:
+      CI_LOG_DIR: ${{ runner.temp }}/perastage-core-mvr-coverage-logs
       VCPKG_ROOT: ${{ github.workspace }}/vcpkg
       VCPKG_INSTALLED: ${{ github.workspace }}/.vcpkg-cache/installed
       VCPKG_DOWNLOADS: ${{ github.workspace }}/.vcpkg-cache/downloads
@@ -65,14 +66,22 @@ jobs:
           git clone https://github.com/microsoft/vcpkg.git "$VCPKG_ROOT"
           git -C "$VCPKG_ROOT" checkout --force "$baseline"
           "$VCPKG_ROOT/bootstrap-vcpkg.sh" -disableMetrics
-          mkdir -p "$VCPKG_INSTALLED" "$VCPKG_DOWNLOADS" "$VCPKG_PACKAGES" "$VCPKG_BINARY_CACHE"
+          mkdir -p "$CI_LOG_DIR" "$VCPKG_INSTALLED" "$VCPKG_DOWNLOADS" "$VCPKG_PACKAGES" "$VCPKG_BINARY_CACHE"
       - name: Install dependencies
         run: |
           python3 .github/scripts/vcpkg_install_retry.py --vcpkg "$VCPKG_ROOT/vcpkg" \
             --triplet x64-linux --manifest-root "$GITHUB_WORKSPACE" \
             --install-root "$VCPKG_INSTALLED" --packages-root "$VCPKG_PACKAGES" \
             --downloads-root "$VCPKG_DOWNLOADS" --attempts 4 \
-            --initial-delay-seconds 30 --max-delay-seconds 120
+            --initial-delay-seconds 30 --max-delay-seconds 120 \
+            --log "$CI_LOG_DIR/vcpkg-install-core-mvr-coverage.log"
+      - name: Upload vcpkg install failure log
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: core-mvr-coverage-vcpkg-install-log
+          path: ${{ env.CI_LOG_DIR }}/vcpkg-install-core-mvr-coverage.log
+          if-no-files-found: ignore
       - name: Configure dedicated GCC coverage build
         run: |
           cmake -S . -B build/linux-coverage -G Ninja \

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -12,6 +12,7 @@ Changes since **v1.6.0**.
 
 ## Technical and packaging changes
 
+- Corrected the informational Core/MVR coverage workflow dependency installation and added a CI policy check to keep its required diagnostics logging configured.
 - Established informational Linux coverage reporting for Core and MVR production code and expanded deterministic MVR import/export characterization ahead of future internal refactoring.
 - Reconciled maintainer documentation with the active main-branch ruleset and dedicated release-App configuration.
 

--- a/tests/check_ci_workflow_architecture.py
+++ b/tests/check_ci_workflow_architecture.py
@@ -5,13 +5,26 @@ import re
 import subprocess
 
 WORKFLOWS = Path('.github/workflows')
-for workflow in WORKFLOWS.glob('*.yml'):
+workflow_paths = sorted((*WORKFLOWS.glob('*.yml'), *WORKFLOWS.glob('*.yaml')))
+for workflow in workflow_paths:
     subprocess.run(['ruby', '-e', "require 'yaml'; YAML.load_file(ARGV[0])", str(workflow)], check=True)
 
 
 
 # GitHub Packages is a second, centrally configured cache layer with one trusted writer.
-all_workflows = {path.name: path.read_text() for path in WORKFLOWS.glob('*.yml')}
+all_workflows = {path.name: path.read_text() for path in workflow_paths}
+
+# Every workflow invocation must satisfy the retry helper's required logging contract.
+for name, workflow_text in all_workflows.items():
+    lines = workflow_text.splitlines()
+    for index, line in enumerate(lines):
+        if 'vcpkg_install_retry.py' not in line or not re.search(r'\bpython(?:3)?\b', line):
+            continue
+        command_lines = [line]
+        while command_lines[-1].rstrip().endswith(('\\', '`')) and index + len(command_lines) < len(lines):
+            command_lines.append(lines[index + len(command_lines)])
+        command = ' '.join(command_lines)
+        assert re.search(r'(?:^|\s)--log(?:\s|=)', command), f'{name} vcpkg_install_retry.py invocation must pass --log'
 writers = [name for name, text in all_workflows.items() if re.search(r'packages:\s*write', text)]
 assert writers == ['vcpkg-binary-cache.yml'], f'only the warming workflow may publish packages: {writers}'
 assert all('pull_request_target' not in text for text in all_workflows.values())


### PR DESCRIPTION
### Motivation
- The Core MVR Coverage workflow failed early because `vcpkg_install_retry.py` requires a mandatory `--log` argument which was omitted in the workflow invocation. 
- Add a narrow fix (provide a runner-local log path) and a lightweight regression guard to prevent the same contract mismatch being reintroduced.

### Description
- Add a runner-local log directory `CI_LOG_DIR: ${{ runner.temp }}/perastage-core-mvr-coverage-logs` and create it before invoking vcpkg in `.github/workflows/core-mvr-coverage.yml`. 
- Pass `--log "$CI_LOG_DIR/vcpkg-install-core-mvr-coverage.log"` to the `vcpkg_install_retry.py` invocation and upload that single install log as a failure-only artifact named `core-mvr-coverage-vcpkg-install-log`. 
- Extend `tests/check_ci_workflow_architecture.py` to scan both `.yml` and `.yaml` workflows and assert that every multiline `vcpkg_install_retry.py` invocation includes `--log`. 
- Add a concise release-note entry documenting the CI reliability correction in `docs/release-notes-draft.md`.

### Testing
- Ran `python3 tests/check_ci_workflow_architecture.py` and it passed, including the new `--log` contract assertions. 
- Ran `python3 tests/check_repository_hygiene.py`, `python3 tests/check_source_file_size.py`, and `python3 tests/check_docs_links.py`, all of which passed. 
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh` with `PERASTAGE_TEST_PYTHON` set and both passed. 
- Performed a static audit of all `.github/workflows/*.yml` and `.yaml` invocations of `vcpkg_install_retry.py` and confirmed all current invocations include `--log`, and ran `python3 .github/scripts/vcpkg_install_retry.py --help` to verify the helper's required arguments.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6aa343124a4c832498cb4f870028dd96)