### PR TITLE
Fix Core/MVR coverage Linux locale setup

### DIFF
--- a/.github/workflows/core-mvr-coverage.yml
+++ b/.github/workflows/core-mvr-coverage.yml
@@ -44,6 +44,24 @@ jobs:
         run: |
           .github/scripts/install_vcpkg_build_prerequisites.sh linux
           python3 -m pip install --disable-pip-version-check gcovr==8.3
+      - name: Validate Linux test tools and locale
+        run: |
+          set -euo pipefail
+          sudo locale-gen es_ES.UTF-8 zh_CN.UTF-8
+          locale -a | grep -qi '^es_ES.utf8$' || {
+            echo "es_ES.UTF-8 locale was not generated"
+            exit 1
+          }
+          locale -a | grep -qi '^zh_CN.utf8$' || {
+            echo "zh_CN.UTF-8 locale was not generated"
+            exit 1
+          }
+          for tool in rg xvfb-run locale xdpyinfo; do
+            command -v "$tool" >/dev/null || {
+              echo "Required Linux test tool is missing: $tool"
+              exit 1
+            }
+          done
       - name: Read pinned vcpkg baseline
         id: vcpkg-baseline
         run: |

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -12,7 +12,7 @@ Changes since **v1.6.0**.
 
 ## Technical and packaging changes
 
-- Corrected the informational Core/MVR coverage workflow diagnostics initialization and dependency logging, with CI policy checks that prevent invalid job-level runner context and missing installation logs.
+- Corrected the informational Core/MVR coverage workflow diagnostics, dependency logging, and Linux locale preparation, with CI policy checks that prevent incomplete test environments.
 - Established informational Linux coverage reporting for Core and MVR production code and expanded deterministic MVR import/export characterization ahead of future internal refactoring.
 - Reconciled maintainer documentation with the active main-branch ruleset and dedicated release-App configuration.
 

--- a/tests/check_ci_workflow_architecture.py
+++ b/tests/check_ci_workflow_architecture.py
@@ -40,6 +40,25 @@ def job_env_runner_context_lines(workflow_text):
 # GitHub Packages is a second, centrally configured cache layer with one trusted writer.
 all_workflows = {path.name: path.read_text() for path in workflow_paths}
 
+# Core/MVR coverage runs the complete Linux test suite and needs its runtime locales.
+coverage = all_workflows['core-mvr-coverage.yml']
+coverage_preflight = coverage[
+    coverage.index('      - name: Validate Linux test tools and locale'):
+    coverage.index('      - name: Read pinned vcpkg baseline')
+]
+assert 'sudo locale-gen es_ES.UTF-8 zh_CN.UTF-8' in coverage_preflight, (
+    'Core/MVR coverage must generate the Spanish and Simplified Chinese locales'
+)
+for locale_name, locale_pattern in [
+    ('es_ES.UTF-8', '^es_ES.utf8$'),
+    ('zh_CN.UTF-8', '^zh_CN.utf8$'),
+]:
+    assert re.search(
+        rf"locale -a \| grep -qi ['\"]{re.escape(locale_pattern)}['\"]",
+        coverage_preflight,
+    ), f'Core/MVR coverage must verify {locale_name} availability'
+assert coverage.index('Validate Linux test tools and locale') < coverage.index('Run registered tests')
+
 # The runner context exists after scheduling, so it cannot be evaluated in jobs.<job_id>.env.
 for name, workflow_text in all_workflows.items():
     invalid_lines = job_env_runner_context_lines(workflow_text)


### PR DESCRIPTION
### Motivation
- The Core/MVR coverage CI run failed `LocalizationCatalogIntegration` because the runner had `locales` installed but did not generate the Spanish and Simplified-Chinese UTF-8 locales required by the full Linux CTest suite. 
- Provide the same deterministic Linux runtime preflight used by the normal Linux Debug CI so the coverage job can run the complete CTest suite without weakening tests or changing production behavior.

### Description
- Added a `Validate Linux test tools and locale` preflight step to `.github/workflows/core-mvr-coverage.yml` that runs `sudo locale-gen es_ES.UTF-8 zh_CN.UTF-8`, verifies both locales via `locale -a | grep -qi ...`, and checks availability of `rg`, `xvfb-run`, `locale`, and `xdpyinfo` before configuring or running tests. 
- Extended `tests/check_ci_workflow_architecture.py` with a narrow regression guard that asserts the coverage workflow contains the locale-generation command, the locale-availability grep checks, and that the validation step precedes test execution. 
- Updated `docs/release-notes-draft.md` to mention the CI reliability correction for Linux locale preparation. 
- No production code, localization tests, or the shared prerequisite installer were changed; an audit confirmed the existing installer already supplies the required runtime tools and only locale generation was missing.

### Testing
- Ran `python3 tests/check_ci_workflow_architecture.py` and it passed, enforcing the new workflow guard. 
- Ran `python3 tests/check_repository_hygiene.py`, `python3 tests/check_source_file_size.py`, and `python3 tests/check_docs_links.py`, all of which passed. 
- Ran repository policy scripts `tests/check_no_configmanager_get_in_gui.sh` (passed) and `tests/check_perastage_tree_modules.sh` which requires `PERASTAGE_TEST_PYTHON` to be set; it passed when invoked with `PERASTAGE_TEST_PYTHON="$(command -v python3)"`. 
- Ran `git diff --check` with no issues. 
- Note: A hosted/manual dispatch of the `Core MVR Coverage` workflow on the corrective branch is still required and must complete successfully (locale/runtime validation -> install -> configure -> build -> full CTest -> report generation -> `core-mvr-coverage-report` upload) before the correction is merged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6aa3f6b9d5148324967a11bd7fc59b08)