### PR TITLE
CH-103: Extract MVR GDTF/resource resolution to MvrImportResourceResolver

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -12,6 +12,8 @@ Changes since **v1.6.0**.
 
 ## Technical and packaging changes
 
+- Isolated MVR GDTF and scene-resource resolution, metadata access, and caching behind a GUI-independent import service to improve maintainability while preserving compatible path and mode matching.
+
 - Separated logical MVR scene-node and hierarchy reading into an independent compiled module while preserving existing fixture, rigging, geometry, layer, and compatibility behavior.
 - Preserved native Unicode filesystem paths across MVR scene-resource resolution on all supported platforms.
 - Improved Windows compiler reliability for the extracted MVR scene-node reader.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -12,7 +12,7 @@ Changes since **v1.6.0**.
 
 ## Technical and packaging changes
 
-- Isolated MVR GDTF and scene-resource resolution, metadata access, and caching behind a GUI-independent import service while preserving compatible path, mode, and fixture-category handling, with reliable Debug test linking across supported builds.
+- Isolated MVR GDTF and scene-resource resolution, metadata access, and caching behind a GUI-independent import service while preserving compatible path, mode, and fixture-category handling, with reliable shared-utility linkage in Debug tests across supported builds.
 
 - Separated logical MVR scene-node and hierarchy reading into an independent compiled module while preserving existing fixture, rigging, geometry, layer, and compatibility behavior.
 - Preserved native Unicode filesystem paths across MVR scene-resource resolution on all supported platforms.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -12,7 +12,7 @@ Changes since **v1.6.0**.
 
 ## Technical and packaging changes
 
-- Isolated MVR GDTF and scene-resource resolution, metadata access, and caching behind a GUI-independent import service to improve maintainability while preserving compatible path and mode matching.
+- Isolated MVR GDTF and scene-resource resolution, metadata access, and caching behind a GUI-independent import service while preserving compatible path, mode, and fixture-category handling across supported builds.
 
 - Separated logical MVR scene-node and hierarchy reading into an independent compiled module while preserving existing fixture, rigging, geometry, layer, and compatibility behavior.
 - Preserved native Unicode filesystem paths across MVR scene-resource resolution on all supported platforms.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -12,7 +12,7 @@ Changes since **v1.6.0**.
 
 ## Technical and packaging changes
 
-- Isolated MVR GDTF and scene-resource resolution, metadata access, and caching behind a GUI-independent import service while preserving compatible path, unresolved support-reference, mode, and fixture-category handling, with reliable shared-utility linkage in Debug tests across supported builds.
+- Isolated MVR GDTF and scene-resource resolution, metadata access, and caching behind a GUI-independent import service while preserving deterministic resource-name spelling, unresolved support references, mode selection, and fixture-category handling across supported platforms.
 
 - Separated logical MVR scene-node and hierarchy reading into an independent compiled module while preserving existing fixture, rigging, geometry, layer, and compatibility behavior.
 - Preserved native Unicode filesystem paths across MVR scene-resource resolution on all supported platforms.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -12,7 +12,7 @@ Changes since **v1.6.0**.
 
 ## Technical and packaging changes
 
-- Isolated MVR GDTF and scene-resource resolution, metadata access, and caching behind a GUI-independent import service while preserving compatible path, mode, and fixture-category handling across supported builds.
+- Isolated MVR GDTF and scene-resource resolution, metadata access, and caching behind a GUI-independent import service while preserving compatible path, mode, and fixture-category handling, with reliable Debug test linking across supported builds.
 
 - Separated logical MVR scene-node and hierarchy reading into an independent compiled module while preserving existing fixture, rigging, geometry, layer, and compatibility behavior.
 - Preserved native Unicode filesystem paths across MVR scene-resource resolution on all supported platforms.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -12,7 +12,7 @@ Changes since **v1.6.0**.
 
 ## Technical and packaging changes
 
-- Isolated MVR GDTF and scene-resource resolution, metadata access, and caching behind a GUI-independent import service while preserving compatible path, mode, and fixture-category handling, with reliable shared-utility linkage in Debug tests across supported builds.
+- Isolated MVR GDTF and scene-resource resolution, metadata access, and caching behind a GUI-independent import service while preserving compatible path, unresolved support-reference, mode, and fixture-category handling, with reliable shared-utility linkage in Debug tests across supported builds.
 
 - Separated logical MVR scene-node and hierarchy reading into an independent compiled module while preserving existing fixture, rigging, geometry, layer, and compatibility behavior.
 - Preserved native Unicode filesystem paths across MVR scene-resource resolution on all supported platforms.

--- a/mvr/CMakeLists.txt
+++ b/mvr/CMakeLists.txt
@@ -2,6 +2,8 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtf_catalog_matcher.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtf_catalog_parser.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mvrimporter.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/mvr_import_resource_resolver.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/mvr_import_resource_resolver.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mvr_import_types.h
     ${CMAKE_CURRENT_SOURCE_DIR}/mvr_scene_node_reader.h
     ${CMAKE_CURRENT_SOURCE_DIR}/mvr_scene_node_reader.cpp

--- a/mvr/mvr_import_resource_resolver.cpp
+++ b/mvr/mvr_import_resource_resolver.cpp
@@ -130,11 +130,13 @@ std::string FindGdtfPath(const fs::path &basePath, const std::string &spec) {
         ToLowerAscii(entry.path().extension().string()) != ".gdtf")
       continue;
     const fs::path entryPath = entry.path();
+    const std::string perastageFixtureName =
+        PerastageFixtureName(entryPath.filename());
     if (ToLowerAscii(Trim(entryPath.stem().string())) == expectedStem ||
         NormalizeGdtfLookupKey(entryPath.filename().generic_string()) ==
             expectedKey ||
-        NormalizeFixtureName(PerastageFixtureName(entryPath.filename())) ==
-            expectedFixture)
+        (!perastageFixtureName.empty() &&
+         NormalizeFixtureName(perastageFixtureName) == expectedFixture))
       return PathUtils::PathToUtf8(entryPath);
   }
   return {};
@@ -234,7 +236,7 @@ std::string MvrImportResourceResolver::NormalizeSupportGdtfSpec(
     return {};
   const std::string resolved = FindGdtfPath(sceneBasePath_, normalized);
   return MakeSceneRelative(
-      PathUtils::PathFromUtf8(resolved.empty() ? normalized : resolved));
+      PathUtils::PathFromUtf8(resolved.empty() ? spec : resolved));
 }
 
 // Resolves and caches a GDTF spec for the lifetime of this resolver.

--- a/mvr/mvr_import_resource_resolver.cpp
+++ b/mvr/mvr_import_resource_resolver.cpp
@@ -91,6 +91,23 @@ std::string PerastageFixtureName(const fs::path &path) {
   return stem.substr(first + 1, second - first - 1);
 }
 
+// Returns the actual directory entry only for a lexically exact filename.
+std::optional<fs::path> FindLexicallyExactRegularFile(
+    const fs::path &candidate) {
+  const fs::path parent = candidate.has_parent_path() ? candidate.parent_path()
+                                                       : fs::path(".");
+  std::error_code ec;
+  for (const auto &entry : fs::directory_iterator(parent, ec)) {
+    if (ec)
+      break;
+    std::error_code regularFileError;
+    if (entry.is_regular_file(regularFileError) && !regularFileError &&
+        entry.path().filename() == candidate.filename())
+      return entry.path();
+  }
+  return std::nullopt;
+}
+
 // Resolves a GDTF spec with the existing permissive filename fallbacks.
 std::string FindGdtfPath(const fs::path &basePath, const std::string &spec) {
   const std::string normalized = NormalizeImportArchivePath(spec);
@@ -99,16 +116,19 @@ std::string FindGdtfPath(const fs::path &basePath, const std::string &spec) {
   const fs::path relative = PathUtils::PathFromUtf8(normalized);
   fs::path candidate = basePath.empty() ? relative : basePath / relative;
   std::error_code ec;
-  if (ToLowerAscii(candidate.extension().string()) == ".gdtf" &&
-      fs::exists(candidate, ec) && !ec)
-    return PathUtils::PathToUtf8(candidate);
-  ec.clear();
+  if (ToLowerAscii(candidate.extension().string()) == ".gdtf") {
+    const std::optional<fs::path> exact =
+        FindLexicallyExactRegularFile(candidate);
+    if (exact)
+      return PathUtils::PathToUtf8(*exact);
+  }
   if (!candidate.has_extension()) {
     fs::path withExtension = candidate;
     withExtension += ".gdtf";
-    if (fs::exists(withExtension, ec) && !ec)
-      return PathUtils::PathToUtf8(withExtension);
-    ec.clear();
+    const std::optional<fs::path> exact =
+        FindLexicallyExactRegularFile(withExtension);
+    if (exact)
+      return PathUtils::PathToUtf8(*exact);
   }
 #if defined(_WIN32)
   if (basePath.empty())

--- a/mvr/mvr_import_resource_resolver.cpp
+++ b/mvr/mvr_import_resource_resolver.cpp
@@ -410,7 +410,8 @@ std::string MvrImportResourceResolver::NormalizeGeometryFile(
     return primitive;
   fs::path resolved = ResolveScenePath(normalized);
   if (!PathUtils::PathFromUtf8(normalized).has_extension()) {
-    for (const std::string &extension : {".gltf", ".glb", ".3ds"}) {
+    const std::array<std::string, 3> extensions = {".gltf", ".glb", ".3ds"};
+    for (const std::string &extension : extensions) {
       fs::path candidate = resolved;
       candidate += extension;
       std::error_code ec;

--- a/mvr/mvr_import_resource_resolver.cpp
+++ b/mvr/mvr_import_resource_resolver.cpp
@@ -1,0 +1,428 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2026 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+#include "mvr_import_resource_resolver.h"
+
+#include "filesystem_path_utils.h"
+#include "gdtfloader.h"
+#include "mvr_import_package.h"
+#include "primitive_model_resources.h"
+#include "trussloader.h"
+#include "uuidutils.h"
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <system_error>
+
+namespace fs = std::filesystem;
+
+namespace mvr {
+namespace {
+
+// Trims surrounding ASCII whitespace from imported identifiers.
+std::string Trim(const std::string &text) {
+  const size_t first = text.find_first_not_of(" \t\r\n");
+  if (first == std::string::npos)
+    return {};
+  return text.substr(first, text.find_last_not_of(" \t\r\n") - first + 1);
+}
+
+// Converts ASCII characters to lower case for compatibility comparisons.
+std::string ToLowerAscii(std::string text) {
+  std::transform(text.begin(), text.end(), text.begin(), [](unsigned char c) {
+    return static_cast<char>(std::tolower(c));
+  });
+  return text;
+}
+
+// Extracts a normalized digit signature from a mode name.
+std::string DigitSignature(const std::string &text) {
+  std::string digits;
+  for (unsigned char c : text) {
+    if (std::isdigit(c))
+      digits.push_back(static_cast<char>(c));
+  }
+  const size_t first = digits.find_first_not_of('0');
+  if (first == std::string::npos)
+    return digits.empty() ? std::string{} : "0";
+  return digits.substr(first);
+}
+
+// Normalizes a GDTF filename for permissive archive lookup.
+std::string NormalizeGdtfLookupKey(const std::string &value) {
+  const std::string normalized = NormalizeImportArchivePath(value);
+  if (normalized.empty())
+    return {};
+  const fs::path path = PathUtils::PathFromUtf8(normalized);
+  std::string extension = ToLowerAscii(path.extension().string());
+  if (extension.empty())
+    extension = ".gdtf";
+  return ToLowerAscii(Trim(path.stem().string()) + extension);
+}
+
+// Normalizes fixture names used by canonical Perastage filenames.
+std::string NormalizeFixtureName(std::string value) {
+  value = ToLowerAscii(Trim(value));
+  value.erase(std::remove_if(value.begin(), value.end(),
+                             [](unsigned char c) {
+                               return std::isspace(c) != 0 || c == '_' ||
+                                      c == '-';
+                             }),
+              value.end());
+  return value;
+}
+
+// Extracts the fixture segment from a canonical Perastage GDTF filename.
+std::string PerastageFixtureName(const fs::path &path) {
+  const std::string stem = path.stem().string();
+  const size_t first = stem.find('@');
+  const size_t second = first == std::string::npos ? std::string::npos
+                                                   : stem.find('@', first + 1);
+  if (second == std::string::npos ||
+      NormalizeFixtureName(stem.substr(second + 1)) != "perastage")
+    return {};
+  return stem.substr(first + 1, second - first - 1);
+}
+
+// Resolves a GDTF spec with the existing permissive filename fallbacks.
+std::string FindGdtfPath(const fs::path &basePath, const std::string &spec) {
+  const std::string normalized = NormalizeImportArchivePath(spec);
+  if (normalized.empty())
+    return {};
+  const fs::path relative = PathUtils::PathFromUtf8(normalized);
+  fs::path candidate = basePath.empty() ? relative : basePath / relative;
+  std::error_code ec;
+  if (ToLowerAscii(candidate.extension().string()) == ".gdtf" &&
+      fs::exists(candidate, ec) && !ec)
+    return PathUtils::PathToUtf8(candidate);
+  ec.clear();
+  if (!candidate.has_extension()) {
+    fs::path withExtension = candidate;
+    withExtension += ".gdtf";
+    if (fs::exists(withExtension, ec) && !ec)
+      return PathUtils::PathToUtf8(withExtension);
+    ec.clear();
+  }
+#if defined(_WIN32)
+  if (basePath.empty())
+    return {};
+  const fs::path lookupDir = basePath;
+#else
+  const fs::path lookupDir = basePath.empty() ? fs::current_path(ec) : basePath;
+#endif
+  if (ec || !fs::exists(lookupDir, ec) || ec)
+    return {};
+  const std::string expectedStem =
+      ToLowerAscii(Trim(relative.filename().stem().string()));
+  const std::string expectedFixture = NormalizeFixtureName(expectedStem);
+  const std::string expectedKey = NormalizeGdtfLookupKey(normalized);
+  for (const auto &entry : fs::directory_iterator(lookupDir, ec)) {
+    if (ec)
+      break;
+    if (!entry.is_regular_file() ||
+        ToLowerAscii(entry.path().extension().string()) != ".gdtf")
+      continue;
+    const fs::path entryPath = entry.path();
+    if (ToLowerAscii(Trim(entryPath.stem().string())) == expectedStem ||
+        NormalizeGdtfLookupKey(entryPath.filename().generic_string()) ==
+            expectedKey ||
+        NormalizeFixtureName(PerastageFixtureName(entryPath.filename())) ==
+            expectedFixture)
+      return PathUtils::PathToUtf8(entryPath);
+  }
+  return {};
+}
+
+// Compares path components with native platform case semantics.
+bool SamePathComponent(const fs::path &lhs, const fs::path &rhs) {
+#if defined(_WIN32)
+  return ToLowerAscii(lhs.string()) == ToLowerAscii(rhs.string());
+#else
+  return lhs == rhs;
+#endif
+}
+
+// Reports whether a normalized path stays within a normalized base path.
+bool IsWithin(const fs::path &candidate, const fs::path &base) {
+  auto candidateIt = candidate.begin();
+  for (auto baseIt = base.begin(); baseIt != base.end();
+       ++baseIt, ++candidateIt) {
+    if (candidateIt == candidate.end() ||
+        !SamePathComponent(*candidateIt, *baseIt))
+      return false;
+  }
+  return true;
+}
+
+// Produces an absolute normalized path without throwing.
+fs::path NormalizedAbsolute(const fs::path &path, std::error_code &ec) {
+  fs::path absolute = path;
+  if (!absolute.is_absolute()) {
+    absolute = fs::absolute(path, ec);
+    if (ec)
+      return {};
+  }
+  std::error_code canonicalError;
+  const fs::path canonical = fs::weakly_canonical(absolute, canonicalError);
+  return canonicalError ? absolute.lexically_normal()
+                        : canonical.lexically_normal();
+}
+
+} // namespace
+
+// Creates a resolver scoped to one extracted scene workspace.
+MvrImportResourceResolver::MvrImportResourceResolver(
+    fs::path sceneBasePath, ArchivePathRemapper archivePathRemapper)
+    : sceneBasePath_(std::move(sceneBasePath)),
+      archivePathRemapper_(std::move(archivePathRemapper)) {}
+
+// Applies package-provided archive entry remapping when available.
+std::string
+MvrImportResourceResolver::RemapArchivePath(const std::string &path) const {
+  return archivePathRemapper_ ? archivePathRemapper_(path) : path;
+}
+
+// Resolves an imported scene reference at the native filesystem boundary.
+fs::path
+MvrImportResourceResolver::ResolveScenePath(const std::string &path) const {
+  const fs::path native = PathUtils::PathFromUtf8(path);
+  return native.is_absolute() || sceneBasePath_.empty()
+             ? native
+             : sceneBasePath_ / native;
+}
+
+// Makes a path scene-relative only when it remains inside the scene workspace.
+std::string
+MvrImportResourceResolver::MakeSceneRelative(const fs::path &path) const {
+  if (path.empty())
+    return {};
+  if (sceneBasePath_.empty() || !path.is_absolute())
+    return PathUtils::PathToUtf8(path);
+  std::error_code ec;
+  const fs::path base = NormalizedAbsolute(sceneBasePath_, ec);
+  if (ec)
+    return PathUtils::PathToUtf8(path);
+  const fs::path candidate = NormalizedAbsolute(path, ec);
+  if (ec || !IsWithin(candidate, base))
+    return PathUtils::PathToUtf8(path);
+  const fs::path relative = fs::relative(candidate, base, ec);
+  return ec || relative.empty() ? PathUtils::PathToUtf8(path)
+                                : PathUtils::PathToUtf8(relative);
+}
+
+// Normalizes and resolves a fixture GDTF spec for scene storage.
+std::string
+MvrImportResourceResolver::NormalizeGdtfSpec(const std::string &spec) {
+  const std::string normalized = NormalizeImportArchivePath(spec);
+  return normalized.empty() ? std::string{}
+                            : MakeSceneRelative(PathUtils::PathFromUtf8(
+                                  ResolveGdtfPath(normalized)));
+}
+
+// Normalizes a support GDTF spec while preserving missing resources.
+std::string MvrImportResourceResolver::NormalizeSupportGdtfSpec(
+    const std::string &spec) const {
+  const std::string normalized = NormalizeImportArchivePath(spec);
+  if (normalized.empty())
+    return {};
+  const std::string resolved = FindGdtfPath(sceneBasePath_, normalized);
+  return MakeSceneRelative(
+      PathUtils::PathFromUtf8(resolved.empty() ? normalized : resolved));
+}
+
+// Resolves and caches a GDTF spec for the lifetime of this resolver.
+const std::string &
+MvrImportResourceResolver::ResolveGdtfPath(const std::string &spec) {
+  const std::string normalized = NormalizeImportArchivePath(spec);
+  if (normalized.empty())
+    return emptyPath_;
+  const auto found = resolvedGdtfPaths_.find(normalized);
+  if (found != resolvedGdtfPaths_.end())
+    return found->second;
+  std::string resolved = FindGdtfPath(sceneBasePath_, normalized);
+  if (resolved.empty())
+    resolved = PathUtils::PathToUtf8(ResolveScenePath(normalized));
+  return resolvedGdtfPaths_.emplace(normalized, std::move(resolved))
+      .first->second;
+}
+
+// Reports whether a resolved GDTF path names a regular file.
+bool MvrImportResourceResolver::GdtfFileExists(const std::string &path) const {
+  std::error_code ec;
+  return !path.empty() &&
+         fs::is_regular_file(PathUtils::PathFromUtf8(path), ec) && !ec;
+}
+
+// Builds a stable native-filesystem identity key for a resolved GDTF.
+std::string
+MvrImportResourceResolver::GdtfIdentityKey(const std::string &path) const {
+  return path.empty() ? std::string{}
+                      : PathUtils::BuildFilesystemIdentityKey(
+                            PathUtils::PathFromUtf8(path));
+}
+
+// Loads and caches the mode list for a GDTF resource.
+const std::vector<std::string> &
+MvrImportResourceResolver::GdtfModes(const std::string &path) {
+  const std::string key = GdtfIdentityKey(path);
+  const auto found = gdtfModes_.find(key);
+  if (found != gdtfModes_.end())
+    return found->second;
+  return gdtfModes_
+      .emplace(key, GdtfFileExists(path) ? GetGdtfModes(path)
+                                         : std::vector<std::string>{})
+      .first->second;
+}
+
+// Loads and caches one GDTF mode channel count.
+int MvrImportResourceResolver::GdtfModeChannelCount(const std::string &path,
+                                                    const std::string &mode) {
+  if (!GdtfFileExists(path))
+    return -1;
+  auto &counts = gdtfModeChannelCounts_[GdtfIdentityKey(path)];
+  const auto found = counts.find(mode);
+  if (found != counts.end())
+    return found->second;
+  return counts.emplace(mode, GetGdtfModeChannelCount(path, mode))
+      .first->second;
+}
+
+// Selects a compatible mode using the established importer fallback order.
+std::string MvrImportResourceResolver::SelectMode(
+    const std::vector<std::string> &modes, const std::string &requestedMode,
+    std::optional<int> channelCountHint,
+    const ModeChannelCountLookup &channelCount) {
+  if (modes.empty())
+    return requestedMode;
+  const std::string requested = ToLowerAscii(Trim(requestedMode));
+  if (!requested.empty()) {
+    for (const std::string &mode : modes) {
+      if (ToLowerAscii(Trim(mode)) == requested)
+        return mode;
+    }
+  }
+  const std::string digits = DigitSignature(requested);
+  if (!digits.empty()) {
+    for (const std::string &mode : modes) {
+      if (DigitSignature(ToLowerAscii(Trim(mode))) == digits)
+        return mode;
+    }
+  }
+  if (channelCountHint && *channelCountHint > 0) {
+    for (const std::string &mode : modes) {
+      if (channelCount(mode) == *channelCountHint)
+        return mode;
+    }
+  }
+  for (const std::string &mode : modes) {
+    const std::string normalized = ToLowerAscii(Trim(mode));
+    if (normalized == "default" || normalized == "standard")
+      return mode;
+  }
+  return modes.front();
+}
+
+// Resolves a requested mode using cached GDTF mode information.
+std::string MvrImportResourceResolver::ResolveGdtfMode(
+    const std::string &path, const std::string &requestedMode,
+    std::optional<int> channelCountHint) {
+  return SelectMode(GdtfModes(path), requestedMode, channelCountHint,
+                    [&](const std::string &mode) {
+                      return GdtfModeChannelCount(path, mode);
+                    });
+}
+
+// Loads and caches fixture metadata exposed by a GDTF resource.
+const ImportGdtfMetadata &
+MvrImportResourceResolver::FixtureMetadata(const std::string &path) {
+  if (!GdtfFileExists(path))
+    return emptyMetadata_;
+  const std::string key = GdtfIdentityKey(path);
+  const auto found = fixtureMetadata_.find(key);
+  if (found != fixtureMetadata_.end())
+    return found->second;
+  ImportGdtfMetadata metadata;
+  metadata.fixtureName = Trim(GetGdtfFixtureName(path));
+  metadata.manufacturer = Trim(GetGdtfFixtureManufacturer(path));
+  const std::string rawId = Trim(GetGdtfFixtureTypeId(path));
+  metadata.fixtureTypeId = CanonicalizeUuid(rawId);
+  if (metadata.fixtureTypeId.empty())
+    metadata.fixtureTypeId = rawId;
+  metadata.hasProperties =
+      GetGdtfProperties(path, metadata.weightKg, metadata.powerW);
+  return fixtureMetadata_.emplace(key, std::move(metadata)).first->second;
+}
+
+// Loads and caches either the successful or failed truss definition result.
+bool MvrImportResourceResolver::LoadTrussDefinition(const std::string &path,
+                                                    Truss &out) {
+  if (path.empty())
+    return false;
+  const std::string key = GdtfIdentityKey(path);
+  auto found = trussDefinitions_.find(key);
+  if (found == trussDefinitions_.end()) {
+    Truss loaded;
+    found = trussDefinitions_
+                .emplace(key, ::LoadTrussDefinition(path, loaded)
+                                  ? std::optional<Truss>(std::move(loaded))
+                                  : std::nullopt)
+                .first;
+  }
+  if (!found->second)
+    return false;
+  out = *found->second;
+  return true;
+}
+
+// Loads and caches a dictionary entry for a fixture type.
+const std::optional<GdtfDictionary::Entry> &
+MvrImportResourceResolver::DictionaryEntry(const std::string &typeName) {
+  static const std::optional<GdtfDictionary::Entry> empty;
+  if (typeName.empty())
+    return empty;
+  const auto found = dictionaryEntries_.find(typeName);
+  if (found != dictionaryEntries_.end())
+    return found->second;
+  return dictionaryEntries_.emplace(typeName, GdtfDictionary::Get(typeName))
+      .first->second;
+}
+
+// Normalizes and resolves a scene geometry resource filename.
+std::string MvrImportResourceResolver::NormalizeGeometryFile(
+    const std::string &fileName) const {
+  const std::string trimmed = Trim(fileName);
+  if (trimmed.empty())
+    return {};
+  std::string normalized =
+      PathUtils::PathToUtf8(PathUtils::PathFromUtf8(trimmed));
+  std::string primitive;
+  if (ResolvePrimitiveTokenFromModelRef(normalized, primitive))
+    return primitive;
+  normalized = RemapArchivePath(normalized);
+  if (ResolvePrimitiveTokenFromModelRef(normalized, primitive))
+    return primitive;
+  fs::path resolved = ResolveScenePath(normalized);
+  if (!PathUtils::PathFromUtf8(normalized).has_extension()) {
+    for (const std::string &extension : {".gltf", ".glb", ".3ds"}) {
+      fs::path candidate = resolved;
+      candidate += extension;
+      std::error_code ec;
+      if (fs::exists(candidate, ec) && !ec) {
+        resolved = std::move(candidate);
+        break;
+      }
+    }
+    if (!resolved.has_extension())
+      resolved += ".3ds";
+  }
+  return MakeSceneRelative(resolved);
+}
+
+} // namespace mvr

--- a/mvr/mvr_import_resource_resolver.h
+++ b/mvr/mvr_import_resource_resolver.h
@@ -1,0 +1,81 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2026 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+#pragma once
+
+#include "gdtfdictionary.h"
+#include "truss.h"
+
+#include <filesystem>
+#include <functional>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace mvr {
+
+struct ImportGdtfMetadata {
+  std::string fixtureName;
+  std::string manufacturer;
+  std::string fixtureTypeId;
+  float weightKg = 0.0f;
+  float powerW = 0.0f;
+  bool hasProperties = false;
+};
+
+class MvrImportResourceResolver {
+public:
+  using ArchivePathRemapper = std::function<std::string(const std::string &)>;
+  using ModeChannelCountLookup = std::function<int(const std::string &)>;
+
+  explicit MvrImportResourceResolver(
+      std::filesystem::path sceneBasePath,
+      ArchivePathRemapper archivePathRemapper = {});
+
+  std::string RemapArchivePath(const std::string &path) const;
+  std::filesystem::path ResolveScenePath(const std::string &path) const;
+  std::string MakeSceneRelative(const std::filesystem::path &path) const;
+  std::string NormalizeGdtfSpec(const std::string &spec);
+  std::string NormalizeSupportGdtfSpec(const std::string &spec) const;
+  const std::string &ResolveGdtfPath(const std::string &spec);
+  bool GdtfFileExists(const std::string &path) const;
+  std::string GdtfIdentityKey(const std::string &path) const;
+  const std::vector<std::string> &GdtfModes(const std::string &path);
+  int GdtfModeChannelCount(const std::string &path, const std::string &mode);
+  std::string ResolveGdtfMode(const std::string &path,
+                              const std::string &requestedMode,
+                              std::optional<int> channelCountHint);
+  const ImportGdtfMetadata &FixtureMetadata(const std::string &path);
+  bool LoadTrussDefinition(const std::string &path, Truss &out);
+  const std::optional<GdtfDictionary::Entry> &
+  DictionaryEntry(const std::string &typeName);
+  std::string NormalizeGeometryFile(const std::string &fileName) const;
+
+  static std::string SelectMode(const std::vector<std::string> &modes,
+                                const std::string &requestedMode,
+                                std::optional<int> channelCountHint,
+                                const ModeChannelCountLookup &channelCount);
+
+private:
+  std::filesystem::path sceneBasePath_;
+  ArchivePathRemapper archivePathRemapper_;
+  std::unordered_map<std::string, std::string> resolvedGdtfPaths_;
+  std::unordered_map<std::string, std::vector<std::string>> gdtfModes_;
+  std::unordered_map<std::string, std::unordered_map<std::string, int>>
+      gdtfModeChannelCounts_;
+  std::unordered_map<std::string, ImportGdtfMetadata> fixtureMetadata_;
+  std::unordered_map<std::string, std::optional<Truss>> trussDefinitions_;
+  std::unordered_map<std::string, std::optional<GdtfDictionary::Entry>>
+      dictionaryEntries_;
+  const std::string emptyPath_;
+  const ImportGdtfMetadata emptyMetadata_;
+};
+
+} // namespace mvr

--- a/mvr/mvr_scene_node_reader.cpp
+++ b/mvr/mvr_scene_node_reader.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "mvr_scene_node_reader.h"
+#include "mvr_import_resource_resolver.h"
 #include "mvr_scene_node_reader_detail.h"
 
 #include "filesystem_path_utils.h"
@@ -141,7 +142,10 @@ void ReadMvrSceneNodes(tinyxml2::XMLElement *sceneNode, MvrScene &scene,
         services.parseMatrixOrIdentity(parent, elementName, context, out,
                                        inspectScale);
       };
-  const auto &remapArchivePathIfNeeded = services.remapArchivePath;
+  auto &resources = services.resources;
+  auto remapArchivePathIfNeeded = [&](const std::string &path) {
+    return resources.RemapArchivePath(path);
+  };
   const auto &buildFixtureTypeInfoKey = services.buildFixtureTypeInfoKey;
   auto resolveStableUuid = [&](const char *kind, tinyxml2::XMLElement *node,
                                const std::string &layer,
@@ -151,17 +155,39 @@ void ReadMvrSceneNodes(tinyxml2::XMLElement *sceneNode, MvrScene &scene,
   };
   const auto &referenceUuidForNode = services.referenceUuid;
   const auto &ensurePositionEntry = services.ensurePosition;
-  const auto &normalizeGdtfSpecForScene = services.normalizeGdtfSpec;
-  const auto &normalizeSupportGdtfSpec = services.normalizeSupportGdtfSpec;
-  const auto &resolveGdtfPathCached = services.resolveGdtfPath;
-  const auto &getFixtureMetadata = services.fixtureMetadata;
-  const auto &resolveExistingGdtfModeCached = services.resolveGdtfMode;
-  const auto &getGdtfModeChannelCountCached = services.gdtfModeChannelCount;
-  const auto &getDictionaryEntryCached = services.dictionaryEntry;
-  const auto &loadTrussDefinitionCached = services.loadTrussDefinition;
+  auto normalizeGdtfSpecForScene = [&](const std::string &spec) {
+    return resources.NormalizeGdtfSpec(spec);
+  };
+  auto normalizeSupportGdtfSpec = [&](const std::string &spec) {
+    return resources.NormalizeSupportGdtfSpec(spec);
+  };
+  auto resolveGdtfPathCached =
+      [&](const std::string &spec) -> const std::string & {
+    return resources.ResolveGdtfPath(spec);
+  };
+  auto getFixtureMetadata =
+      [&](const std::string &path) -> const ImportGdtfMetadata & {
+    return resources.FixtureMetadata(path);
+  };
+  auto resolveExistingGdtfModeCached = [&](const std::string &path,
+                                           const std::string &mode,
+                                           std::optional<int> count) {
+    return resources.ResolveGdtfMode(path, mode, count);
+  };
+  auto getGdtfModeChannelCountCached = [&](const std::string &path,
+                                           const std::string &mode) {
+    return resources.GdtfModeChannelCount(path, mode);
+  };
+  auto getDictionaryEntryCached = [&](const std::string &type) -> const auto & {
+    return resources.DictionaryEntry(type);
+  };
+  auto loadTrussDefinitionCached = [&](const std::string &path, Truss &out) {
+    return resources.LoadTrussDefinition(path, out);
+  };
   const auto &resolveSymdefReference = services.resolveSymdef;
-  const auto &normalizeAndResolveGeometryFileName =
-      services.normalizeGeometryFile;
+  auto normalizeAndResolveGeometryFileName = [&](const std::string &path) {
+    return resources.NormalizeGeometryFile(path);
+  };
   auto appendGeometryInstance = [&](std::vector<GeometryInstance> &instances,
                                     const std::string &fileName,
                                     const Matrix &localTransform,
@@ -540,7 +566,7 @@ void ReadMvrSceneNodes(tinyxml2::XMLElement *sceneNode, MvrScene &scene,
                "Ignored unsafe TrussInfo AuxGdtf path '" + archiveName + "'."});
         } else {
           const std::string remapped = remapArchivePathIfNeeded(archiveName);
-          const fs::path resolved = services.resolveScenePath(remapped);
+          const fs::path resolved = resources.ResolveScenePath(remapped);
           std::error_code existsEc;
           if (fs::is_regular_file(resolved, existsEc) && !existsEc) {
             truss.perastageAuxGdtfArchivePath = remapped;
@@ -740,7 +766,7 @@ void ReadMvrSceneNodes(tinyxml2::XMLElement *sceneNode, MvrScene &scene,
         }
 
         const fs::path resolvedSymbolPath =
-            services.resolveScenePath(truss.symbolFile);
+            resources.ResolveScenePath(truss.symbolFile);
         const bool symbolRenderable =
             scene_reader_detail::IsRenderableTrussGeometry(truss.symbolFile);
         std::error_code symbolExistsEc;

--- a/mvr/mvr_scene_node_reader.h
+++ b/mvr/mvr_scene_node_reader.h
@@ -11,7 +11,6 @@
 
 #include "fixture.h"
 #include "gdtf_fixture_category.h"
-#include "gdtfdictionary.h"
 #include "mvr_import_types.h"
 #include "truss.h"
 
@@ -29,14 +28,7 @@ class XMLElement;
 
 namespace mvr {
 
-struct SceneReadGdtfMetadata {
-  std::string fixtureName;
-  std::string manufacturer;
-  std::string fixtureTypeId;
-  float weightKg = 0.0f;
-  float powerW = 0.0f;
-  bool hasProperties = false;
-};
+class MvrImportResourceResolver;
 
 struct SceneReadLegacyFixtureIdentity {
   std::string stableId;
@@ -76,13 +68,13 @@ struct SceneReadGdtfConflict {
 };
 
 struct MvrSceneReadServices {
+  MvrImportResourceResolver &resources;
   std::function<std::string(tinyxml2::XMLElement *, const char *)> textOf;
   std::function<void(tinyxml2::XMLElement *, const char *, int &)> intOf;
   std::function<void(tinyxml2::XMLElement *, std::string &, int &)> fixtureIdOf;
   std::function<void(tinyxml2::XMLElement *, const char *, const std::string &,
                      Matrix &, bool)>
       parseMatrixOrIdentity;
-  std::function<std::string(const std::string &)> remapArchivePath;
   std::function<std::string(const std::string &, const std::string &,
                             const std::string &)>
       buildFixtureTypeInfoKey;
@@ -94,30 +86,14 @@ struct MvrSceneReadServices {
                             const std::string &, const Matrix &)>
       referenceUuid;
   std::function<std::string(const std::string &)> ensurePosition;
-  std::function<std::string(const std::string &)> normalizeGdtfSpec;
-  std::function<std::string(const std::string &)> normalizeSupportGdtfSpec;
-  std::function<const std::string &(const std::string &)> resolveGdtfPath;
-  std::function<const SceneReadGdtfMetadata &(const std::string &)>
-      fixtureMetadata;
-  std::function<std::string(const std::string &, const std::string &,
-                            std::optional<int>)>
-      resolveGdtfMode;
-  std::function<int(const std::string &, const std::string &)>
-      gdtfModeChannelCount;
-  std::function<const std::optional<GdtfDictionary::Entry> &(
-      const std::string &)>
-      dictionaryEntry;
-  std::function<bool(const std::string &, Truss &)> loadTrussDefinition;
   std::function<void(tinyxml2::XMLElement *, std::vector<SymdefGeometry> &,
                      std::string &, Matrix &)>
       resolveSymdef;
-  std::function<std::string(std::string)> normalizeGeometryFile;
   std::function<void(std::vector<GeometryInstance> &, const std::string &,
                      const Matrix &, const std::string &, const std::string &,
                      const std::string &)>
       appendGeometry;
   std::function<void(std::string, int, int)> reportProgress;
-  std::function<std::filesystem::path(const std::string &)> resolveScenePath;
   std::function<void(const std::string &)> logDebug;
   std::function<void(const std::string &)> logInfo;
   std::function<void(const std::string &)> logWarning;

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -22,6 +22,7 @@
 #include "configmanager.h"
 #include "filesystem_path_utils.h"
 #include "mvr_import_package.h"
+#include "mvr_import_resource_resolver.h"
 #include "mvr_scene_node_reader.h"
 #ifdef PERASTAGE_ENABLE_MVR_GDTF_DOWNLOAD_API
 #include "credentialstore.h"
@@ -142,89 +143,6 @@ static std::string NormalizeSlashes(std::string path) {
   return path;
 }
 
-static std::string ToLowerAscii(std::string text) {
-  std::transform(text.begin(), text.end(), text.begin(), [](unsigned char c) {
-    return static_cast<char>(std::tolower(c));
-  });
-  return text;
-}
-
-static std::string ResolveGdtfPath(const std::string &baseDir,
-                                   const std::string &spec);
-
-// Reports whether extension metadata names one portable root-level archive
-// file.
-static bool IsPortableRootArchiveFileName(const std::string &value) {
-  if (value.empty() || value == "." || value == "..")
-    return false;
-  if (std::any_of(value.begin(), value.end(),
-                  [](unsigned char ch) { return ch < 32 || ch == 127; }))
-    return false;
-  if (value.find('/') != std::string::npos ||
-      value.find('\\') != std::string::npos ||
-      value.find(':') != std::string::npos)
-    return false;
-  const fs::path path = PathUtils::PathFromUtf8(value);
-  return !path.is_absolute() && !path.has_root_name() &&
-         path.filename().generic_string() == value;
-}
-
-static std::string NormalizeGdtfLookupKey(const std::string &value) {
-  std::string normalized = mvr::NormalizeImportArchivePath(value);
-  if (normalized.empty())
-    return normalized;
-
-  fs::path path = PathUtils::PathFromUtf8(normalized);
-  std::string stem = Trim(path.stem().string());
-  std::string ext = ToLowerAscii(path.extension().string());
-  if (ext.empty())
-    ext = ".gdtf";
-  return ToLowerAscii(stem + ext);
-}
-
-// Normalizes fixture names for filename-based GDTF identity matching.
-static std::string NormalizeFixtureNameLookupKey(std::string value) {
-  value = ToLowerAscii(Trim(value));
-  value.erase(std::remove_if(value.begin(), value.end(),
-                             [](unsigned char ch) {
-                               return std::isspace(ch) != 0 || ch == '_' ||
-                                      ch == '-';
-                             }),
-              value.end());
-  return value;
-}
-
-// Extracts the fixture-name segment from a Perastage canonical GDTF filename.
-static std::string
-ExtractPerastageFixtureNameFromFileName(const fs::path &path) {
-  const std::string stem = path.stem().string();
-  const size_t firstAt = stem.find('@');
-  if (firstAt == std::string::npos)
-    return {};
-  const size_t secondAt = stem.find('@', firstAt + 1);
-  if (secondAt == std::string::npos)
-    return {};
-  if (NormalizeFixtureNameLookupKey(stem.substr(secondAt + 1)) != "perastage")
-    return {};
-  return stem.substr(firstAt + 1, secondAt - firstAt - 1);
-}
-
-static std::string ExtractDigitSignature(const std::string &text) {
-  std::string digits;
-  digits.reserve(text.size());
-  for (unsigned char c : text) {
-    if (std::isdigit(c))
-      digits.push_back(static_cast<char>(c));
-  }
-  if (digits.empty())
-    return digits;
-
-  const size_t firstNonZero = digits.find_first_not_of('0');
-  if (firstNonZero == std::string::npos)
-    return "0";
-  return digits.substr(firstNonZero);
-}
-
 static bool IsNearlyEqualRelative(float a, float b, float relEps) {
   if (!std::isfinite(a) || !std::isfinite(b))
     return false;
@@ -304,181 +222,6 @@ static bool TryParseFloat(const std::string &text, float &out) {
 }
 
 
-
-static fs::path ResolveSceneRelativePath(const std::string &basePath,
-                                         const std::string &pathText) {
-  fs::path path = PathUtils::PathFromUtf8(pathText);
-  if (path.is_absolute() || basePath.empty())
-    return path;
-  return PathUtils::PathFromUtf8(basePath) / path;
-}
-
-// Compares path components using platform filesystem case-sensitivity rules.
-static bool SameFilesystemPathComponent(const fs::path &lhs,
-                                        const fs::path &rhs) {
-#if defined(_WIN32)
-  return ToLowerAscii(lhs.string()) == ToLowerAscii(rhs.string());
-#else
-  return lhs == rhs;
-#endif
-}
-
-// Returns true when candidate is inside base after both paths have been
-// normalized.
-static bool IsPathWithinDirectoryByComponents(const fs::path &candidate,
-                                              const fs::path &base) {
-  auto candidateIt = candidate.begin();
-  auto baseIt = base.begin();
-  for (; baseIt != base.end(); ++baseIt, ++candidateIt) {
-    if (candidateIt == candidate.end() ||
-        !SameFilesystemPathComponent(*candidateIt, *baseIt))
-      return false;
-  }
-  return true;
-}
-
-// Builds a normalized absolute path without throwing filesystem exceptions.
-static fs::path NormalizedAbsolutePathForImport(const fs::path &path,
-                                                std::error_code &ec) {
-  ec.clear();
-  fs::path absolute = path;
-  if (!absolute.is_absolute()) {
-    absolute = fs::absolute(path, ec);
-    if (ec)
-      return {};
-  }
-
-  std::error_code canonicalEc;
-  fs::path canonical = fs::weakly_canonical(absolute, canonicalEc);
-  if (!canonicalEc)
-    return canonical.lexically_normal();
-
-  return absolute.lexically_normal();
-}
-
-// Converts imported resource paths to scene-relative references only when they
-// stay under scene.basePath.
-static std::string
-ToSceneRelativePathIfPossible(const std::string &basePath,
-                                                 const fs::path &candidatePath) {
-  if (candidatePath.empty())
-    return {};
-
-  if (basePath.empty() || !candidatePath.is_absolute())
-    return ToString(candidatePath.u8string());
-
-  std::error_code ec;
-  const fs::path base =
-      NormalizedAbsolutePathForImport(PathUtils::PathFromUtf8(basePath), ec);
-  if (ec)
-    return ToString(candidatePath.u8string());
-
-  const fs::path candidate = NormalizedAbsolutePathForImport(candidatePath, ec);
-  if (ec)
-    return ToString(candidatePath.u8string());
-
-  if (!IsPathWithinDirectoryByComponents(candidate, base))
-    return ToString(candidatePath.u8string());
-
-  fs::path relative = fs::relative(candidate, base, ec);
-  if (ec || relative.empty())
-    return ToString(candidatePath.u8string());
-
-  return ToString(relative.u8string());
-}
-
-static std::string ResolveScenePathForRead(const std::string &basePath,
-                                           const std::string &pathText) {
-  if (pathText.empty())
-    return {};
-  const std::string normalized = mvr::NormalizeImportArchivePath(pathText);
-  if (normalized.empty())
-    return {};
-  const std::string gdtfResolved = ResolveGdtfPath(basePath, normalized);
-  if (!gdtfResolved.empty())
-    return gdtfResolved;
-  return ToString(ResolveSceneRelativePath(basePath, normalized).u8string());
-}
-
-// Resolves a scene-provided GDTF spec to the real extracted file path.
-// MVR files may omit ".gdtf" in <GDTFSpec> or use a different filename case,
-// so we progressively try exact, extension-appended and case-insensitive
-// matches.
-static std::string ResolveGdtfPath(const std::string &baseDir,
-                                   const std::string &spec) {
-  const std::string normalizedSpec = mvr::NormalizeImportArchivePath(spec);
-  if (normalizedSpec.empty())
-    return {};
-
-  fs::path candidate = baseDir.empty()
-                           ? PathUtils::PathFromUtf8(normalizedSpec)
-                           : PathUtils::PathFromUtf8(baseDir) /
-                                 PathUtils::PathFromUtf8(normalizedSpec);
-
-  std::error_code ec;
-  const std::string candidateExt = ToLowerAscii(candidate.extension().string());
-  if (candidateExt == ".gdtf" && fs::exists(candidate, ec) && !ec)
-    return ToString(candidate.u8string());
-  ec.clear();
-
-  if (!candidate.has_extension()) {
-    fs::path withExtension = candidate;
-    withExtension += ".gdtf";
-    if (fs::exists(withExtension, ec) && !ec)
-      return ToString(withExtension.u8string());
-    ec.clear();
-  }
-
-#if defined(_WIN32)
-  // Restricts fallback directory scans to the extracted MVR base directory on
-  // Windows.
-  if (baseDir.empty())
-    return {};
-  fs::path lookupDir = PathUtils::PathFromUtf8(baseDir);
-#else
-  fs::path lookupDir =
-      baseDir.empty() ? fs::current_path(ec) : PathUtils::PathFromUtf8(baseDir);
-#endif
-  if (ec || !fs::exists(lookupDir, ec) || ec)
-    return {};
-
-  const std::string expectedStem = ToLowerAscii(
-      Trim(PathUtils::PathFromUtf8(normalizedSpec).filename().stem().string()));
-  const std::string expectedFixtureNameKey =
-      NormalizeFixtureNameLookupKey(expectedStem);
-  const std::string normalizedSpecKey = NormalizeGdtfLookupKey(normalizedSpec);
-  for (const auto &entry : fs::directory_iterator(lookupDir, ec)) {
-    if (ec)
-      break;
-    if (!entry.is_regular_file())
-      continue;
-
-    const fs::path entryPath = entry.path();
-    if (ToLowerAscii(entryPath.extension().string()) != ".gdtf")
-      continue;
-    const std::string entryStem = ToLowerAscii(Trim(entryPath.stem().string()));
-    if (entryStem == expectedStem)
-      return ToString(entryPath.u8string());
-
-    // Last fallback: compare normalized names ignoring case and extra blanks
-    // before extension.
-    if (!normalizedSpecKey.empty() &&
-        NormalizeGdtfLookupKey(entryPath.filename().generic_string()) ==
-            normalizedSpecKey) {
-      return ToString(entryPath.u8string());
-    }
-
-    const std::string perastageFixtureName =
-        ExtractPerastageFixtureNameFromFileName(entryPath.filename());
-    if (!perastageFixtureName.empty() &&
-        NormalizeFixtureNameLookupKey(perastageFixtureName) ==
-            expectedFixtureNameKey) {
-      return ToString(entryPath.u8string());
-    }
-  }
-
-  return {};
-}
 
 static std::string CieToHex(const std::string &cie) {
   std::string t = cie;
@@ -1616,204 +1359,33 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
     return ToString(PathUtils::PathFromUtf8(fileName).u8string());
   };
 
-  auto normalizeAndResolveGeometryFileName = [&](std::string fileName) {
-    std::string normalized = normalizeGeometryFileName(std::move(fileName));
-    if (normalized.empty())
-      return normalized;
-    std::string primitiveToken;
-    if (mvr::ResolvePrimitiveTokenFromModelRef(normalized, primitiveToken))
-      return primitiveToken;
-    std::string remapped = RemapArchivePathIfNeeded(normalized);
-    if (mvr::ResolvePrimitiveTokenFromModelRef(remapped, primitiveToken))
-      return primitiveToken;
-    fs::path remappedPath = PathUtils::PathFromUtf8(remapped);
-    fs::path resolved = ResolveSceneRelativePath(scene.basePath, remapped);
-    if (!remappedPath.has_extension()) {
-      const std::array<std::string, 3> extensions = {".gltf", ".glb", ".3ds"};
-      for (const std::string &ext : extensions) {
-        fs::path candidate = resolved;
-        candidate += ext;
-        std::error_code existsEc;
-        if (fs::exists(candidate, existsEc) && !existsEc) {
-          resolved = candidate;
-          break;
-        }
-      }
-      if (!resolved.has_extension())
-        resolved += ".3ds";
-    }
-    return ToSceneRelativePathIfPossible(scene.basePath, resolved);
+  mvr::MvrImportResourceResolver resources(
+      PathUtils::PathFromUtf8(scene.basePath),
+      [&](const std::string &path) { return RemapArchivePathIfNeeded(path); });
+  auto normalizeAndResolveGeometryFileName = [&](const std::string &path) {
+    return resources.NormalizeGeometryFile(path);
   };
-
-  std::unordered_map<std::string, std::string> resolvedGdtfPathCache;
-  std::unordered_map<std::string, std::vector<std::string>> gdtfModesCache;
-  std::unordered_map<std::string, std::unordered_map<std::string, int>>
-      gdtfModeChannelCountCache;
-  std::unordered_map<std::string, GdtfFixtureCategory::InferenceResult>
-      categoryInferenceByResolvedPath;
-  const std::string kEmptyResolvedPath;
-  auto resolveGdtfPathCached =
-      [&](const std::string &spec) -> const std::string & {
-    const std::string normalized = mvr::NormalizeImportArchivePath(spec);
-    if (normalized.empty())
-      return kEmptyResolvedPath;
-
-    auto it = resolvedGdtfPathCache.find(normalized);
-    if (it != resolvedGdtfPathCache.end())
-      return it->second;
-
-    std::string resolved = ResolveGdtfPath(scene.basePath, normalized);
-    if (resolved.empty())
-      resolved = ToString(
-          ResolveSceneRelativePath(scene.basePath, normalized).u8string());
-    return resolvedGdtfPathCache.emplace(normalized, std::move(resolved))
-        .first->second;
+  auto resolveGdtfPathCached = [&](const std::string &spec)
+      -> const std::string & { return resources.ResolveGdtfPath(spec); };
+  auto getFixtureMetadata = [&](const std::string &path)
+      -> const mvr::ImportGdtfMetadata & {
+    return resources.FixtureMetadata(path);
   };
-
-  auto normalizeGdtfSpecForScene = [&](const std::string &spec) {
-    const std::string normalized = mvr::NormalizeImportArchivePath(spec);
-    if (normalized.empty())
-      return std::string{};
-    return ToSceneRelativePathIfPossible(
-        scene.basePath,
-        PathUtils::PathFromUtf8(resolveGdtfPathCached(normalized)));
+  auto resolvedGdtfFileExists = [&](const std::string &path) {
+    return resources.GdtfFileExists(path);
   };
-
-  auto resolvedGdtfFileExists = [](const std::string &gdtfPath) {
-    if (gdtfPath.empty())
-      return false;
-    std::error_code ec;
-    return fs::is_regular_file(PathUtils::PathFromUtf8(gdtfPath), ec) && !ec;
-  };
-
-  auto buildResolvedGdtfIdentityKey = [&](const std::string &gdtfPath) {
-    if (gdtfPath.empty())
-      return std::string{};
-    return PathUtils::BuildFilesystemIdentityKey(
-        PathUtils::PathFromUtf8(gdtfPath));
-  };
-
-  auto getGdtfModesCached =
-      [&](const std::string &gdtfPath) -> const std::vector<std::string> & {
-    const std::string cacheKey = buildResolvedGdtfIdentityKey(gdtfPath);
-    auto cacheIt = gdtfModesCache.find(cacheKey);
-    if (cacheIt != gdtfModesCache.end())
-      return cacheIt->second;
-    if (!resolvedGdtfFileExists(gdtfPath))
-      return gdtfModesCache.emplace(cacheKey, std::vector<std::string>{})
-          .first->second;
-    return gdtfModesCache.emplace(cacheKey, GetGdtfModes(gdtfPath))
-        .first->second;
-  };
-
-  auto getGdtfModeChannelCountCached = [&](const std::string &gdtfPath,
-                                           const std::string &modeName) {
-    if (!resolvedGdtfFileExists(gdtfPath))
-      return -1;
-    const std::string cacheKey = buildResolvedGdtfIdentityKey(gdtfPath);
-    auto &channelCountByMode = gdtfModeChannelCountCache[cacheKey];
-    auto countIt = channelCountByMode.find(modeName);
-    if (countIt != channelCountByMode.end())
-      return countIt->second;
-    const int count = GetGdtfModeChannelCount(gdtfPath, modeName);
-    channelCountByMode.emplace(modeName, count);
-    return count;
-  };
-
+  auto getGdtfModeChannelCountCached =
+      [&](const std::string &path, const std::string &mode) {
+        return resources.GdtfModeChannelCount(path, mode);
+      };
   auto resolveExistingGdtfModeCached =
-      [&](const std::string &gdtfPath, const std::string &requestedMode,
-                                           std::optional<int> channelCountHint) {
-    const std::vector<std::string> &modes = getGdtfModesCached(gdtfPath);
-    if (modes.empty())
-      return requestedMode;
-
-        const std::string normalizedRequested =
-            ToLowerAscii(Trim(requestedMode));
-    if (!normalizedRequested.empty()) {
-      for (const std::string &mode : modes) {
-        if (ToLowerAscii(Trim(mode)) == normalizedRequested)
-          return mode;
-      }
-    }
-
-    const std::string requestedDigitSignature =
-        ExtractDigitSignature(normalizedRequested);
-    if (!requestedDigitSignature.empty()) {
-      for (const std::string &mode : modes) {
-        const std::string modeDigitSignature =
-            ExtractDigitSignature(ToLowerAscii(Trim(mode)));
-        if (!modeDigitSignature.empty() &&
-            modeDigitSignature == requestedDigitSignature) {
-          return mode;
-        }
-      }
-    }
-
-    if (channelCountHint.has_value() && channelCountHint.value() > 0) {
-      for (const std::string &mode : modes) {
-        const int modeChannelCount =
-            getGdtfModeChannelCountCached(gdtfPath, mode);
-        if (modeChannelCount == channelCountHint.value())
-          return mode;
-      }
-    }
-
-    for (const std::string &mode : modes) {
-      const std::string normalized = ToLowerAscii(Trim(mode));
-      if (normalized == "default" || normalized == "standard")
-        return mode;
-    }
-
-    return modes.front();
-  };
-  using GdtfFixtureMetadata = mvr::SceneReadGdtfMetadata;
-  std::unordered_map<std::string, GdtfFixtureMetadata>
-      gdtfFixtureMetadataCache;
-  const GdtfFixtureMetadata kEmptyFixtureMetadata{};
-  auto getFixtureMetadata =
-      [&](const std::string &resolvedGdtfPath) -> const GdtfFixtureMetadata & {
-    if (resolvedGdtfPath.empty() || !resolvedGdtfFileExists(resolvedGdtfPath))
-      return kEmptyFixtureMetadata;
-
-    const std::string cacheKey = buildResolvedGdtfIdentityKey(resolvedGdtfPath);
-    auto it = gdtfFixtureMetadataCache.find(cacheKey);
-    if (it != gdtfFixtureMetadataCache.end())
-      return it->second;
-
-    GdtfFixtureMetadata metadata;
-    metadata.fixtureName = Trim(GetGdtfFixtureName(resolvedGdtfPath));
-    metadata.manufacturer = Trim(GetGdtfFixtureManufacturer(resolvedGdtfPath));
-    const std::string rawFixtureTypeId =
-        Trim(GetGdtfFixtureTypeId(resolvedGdtfPath));
-    metadata.fixtureTypeId = CanonicalizeUuid(rawFixtureTypeId);
-    if (metadata.fixtureTypeId.empty())
-      metadata.fixtureTypeId = rawFixtureTypeId;
-    metadata.hasProperties =
-        GetGdtfProperties(resolvedGdtfPath, metadata.weightKg, metadata.powerW);
-    return gdtfFixtureMetadataCache.emplace(cacheKey, std::move(metadata))
-        .first->second;
-  };
-
-  std::unordered_map<std::string, std::optional<Truss>> trussDefinitionCache;
-  auto loadTrussDefinitionCached = [&](const std::string &resolvedGdtfPath,
-                                       Truss &out) {
-    if (resolvedGdtfPath.empty())
-      return false;
-
-    const std::string cacheKey = buildResolvedGdtfIdentityKey(resolvedGdtfPath);
-    auto it = trussDefinitionCache.find(cacheKey);
-    if (it == trussDefinitionCache.end()) {
-      Truss loaded;
-      if (LoadTrussDefinition(resolvedGdtfPath, loaded))
-        it = trussDefinitionCache.emplace(cacheKey, std::move(loaded)).first;
-      else
-        it = trussDefinitionCache.emplace(cacheKey, std::nullopt).first;
-    }
-
-    if (!it->second.has_value())
-      return false;
-    out = *it->second;
-    return true;
+      [&](const std::string &path, const std::string &mode,
+          std::optional<int> channelCount) {
+        return resources.ResolveGdtfMode(path, mode, channelCount);
+      };
+  auto getDictionaryEntryCached = [&](const std::string &type)
+      -> const std::optional<GdtfDictionary::Entry> & {
+    return resources.DictionaryEntry(type);
   };
 
   auto appendGeometryInstance =
@@ -1991,57 +1563,21 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
     return DeriveDeterministicUuid(seed);
   };
 
-  std::unordered_map<std::string, std::optional<GdtfDictionary::Entry>>
-      dictionaryEntryByTypeCache;
-  auto getDictionaryEntryCached = [&](const std::string &typeName)
-      -> const std::optional<GdtfDictionary::Entry> & {
-    static const std::optional<GdtfDictionary::Entry> kEmptyEntry =
-        std::nullopt;
-    if (typeName.empty())
-      return kEmptyEntry;
-    auto it = dictionaryEntryByTypeCache.find(typeName);
-    if (it != dictionaryEntryByTypeCache.end())
-      return it->second;
-    return dictionaryEntryByTypeCache
-        .emplace(typeName, GdtfDictionary::Get(typeName))
-        .first->second;
-  };
-
   std::unordered_map<std::string, GdtfConflict> pendingGdtfConflictByType;
-  auto remapArchivePathIfNeeded = [&](const std::string &path) {
-    return RemapArchivePathIfNeeded(path);
-  };
 
   mvr::MvrSceneReadServices sceneReadServices{
+      resources,
       textOf,
       intOf,
       fixtureIdOf,
       parseMatrixOrIdentity,
-      remapArchivePathIfNeeded,
       buildFixtureTypeInfoKey,
       resolveStableUuid,
       referenceUuidForNode,
       ensurePositionEntry,
-      normalizeGdtfSpecForScene,
-      [&](const std::string &spec) {
-        const std::string resolved = ResolveGdtfPath(scene.basePath, spec);
-        return ToSceneRelativePathIfPossible(
-            scene.basePath,
-            PathUtils::PathFromUtf8(resolved.empty() ? spec : resolved));
-      },
-      resolveGdtfPathCached,
-      getFixtureMetadata,
-      resolveExistingGdtfModeCached,
-      getGdtfModeChannelCountCached,
-      getDictionaryEntryCached,
-      loadTrussDefinitionCached,
       resolveSymdefReference,
-      normalizeAndResolveGeometryFileName,
       appendGeometryInstance,
       reportProgress,
-      [&](const std::string &path) {
-        return ResolveSceneRelativePath(scene.basePath, path);
-      },
       [](const std::string &message) {
         LogMessage(Logger::Level::Debug, message);
       },
@@ -2985,8 +2521,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
               if (selectedPathIt == selectedPathByType.end())
                 continue;
               f.gdtfSpec = selectedPathIt->second;
-            f.gdtfSpec = ToSceneRelativePathIfPossible(
-                  scene.basePath,
+            f.gdtfSpec = resources.MakeSceneRelative(
                   PathUtils::PathFromUtf8(
                       resolveFixtureGdtfPathForRead(f.gdtfSpec)));
               const std::string selectedResolvedGdtfPath =
@@ -3051,8 +2586,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                     ? getGdtfModeChannelCountCached(resolvedGdtfPath,
                                                     f.gdtfMode)
                     : -1;
-            f.gdtfSpec = ToSceneRelativePathIfPossible(
-                scene.basePath,
+            f.gdtfSpec = resources.MakeSceneRelative(
                 PathUtils::PathFromUtf8(dictionaryResolvedPath));
             if (f.gdtfMode.empty())
               f.gdtfMode = dictEntry->mode;
@@ -3120,11 +2654,9 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
       std::string resolvedCategoryPath =
           resolveFixtureGdtfPathForRead(fixture.gdtfSpec);
       if (!resolvedCategoryPath.empty()) {
-        resolvedCategoryPath =
-            ResolveScenePathForRead(scene.basePath, resolvedCategoryPath);
+        resolvedCategoryPath = resources.ResolveGdtfPath(resolvedCategoryPath);
       } else {
-        resolvedCategoryPath =
-            ResolveScenePathForRead(scene.basePath, fixture.gdtfSpec);
+        resolvedCategoryPath = resources.ResolveGdtfPath(fixture.gdtfSpec);
       }
 
       GdtfFixtureCategory::InferenceResult inferred;

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -1359,6 +1359,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
     return ToString(PathUtils::PathFromUtf8(fileName).u8string());
   };
 
+  std::unordered_map<std::string, GdtfFixtureCategory::InferenceResult>
+      categoryInferenceByResolvedPath;
   mvr::MvrImportResourceResolver resources(
       PathUtils::PathFromUtf8(scene.basePath),
       [&](const std::string &path) { return RemapArchivePathIfNeeded(path); });

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -108,6 +108,15 @@ add_library(perastage_test_path_utils STATIC
             ../core/filesystem_path_utils.cpp)
 target_include_directories(perastage_test_path_utils PRIVATE ../core)
 
+add_executable(mvr_import_resource_resolver_test
+               mvr_import_resource_resolver_test.cpp
+               ../mvr/mvr_import_resource_resolver.cpp)
+target_include_directories(mvr_import_resource_resolver_test PRIVATE
+                           ../core ../models ../mvr ../viewer3d)
+target_link_libraries(mvr_import_resource_resolver_test PRIVATE
+                      perastage_test_path_utils)
+add_test(NAME MvrImportResourceResolver COMMAND mvr_import_resource_resolver_test)
+
 add_executable(runtime_storage_test
                runtime_storage_test.cpp
                ../core/runtime_storage.cpp
@@ -142,6 +151,7 @@ if(BASH_EXECUTABLE)
     add_bash_policy_test(DocsPerastageTreeModules ${CMAKE_CURRENT_SOURCE_DIR}/check_perastage_tree_modules.sh)
     add_bash_policy_test(GuiNoConfigManagerGet ${CMAKE_CURRENT_SOURCE_DIR}/check_no_configmanager_get_in_gui.sh)
     add_bash_policy_test(MvrSceneNodeReaderBoundary ${CMAKE_CURRENT_SOURCE_DIR}/check_mvr_scene_node_reader_boundary.sh)
+    add_bash_policy_test(MvrImportResourceResolverBoundary ${CMAKE_CURRENT_SOURCE_DIR}/check_mvr_import_resource_resolver_boundary.sh)
     add_bash_policy_test(OpenGLLifecycleCentralized ${CMAKE_CURRENT_SOURCE_DIR}/check_opengl_lifecycle_centralized.sh)
     add_bash_policy_test(ViewerSceneReplacementLifecycle ${CMAKE_CURRENT_SOURCE_DIR}/check_viewer_scene_replacement_lifecycle.sh)
     add_bash_policy_test(Viewer3DRawDragAnchor ${CMAKE_CURRENT_SOURCE_DIR}/check_viewer3d_raw_drag_anchor.sh)
@@ -1008,7 +1018,7 @@ add_executable(save_load_roundtrip_test save_load_roundtrip_test.cpp
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp ../mvr/mvr_scene_node_reader.cpp
+               ../mvr/mvrimporter.cpp ../mvr/mvr_import_resource_resolver.cpp ../mvr/mvr_scene_node_reader.cpp
                ../mvr/mvr_scene_node_reader_support.cpp
                ../mvr/mvr_import_package.cpp
                ../core/fixture_visual_color.cpp
@@ -1048,7 +1058,7 @@ add_executable(mvr_project_fixture_metadata_contracts_test
                ../core/trussloader.cpp ../core/wx_path_utils.cpp
                ../core/runtime_storage.cpp ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp ../mvr/mvr_scene_node_reader.cpp
+               ../mvr/mvrimporter.cpp ../mvr/mvr_import_resource_resolver.cpp ../mvr/mvr_scene_node_reader.cpp
                ../mvr/mvr_scene_node_reader_support.cpp
                ../mvr/mvr_import_package.cpp
                ../core/fixture_visual_color.cpp ${PERASTAGE_TEST_MVR_CATALOG_SOURCES}
@@ -1087,7 +1097,7 @@ add_executable(project_support_userdata_roundtrip_test project_support_userdata_
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp ../mvr/mvr_scene_node_reader.cpp
+               ../mvr/mvrimporter.cpp ../mvr/mvr_import_resource_resolver.cpp ../mvr/mvr_scene_node_reader.cpp
                ../mvr/mvr_scene_node_reader_support.cpp
                ../mvr/mvr_import_package.cpp
                ../core/fixture_visual_color.cpp
@@ -1175,7 +1185,7 @@ add_executable(rider_truss_dictionary_normalization_test
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp ../mvr/mvr_scene_node_reader.cpp
+               ../mvr/mvrimporter.cpp ../mvr/mvr_import_resource_resolver.cpp ../mvr/mvr_scene_node_reader.cpp
                ../mvr/mvr_scene_node_reader_support.cpp
                ../mvr/mvr_import_package.cpp
                ../core/fixture_visual_color.cpp
@@ -1228,7 +1238,7 @@ add_executable(mvr_dmx_address_test mvr_dmx_address_test.cpp
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp ../mvr/mvr_scene_node_reader.cpp
+               ../mvr/mvrimporter.cpp ../mvr/mvr_import_resource_resolver.cpp ../mvr/mvr_scene_node_reader.cpp
                ../mvr/mvr_scene_node_reader_support.cpp
                ../mvr/mvr_import_package.cpp
                ../core/fixture_visual_color.cpp
@@ -1270,7 +1280,7 @@ add_executable(mvr_support_userdata_roundtrip_test mvr_support_userdata_roundtri
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp ../mvr/mvr_scene_node_reader.cpp
+               ../mvr/mvrimporter.cpp ../mvr/mvr_import_resource_resolver.cpp ../mvr/mvr_scene_node_reader.cpp
                ../mvr/mvr_scene_node_reader_support.cpp
                ../mvr/mvr_import_package.cpp
                ../core/fixture_visual_color.cpp
@@ -1312,7 +1322,7 @@ add_executable(mvr_perastage_metadata_recovery_test
                ../core/trussloader.cpp ../core/wx_path_utils.cpp
                ../core/runtime_storage.cpp ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp ../mvr/mvr_scene_node_reader.cpp
+               ../mvr/mvrimporter.cpp ../mvr/mvr_import_resource_resolver.cpp ../mvr/mvr_scene_node_reader.cpp
                ../mvr/mvr_scene_node_reader_support.cpp
                ../mvr/mvr_import_package.cpp
                ../core/fixture_visual_color.cpp ${PERASTAGE_TEST_MVR_CATALOG_SOURCES}
@@ -1358,7 +1368,7 @@ add_executable(mvr_layer_appearance_userdata_test mvr_layer_appearance_userdata_
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp ../mvr/mvr_scene_node_reader.cpp
+               ../mvr/mvrimporter.cpp ../mvr/mvr_import_resource_resolver.cpp ../mvr/mvr_scene_node_reader.cpp
                ../mvr/mvr_scene_node_reader_support.cpp
                ../mvr/mvr_import_package.cpp
                ../core/fixture_visual_color.cpp
@@ -1406,7 +1416,7 @@ add_executable(mvr_fixture_category_roundtrip_test mvr_fixture_category_roundtri
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp ../mvr/mvr_scene_node_reader.cpp
+               ../mvr/mvrimporter.cpp ../mvr/mvr_import_resource_resolver.cpp ../mvr/mvr_scene_node_reader.cpp
                ../mvr/mvr_scene_node_reader_support.cpp
                ../mvr/mvr_import_package.cpp
                ../core/fixture_visual_color.cpp
@@ -1452,7 +1462,7 @@ add_executable(mvr_sceneobject_symbol_identity_test mvr_sceneobject_symbol_ident
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp ../mvr/mvr_scene_node_reader.cpp
+               ../mvr/mvrimporter.cpp ../mvr/mvr_import_resource_resolver.cpp ../mvr/mvr_scene_node_reader.cpp
                ../mvr/mvr_scene_node_reader_support.cpp
                ../mvr/mvr_import_package.cpp
                ../core/fixture_visual_color.cpp
@@ -1503,7 +1513,7 @@ add_executable(mvr_truss_roundtrip_structure_test mvr_truss_roundtrip_structure_
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp ../mvr/mvr_scene_node_reader.cpp
+               ../mvr/mvrimporter.cpp ../mvr/mvr_import_resource_resolver.cpp ../mvr/mvr_scene_node_reader.cpp
                ../mvr/mvr_scene_node_reader_support.cpp
                ../mvr/mvr_import_package.cpp
                ../core/fixture_visual_color.cpp
@@ -1550,7 +1560,7 @@ add_executable(mvr_exporter_compliance_test mvr_exporter_compliance_test.cpp
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp ../mvr/mvr_scene_node_reader.cpp
+               ../mvr/mvrimporter.cpp ../mvr/mvr_import_resource_resolver.cpp ../mvr/mvr_scene_node_reader.cpp
                ../mvr/mvr_scene_node_reader_support.cpp
                ../mvr/mvr_import_package.cpp
                ../core/fixture_visual_color.cpp
@@ -1590,7 +1600,7 @@ add_executable(mvr_importer_archive_characterization_test
                ../core/trussdictionary.cpp ../core/trussloader.cpp
                ../core/wx_path_utils.cpp ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp ../mvr/mvr_scene_node_reader.cpp
+               ../mvr/mvrimporter.cpp ../mvr/mvr_import_resource_resolver.cpp ../mvr/mvr_scene_node_reader.cpp
                ../mvr/mvr_scene_node_reader_support.cpp
                ../mvr/mvr_import_package.cpp
                ../core/fixture_visual_color.cpp
@@ -1650,7 +1660,7 @@ add_executable(rider_save_roundtrip_test rider_save_roundtrip_test.cpp
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp ../mvr/mvr_scene_node_reader.cpp
+               ../mvr/mvrimporter.cpp ../mvr/mvr_import_resource_resolver.cpp ../mvr/mvr_scene_node_reader.cpp
                ../mvr/mvr_scene_node_reader_support.cpp
                ../mvr/mvr_import_package.cpp
                ../core/fixture_visual_color.cpp
@@ -2336,7 +2346,7 @@ add_executable(symbol_fixture_applier_gdtf_test symbol_fixture_applier_gdtf_test
                ../viewer3d/loader3ds.cpp
                ../viewer3d/loaderglb.cpp
                ../viewer3d/meshprimitives.cpp
-               ../mvr/mvrimporter.cpp ../mvr/mvr_scene_node_reader.cpp
+               ../mvr/mvrimporter.cpp ../mvr/mvr_import_resource_resolver.cpp ../mvr/mvr_scene_node_reader.cpp
                ../mvr/mvr_scene_node_reader_support.cpp
                ../mvr/mvr_import_package.cpp
                ../core/fixture_visual_color.cpp
@@ -2399,7 +2409,7 @@ add_executable(mvr_patched_gdtf_export_test mvr_patched_gdtf_export_test.cpp
                ../viewer3d/loader3ds.cpp
                ../viewer3d/loaderglb.cpp
                ../viewer3d/meshprimitives.cpp
-               ../mvr/mvrimporter.cpp ../mvr/mvr_scene_node_reader.cpp
+               ../mvr/mvrimporter.cpp ../mvr/mvr_import_resource_resolver.cpp ../mvr/mvr_scene_node_reader.cpp
                ../mvr/mvr_scene_node_reader_support.cpp
                ../mvr/mvr_import_package.cpp
                ../core/fixture_visual_color.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -110,7 +110,8 @@ target_include_directories(perastage_test_path_utils PRIVATE ../core)
 
 add_executable(mvr_import_resource_resolver_test
                mvr_import_resource_resolver_test.cpp
-               ../mvr/mvr_import_resource_resolver.cpp)
+               ../mvr/mvr_import_resource_resolver.cpp
+               ../core/uuidutils.cpp)
 target_include_directories(mvr_import_resource_resolver_test PRIVATE
                            ../core ../models ../mvr ../viewer3d)
 target_link_libraries(mvr_import_resource_resolver_test PRIVATE

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -110,8 +110,7 @@ target_include_directories(perastage_test_path_utils PRIVATE ../core)
 
 add_executable(mvr_import_resource_resolver_test
                mvr_import_resource_resolver_test.cpp
-               ../mvr/mvr_import_resource_resolver.cpp
-               ../core/uuidutils.cpp)
+               ../mvr/mvr_import_resource_resolver.cpp)
 target_include_directories(mvr_import_resource_resolver_test PRIVATE
                            ../core ../models ../mvr ../viewer3d)
 target_link_libraries(mvr_import_resource_resolver_test PRIVATE

--- a/tests/check_mvr_import_resource_resolver_boundary.sh
+++ b/tests/check_mvr_import_resource_resolver_boundary.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+resolver_files=(mvr/mvr_import_resource_resolver.h mvr/mvr_import_resource_resolver.cpp)
+if rg -n '#include .*gui/|#include "(credentialstore|gdtfnet|logindialog|consolepanel)|wx(Dialog|Window|MessageBox)' "${resolver_files[@]}"; then
+  echo "The MVR import resource resolver must remain GUI and download independent." >&2
+  exit 1
+fi
+
+if rg -n 'resolvedGdtfPathCache|gdtfModesCache|gdtfModeChannelCountCache|gdtfFixtureMetadataCache|trussDefinitionCache|dictionaryEntryByTypeCache' mvr/mvrimporter.cpp; then
+  echo "MvrImporter must not own resource-resolution caches." >&2
+  exit 1
+fi
+
+if ! rg -q 'MvrImportResourceResolver &resources' mvr/mvr_scene_node_reader.h; then
+  echo "The scene reader must consume the cohesive resource resolver boundary." >&2
+  exit 1
+fi
+
+echo "MVR import resource resolver boundary check passed."

--- a/tests/mvr_import_resource_resolver_test.cpp
+++ b/tests/mvr_import_resource_resolver_test.cpp
@@ -21,6 +21,14 @@ std::string NormalizeImportArchivePath(const std::string &path) {
   std::replace(normalized.begin(), normalized.end(), '\\', '/');
   while (normalized.starts_with("./"))
     normalized.erase(0, 2);
+  const std::string extension = ".gdtf";
+  const size_t extensionPosition = normalized.rfind(extension);
+  if (extensionPosition != std::string::npos) {
+    size_t trimPosition = extensionPosition;
+    while (trimPosition > 0 && normalized[trimPosition - 1] == ' ')
+      --trimPosition;
+    normalized.erase(trimPosition, extensionPosition - trimPosition);
+  }
   return normalized;
 }
 
@@ -69,6 +77,12 @@ int main() {
   fs::create_directories(root);
   const fs::path exact = root / fs::path("Fixture Ä.gdtf");
   std::ofstream(exact).put('\n');
+  const fs::path unrelated = root / "Unrelated.gdtf";
+  std::ofstream(unrelated).put('\n');
+  const fs::path canonical = root / "Maker@Canonical Fixture@Perastage.gdtf";
+  std::ofstream(canonical).put('\n');
+  const fs::path support = root / "Support Fixture.gdtf";
+  std::ofstream(support).put('\n');
 
   mvr::MvrImportResourceResolver resolver(root);
   assert(resolver.ResolveGdtfPath("Fixture Ä.gdtf") ==
@@ -76,6 +90,11 @@ int main() {
   assert(resolver.ResolveGdtfPath("Fixture Ä") == PathUtils::PathToUtf8(exact));
   assert(resolver.ResolveGdtfPath("fixture Ä.GDTF") ==
          PathUtils::PathToUtf8(exact));
+  assert(resolver.ResolveGdtfPath("Canonical Fixture") ==
+         PathUtils::PathToUtf8(canonical));
+  assert(resolver.ResolveGdtfPath("---.gdtf") !=
+         PathUtils::PathToUtf8(unrelated));
+  assert(!resolver.GdtfFileExists(resolver.ResolveGdtfPath("---.gdtf")));
   const std::string &first = resolver.ResolveGdtfPath("Fixture Ä.gdtf");
   const std::string &second = resolver.ResolveGdtfPath("Fixture Ä.gdtf");
   assert(&first == &second);
@@ -83,6 +102,12 @@ int main() {
   assert(resolver.MakeSceneRelative(exact) == "Fixture Ä.gdtf");
   assert(resolver.ResolveScenePath("models/é.glb") ==
          root / fs::path("models/é.glb"));
+  assert(!resolver.GdtfFileExists(
+      resolver.ResolveGdtfPath("Missing Fixture .gdtf")));
+  assert(resolver.NormalizeSupportGdtfSpec("Missing Fixture .gdtf") ==
+         "Missing Fixture .gdtf");
+  assert(resolver.NormalizeSupportGdtfSpec("Support Fixture .gdtf") ==
+         "Support Fixture.gdtf");
 
   const std::vector<std::string> modes = {"Mode 16", "Standard", "Basic"};
   const auto count = [](const std::string &mode) {

--- a/tests/mvr_import_resource_resolver_test.cpp
+++ b/tests/mvr_import_resource_resolver_test.cpp
@@ -61,9 +61,6 @@ bool GetGdtfProperties(const std::string &, float &, float &) { return false; }
 // Supplies failed truss loading for path-only test resources.
 bool LoadTrussDefinition(const std::string &, Truss &) { return false; }
 
-// Preserves identifiers because metadata parsing is outside this focused test.
-std::string CanonicalizeUuid(const std::string &uuid) { return uuid; }
-
 // Exercises resource lookup, caching, Unicode paths, and mode fallback order.
 int main() {
   const fs::path root =

--- a/tests/mvr_import_resource_resolver_test.cpp
+++ b/tests/mvr_import_resource_resolver_test.cpp
@@ -75,7 +75,9 @@ int main() {
       fs::temp_directory_path() / fs::path(u8"perastage_resource_ünicode");
   fs::remove_all(root);
   fs::create_directories(root);
-  const fs::path exact = root / fs::path("Fixture Ä.gdtf");
+  const fs::path exactNamePath = fs::path(u8"Fixture Ä.gdtf");
+  const std::string exactName = PathUtils::PathToUtf8(exactNamePath);
+  const fs::path exact = root / exactNamePath;
   std::ofstream(exact).put('\n');
   const fs::path unrelated = root / "Unrelated.gdtf";
   std::ofstream(unrelated).put('\n');
@@ -85,23 +87,26 @@ int main() {
   std::ofstream(support).put('\n');
 
   mvr::MvrImportResourceResolver resolver(root);
-  assert(resolver.ResolveGdtfPath("Fixture Ä.gdtf") ==
+  assert(resolver.ResolveGdtfPath(exactName) == PathUtils::PathToUtf8(exact));
+  assert(resolver.ResolveGdtfPath(
+             PathUtils::PathToUtf8(fs::path(u8"Fixture Ä"))) ==
          PathUtils::PathToUtf8(exact));
-  assert(resolver.ResolveGdtfPath("Fixture Ä") == PathUtils::PathToUtf8(exact));
-  assert(resolver.ResolveGdtfPath("fixture Ä.GDTF") ==
+  assert(resolver.ResolveGdtfPath(
+             PathUtils::PathToUtf8(fs::path(u8"fixture Ä.GDTF"))) ==
          PathUtils::PathToUtf8(exact));
   assert(resolver.ResolveGdtfPath("Canonical Fixture") ==
          PathUtils::PathToUtf8(canonical));
   assert(resolver.ResolveGdtfPath("---.gdtf") !=
          PathUtils::PathToUtf8(unrelated));
   assert(!resolver.GdtfFileExists(resolver.ResolveGdtfPath("---.gdtf")));
-  const std::string &first = resolver.ResolveGdtfPath("Fixture Ä.gdtf");
-  const std::string &second = resolver.ResolveGdtfPath("Fixture Ä.gdtf");
+  const std::string &first = resolver.ResolveGdtfPath(exactName);
+  const std::string &second = resolver.ResolveGdtfPath(exactName);
   assert(&first == &second);
   assert(!resolver.GdtfFileExists(resolver.ResolveGdtfPath("missing")));
-  assert(resolver.MakeSceneRelative(exact) == "Fixture Ä.gdtf");
-  assert(resolver.ResolveScenePath("models/é.glb") ==
-         root / fs::path("models/é.glb"));
+  assert(resolver.MakeSceneRelative(exact) == exactName);
+  const fs::path unicodeModelPath = fs::path(u8"models/é.glb");
+  assert(resolver.ResolveScenePath(PathUtils::PathToUtf8(unicodeModelPath)) ==
+         root / unicodeModelPath);
   assert(!resolver.GdtfFileExists(
       resolver.ResolveGdtfPath("Missing Fixture .gdtf")));
   assert(resolver.NormalizeSupportGdtfSpec("Missing Fixture .gdtf") ==

--- a/tests/mvr_import_resource_resolver_test.cpp
+++ b/tests/mvr_import_resource_resolver_test.cpp
@@ -1,0 +1,110 @@
+#include "mvr_import_resource_resolver.h"
+
+#include "filesystem_path_utils.h"
+#include "truss.h"
+
+#include <algorithm>
+#include <cassert>
+#include <filesystem>
+#include <fstream>
+
+namespace fs = std::filesystem;
+
+namespace {
+int dictionaryLookups = 0;
+}
+
+namespace mvr {
+// Supplies archive-path normalization for this isolated resolver test.
+std::string NormalizeImportArchivePath(const std::string &path) {
+  std::string normalized = path;
+  std::replace(normalized.begin(), normalized.end(), '\\', '/');
+  while (normalized.starts_with("./"))
+    normalized.erase(0, 2);
+  return normalized;
+}
+
+// Disables primitive aliases because this test exercises file resources.
+bool ResolvePrimitiveTokenFromModelRef(const std::string &, std::string &) {
+  return false;
+}
+} // namespace mvr
+
+namespace GdtfDictionary {
+// Counts dictionary loads so cache behavior can be verified deterministically.
+std::optional<Entry> Get(const std::string &) {
+  ++dictionaryLookups;
+  return Entry{};
+}
+} // namespace GdtfDictionary
+
+// Supplies empty GDTF modes for path-only test resources.
+std::vector<std::string> GetGdtfModes(const std::string &) { return {}; }
+
+// Supplies an unavailable channel count for path-only test resources.
+int GetGdtfModeChannelCount(const std::string &, const std::string &) {
+  return -1;
+}
+
+// Supplies empty fixture names for path-only test resources.
+std::string GetGdtfFixtureName(const std::string &) { return {}; }
+
+// Supplies empty manufacturers for path-only test resources.
+std::string GetGdtfFixtureManufacturer(const std::string &) { return {}; }
+
+// Supplies empty fixture identifiers for path-only test resources.
+std::string GetGdtfFixtureTypeId(const std::string &) { return {}; }
+
+// Supplies absent physical properties for path-only test resources.
+bool GetGdtfProperties(const std::string &, float &, float &) { return false; }
+
+// Supplies failed truss loading for path-only test resources.
+bool LoadTrussDefinition(const std::string &, Truss &) { return false; }
+
+// Preserves identifiers because metadata parsing is outside this focused test.
+std::string CanonicalizeUuid(const std::string &uuid) { return uuid; }
+
+// Exercises resource lookup, caching, Unicode paths, and mode fallback order.
+int main() {
+  const fs::path root =
+      fs::temp_directory_path() / fs::path(u8"perastage_resource_ünicode");
+  fs::remove_all(root);
+  fs::create_directories(root);
+  const fs::path exact = root / fs::path("Fixture Ä.gdtf");
+  std::ofstream(exact).put('\n');
+
+  mvr::MvrImportResourceResolver resolver(root);
+  assert(resolver.ResolveGdtfPath("Fixture Ä.gdtf") ==
+         PathUtils::PathToUtf8(exact));
+  assert(resolver.ResolveGdtfPath("Fixture Ä") == PathUtils::PathToUtf8(exact));
+  assert(resolver.ResolveGdtfPath("fixture Ä.GDTF") ==
+         PathUtils::PathToUtf8(exact));
+  const std::string &first = resolver.ResolveGdtfPath("Fixture Ä.gdtf");
+  const std::string &second = resolver.ResolveGdtfPath("Fixture Ä.gdtf");
+  assert(&first == &second);
+  assert(!resolver.GdtfFileExists(resolver.ResolveGdtfPath("missing")));
+  assert(resolver.MakeSceneRelative(exact) == "Fixture Ä.gdtf");
+  assert(resolver.ResolveScenePath("models/é.glb") ==
+         root / fs::path("models/é.glb"));
+
+  const std::vector<std::string> modes = {"Mode 16", "Standard", "Basic"};
+  const auto count = [](const std::string &mode) {
+    return mode == "Basic" ? 8 : 16;
+  };
+  assert(mvr::MvrImportResourceResolver::SelectMode(modes, " mode 16 ", {},
+                                                    count) == "Mode 16");
+  assert(mvr::MvrImportResourceResolver::SelectMode(modes, "Legacy 016", {},
+                                                    count) == "Mode 16");
+  assert(mvr::MvrImportResourceResolver::SelectMode(modes, "Unknown", 8,
+                                                    count) == "Basic");
+  assert(mvr::MvrImportResourceResolver::SelectMode(modes, "Unknown", {},
+                                                    count) == "Standard");
+  assert(mvr::MvrImportResourceResolver::SelectMode(
+             {"First", "Second"}, "Unknown", {}, count) == "First");
+
+  resolver.DictionaryEntry("Fixture");
+  resolver.DictionaryEntry("Fixture");
+  assert(dictionaryLookups == 1);
+  fs::remove_all(root);
+  return 0;
+}

--- a/tests/source_file_size_policy.json
+++ b/tests/source_file_size_policy.json
@@ -29,7 +29,7 @@
     "gui/mainwindow_menu.cpp": 2082,
     "gui/trusstablepanel.cpp": 1528,
     "mvr/mvrexporter.cpp": 4911,
-    "mvr/mvrimporter.cpp": 2989,
+    "mvr/mvrimporter.cpp": 2991,
     "tests/mvr_exporter_compliance_test.cpp": 1664,
     "viewer2d/pdf/layout_pdf_exporter.cpp": 2352,
     "viewer2d/viewer2dpanel.cpp": 4550,

--- a/tests/source_file_size_policy.json
+++ b/tests/source_file_size_policy.json
@@ -29,7 +29,7 @@
     "gui/mainwindow_menu.cpp": 2082,
     "gui/trusstablepanel.cpp": 1528,
     "mvr/mvrexporter.cpp": 4911,
-    "mvr/mvrimporter.cpp": 3457,
+    "mvr/mvrimporter.cpp": 2989,
     "tests/mvr_exporter_compliance_test.cpp": 1664,
     "viewer2d/pdf/layout_pdf_exporter.cpp": 2352,
     "viewer2d/viewer2dpanel.cpp": 4550,


### PR DESCRIPTION
### Motivation
- Move permissive GDTF/resource lookup, normalization, identity, metadata and caching out of the large `MvrImporter::ParseSceneXml(...)` implementation into a focused, GUI-independent owner. 
- Provide a single cohesive resource boundary the scene reader can consume instead of many separate importer callbacks. 
- Reduce the `mvr/mvrimporter.cpp` hotspot size and make resource concerns reusable and testable without GUI/download side effects.

### Description
- Added a new resolver class `mvr::MvrImportResourceResolver` with public APIs including `ResolveGdtfPath`, `ResolveGdtfMode`, `GdtfModes`, `GdtfModeChannelCount`, `FixtureMetadata`, `LoadTrussDefinition`, `DictionaryEntry`, `NormalizeGeometryFile`, `ResolveScenePath`, `MakeSceneRelative` and `RemapArchivePath` (files: `mvr/mvr_import_resource_resolver.h` and `mvr/mvr_import_resource_resolver.cpp`).
- Replaced the resource callback cluster in `MvrSceneReadServices` with a single `MvrImportResourceResolver &resources` reference and updated `mvr_scene_node_reader.*` to call resolver methods for GDTF/mode/metadata/truss/dictionary/geometry lookups. 
- Updated `MvrImporter::ParseSceneXml(...)` to construct the resolver and delegate low-level resource operations to it, removed the moved resource caches from the importer, and adjusted CMake/test wiring (`mvr/CMakeLists.txt`, `tests/CMakeLists.txt`).
- Added a focused deterministic resolver unit test `tests/mvr_import_resource_resolver_test.cpp` and a small architecture boundary policy script `tests/check_mvr_import_resource_resolver_boundary.sh`; updated `docs/release-notes-draft.md` and the source-size baseline policy to reflect the importer reduction.

### Testing
- Built and ran the focused resolver test with `g++` and the test binary executed successfully (path resolution, Unicode handling, permissive lookup, caching and mode-selection cases passed). 
- Ran repository policy and boundary checks: `tests/check_perastage_tree_modules.sh`, `tests/check_no_configmanager_get_in_gui.sh`, `tests/check_mvr_scene_node_reader_boundary.sh`, and the new `tests/check_mvr_import_resource_resolver_boundary.sh` — all passed locally. 
- Ran project checks: `python3 tests/check_source_file_size.py`, `python3 tests/check_repository_hygiene.py`, `python3 tests/check_docs_links.py`, and `python3 tests/check_ci_workflow_architecture.py` — all passed locally. 
- Limitation: a full CTest/in-tree build was not completed because the environment lacks the system wxWidgets development libraries required to configure the full build; resolver sources compiled and syntax-checked independently and the focused test ran successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6aa49d8a02d4832490e70d675d1ab44c)