### PR TITLE
Fix Core/MVR coverage runner context initialization

### DIFF
--- a/.github/workflows/core-mvr-coverage.yml
+++ b/.github/workflows/core-mvr-coverage.yml
@@ -23,7 +23,6 @@ jobs:
   core-mvr-coverage:
     runs-on: ubuntu-latest
     env:
-      CI_LOG_DIR: ${{ runner.temp }}/perastage-core-mvr-coverage-logs
       VCPKG_ROOT: ${{ github.workspace }}/vcpkg
       VCPKG_INSTALLED: ${{ github.workspace }}/.vcpkg-cache/installed
       VCPKG_DOWNLOADS: ${{ github.workspace }}/.vcpkg-cache/downloads
@@ -34,6 +33,13 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+      - name: Initialize Core/MVR coverage diagnostics
+        shell: bash
+        run: |
+          set -euo pipefail
+          ci_log_dir="$RUNNER_TEMP/perastage-core-mvr-coverage-logs"
+          mkdir -p "$ci_log_dir"
+          echo "CI_LOG_DIR=$ci_log_dir" >> "$GITHUB_ENV"
       - name: Install build and coverage prerequisites
         run: |
           .github/scripts/install_vcpkg_build_prerequisites.sh linux

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -12,7 +12,7 @@ Changes since **v1.6.0**.
 
 ## Technical and packaging changes
 
-- Corrected the informational Core/MVR coverage workflow dependency installation and added a CI policy check to keep its required diagnostics logging configured.
+- Corrected the informational Core/MVR coverage workflow diagnostics initialization and dependency logging, with CI policy checks that prevent invalid job-level runner context and missing installation logs.
 - Established informational Linux coverage reporting for Core and MVR production code and expanded deterministic MVR import/export characterization ahead of future internal refactoring.
 - Reconciled maintainer documentation with the active main-branch ruleset and dedicated release-App configuration.
 

--- a/tests/check_ci_workflow_architecture.py
+++ b/tests/check_ci_workflow_architecture.py
@@ -10,9 +10,40 @@ for workflow in workflow_paths:
     subprocess.run(['ruby', '-e', "require 'yaml'; YAML.load_file(ARGV[0])", str(workflow)], check=True)
 
 
+def job_env_runner_context_lines(workflow_text):
+    """Return lines using the unavailable runner context in a job-level env mapping."""
+    mapping_stack = []
+    invalid_lines = []
+    mapping_key = re.compile(r'^( *)([A-Za-z0-9_-]+):')
+    runner_context = re.compile(r'\$\{\{\s*runner\.')
+
+    for line_number, line in enumerate(workflow_text.splitlines(), start=1):
+        if not line.strip() or line.lstrip().startswith('#'):
+            continue
+
+        indentation = len(line) - len(line.lstrip(' '))
+        while mapping_stack and mapping_stack[-1][0] >= indentation:
+            mapping_stack.pop()
+
+        match = mapping_key.match(line)
+        if match:
+            mapping_stack.append((indentation, match.group(2)))
+
+        path = [key for _, key in mapping_stack]
+        if len(path) >= 3 and path[0] == 'jobs' and path[2] == 'env' and runner_context.search(line):
+            invalid_lines.append(line_number)
+
+    return invalid_lines
+
+
 
 # GitHub Packages is a second, centrally configured cache layer with one trusted writer.
 all_workflows = {path.name: path.read_text() for path in workflow_paths}
+
+# The runner context exists after scheduling, so it cannot be evaluated in jobs.<job_id>.env.
+for name, workflow_text in all_workflows.items():
+    invalid_lines = job_env_runner_context_lines(workflow_text)
+    assert not invalid_lines, f'{name} job-level env uses runner context on lines {invalid_lines}'
 
 # Every workflow invocation must satisfy the retry helper's required logging contract.
 for name, workflow_text in all_workflows.items():


### PR DESCRIPTION
### Motivation
- The `core-mvr-coverage` workflow was rejected at job validation because `jobs.core-mvr-coverage.env` used the unavailable `runner` context (`${{ runner.temp }}`), preventing any jobs from being scheduled.
- The change ensures runner-local diagnostics are available at runtime without using unsupported job-level expressions and prevents the same regression from recurring.

### Description
- Remove the invalid job-level `CI_LOG_DIR: ${{ runner.temp }}/…` entry from `.github/workflows/core-mvr-coverage.yml` and keep all existing vcpkg environment variables and cache keys unchanged.
- Add an early Bash step (after checkout) that resolves `CI_LOG_DIR` from the runner-provided `RUNNER_TEMP`, creates the directory, and exports it via `GITHUB_ENV` so steps can use `CI_LOG_DIR` at runtime.
- Preserve the `vcpkg_install_retry.py` `--log "$CI_LOG_DIR/..."` usage and the failure-only artifact upload for the vcpkg install log.
- Add a focused regression guard in `tests/check_ci_workflow_architecture.py` (`job_env_runner_context_lines`) that rejects `${{ runner.* }}` usage specifically when it appears inside a job-level `env` mapping while allowing valid step-level `runner` expressions.
- Update `docs/release-notes-draft.md` to describe the diagnostics initialization fix and the new CI policy guard.

### Testing
- Ran `python3 tests/check_ci_workflow_architecture.py` and confirmed the new guard passes for repository workflows and rejects a synthetic fixture that places `${{ runner.temp }}` in `jobs.<id>.env`.
- Ran `PERASTAGE_TEST_PYTHON="$(command -v python3)" tests/check_perastage_tree_modules.sh` which passed when invoked with the required environment, and ran `tests/check_no_configmanager_get_in_gui.sh` which passed.
- Ran `python3 tests/check_repository_hygiene.py`, `python3 tests/check_source_file_size.py`, and `python3 tests/check_docs_links.py`, all of which passed with no failures.
- Ran `git diff --check` and observed no whitespace or diff errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6aa3a25aa73c8324ab4e37de34b51929)