### PR TITLE
Isolate MVR package acquisition into `mvr_import_package` and add extraction safety/remapping with tests

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -12,6 +12,7 @@ Changes since **v1.6.0**.
 
 ## Technical and packaging changes
 
+- Separated MVR package acquisition and archive safety handling from semantic scene parsing to improve importer maintainability without changing supported MVR behavior.
 - Corrected the informational Core/MVR coverage workflow diagnostics, dependency logging, and Linux locale preparation, with CI policy checks that prevent incomplete test environments.
 - Established informational Linux coverage reporting for Core and MVR production code and expanded deterministic MVR import/export characterization ahead of future internal refactoring.
 - Reconciled maintainer documentation with the active main-branch ruleset and dedicated release-App configuration.

--- a/mvr/CMakeLists.txt
+++ b/mvr/CMakeLists.txt
@@ -2,6 +2,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtf_catalog_matcher.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtf_catalog_parser.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mvrimporter.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/mvr_import_package.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mvr_merge_analyzer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mvr_merge_applier.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mvr_merge_resource_rewriter.cpp

--- a/mvr/mvr_import_package.cpp
+++ b/mvr/mvr_import_package.cpp
@@ -1,0 +1,344 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2026 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+#include "mvr_import_package.h"
+
+#include "filesystem_path_utils.h"
+#include "logger.h"
+
+#include <algorithm>
+#include <cctype>
+#include <fstream>
+#include <functional>
+#include <iomanip>
+#include <memory>
+#include <sstream>
+#include <unordered_set>
+
+#include <wx/filename.h>
+#include <wx/zipstrm.h>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+// Converts a UTF-8 filesystem string without changing its byte sequence.
+std::string ToString(const std::u8string &value) {
+  return std::string(value.begin(), value.end());
+}
+
+// Removes surrounding ASCII whitespace from an archive path.
+std::string Trim(const std::string &value) {
+  const char *whitespace = " \t\r\n";
+  const size_t start = value.find_first_not_of(whitespace);
+  if (start == std::string::npos)
+    return {};
+  const size_t end = value.find_last_not_of(whitespace);
+  return value.substr(start, end - start + 1);
+}
+
+// Converts archive separators to their portable representation.
+std::string NormalizeSlashes(std::string path) {
+  std::replace(path.begin(), path.end(), '\\', '/');
+  return path;
+}
+
+// Lowercases ASCII text used for portable archive comparisons.
+std::string ToLowerAscii(std::string text) {
+  std::transform(text.begin(), text.end(), text.begin(), [](unsigned char ch) {
+    return static_cast<char>(std::tolower(ch));
+  });
+  return text;
+}
+
+// Reports whether a destination path risks the legacy Windows path limit.
+bool IsPathLikelyTooLong(const fs::path &path) {
+#ifdef _WIN32
+  constexpr size_t kLegacyMaxPathSafetyLimit = 245;
+  return ToString(path.u8string()).size() >= kLegacyMaxPathSafetyLimit;
+#else
+  (void)path;
+  return false;
+#endif
+}
+
+// Folds only ASCII uppercase characters for platform-neutral archive identity.
+std::string FoldArchiveIdentityAscii(std::string text) {
+  for (char &ch : text) {
+    if (ch >= 'A' && ch <= 'Z')
+      ch = static_cast<char>(ch - 'A' + 'a');
+  }
+  return text;
+}
+
+// Escapes control characters in archive identities used by diagnostics.
+std::string EscapeArchiveIdentity(const std::string &identity) {
+  std::ostringstream escaped;
+  for (unsigned char ch : identity) {
+    if (ch < 32 || ch == 127) {
+      escaped << "\\x" << std::hex << std::setw(2) << std::setfill('0')
+              << static_cast<int>(ch) << std::dec;
+    } else {
+      escaped << static_cast<char>(ch);
+    }
+  }
+  return escaped.str();
+}
+
+// Extracts an MVR stream while preserving archive safety and collision rules.
+bool ExtractArchive(wxInputStream &input, const fs::path &destination,
+                    std::unordered_map<std::string, std::string> &pathRemap,
+                    std::vector<MvrImportDiagnostic> &diagnostics) {
+  wxZipInputStream zipStream(input);
+  std::unique_ptr<wxZipEntry> entry;
+  std::unordered_map<std::string, std::string> identityByFoldedKey;
+  std::unordered_map<std::string, fs::path> extractedPathByIdentity;
+  std::unordered_set<std::string> ambiguousFoldedKeys;
+
+  auto discardCurrentEntry = [&]() {
+    char discardBuffer[4096];
+    while (true) {
+      zipStream.Read(discardBuffer, sizeof(discardBuffer));
+      if (zipStream.LastRead() == 0)
+        break;
+    }
+  };
+
+  while ((entry.reset(zipStream.GetNextEntry())), entry) {
+    const std::string entryName = entry->GetName().ToUTF8().data();
+    const std::string normalizedUnsafeCheck = NormalizeSlashes(entryName);
+    const fs::path relativeEntryPath =
+        PathUtils::PathFromUtf8(normalizedUnsafeCheck);
+    if (normalizedUnsafeCheck.empty() || relativeEntryPath.is_absolute() ||
+        relativeEntryPath.has_root_name() ||
+        normalizedUnsafeCheck.find(':') != std::string::npos ||
+        std::any_of(relativeEntryPath.begin(), relativeEntryPath.end(),
+                    [](const fs::path &part) { return part == ".."; })) {
+      Logger::Instance().Log(Logger::Level::Warn,
+                             "Skipping unsafe MVR archive entry: " + entryName);
+      discardCurrentEntry();
+      continue;
+    }
+    fs::path fullPath = destination / relativeEntryPath;
+
+    if (entry->IsDir()) {
+      const std::string dirUtf8 = ToString(fullPath.u8string());
+      wxFileName::Mkdir(wxString::FromUTF8(dirUtf8.c_str()), wxS_DIR_DEFAULT,
+                        wxPATH_MKDIR_FULL);
+      continue;
+    }
+
+    const std::string archiveIdentity = normalizedUnsafeCheck;
+    const std::string foldedIdentity =
+        FoldArchiveIdentityAscii(archiveIdentity);
+    if (ambiguousFoldedKeys.contains(foldedIdentity)) {
+      pathRemap.erase(mvr::NormalizeImportArchivePath(archiveIdentity));
+      discardCurrentEntry();
+      continue;
+    }
+    auto priorIdentityIt = identityByFoldedKey.find(foldedIdentity);
+    if (priorIdentityIt != identityByFoldedKey.end()) {
+      const bool exactDuplicate = priorIdentityIt->second == archiveIdentity;
+      const char *code = exactDuplicate ? "duplicate_mvr_archive_entry"
+                                        : "case_colliding_mvr_archive_entry";
+      diagnostics.push_back(
+          {code, std::string("Rejected ambiguous MVR archive entries '") +
+                     EscapeArchiveIdentity(priorIdentityIt->second) +
+                     "' and '" + EscapeArchiveIdentity(archiveIdentity) +
+                     "'."});
+      auto extractedIt = extractedPathByIdentity.find(priorIdentityIt->second);
+      if (extractedIt != extractedPathByIdentity.end()) {
+        std::error_code removeEc;
+        fs::remove(extractedIt->second, removeEc);
+        extractedPathByIdentity.erase(extractedIt);
+      }
+      pathRemap.erase(mvr::NormalizeImportArchivePath(priorIdentityIt->second));
+      pathRemap.erase(mvr::NormalizeImportArchivePath(archiveIdentity));
+      ambiguousFoldedKeys.insert(foldedIdentity);
+      discardCurrentEntry();
+      if (foldedIdentity == "generalscenedescription.xml")
+        return false;
+      continue;
+    }
+    identityByFoldedKey.emplace(foldedIdentity, archiveIdentity);
+
+    const std::string parentUtf8 = ToString(fullPath.parent_path().u8string());
+    wxFileName::Mkdir(wxString::FromUTF8(parentUtf8.c_str()), wxS_DIR_DEFAULT,
+                      wxPATH_MKDIR_FULL);
+
+    const std::string normalizedEntryName =
+        mvr::NormalizeImportArchivePath(entryName);
+    const size_t fullPathLength = ToString(fullPath.u8string()).size();
+    auto tryOpenOutput = [](const fs::path &path) {
+      return std::ofstream(path, std::ios::binary);
+    };
+
+    std::ofstream output;
+    bool remapped = false;
+    if (!IsPathLikelyTooLong(fullPath))
+      output = tryOpenOutput(fullPath);
+
+    if (!output.is_open()) {
+      const fs::path longDir = destination / "_long";
+      const std::string extension =
+          PathUtils::PathFromUtf8(entryName).extension().string();
+      const std::string hashBase =
+          std::to_string(std::hash<std::string>{}(normalizedEntryName));
+      wxFileName::Mkdir(
+          wxString::FromUTF8(ToString(longDir.u8string()).c_str()),
+          wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
+
+      for (int suffix = 0; suffix < 64 && !output.is_open(); ++suffix) {
+        std::string candidateName = hashBase;
+        if (suffix > 0)
+          candidateName += "_" + std::to_string(suffix);
+        candidateName += extension;
+        const fs::path candidatePath =
+            longDir / PathUtils::PathFromUtf8(candidateName);
+        output = tryOpenOutput(candidatePath);
+        if (output.is_open()) {
+          fullPath = candidatePath;
+          pathRemap[normalizedEntryName] = ToString(
+              (fs::path("_long") / PathUtils::PathFromUtf8(candidateName))
+                  .u8string());
+          remapped = true;
+        }
+      }
+    }
+
+    if (!output.is_open()) {
+      std::ostringstream message;
+      message << "Cannot create file while extracting MVR entry. entry='"
+              << entryName << "', path='" << ToString(fullPath.u8string())
+              << "', pathLength=" << fullPathLength;
+      const std::string loweredEntry = ToLowerAscii(normalizedEntryName);
+      const bool isSceneXml =
+          loweredEntry == "generalscenedescription.xml" ||
+          fs::path(loweredEntry).filename().generic_string() ==
+              "generalscenedescription.xml";
+      if (isSceneXml) {
+        Logger::Instance().Log(Logger::Level::Error,
+                               message.str() +
+                                   " (required scene XML; aborting import)");
+        return false;
+      }
+      Logger::Instance().Log(Logger::Level::Warn,
+                             message.str() +
+                                 " (asset entry skipped, continuing import)");
+      discardCurrentEntry();
+      continue;
+    }
+
+    if (remapped) {
+      const std::string remappedPath = pathRemap[normalizedEntryName];
+      std::ostringstream warning;
+      warning << "MVR extraction remapped long path entry. entry='" << entryName
+              << "', remapped='" << remappedPath
+              << "', originalLength=" << fullPathLength;
+      Logger::Instance().Log(Logger::Level::Warn, warning.str());
+    }
+
+    char buffer[4096];
+    while (true) {
+      zipStream.Read(buffer, sizeof(buffer));
+      const size_t bytes = zipStream.LastRead();
+      if (bytes == 0)
+        break;
+      output.write(buffer, bytes);
+    }
+    output.close();
+    extractedPathByIdentity[archiveIdentity] = fullPath;
+  }
+  return true;
+}
+
+// Locates the normative root scene XML or its legacy case-insensitive variant.
+fs::path FindSceneXml(const fs::path &rootPath) {
+  fs::path sceneFile = rootPath / "GeneralSceneDescription.xml";
+  std::error_code error;
+  if (fs::exists(sceneFile, error) && !error)
+    return sceneFile;
+
+  error.clear();
+  for (const auto &entry : fs::directory_iterator(rootPath, error)) {
+    if (error)
+      break;
+    std::error_code regularFileError;
+    if (entry.is_regular_file(regularFileError) && !regularFileError &&
+        ToLowerAscii(entry.path().filename().string()) ==
+            "generalscenedescription.xml") {
+      return entry.path();
+    }
+  }
+  return {};
+}
+
+} // namespace
+
+namespace mvr {
+
+// Normalizes a packaged resource path for importer lookup and remapping.
+std::string NormalizeImportArchivePath(const std::string &archivePath) {
+  std::string normalized = Trim(NormalizeSlashes(archivePath));
+  const std::string lowered = ToLowerAscii(normalized);
+  const size_t gdtfPos = lowered.rfind(".gdtf");
+  if (gdtfPos != std::string::npos && gdtfPos > 0) {
+    size_t trimPos = gdtfPos;
+    while (trimPos > 0 && normalized[trimPos - 1] == ' ')
+      --trimPos;
+    if (trimPos != gdtfPos)
+      normalized.erase(trimPos, gdtfPos - trimPos);
+  }
+  return normalized;
+}
+
+// Safely extracts an MVR stream and locates its root scene description.
+std::optional<ImportPackage>
+AcquireImportPackage(wxInputStream &input,
+                     std::vector<MvrImportDiagnostic> &diagnostics) {
+  runtime_storage::TemporaryWorkspace workspace("mvr-import");
+  if (!workspace.IsValid()) {
+    Logger::Instance().Log("Failed to create MVR import workspace.");
+    return std::nullopt;
+  }
+
+  const fs::path rootPath = workspace.Path();
+  std::unordered_map<std::string, std::string> pathRemap;
+  if (!ExtractArchive(input, rootPath, pathRemap, diagnostics)) {
+    Logger::Instance().Log("Failed to extract MVR file.");
+    return std::nullopt;
+  }
+
+  int extractedGdtfEntryCount = 0;
+  std::error_code countError;
+  for (const auto &entry : fs::directory_iterator(rootPath, countError)) {
+    if (countError)
+      break;
+    std::error_code regularFileError;
+    if (entry.is_regular_file(regularFileError) && !regularFileError &&
+        ToLowerAscii(entry.path().extension().string()) == ".gdtf") {
+      ++extractedGdtfEntryCount;
+    }
+  }
+  Logger::Instance().Log(
+      Logger::Level::Info,
+      "MVR extraction diagnostics: basePath='" + ToString(rootPath.u8string()) +
+          "', extractedGdtfEntries=" + std::to_string(extractedGdtfEntryCount));
+
+  const fs::path sceneXmlPath = FindSceneXml(rootPath);
+  if (sceneXmlPath.empty()) {
+    Logger::Instance().Log("Missing GeneralSceneDescription.xml in MVR.");
+    return std::nullopt;
+  }
+
+  return ImportPackage{std::move(workspace), rootPath, sceneXmlPath,
+                       std::move(pathRemap)};
+}
+
+} // namespace mvr

--- a/mvr/mvr_import_package.h
+++ b/mvr/mvr_import_package.h
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2026 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+#pragma once
+
+#include "mvrimporter.h"
+#include "runtime_storage.h"
+
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+class wxInputStream;
+
+namespace mvr {
+
+// Owns an extracted MVR package and keeps its temporary workspace alive.
+struct ImportPackage {
+  runtime_storage::TemporaryWorkspace workspace;
+  std::filesystem::path rootPath;
+  std::filesystem::path sceneXmlPath;
+  std::unordered_map<std::string, std::string> pathRemap;
+};
+
+// Normalizes a packaged resource path for importer lookup and remapping.
+std::string NormalizeImportArchivePath(const std::string &archivePath);
+
+// Safely extracts an MVR stream and locates its root scene description.
+std::optional<ImportPackage>
+AcquireImportPackage(wxInputStream &input,
+                     std::vector<MvrImportDiagnostic> &diagnostics);
+
+} // namespace mvr

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "mvrimporter.h"
+#include "mvr_import_package.h"
 #include "../gui/gdtf_resolution_status_style.h"
 #include "apppaths.h"
 #include "build_info.h"
@@ -96,10 +97,8 @@
 #include <wx/wfstream.h>
 #include <wx/mstream.h>
 #include <wx/wx.h>
-class wxZipStreamLink;
 #include <wx/filename.h>
 #include <wx/stdpaths.h>
-#include <wx/zipstrm.h>
 
 namespace fs = std::filesystem;
 namespace gdtf_catalog_matcher = mvr::gdtf_catalog_matcher;
@@ -149,47 +148,8 @@ static std::string ToLowerAscii(std::string text) {
   return text;
 }
 
-// Folds only ASCII uppercase characters for platform-neutral archive identity.
-static std::string FoldArchiveIdentityAscii(std::string text) {
-  for (char &ch : text) {
-    if (ch >= 'A' && ch <= 'Z')
-      ch = static_cast<char>(ch - 'A' + 'a');
-  }
-  return text;
-}
-
-// Escapes control characters in archive identities used by diagnostics.
-static std::string EscapeArchiveIdentity(const std::string &identity) {
-  std::ostringstream escaped;
-  for (unsigned char ch : identity) {
-    if (ch < 32 || ch == 127) {
-      escaped << "\\x" << std::hex << std::setw(2) << std::setfill('0')
-              << static_cast<int>(ch) << std::dec;
-    } else {
-      escaped << static_cast<char>(ch);
-    }
-  }
-  return escaped.str();
-}
-
 static std::string ResolveGdtfPath(const std::string &baseDir,
                                    const std::string &spec);
-
-static std::string NormalizeArchivePathValue(const std::string &archivePath) {
-  std::string normalized = Trim(NormalizeSlashes(archivePath));
-  // Be permissive with vendor MVRs that include an extra blank right before
-  // ".gdtf" (e.g. "Fixture Name .gdtf").
-  const std::string lowered = ToLowerAscii(normalized);
-  const size_t gdtfPos = lowered.rfind(".gdtf");
-  if (gdtfPos != std::string::npos && gdtfPos > 0) {
-    size_t trimPos = gdtfPos;
-    while (trimPos > 0 && normalized[trimPos - 1] == ' ')
-      --trimPos;
-    if (trimPos != gdtfPos)
-      normalized.erase(trimPos, gdtfPos - trimPos);
-  }
-  return normalized;
-}
 
 // Reports whether extension metadata names one portable root-level archive file.
 static bool IsPortableRootArchiveFileName(const std::string &value) {
@@ -209,7 +169,7 @@ static bool IsPortableRootArchiveFileName(const std::string &value) {
 }
 
 static std::string NormalizeGdtfLookupKey(const std::string &value) {
-  std::string normalized = NormalizeArchivePathValue(value);
+  std::string normalized = mvr::NormalizeImportArchivePath(value);
   if (normalized.empty())
     return normalized;
 
@@ -312,16 +272,6 @@ static std::string GenerateShortToken(size_t length = 10) {
   for (size_t i = 0; i < length; ++i)
     token.push_back(kAlphabet[dist(rng)]);
   return token;
-}
-
-static bool IsPathLikelyTooLong(const fs::path &path) {
-#ifdef _WIN32
-  constexpr size_t kLegacyMaxPathSafetyLimit = 245;
-  return ToString(path.u8string()).size() >= kLegacyMaxPathSafetyLimit;
-#else
-  (void)path;
-  return false;
-#endif
 }
 
 // Parses a trimmed float token and accepts only full-token numeric input.
@@ -450,7 +400,7 @@ static std::string ResolveScenePathForRead(const std::string &basePath,
                                            const std::string &pathText) {
   if (pathText.empty())
     return {};
-  const std::string normalized = NormalizeArchivePathValue(pathText);
+  const std::string normalized = mvr::NormalizeImportArchivePath(pathText);
   if (normalized.empty())
     return {};
   const std::string gdtfResolved = ResolveGdtfPath(basePath, normalized);
@@ -465,7 +415,7 @@ static std::string ResolveScenePathForRead(const std::string &basePath,
 // matches.
 static std::string ResolveGdtfPath(const std::string &baseDir,
                                    const std::string &spec) {
-  const std::string normalizedSpec = NormalizeArchivePathValue(spec);
+  const std::string normalizedSpec = mvr::NormalizeImportArchivePath(spec);
   if (normalizedSpec.empty())
     return {};
 
@@ -1219,63 +1169,13 @@ bool MvrImporter::ImportFromStreamIntoResult(
   importResult = MvrImportResult{};
   reportProgress("Extracting package resources...");
 
-  runtime_storage::TemporaryWorkspace importWorkspace("mvr-import");
-  if (!importWorkspace.IsValid()) {
-    LogMessage("Failed to create MVR import workspace.");
+  std::optional<mvr::ImportPackage> package =
+      mvr::AcquireImportPackage(input, importResult.diagnostics);
+  if (!package)
     return false;
-  }
-  std::string tempDir = ToString(importWorkspace.Path().u8string());
-  fs::path tempPath(tempDir);
-  if (!ExtractMvrZip(input, tempDir, importResult.diagnostics)) {
-    LogMessage("Failed to extract MVR file.");
-    return false;
-  }
 
-  int extractedGdtfEntryCount = 0;
-  std::error_code gdtfCountEc;
-  for (const auto &entry : fs::directory_iterator(tempPath, gdtfCountEc)) {
-    if (gdtfCountEc)
-      break;
-    std::error_code regularEc;
-    if (entry.is_regular_file(regularEc) && !regularEc &&
-        ToLowerAscii(entry.path().extension().string()) == ".gdtf") {
-      ++extractedGdtfEntryCount;
-    }
-  }
-  LogMessage(
-      Logger::Level::Info,
-      "MVR extraction diagnostics: basePath='" + ToString(tempPath.u8string()) +
-          "', extractedGdtfEntries=" + std::to_string(extractedGdtfEntryCount));
-
-  fs::path sceneFile = tempPath / "GeneralSceneDescription.xml";
-  std::error_code sceneFileEc;
-  if (!fs::exists(sceneFile, sceneFileEc) || sceneFileEc) {
-    // Some MVR packages may store the file with a different case.
-    std::string target = "generalscenedescription.xml";
-    sceneFileEc.clear();
-    for (const auto &entry : fs::directory_iterator(tempPath, sceneFileEc)) {
-      if (sceneFileEc)
-        break;
-      std::error_code regularFileEc;
-      if (entry.is_regular_file(regularFileEc) && !regularFileEc) {
-        std::string name = entry.path().filename().string();
-        std::string lower = name;
-        std::transform(lower.begin(), lower.end(), lower.begin(),
-                       [](unsigned char c) { return std::tolower(c); });
-        if (lower == target) {
-          sceneFile = entry.path();
-          break;
-        }
-      }
-    }
-  }
-  sceneFileEc.clear();
-  if (!fs::exists(sceneFile, sceneFileEc) || sceneFileEc) {
-    LogMessage("Missing GeneralSceneDescription.xml in MVR.");
-    return false;
-  }
-
-  std::string scenePath = ToString(sceneFile.u8string());
+  pathRemap = package->pathRemap;
+  const std::string scenePath = ToString(package->sceneXmlPath.u8string());
   reportProgress("Parsing scene data...");
   const bool parsed =
       ParseSceneXml(scenePath, importResult, options, progressCallback);
@@ -1283,7 +1183,7 @@ bool MvrImporter::ImportFromStreamIntoResult(
     return false;
 
   importResult.scene.runtimeResourceLeases.push_back(
-      importWorkspace.TransferToSceneLease());
+      package->workspace.TransferToSceneLease());
 
   if (mode == MvrImportMode::ReplaceProject) {
     ConfigManager::Get().Reset();
@@ -1297,7 +1197,7 @@ bool MvrImporter::ImportFromStreamIntoResult(
 // Normalizes an MVR archive path so extracted resources can be found reliably.
 std::string
 MvrImporter::NormalizeArchivePath(const std::string &archivePath) const {
-  return NormalizeArchivePathValue(archivePath);
+  return mvr::NormalizeImportArchivePath(archivePath);
 }
 
 // Returns a remapped extraction path for long archive entries when one exists.
@@ -1308,193 +1208,6 @@ MvrImporter::RemapArchivePathIfNeeded(const std::string &archivePath) const {
   if (it != pathRemap.end())
     return it->second;
   return archivePath;
-}
-
-// Extracts an MVR zip archive into the destination directory.
-bool MvrImporter::ExtractMvrZip(
-    const std::string &mvrPath, const std::string &destDir,
-    std::vector<MvrImportDiagnostic> &diagnostics) {
-  wxFileInputStream input(wxString::FromUTF8(mvrPath.c_str()));
-  if (!input.IsOk()) {
-    LogMessage("Failed to open MVR file.");
-    return false;
-  }
-
-  return ExtractMvrZip(input, destDir, diagnostics);
-}
-
-// Extracts an MVR stream with the same security and collision checks as files.
-bool MvrImporter::ExtractMvrZip(
-    wxInputStream &input, const std::string &destDir,
-    std::vector<MvrImportDiagnostic> &diagnostics) {
-  wxZipInputStream zipStream(input);
-  std::unique_ptr<wxZipEntry> entry;
-  std::unordered_map<std::string, std::string> identityByFoldedKey;
-  std::unordered_map<std::string, fs::path> extractedPathByIdentity;
-  std::unordered_set<std::string> ambiguousFoldedKeys;
-
-  auto discardCurrentEntry = [&]() {
-    char discardBuffer[4096];
-    while (true) {
-      zipStream.Read(discardBuffer, sizeof(discardBuffer));
-      if (zipStream.LastRead() == 0)
-        break;
-    }
-  };
-
-  while ((entry.reset(zipStream.GetNextEntry())), entry) {
-    // Extract entry names using UTF-8 to preserve special characters
-    std::string entryName = entry->GetName().ToUTF8().data();
-    const std::string normalizedUnsafeCheck = NormalizeSlashes(entryName);
-    const fs::path relativeEntryPath = PathUtils::PathFromUtf8(normalizedUnsafeCheck);
-    if (normalizedUnsafeCheck.empty() || relativeEntryPath.is_absolute() ||
-        relativeEntryPath.has_root_name() ||
-        normalizedUnsafeCheck.find(':') != std::string::npos ||
-        std::any_of(relativeEntryPath.begin(), relativeEntryPath.end(),
-                    [](const fs::path &part) { return part == ".."; })) {
-      LogMessage(Logger::Level::Warn,
-                 "Skipping unsafe MVR archive entry: " + entryName);
-      discardCurrentEntry();
-      continue;
-    }
-    fs::path fullPath =
-        PathUtils::PathFromUtf8(destDir) / relativeEntryPath;
-
-    if (entry->IsDir()) {
-      std::string dirUtf8 = ToString(fullPath.u8string());
-      wxFileName::Mkdir(wxString::FromUTF8(dirUtf8.c_str()), wxS_DIR_DEFAULT,
-                        wxPATH_MKDIR_FULL);
-      continue;
-    }
-
-    const std::string archiveIdentity = normalizedUnsafeCheck;
-    const std::string foldedIdentity =
-        FoldArchiveIdentityAscii(archiveIdentity);
-    if (ambiguousFoldedKeys.contains(foldedIdentity)) {
-      pathRemap.erase(NormalizeArchivePath(archiveIdentity));
-      discardCurrentEntry();
-      continue;
-    }
-    auto priorIdentityIt = identityByFoldedKey.find(foldedIdentity);
-    if (priorIdentityIt != identityByFoldedKey.end()) {
-      const bool exactDuplicate = priorIdentityIt->second == archiveIdentity;
-      const char *code = exactDuplicate ? "duplicate_mvr_archive_entry"
-                                        : "case_colliding_mvr_archive_entry";
-      diagnostics.push_back(
-          {code, std::string("Rejected ambiguous MVR archive entries '") +
-                     EscapeArchiveIdentity(priorIdentityIt->second) + "' and '" +
-                     EscapeArchiveIdentity(archiveIdentity) + "'."});
-      auto extractedIt =
-          extractedPathByIdentity.find(priorIdentityIt->second);
-      if (extractedIt != extractedPathByIdentity.end()) {
-        std::error_code removeEc;
-        fs::remove(extractedIt->second, removeEc);
-        extractedPathByIdentity.erase(extractedIt);
-      }
-      pathRemap.erase(NormalizeArchivePath(priorIdentityIt->second));
-      pathRemap.erase(NormalizeArchivePath(archiveIdentity));
-      ambiguousFoldedKeys.insert(foldedIdentity);
-      discardCurrentEntry();
-      if (foldedIdentity == "generalscenedescription.xml")
-        return false;
-      continue;
-    }
-    identityByFoldedKey.emplace(foldedIdentity, archiveIdentity);
-
-    std::string parentUtf8 = ToString(fullPath.parent_path().u8string());
-    wxFileName::Mkdir(wxString::FromUTF8(parentUtf8.c_str()), wxS_DIR_DEFAULT,
-                      wxPATH_MKDIR_FULL);
-
-    const std::string normalizedEntryName = NormalizeArchivePath(entryName);
-    const size_t fullPathLength = ToString(fullPath.u8string()).size();
-
-    auto tryOpenOutput = [](const fs::path &path) {
-      return std::ofstream(path, std::ios::binary);
-    };
-
-    std::ofstream output;
-    bool remapped = false;
-    if (!IsPathLikelyTooLong(fullPath))
-      output = tryOpenOutput(fullPath);
-
-    if (!output.is_open()) {
-      fs::path longDir = PathUtils::PathFromUtf8(destDir) / "_long";
-      std::string extension =
-          PathUtils::PathFromUtf8(entryName).extension().string();
-      std::string hashBase =
-          std::to_string(std::hash<std::string>{}(normalizedEntryName));
-      wxFileName::Mkdir(
-          wxString::FromUTF8(ToString(longDir.u8string()).c_str()),
-                        wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
-
-      for (int suffix = 0; suffix < 64 && !output.is_open(); ++suffix) {
-        std::string candidateName = hashBase;
-        if (suffix > 0)
-          candidateName += "_" + std::to_string(suffix);
-        candidateName += extension;
-        fs::path candidatePath =
-            longDir / PathUtils::PathFromUtf8(candidateName);
-        output = tryOpenOutput(candidatePath);
-        if (output.is_open()) {
-          fullPath = candidatePath;
-          pathRemap[normalizedEntryName] = ToString(
-              (fs::path("_long") / PathUtils::PathFromUtf8(candidateName))
-                                                        .u8string());
-          remapped = true;
-        }
-      }
-    }
-
-    if (!output.is_open()) {
-      std::ostringstream msg;
-      msg << "Cannot create file while extracting MVR entry. entry='"
-          << entryName << "', path='" << ToString(fullPath.u8string())
-          << "', pathLength=" << fullPathLength;
-      const std::string loweredEntry = ToLowerAscii(normalizedEntryName);
-      const bool isSceneXml =
-          loweredEntry == "generalscenedescription.xml" ||
-          fs::path(loweredEntry).filename().generic_string() ==
-              "generalscenedescription.xml";
-      if (isSceneXml) {
-        LogMessage(Logger::Level::Error,
-                   msg.str() + " (required scene XML; aborting import)");
-        return false;
-      }
-
-      LogMessage(Logger::Level::Warn,
-                 msg.str() + " (asset entry skipped, continuing import)");
-      char discardBuffer[4096];
-      while (true) {
-        zipStream.Read(discardBuffer, sizeof(discardBuffer));
-        if (zipStream.LastRead() == 0)
-          break;
-      }
-      continue;
-    }
-
-    if (remapped) {
-      const std::string remappedPath = pathRemap[normalizedEntryName];
-      std::ostringstream warn;
-      warn << "MVR extraction remapped long path entry. entry='" << entryName
-           << "', remapped='" << remappedPath
-           << "', originalLength=" << fullPathLength;
-      LogMessage(Logger::Level::Warn, warn.str());
-    }
-
-    char buffer[4096];
-    while (true) {
-      zipStream.Read(buffer, sizeof(buffer));
-      size_t bytes = zipStream.LastRead();
-      if (bytes == 0)
-        break;
-      output.write(buffer, bytes);
-    }
-
-    output.close();
-    extractedPathByIdentity[archiveIdentity] = fullPath;
-  }
-
-  return true;
 }
 
 // Parses GeneralSceneDescription.xml and populates the import result scene
@@ -2261,7 +1974,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
   const std::string kEmptyResolvedPath;
   auto resolveGdtfPathCached =
       [&](const std::string &spec) -> const std::string & {
-    const std::string normalized = NormalizeArchivePathValue(spec);
+    const std::string normalized = mvr::NormalizeImportArchivePath(spec);
     if (normalized.empty())
       return kEmptyResolvedPath;
 
@@ -2278,7 +1991,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
   };
 
   auto normalizeGdtfSpecForScene = [&](const std::string &spec) {
-    const std::string normalized = NormalizeArchivePathValue(spec);
+    const std::string normalized = mvr::NormalizeImportArchivePath(spec);
     if (normalized.empty())
       return std::string{};
     return ToSceneRelativePathIfPossible(

--- a/mvr/mvrimporter.h
+++ b/mvr/mvrimporter.h
@@ -137,14 +137,6 @@ private:
     std::unordered_map<std::string, std::string> pathRemap;
     std::unordered_map<std::string, std::string> fixtureUuidRemap;
 
-    // Creates a temporary directory for extracting the contents of the MVR archive
-
-    // Extracts the .mvr (ZIP) contents into the given destination directory
-    bool ExtractMvrZip(const std::string& mvrPath, const std::string& destDir,
-                       std::vector<MvrImportDiagnostic>& diagnostics);
-    bool ExtractMvrZip(wxInputStream& input, const std::string& destDir,
-                       std::vector<MvrImportDiagnostic>& diagnostics);
-
     bool ImportFromStreamIntoResult(wxInputStream& input,
                                     MvrImportResult& importResult,
                                     MvrImportMode mode,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1007,7 +1007,8 @@ add_executable(save_load_roundtrip_test save_load_roundtrip_test.cpp
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp ../core/fixture_visual_color.cpp
+               ../mvr/mvrimporter.cpp ../mvr/mvr_import_package.cpp
+               ../core/fixture_visual_color.cpp
                ${PERASTAGE_TEST_MVR_CATALOG_SOURCES}
                ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
@@ -1044,7 +1045,8 @@ add_executable(mvr_project_fixture_metadata_contracts_test
                ../core/trussloader.cpp ../core/wx_path_utils.cpp
                ../core/runtime_storage.cpp ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp ../core/fixture_visual_color.cpp ${PERASTAGE_TEST_MVR_CATALOG_SOURCES}
+               ../mvr/mvrimporter.cpp ../mvr/mvr_import_package.cpp
+               ../core/fixture_visual_color.cpp ${PERASTAGE_TEST_MVR_CATALOG_SOURCES}
                ../viewer2d/fixture_label_overrides.cpp ../mvr/mvrexporter.cpp
                ../core/scene_transform_integrity.cpp
                ../core/mvr_identity_recovery.cpp
@@ -1080,7 +1082,8 @@ add_executable(project_support_userdata_roundtrip_test project_support_userdata_
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp ../core/fixture_visual_color.cpp
+               ../mvr/mvrimporter.cpp ../mvr/mvr_import_package.cpp
+               ../core/fixture_visual_color.cpp
                ${PERASTAGE_TEST_MVR_CATALOG_SOURCES}
                ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
@@ -1165,7 +1168,8 @@ add_executable(rider_truss_dictionary_normalization_test
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp ../core/fixture_visual_color.cpp
+               ../mvr/mvrimporter.cpp ../mvr/mvr_import_package.cpp
+               ../core/fixture_visual_color.cpp
                ${PERASTAGE_TEST_MVR_CATALOG_SOURCES}
                ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
@@ -1215,7 +1219,8 @@ add_executable(mvr_dmx_address_test mvr_dmx_address_test.cpp
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp ../core/fixture_visual_color.cpp
+               ../mvr/mvrimporter.cpp ../mvr/mvr_import_package.cpp
+               ../core/fixture_visual_color.cpp
                ${PERASTAGE_TEST_MVR_CATALOG_SOURCES}
                ../viewer2d/fixture_label_overrides.cpp
                ../core/logger.cpp
@@ -1254,7 +1259,8 @@ add_executable(mvr_support_userdata_roundtrip_test mvr_support_userdata_roundtri
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp ../core/fixture_visual_color.cpp
+               ../mvr/mvrimporter.cpp ../mvr/mvr_import_package.cpp
+               ../core/fixture_visual_color.cpp
                ${PERASTAGE_TEST_MVR_CATALOG_SOURCES}
                ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
@@ -1293,7 +1299,8 @@ add_executable(mvr_perastage_metadata_recovery_test
                ../core/trussloader.cpp ../core/wx_path_utils.cpp
                ../core/runtime_storage.cpp ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp ../core/fixture_visual_color.cpp ${PERASTAGE_TEST_MVR_CATALOG_SOURCES}
+               ../mvr/mvrimporter.cpp ../mvr/mvr_import_package.cpp
+               ../core/fixture_visual_color.cpp ${PERASTAGE_TEST_MVR_CATALOG_SOURCES}
                ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
                ../core/scene_transform_integrity.cpp
@@ -1336,7 +1343,8 @@ add_executable(mvr_layer_appearance_userdata_test mvr_layer_appearance_userdata_
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp ../core/fixture_visual_color.cpp
+               ../mvr/mvrimporter.cpp ../mvr/mvr_import_package.cpp
+               ../core/fixture_visual_color.cpp
                ${PERASTAGE_TEST_MVR_CATALOG_SOURCES}
                ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
@@ -1381,7 +1389,8 @@ add_executable(mvr_fixture_category_roundtrip_test mvr_fixture_category_roundtri
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp ../core/fixture_visual_color.cpp
+               ../mvr/mvrimporter.cpp ../mvr/mvr_import_package.cpp
+               ../core/fixture_visual_color.cpp
                ${PERASTAGE_TEST_MVR_CATALOG_SOURCES}
                ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
@@ -1424,7 +1433,8 @@ add_executable(mvr_sceneobject_symbol_identity_test mvr_sceneobject_symbol_ident
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp ../core/fixture_visual_color.cpp
+               ../mvr/mvrimporter.cpp ../mvr/mvr_import_package.cpp
+               ../core/fixture_visual_color.cpp
                ${PERASTAGE_TEST_MVR_CATALOG_SOURCES}
                ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
@@ -1472,7 +1482,8 @@ add_executable(mvr_truss_roundtrip_structure_test mvr_truss_roundtrip_structure_
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp ../core/fixture_visual_color.cpp
+               ../mvr/mvrimporter.cpp ../mvr/mvr_import_package.cpp
+               ../core/fixture_visual_color.cpp
                ${PERASTAGE_TEST_MVR_CATALOG_SOURCES}
                ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
@@ -1516,7 +1527,8 @@ add_executable(mvr_exporter_compliance_test mvr_exporter_compliance_test.cpp
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp ../core/fixture_visual_color.cpp
+               ../mvr/mvrimporter.cpp ../mvr/mvr_import_package.cpp
+               ../core/fixture_visual_color.cpp
                ${PERASTAGE_TEST_MVR_CATALOG_SOURCES}
                ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
@@ -1553,7 +1565,8 @@ add_executable(mvr_importer_archive_characterization_test
                ../core/trussdictionary.cpp ../core/trussloader.cpp
                ../core/wx_path_utils.cpp ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp ../core/fixture_visual_color.cpp
+               ../mvr/mvrimporter.cpp ../mvr/mvr_import_package.cpp
+               ../core/fixture_visual_color.cpp
                ${PERASTAGE_TEST_MVR_CATALOG_SOURCES}
                ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp ../core/scene_transform_integrity.cpp
@@ -1576,9 +1589,13 @@ set_perastage_test_labels(MvrImporterArchiveLegacy LAYER legacy-compatibility DO
 add_test(NAME MvrImporterArchiveRecovery
          COMMAND mvr_importer_archive_characterization_test recovery)
 set_perastage_test_labels(MvrImporterArchiveRecovery LAYER tolerant-recovery DOMAINS mvr zip)
+add_test(NAME MvrImporterPackageAcquisition
+         COMMAND mvr_importer_archive_characterization_test package)
+set_perastage_test_labels(MvrImporterPackageAcquisition LAYER standard-strict DOMAINS mvr zip)
 set_library_env(MvrImporterArchiveStrict)
 set_library_env(MvrImporterArchiveLegacy)
 set_library_env(MvrImporterArchiveRecovery)
+set_library_env(MvrImporterPackageAcquisition)
 
 add_executable(rider_save_roundtrip_test rider_save_roundtrip_test.cpp
                build_info_stub.cpp
@@ -1606,7 +1623,8 @@ add_executable(rider_save_roundtrip_test rider_save_roundtrip_test.cpp
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp ../core/fixture_visual_color.cpp
+               ../mvr/mvrimporter.cpp ../mvr/mvr_import_package.cpp
+               ../core/fixture_visual_color.cpp
                ${PERASTAGE_TEST_MVR_CATALOG_SOURCES}
                ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
@@ -2289,7 +2307,8 @@ add_executable(symbol_fixture_applier_gdtf_test symbol_fixture_applier_gdtf_test
                ../viewer3d/loader3ds.cpp
                ../viewer3d/loaderglb.cpp
                ../viewer3d/meshprimitives.cpp
-               ../mvr/mvrimporter.cpp ../core/fixture_visual_color.cpp
+               ../mvr/mvrimporter.cpp ../mvr/mvr_import_package.cpp
+               ../core/fixture_visual_color.cpp
                ${PERASTAGE_TEST_MVR_CATALOG_SOURCES}
                ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
@@ -2349,7 +2368,8 @@ add_executable(mvr_patched_gdtf_export_test mvr_patched_gdtf_export_test.cpp
                ../viewer3d/loader3ds.cpp
                ../viewer3d/loaderglb.cpp
                ../viewer3d/meshprimitives.cpp
-               ../mvr/mvrimporter.cpp ../core/fixture_visual_color.cpp
+               ../mvr/mvrimporter.cpp ../mvr/mvr_import_package.cpp
+               ../core/fixture_visual_color.cpp
                ${PERASTAGE_TEST_MVR_CATALOG_SOURCES}
                ../viewer2d/fixture_label_overrides.cpp
                consolepanel_stub.cpp

--- a/tests/check_mvr_import_package_boundary.sh
+++ b/tests/check_mvr_import_package_boundary.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+if rg -n '#include .*gui/|#include "(consolepanel|logindialog)' \
+    mvr/mvr_import_package.cpp mvr/mvr_import_package.h; then
+  echo "MVR import package acquisition must not depend on GUI code." >&2
+  exit 1
+fi
+
+if rg -n 'wxZipInputStream|ExtractMvrZip' mvr/mvrimporter.cpp mvr/mvrimporter.h; then
+  echo "MvrImporter must delegate archive extraction to mvr_import_package." >&2
+  exit 1
+fi
+
+echo "MVR import package boundary check passed."

--- a/tests/mvr_importer_archive_characterization_test.cpp
+++ b/tests/mvr_importer_archive_characterization_test.cpp
@@ -3,6 +3,8 @@
  */
 #include <cassert>
 #include <cstdint>
+#include <filesystem>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -10,11 +12,12 @@
 #include <wx/mstream.h>
 #include <wx/zipstrm.h>
 
+#include "mvr_import_package.h"
 #include "mvrimporter.h"
 
 // Builds an in-memory MVR archive with entries in deterministic order.
-static std::vector<std::uint8_t> BuildArchive(
-    const std::vector<std::pair<std::string, std::string>> &entries) {
+static std::vector<std::uint8_t>
+BuildArchive(const std::vector<std::pair<std::string, std::string>> &entries) {
   wxMemoryOutputStream memory;
   {
     wxZipOutputStream zip(memory);
@@ -53,7 +56,8 @@ static void TestStrictArchiveRejection() {
 static void TestLegacyRootNameCompatibility() {
   const std::string xml =
       "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-      "<GeneralSceneDescription verMajor=\"1\" verMinor=\"5\" provider=\"Legacy\" providerVersion=\"1\">"
+      "<GeneralSceneDescription verMajor=\"1\" verMinor=\"5\" "
+      "provider=\"Legacy\" providerVersion=\"1\">"
       "<Scene><Layers/></Scene></GeneralSceneDescription>";
   MvrImportResult result;
   assert(Import(BuildArchive({{"generalscenedescription.xml", xml}}), result));
@@ -66,7 +70,8 @@ static void TestLegacyRootNameCompatibility() {
 static void TestRecoverableUserDataDiagnostics() {
   const std::string xml =
       "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-      "<GeneralSceneDescription verMajor=\"1\" verMinor=\"6\" provider=\"Test\" providerVersion=\"1\">"
+      "<GeneralSceneDescription verMajor=\"1\" verMinor=\"6\" "
+      "provider=\"Test\" providerVersion=\"1\">"
       "<UserData><Unknown/><Data ver=\"1\"><Value/></Data></UserData>"
       "<UserData><Data provider=\"Ignored\"/></UserData>"
       "<Scene><Layers/></Scene></GeneralSceneDescription>";
@@ -84,6 +89,39 @@ static void TestRecoverableUserDataDiagnostics() {
   assert(hasCode("missing_userdata_provider"));
 }
 
+// Verifies package acquisition safety, diagnostics, discovery, and lifetime.
+static void TestPackageAcquisitionBoundary() {
+  const std::string xml =
+      "<GeneralSceneDescription verMajor=\"1\" verMinor=\"6\">"
+      "<Scene><Layers/></Scene></GeneralSceneDescription>";
+  const std::vector<std::uint8_t> validBytes = BuildArchive(
+      {{"../outside.txt", "unsafe"}, {"generalscenedescription.xml", xml}});
+  wxMemoryInputStream validInput(validBytes.data(), validBytes.size());
+  std::vector<MvrImportDiagnostic> diagnostics;
+  std::optional<mvr::ImportPackage> package =
+      mvr::AcquireImportPackage(validInput, diagnostics);
+  assert(package);
+  assert(std::filesystem::exists(package->sceneXmlPath));
+  assert(package->sceneXmlPath.parent_path() == package->rootPath);
+  assert(!std::filesystem::exists(package->rootPath.parent_path() /
+                                  "outside.txt"));
+
+  const std::vector<std::uint8_t> collisionBytes =
+      BuildArchive({{"GeneralSceneDescription.xml", xml},
+                    {"generalscenedescription.xml", xml}});
+  wxMemoryInputStream collisionInput(collisionBytes.data(),
+                                     collisionBytes.size());
+  diagnostics.clear();
+  assert(!mvr::AcquireImportPackage(collisionInput, diagnostics));
+  assert(diagnostics.size() == 1);
+  assert(diagnostics.front().code == "case_colliding_mvr_archive_entry");
+
+  const std::vector<std::uint8_t> invalidBytes = {'n', 'o', 't', 'z', 'i', 'p'};
+  wxMemoryInputStream invalidInput(invalidBytes.data(), invalidBytes.size());
+  diagnostics.clear();
+  assert(!mvr::AcquireImportPackage(invalidInput, diagnostics));
+}
+
 // Runs one independently labeled importer characterization scenario.
 int main(int argc, char **argv) {
   wxInitializer initializer;
@@ -96,6 +134,8 @@ int main(int argc, char **argv) {
     TestLegacyRootNameCompatibility();
   else if (scenario == "recovery")
     TestRecoverableUserDataDiagnostics();
+  else if (scenario == "package")
+    TestPackageAcquisitionBoundary();
   else
     assert(false);
   return 0;

--- a/tests/source_file_size_policy.json
+++ b/tests/source_file_size_policy.json
@@ -29,7 +29,7 @@
     "gui/mainwindow_menu.cpp": 2082,
     "gui/trusstablepanel.cpp": 1528,
     "mvr/mvrexporter.cpp": 4911,
-    "mvr/mvrimporter.cpp": 5172,
+    "mvr/mvrimporter.cpp": 4885,
     "tests/mvr_exporter_compliance_test.cpp": 1664,
     "viewer2d/pdf/layout_pdf_exporter.cpp": 2352,
     "viewer2d/viewer2dpanel.cpp": 4550,


### PR DESCRIPTION
### Motivation

- Separate low-level MVR archive acquisition, extraction safety, and path remapping from the semantic scene parsing to improve importer maintainability while preserving existing MVR behavior. 
- Make archive extraction and long-path collision handling platform-aware and testable outside GUI or higher-level import logic.

### Description

- Added `mvr/mvr_import_package.h` and `mvr/mvr_import_package.cpp` implementing `mvr::AcquireImportPackage` and `mvr::NormalizeImportArchivePath`, with robust ZIP extraction, ASCII-folded collision detection, long-path remapping into a `_long` directory, diagnostics, and `GeneralSceneDescription.xml` discovery. 
- Refactored `mvr/mvrimporter.cpp`/`.h` to delegate archive acquisition to `mvr::AcquireImportPackage`, removed the embedded extraction helpers, and updated archive-normalization call sites to use the new API. 
- Updated `mvr/CMakeLists.txt` and many `tests/CMakeLists.txt` entries to compile the new source file and added a new CTest entry `MvrImporterPackageAcquisition`. 
- Added `tests/check_mvr_import_package_boundary.sh`, extended `tests/mvr_importer_archive_characterization_test.cpp` with a `package` scenario that exercises `AcquireImportPackage`, and updated `tests/source_file_size_policy.json` to reflect the moved code size.

### Testing

- Built and executed the modified MVR importer tests, specifically `mvr_importer_archive_characterization_test` in scenarios `strict`, `legacy`, `recovery`, and the new `package` scenario, and they passed. 
- Ran the new package-boundary script `tests/check_mvr_import_package_boundary.sh` and it succeeded, ensuring no GUI or forbidden includes leaked into the acquisition module. 
- Verified test targets that include the new `mvr_import_package.cpp` compile in the test suite and the added CTest entry `MvrImporterPackageAcquisition` is registered and runnable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6aa4197260488324ab1d8bfff7e31cbf)