### PR TITLE
CH-104: Extract MVR reference normalization and post-processing

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -12,6 +12,8 @@ Changes since **v1.6.0**.
 
 ## Technical and packaging changes
 
+- Isolated MVR identity normalization, legacy reference remapping, and post-parse cross-reference validation behind a reusable import component while preserving deterministic recovery and structured diagnostics.
+
 - Isolated MVR GDTF and scene-resource resolution, metadata access, and caching behind a GUI-independent import service while preserving deterministic resource-name spelling, unresolved support references, mode selection, and fixture-category handling across supported platforms.
 
 - Separated logical MVR scene-node and hierarchy reading into an independent compiled module while preserving existing fixture, rigging, geometry, layer, and compatibility behavior.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -14,6 +14,7 @@ Changes since **v1.6.0**.
 
 - Isolated MVR identity normalization, legacy reference remapping, and post-parse cross-reference validation behind a reusable import component while preserving deterministic recovery and structured diagnostics.
 - Preserved Position names exactly as authored, including surrounding whitespace, when importing MVR files.
+- Fixed duplicate UUID utility linkage in the focused MVR reference resolver test on Windows.
 
 - Isolated MVR GDTF and scene-resource resolution, metadata access, and caching behind a GUI-independent import service while preserving deterministic resource-name spelling, unresolved support references, mode selection, and fixture-category handling across supported platforms.
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -13,6 +13,7 @@ Changes since **v1.6.0**.
 ## Technical and packaging changes
 
 - Isolated MVR identity normalization, legacy reference remapping, and post-parse cross-reference validation behind a reusable import component while preserving deterministic recovery and structured diagnostics.
+- Preserved Position names exactly as authored, including surrounding whitespace, when importing MVR files.
 
 - Isolated MVR GDTF and scene-resource resolution, metadata access, and caching behind a GUI-independent import service while preserving deterministic resource-name spelling, unresolved support references, mode selection, and fixture-category handling across supported platforms.
 

--- a/mvr/CMakeLists.txt
+++ b/mvr/CMakeLists.txt
@@ -4,6 +4,8 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/mvrimporter.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mvr_import_resource_resolver.h
     ${CMAKE_CURRENT_SOURCE_DIR}/mvr_import_resource_resolver.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/mvr_import_reference_resolver.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/mvr_import_reference_resolver.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mvr_import_types.h
     ${CMAKE_CURRENT_SOURCE_DIR}/mvr_scene_node_reader.h
     ${CMAKE_CURRENT_SOURCE_DIR}/mvr_scene_node_reader.cpp

--- a/mvr/mvr_import_reference_resolver.cpp
+++ b/mvr/mvr_import_reference_resolver.cpp
@@ -1,0 +1,197 @@
+#include "mvr_import_reference_resolver.h"
+
+#include "uuidutils.h"
+
+#include <algorithm>
+#include <utility>
+#include <vector>
+
+namespace mvr {
+namespace {
+
+// Appends unknown metadata diagnostics in stable UUID order.
+void DiagnoseUnknownMetadata(const std::unordered_set<std::string> &entries,
+                             const std::unordered_set<std::string> &consumed,
+                             const char *code, const char *kind,
+                             MvrImportResult &result) {
+  std::vector<std::string> unknown;
+  for (const std::string &uuid : entries) {
+    if (!consumed.contains(uuid))
+      unknown.push_back(uuid);
+  }
+  std::sort(unknown.begin(), unknown.end());
+  for (const std::string &uuid : unknown) {
+    result.diagnostics.push_back(
+        {code,
+         std::string("Ignored ") + kind + " for unknown UUID '" + uuid + "'."});
+  }
+}
+
+} // namespace
+
+// Creates an import reference resolver with an optional compatibility warning
+// sink.
+MvrImportReferenceResolver::MvrImportReferenceResolver(WarningSink warningSink)
+    : warningSink_(std::move(warningSink)) {}
+
+// Builds the legacy-compatible deterministic seed for one imported identity.
+std::string MvrImportReferenceResolver::StableSeed(
+    const MvrImportedIdentity &identity) const {
+  return "mvr:" + identity.kind + ':' + identity.layerName + ':' +
+         identity.objectName + ':' + identity.transform + ':' +
+         identity.rawUuid;
+}
+
+// Reports a non-fatal compatibility recovery warning when a sink is available.
+void MvrImportReferenceResolver::Warn(const std::string &message) const {
+  if (warningSink_)
+    warningSink_(message);
+}
+
+// Canonicalizes or deterministically repairs one stable imported identity.
+std::string MvrImportReferenceResolver::ResolveStableUuid(
+    const MvrImportedIdentity &identity) {
+  std::string stableUuid = CanonicalizeUuid(identity.rawUuid);
+  const std::string seed = StableSeed(identity);
+  if (stableUuid.empty()) {
+    stableUuid = CanonicalizeUuid(identity.legacyStableId);
+    if (stableUuid.empty() && !identity.rawUuid.empty()) {
+      Warn("MVR import: " + identity.kind + " UUID '" + identity.rawUuid +
+           "' is invalid. Applying deterministic fallback.");
+    }
+    if (stableUuid.empty())
+      stableUuid = DeriveDeterministicUuid(seed);
+  }
+
+  if (usedStableUuids_.contains(stableUuid)) {
+    Warn("MVR import: UUID collision for " + identity.kind + " '" + stableUuid +
+         "'. Applying controlled fallback UUID.");
+    int suffix = 1;
+    std::string candidate;
+    do {
+      candidate =
+          DeriveDeterministicUuid(seed + "#" + std::to_string(suffix++));
+    } while (usedStableUuids_.contains(candidate));
+    stableUuid = std::move(candidate);
+  }
+  usedStableUuids_.insert(stableUuid);
+  return stableUuid;
+}
+
+// Returns the canonical or deterministic reference identity without reserving
+// it.
+std::string MvrImportReferenceResolver::ReferenceUuid(
+    const MvrImportedIdentity &identity) const {
+  const std::string canonical = CanonicalizeUuid(identity.rawUuid);
+  return canonical.empty() ? DeriveDeterministicUuid(StableSeed(identity))
+                           : canonical;
+}
+
+// Imports a standard Position UUID or isolates deterministic legacy recovery.
+void MvrImportReferenceResolver::ImportPosition(const std::string &rawUuid,
+                                                const std::string &name,
+                                                MvrScene &scene) {
+  const std::string canonical = CanonicalizeUuid(rawUuid);
+  if (canonical.empty()) {
+    if (rawUuid.empty())
+      return;
+    const std::string generated =
+        DeriveDeterministicUuid("mvr:legacy-position:" + rawUuid + ":" + name);
+    legacyPositionRemap_[rawUuid] = generated;
+    scene.positions[generated] = name.empty() ? rawUuid : name;
+    Warn("MVR import migrated non-canonical Position uuid '" + rawUuid +
+         "' -> '" + generated + "'");
+    return;
+  }
+  if (canonical != rawUuid)
+    legacyPositionRemap_[rawUuid] = canonical;
+  scene.positions[canonical] = name;
+}
+
+// Preserves an unresolved Position reference for a lossless subsequent export.
+std::string
+MvrImportReferenceResolver::EnsurePosition(const std::string &positionId,
+                                           MvrScene &scene) {
+  if (positionId.empty())
+    return {};
+  const auto legacy = legacyPositionRemap_.find(positionId);
+  const std::string remapped =
+      legacy == legacyPositionRemap_.end() ? positionId : legacy->second;
+  const std::string canonical = CanonicalizeUuid(remapped);
+  const std::string normalized = canonical.empty() ? remapped : canonical;
+  const auto existing = scene.positions.find(normalized);
+  if (existing != scene.positions.end())
+    return existing->second;
+  scene.positions[normalized] = positionId;
+  return positionId;
+}
+
+// Records an imported fixture spelling that resolves to a final stable UUID.
+void MvrImportReferenceResolver::RecordFixtureUuid(
+    const std::string &rawUuid, const std::string &resolvedUuid) {
+  if (!rawUuid.empty() && rawUuid != resolvedUuid)
+    fixtureUuidRemap_[rawUuid] = resolvedUuid;
+}
+
+// Exposes fixture aliases through the narrow scene-reader state contract.
+std::unordered_map<std::string, std::string> &
+MvrImportReferenceResolver::FixtureUuidRemap() {
+  return fixtureUuidRemap_;
+}
+
+// Exposes fixture aliases through the read-only import result contract.
+const std::unordered_map<std::string, std::string> &
+MvrImportReferenceResolver::FixtureUuidRemap() const {
+  return fixtureUuidRemap_;
+}
+
+// Exposes recovered Position aliases as read-only scene metadata.
+const std::unordered_map<std::string, std::string> &
+MvrImportReferenceResolver::LegacyPositionRemap() const {
+  return legacyPositionRemap_;
+}
+
+// Reconciles references that require a complete scene and diagnoses leftovers.
+void MvrImportReferenceResolver::Reconcile(
+    MvrImportResult &result,
+    const MvrImportPostParseReferences &references) const {
+  std::vector<std::string> supportUuids;
+  for (const auto &[uuid, support] : result.scene.supports) {
+    (void)support;
+    supportUuids.push_back(uuid);
+  }
+  std::sort(supportUuids.begin(), supportUuids.end());
+  for (const std::string &uuid : supportUuids) {
+    Support &support = result.scene.supports.at(uuid);
+    if (support.motorFixtureUuid.empty())
+      continue;
+    const std::string canonical = CanonicalizeUuid(support.motorFixtureUuid);
+    if (canonical.empty())
+      continue;
+    const auto alias = fixtureUuidRemap_.find(support.motorFixtureUuid);
+    const std::string resolved =
+        alias == fixtureUuidRemap_.end() ? canonical : alias->second;
+    if (result.scene.fixtures.contains(resolved)) {
+      support.motorFixtureUuid = resolved;
+    } else {
+      result.diagnostics.push_back(
+          {"unknown_motor_fixture_uuid",
+           "Support '" + uuid + "' references an unknown MotorFixtureUuid."});
+      support.motorFixtureUuid.clear();
+    }
+  }
+
+  DiagnoseUnknownMetadata(references.hoistInfoUuids,
+                          references.consumedHoistInfoUuids,
+                          "unknown_hoist_info_uuid", "HoistInfo", result);
+  DiagnoseUnknownMetadata(references.trussInfoUuids,
+                          references.consumedTrussInfoUuids,
+                          "unknown_truss_info_uuid", "TrussInfo", result);
+  DiagnoseUnknownMetadata(references.projectFixtureMetadataUuids,
+                          references.consumedProjectFixtureMetadataUuids,
+                          "unknown_project_fixture_metadata_uuid",
+                          "project fixture metadata", result);
+  result.fixtureUuidRemap = fixtureUuidRemap_;
+}
+
+} // namespace mvr

--- a/mvr/mvr_import_reference_resolver.cpp
+++ b/mvr/mvr_import_reference_resolver.cpp
@@ -145,18 +145,6 @@ void MvrImportReferenceResolver::RecordFixtureUuid(
     fixtureUuidRemap_[rawUuid] = resolvedUuid;
 }
 
-// Exposes fixture aliases through the narrow scene-reader state contract.
-std::unordered_map<std::string, std::string> &
-MvrImportReferenceResolver::FixtureUuidRemap() {
-  return fixtureUuidRemap_;
-}
-
-// Exposes fixture aliases through the read-only import result contract.
-const std::unordered_map<std::string, std::string> &
-MvrImportReferenceResolver::FixtureUuidRemap() const {
-  return fixtureUuidRemap_;
-}
-
 // Exposes recovered Position aliases as read-only scene metadata.
 const std::unordered_map<std::string, std::string> &
 MvrImportReferenceResolver::LegacyPositionRemap() const {

--- a/mvr/mvr_import_reference_resolver.cpp
+++ b/mvr/mvr_import_reference_resolver.cpp
@@ -9,6 +9,16 @@
 namespace mvr {
 namespace {
 
+// Trims the XML whitespace characters used by the legacy Position UUID seed.
+std::string TrimPositionSeedName(const std::string &name) {
+  constexpr const char *whitespace = " \t\r\n";
+  const std::size_t start = name.find_first_not_of(whitespace);
+  if (start == std::string::npos)
+    return {};
+  const std::size_t end = name.find_last_not_of(whitespace);
+  return name.substr(start, end - start + 1);
+}
+
 // Appends unknown metadata diagnostics in stable UUID order.
 void DiagnoseUnknownMetadata(const std::unordered_set<std::string> &entries,
                              const std::unordered_set<std::string> &consumed,
@@ -88,24 +98,26 @@ std::string MvrImportReferenceResolver::ReferenceUuid(
 }
 
 // Imports a standard Position UUID or isolates deterministic legacy recovery.
-void MvrImportReferenceResolver::ImportPosition(const std::string &rawUuid,
-                                                const std::string &name,
-                                                MvrScene &scene) {
+void MvrImportReferenceResolver::ImportPosition(
+    const std::string &rawUuid, const std::optional<std::string> &name,
+    MvrScene &scene) {
   const std::string canonical = CanonicalizeUuid(rawUuid);
   if (canonical.empty()) {
     if (rawUuid.empty())
       return;
+    const std::string originalName = name.value_or("");
     const std::string generated =
-        DeriveDeterministicUuid("mvr:legacy-position:" + rawUuid + ":" + name);
+        DeriveDeterministicUuid("mvr:legacy-position:" + rawUuid + ":" +
+                                TrimPositionSeedName(originalName));
     legacyPositionRemap_[rawUuid] = generated;
-    scene.positions[generated] = name.empty() ? rawUuid : name;
+    scene.positions[generated] = name ? originalName : rawUuid;
     Warn("MVR import migrated non-canonical Position uuid '" + rawUuid +
          "' -> '" + generated + "'");
     return;
   }
   if (canonical != rawUuid)
     legacyPositionRemap_[rawUuid] = canonical;
-  scene.positions[canonical] = name;
+  scene.positions[canonical] = name.value_or("");
 }
 
 // Preserves an unresolved Position reference for a lossless subsequent export.

--- a/mvr/mvr_import_reference_resolver.h
+++ b/mvr/mvr_import_reference_resolver.h
@@ -51,8 +51,6 @@ public:
   std::string EnsurePosition(const std::string &positionId, MvrScene &scene);
   void RecordFixtureUuid(const std::string &rawUuid,
                          const std::string &resolvedUuid);
-  std::unordered_map<std::string, std::string> &FixtureUuidRemap();
-  const std::unordered_map<std::string, std::string> &FixtureUuidRemap() const;
   const std::unordered_map<std::string, std::string> &
   LegacyPositionRemap() const;
   void Reconcile(MvrImportResult &result,

--- a/mvr/mvr_import_reference_resolver.h
+++ b/mvr/mvr_import_reference_resolver.h
@@ -1,0 +1,70 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2026 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+#pragma once
+
+#include "mvr_import_types.h"
+
+#include <functional>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace mvr {
+
+struct MvrImportedIdentity {
+  std::string kind;
+  std::string layerName;
+  std::string objectName;
+  std::string transform;
+  std::string rawUuid;
+  std::string legacyStableId;
+};
+
+struct MvrImportPostParseReferences {
+  const std::unordered_set<std::string> &trussInfoUuids;
+  const std::unordered_set<std::string> &consumedTrussInfoUuids;
+  const std::unordered_set<std::string> &hoistInfoUuids;
+  const std::unordered_set<std::string> &consumedHoistInfoUuids;
+  const std::unordered_set<std::string> &projectFixtureMetadataUuids;
+  const std::unordered_set<std::string> &consumedProjectFixtureMetadataUuids;
+};
+
+// Owns tolerant imported identity aliases and complete-scene reconciliation.
+class MvrImportReferenceResolver {
+public:
+  using WarningSink = std::function<void(const std::string &)>;
+
+  explicit MvrImportReferenceResolver(WarningSink warningSink = {});
+
+  std::string ResolveStableUuid(const MvrImportedIdentity &identity);
+  std::string ReferenceUuid(const MvrImportedIdentity &identity) const;
+  void ImportPosition(const std::string &rawUuid, const std::string &name,
+                      MvrScene &scene);
+  std::string EnsurePosition(const std::string &positionId, MvrScene &scene);
+  void RecordFixtureUuid(const std::string &rawUuid,
+                         const std::string &resolvedUuid);
+  std::unordered_map<std::string, std::string> &FixtureUuidRemap();
+  const std::unordered_map<std::string, std::string> &FixtureUuidRemap() const;
+  const std::unordered_map<std::string, std::string> &
+  LegacyPositionRemap() const;
+  void Reconcile(MvrImportResult &result,
+                 const MvrImportPostParseReferences &references) const;
+
+private:
+  std::string StableSeed(const MvrImportedIdentity &identity) const;
+  void Warn(const std::string &message) const;
+
+  WarningSink warningSink_;
+  std::unordered_set<std::string> usedStableUuids_;
+  std::unordered_map<std::string, std::string> fixtureUuidRemap_;
+  std::unordered_map<std::string, std::string> legacyPositionRemap_;
+};
+
+} // namespace mvr

--- a/mvr/mvr_import_reference_resolver.h
+++ b/mvr/mvr_import_reference_resolver.h
@@ -12,6 +12,7 @@
 #include "mvr_import_types.h"
 
 #include <functional>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -45,8 +46,8 @@ public:
 
   std::string ResolveStableUuid(const MvrImportedIdentity &identity);
   std::string ReferenceUuid(const MvrImportedIdentity &identity) const;
-  void ImportPosition(const std::string &rawUuid, const std::string &name,
-                      MvrScene &scene);
+  void ImportPosition(const std::string &rawUuid,
+                      const std::optional<std::string> &name, MvrScene &scene);
   std::string EnsurePosition(const std::string &positionId, MvrScene &scene);
   void RecordFixtureUuid(const std::string &rawUuid,
                          const std::string &resolvedUuid);

--- a/mvr/mvr_scene_node_reader.cpp
+++ b/mvr/mvr_scene_node_reader.cpp
@@ -132,7 +132,6 @@ void ReadMvrSceneNodes(tinyxml2::XMLElement *sceneNode, MvrScene &scene,
                        const MvrSceneReadMetadata &metadata,
                        MvrSceneReadState &state, MvrSceneReadMetrics &metrics) {
 
-  auto &fixtureUuidRemap = state.fixtures.uuidRemap;
   const auto &textOf = services.textOf;
   const auto &intOf = services.intOf;
   const auto &fixtureIdOf = services.fixtureIdOf;
@@ -262,8 +261,7 @@ void ReadMvrSceneNodes(tinyxml2::XMLElement *sceneNode, MvrScene &scene,
             rawUuidAttr ? Trim(rawUuidAttr) : std::string{};
         fixture.uuid = resolveStableUuid(
             "Fixture", node, layerName, nodeTransform, legacyIdentity.stableId);
-        if (!rawFixtureUuid.empty() && rawFixtureUuid != fixture.uuid)
-          fixtureUuidRemap[rawFixtureUuid] = fixture.uuid;
+        services.recordFixtureUuid(rawFixtureUuid, fixture.uuid);
         fixture.layer = layerName;
         fixture.transform = nodeTransform;
         fixture.localTransform = localTransform;

--- a/mvr/mvr_scene_node_reader.h
+++ b/mvr/mvr_scene_node_reader.h
@@ -85,6 +85,8 @@ struct MvrSceneReadServices {
   std::function<std::string(const char *, tinyxml2::XMLElement *,
                             const std::string &, const Matrix &)>
       referenceUuid;
+  std::function<void(const std::string &, const std::string &)>
+      recordFixtureUuid;
   std::function<std::string(const std::string &)> ensurePosition;
   std::function<void(tinyxml2::XMLElement *, std::vector<SymdefGeometry> &,
                      std::string &, Matrix &)>
@@ -134,7 +136,6 @@ struct MvrSceneReadMetadata {
 };
 
 struct MvrSceneFixtureReadState {
-  std::unordered_map<std::string, std::string> &uuidRemap;
   std::unordered_map<std::string, SceneReadGdtfConflict> &pendingGdtfConflicts;
   std::unordered_map<std::string, SceneReadCachedCategory> &categoriesByType;
   std::unordered_map<std::string, GdtfFixtureCategory::InferenceResult>

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -22,6 +22,7 @@
 #include "configmanager.h"
 #include "filesystem_path_utils.h"
 #include "mvr_import_package.h"
+#include "mvr_import_reference_resolver.h"
 #include "mvr_import_resource_resolver.h"
 #include "mvr_scene_node_reader.h"
 #ifdef PERASTAGE_ENABLE_MVR_GDTF_DOWNLOAD_API
@@ -669,6 +670,10 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
 
   MvrScene &scene = importResult.scene;
   scene.Clear();
+  mvr::MvrImportReferenceResolver referenceResolver(
+      [](const std::string &message) {
+        LogMessage(Logger::Level::Warn, message);
+      });
   scene.basePath =
       ToString(PathUtils::PathFromUtf8(sceneXmlPath).parent_path().u8string());
   LogMessage(
@@ -1186,30 +1191,13 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
   parseRootHoistInfoMap(root->FirstChildElement("UserData"));
 
   // ---- Parse AUXData for Symdefs and Positions ----
-  std::unordered_map<std::string, std::string> legacyPositionIdToCanonical;
   if (tinyxml2::XMLElement *auxNode = sceneNode->FirstChildElement("AUXData")) {
     for (tinyxml2::XMLElement *pos = auxNode->FirstChildElement("Position");
          pos; pos = pos->NextSiblingElement("Position")) {
       const std::string rawUid =
           Trim(pos->Attribute("uuid") ? pos->Attribute("uuid") : "");
       const char *name = pos->Attribute("name");
-      const std::string canonicalUid = CanonicalizeUuid(rawUid);
-      if (canonicalUid.empty()) {
-        if (rawUid.empty())
-          continue;
-        std::string seed =
-            "mvr:legacy-position:" + rawUid + ":" + (name ? Trim(name) : "");
-        const std::string generated = DeriveDeterministicUuid(seed);
-        legacyPositionIdToCanonical[rawUid] = generated;
-        scene.positions[generated] = name ? name : rawUid;
-        LogMessage(Logger::Level::Warn,
-                   "MVR import migrated non-canonical Position uuid '" +
-                       rawUid + "' -> '" + generated + "'");
-      } else {
-        if (canonicalUid != rawUid)
-          legacyPositionIdToCanonical[rawUid] = canonicalUid;
-        scene.positions[canonicalUid] = name ? name : "";
-      }
+      referenceResolver.ImportPosition(rawUid, name ? Trim(name) : "", scene);
     }
 
     std::function<void(tinyxml2::XMLElement *, const Matrix &,
@@ -1463,106 +1451,33 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                      const Matrix &, const std::string &)>
       parseChildList;
 
-  auto ensurePositionEntry = [&](const std::string &positionId) -> std::string {
-    if (positionId.empty())
-      return {};
-
-    auto legacyIt = legacyPositionIdToCanonical.find(positionId);
-    const std::string remappedId = legacyIt != legacyPositionIdToCanonical.end()
-                                       ? legacyIt->second
-                                       : positionId;
-    const std::string canonicalId = CanonicalizeUuid(remappedId);
-    const std::string normalizedId =
-        canonicalId.empty() ? remappedId : canonicalId;
-
-    auto it = scene.positions.find(normalizedId);
-    if (it != scene.positions.end())
-      return it->second;
-
-    // Create a placeholder entry so the position is preserved on export.
-    std::string generated = normalizedId;
-    if (generated.empty()) {
-      generated = DeriveDeterministicUuid("mvr:position-ref:" + positionId);
-      legacyPositionIdToCanonical[positionId] = generated;
-      LogMessage(Logger::Level::Warn,
-                 "MVR import generated canonical Position uuid '" + generated +
-                     "' for unresolved reference '" + positionId + "'");
-    }
-    scene.positions[generated] = positionId;
-    return positionId;
+  auto ensurePositionEntry = [&](const std::string &positionId) {
+    return referenceResolver.EnsurePosition(positionId, scene);
   };
-
-  std::unordered_set<std::string> usedStableUuids;
 
   using CachedCategory = mvr::SceneReadCachedCategory;
   std::unordered_map<std::string, CachedCategory> categoryByTypeKey;
-  auto buildStableIdSeed = [&](const char *kind, tinyxml2::XMLElement *node,
-                               const std::string &layerName,
-                               const Matrix &nodeTransform,
-                               const std::string &rawUuid) {
-    std::ostringstream seed;
-    seed << "mvr:" << kind << ':' << layerName << ':';
-    if (const char *nameAttr = node->Attribute("name"))
-      seed << Trim(nameAttr);
-    seed << ':' << MatrixUtils::FormatMatrix(nodeTransform) << ':' << rawUuid;
-    return seed.str();
-  };
-
   auto resolveStableUuid = [&](const char *kind, tinyxml2::XMLElement *node,
                                const std::string &layerName,
                                const Matrix &nodeTransform,
                                const std::string &legacyStableId = {}) {
     const char *uuidAttr = node->Attribute("uuid");
-    std::string rawUuid = uuidAttr ? Trim(uuidAttr) : std::string{};
-    std::string stableUuid = CanonicalizeUuid(rawUuid);
-    const std::string seed =
-        buildStableIdSeed(kind, node, layerName, nodeTransform, rawUuid);
-
-    if (stableUuid.empty()) {
-      const std::string legacyUuid = CanonicalizeUuid(Trim(legacyStableId));
-      if (!legacyUuid.empty()) {
-        stableUuid = legacyUuid;
-      } else if (!rawUuid.empty()) {
-        LogMessage(Logger::Level::Warn,
-                   wxString::Format("MVR import: %s UUID '%s' is invalid. "
-                                    "Applying deterministic fallback.",
-                                    kind, rawUuid.c_str())
-                       .ToStdString());
-      }
-      if (stableUuid.empty())
-        stableUuid = DeriveDeterministicUuid(seed);
-    }
-
-    if (usedStableUuids.contains(stableUuid)) {
-      LogMessage(Logger::Level::Warn,
-                 wxString::Format("MVR import: UUID collision for %s '%s'. "
-                                  "Applying controlled fallback UUID.",
-                                  kind, stableUuid.c_str())
-                     .ToStdString());
-      int suffix = 1;
-      std::string candidate;
-      do {
-        candidate =
-            DeriveDeterministicUuid(seed + "#" + std::to_string(suffix++));
-      } while (usedStableUuids.contains(candidate));
-      stableUuid = std::move(candidate);
-    }
-
-    usedStableUuids.insert(stableUuid);
-    return stableUuid;
+    const char *nameAttr = node->Attribute("name");
+    return referenceResolver.ResolveStableUuid(
+        {kind, layerName, nameAttr ? Trim(nameAttr) : "",
+         MatrixUtils::FormatMatrix(nodeTransform),
+         uuidAttr ? Trim(uuidAttr) : "", Trim(legacyStableId)});
   };
 
   auto referenceUuidForNode = [&](const char *kind, tinyxml2::XMLElement *node,
                                   const std::string &layerName,
                                   const Matrix &nodeTransform) {
     const char *uuidAttr = node->Attribute("uuid");
-    std::string rawUuid = uuidAttr ? Trim(uuidAttr) : std::string{};
-    std::string stableUuid = CanonicalizeUuid(rawUuid);
-    if (!stableUuid.empty())
-      return stableUuid;
-    const std::string seed =
-        buildStableIdSeed(kind, node, layerName, nodeTransform, rawUuid);
-    return DeriveDeterministicUuid(seed);
+    const char *nameAttr = node->Attribute("name");
+    return referenceResolver.ReferenceUuid(
+        {kind, layerName, nameAttr ? Trim(nameAttr) : "",
+         MatrixUtils::FormatMatrix(nodeTransform),
+         uuidAttr ? Trim(uuidAttr) : "", {}});
   };
 
   std::unordered_map<std::string, GdtfConflict> pendingGdtfConflictByType;
@@ -1597,10 +1512,12 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
        projectFixtureColorsByUuid, projectFixtureColorMetadataUuids},
       {rootTrussInfoByUuid, rootHoistInfoByUuid, perastageTypeToGdtfPath,
        perastageInstanceToTypeKey},
-      {rootPrimitiveModelRefsBySceneObjectAndFile, legacyPositionIdToCanonical},
+      {rootPrimitiveModelRefsBySceneObjectAndFile,
+       referenceResolver.LegacyPositionRemap()},
       {layerColorByUuid, layerColorByName}};
   mvr::MvrSceneReadState sceneReadState{
-      {fixtureUuidRemap, pendingGdtfConflictByType, categoryByTypeKey,
+      {referenceResolver.FixtureUuidRemap(), pendingGdtfConflictByType,
+       categoryByTypeKey,
        categoryInferenceByResolvedPath, consumedProjectFixtureColorUuids},
       {consumedRootTrussInfoUuids, consumedRootHoistInfoUuids}};
   mvr::MvrSceneReadMetrics sceneReadMetrics;
@@ -2870,58 +2787,23 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
   }
   LogMessage(Logger::Level::Info, importDiagnostics.str());
 
-  for (auto &[uuid, support] : scene.supports) {
-    if (support.motorFixtureUuid.empty())
-      continue;
-    const std::string canonical = CanonicalizeUuid(support.motorFixtureUuid);
-    if (canonical.empty())
-      continue;
-    auto aliasIt = fixtureUuidRemap.find(support.motorFixtureUuid);
-    const std::string resolved = aliasIt == fixtureUuidRemap.end()
-                                     ? canonical
-                                     : aliasIt->second;
-    if (scene.fixtures.contains(resolved)) {
-      support.motorFixtureUuid = resolved;
-    } else {
-      importResult.diagnostics.push_back(
-          {"unknown_motor_fixture_uuid",
-           "Support '" + uuid +
-               "' references an unknown MotorFixtureUuid."});
-      support.motorFixtureUuid.clear();
+  auto metadataUuids = [](const auto &entries) {
+    std::unordered_set<std::string> uuids;
+    for (const auto &[uuid, value] : entries) {
+      (void)value;
+      uuids.insert(uuid);
     }
-  }
-
-  auto diagnoseUnusedRootEntries =
-      [&](const auto &entries, const auto &consumed, const char *code,
-          const char *kind) {
-        std::vector<std::string> unknown;
-        for (const auto &[uuid, element] : entries) {
-          (void)element;
-          if (!consumed.contains(uuid))
-            unknown.push_back(uuid);
-        }
-        std::sort(unknown.begin(), unknown.end());
-        for (const std::string &uuid : unknown) {
-          importResult.diagnostics.push_back(
-              {code, std::string("Ignored ") + kind +
-                         " for unknown UUID '" + uuid + "'."});
-        }
-      };
-  diagnoseUnusedRootEntries(rootHoistInfoByUuid,
-                            consumedRootHoistInfoUuids,
-                            "unknown_hoist_info_uuid", "HoistInfo");
-  diagnoseUnusedRootEntries(rootTrussInfoByUuid,
-                            consumedRootTrussInfoUuids,
-                            "unknown_truss_info_uuid", "TrussInfo");
-  for (const auto &[uuid, color] : projectFixtureColorsByUuid) {
-    (void)color;
-    if (!consumedProjectFixtureColorUuids.contains(uuid)) {
-      importResult.diagnostics.push_back(
-          {"unknown_project_fixture_metadata_uuid",
-           "Ignored project fixture metadata for unknown UUID '" + uuid +
-               "'."});
-    }
-  }
+    return uuids;
+  };
+  const auto trussInfoUuids = metadataUuids(rootTrussInfoByUuid);
+  const auto hoistInfoUuids = metadataUuids(rootHoistInfoByUuid);
+  const auto projectFixtureMetadataUuids =
+      metadataUuids(projectFixtureColorsByUuid);
+  referenceResolver.Reconcile(
+      importResult,
+      {trussInfoUuids, consumedRootTrussInfoUuids, hoistInfoUuids,
+       consumedRootHoistInfoUuids, projectFixtureMetadataUuids,
+       consumedProjectFixtureColorUuids});
 
   std::string summary =
       "Parsed scene: " + std::to_string(scene.fixtures.size()) + " fixtures, " +
@@ -2929,7 +2811,6 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
       std::to_string(scene.supports.size()) + " supports, " +
       std::to_string(scene.sceneObjects.size()) + " objects";
   LogMessage(summary);
-  importResult.fixtureUuidRemap = fixtureUuidRemap;
   return true;
 }
 

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -1197,9 +1197,9 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
       const std::string rawUid =
           Trim(pos->Attribute("uuid") ? pos->Attribute("uuid") : "");
       const char *name = pos->Attribute("name");
-      referenceResolver.ImportPosition(rawUid, name ? Trim(name) : "", scene);
+      referenceResolver.ImportPosition(
+          rawUid, name ? std::optional<std::string>{name} : std::nullopt, scene);
     }
-
     std::function<void(tinyxml2::XMLElement *, const Matrix &,
                        std::vector<SymdefGeometry> &)>
         parseSymdefChildList;

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -1479,9 +1479,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
          MatrixUtils::FormatMatrix(nodeTransform),
          uuidAttr ? Trim(uuidAttr) : "", {}});
   };
-
   std::unordered_map<std::string, GdtfConflict> pendingGdtfConflictByType;
-
   mvr::MvrSceneReadServices sceneReadServices{
       resources,
       textOf,
@@ -1491,6 +1489,9 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
       buildFixtureTypeInfoKey,
       resolveStableUuid,
       referenceUuidForNode,
+      [&](const std::string &rawUuid, const std::string &resolvedUuid) {
+        referenceResolver.RecordFixtureUuid(rawUuid, resolvedUuid);
+      },
       ensurePositionEntry,
       resolveSymdefReference,
       appendGeometryInstance,
@@ -1516,8 +1517,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
        referenceResolver.LegacyPositionRemap()},
       {layerColorByUuid, layerColorByName}};
   mvr::MvrSceneReadState sceneReadState{
-      {referenceResolver.FixtureUuidRemap(), pendingGdtfConflictByType,
-       categoryByTypeKey,
+      {pendingGdtfConflictByType, categoryByTypeKey,
        categoryInferenceByResolvedPath, consumedProjectFixtureColorUuids},
       {consumedRootTrussInfoUuids, consumedRootHoistInfoUuids}};
   mvr::MvrSceneReadMetrics sceneReadMetrics;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -119,8 +119,7 @@ add_test(NAME MvrImportResourceResolver COMMAND mvr_import_resource_resolver_tes
 
 add_executable(mvr_import_reference_resolver_test
                mvr_import_reference_resolver_test.cpp
-               ../mvr/mvr_import_reference_resolver.cpp
-               ../core/uuidutils.cpp)
+               ../mvr/mvr_import_reference_resolver.cpp)
 target_include_directories(mvr_import_reference_resolver_test PRIVATE
                            ../core ../models ../mvr)
 add_test(NAME MvrImportReferenceResolver

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -117,6 +117,17 @@ target_link_libraries(mvr_import_resource_resolver_test PRIVATE
                       perastage_test_path_utils)
 add_test(NAME MvrImportResourceResolver COMMAND mvr_import_resource_resolver_test)
 
+add_executable(mvr_import_reference_resolver_test
+               mvr_import_reference_resolver_test.cpp
+               ../mvr/mvr_import_reference_resolver.cpp
+               ../core/uuidutils.cpp)
+target_include_directories(mvr_import_reference_resolver_test PRIVATE
+                           ../core ../models ../mvr)
+add_test(NAME MvrImportReferenceResolver
+         COMMAND mvr_import_reference_resolver_test)
+set_perastage_test_labels(MvrImportReferenceResolver
+                          LAYER standard-strict DOMAINS mvr architecture)
+
 add_executable(runtime_storage_test
                runtime_storage_test.cpp
                ../core/runtime_storage.cpp
@@ -152,6 +163,7 @@ if(BASH_EXECUTABLE)
     add_bash_policy_test(GuiNoConfigManagerGet ${CMAKE_CURRENT_SOURCE_DIR}/check_no_configmanager_get_in_gui.sh)
     add_bash_policy_test(MvrSceneNodeReaderBoundary ${CMAKE_CURRENT_SOURCE_DIR}/check_mvr_scene_node_reader_boundary.sh)
     add_bash_policy_test(MvrImportResourceResolverBoundary ${CMAKE_CURRENT_SOURCE_DIR}/check_mvr_import_resource_resolver_boundary.sh)
+    add_bash_policy_test(MvrImportReferenceResolverBoundary ${CMAKE_CURRENT_SOURCE_DIR}/check_mvr_import_reference_resolver_boundary.sh)
     add_bash_policy_test(OpenGLLifecycleCentralized ${CMAKE_CURRENT_SOURCE_DIR}/check_opengl_lifecycle_centralized.sh)
     add_bash_policy_test(ViewerSceneReplacementLifecycle ${CMAKE_CURRENT_SOURCE_DIR}/check_viewer_scene_replacement_lifecycle.sh)
     add_bash_policy_test(Viewer3DRawDragAnchor ${CMAKE_CURRENT_SOURCE_DIR}/check_viewer3d_raw_drag_anchor.sh)
@@ -1018,7 +1030,7 @@ add_executable(save_load_roundtrip_test save_load_roundtrip_test.cpp
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp ../mvr/mvr_import_resource_resolver.cpp ../mvr/mvr_scene_node_reader.cpp
+               ../mvr/mvrimporter.cpp ../mvr/mvr_import_resource_resolver.cpp ../mvr/mvr_import_reference_resolver.cpp ../mvr/mvr_scene_node_reader.cpp
                ../mvr/mvr_scene_node_reader_support.cpp
                ../mvr/mvr_import_package.cpp
                ../core/fixture_visual_color.cpp
@@ -1058,7 +1070,7 @@ add_executable(mvr_project_fixture_metadata_contracts_test
                ../core/trussloader.cpp ../core/wx_path_utils.cpp
                ../core/runtime_storage.cpp ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp ../mvr/mvr_import_resource_resolver.cpp ../mvr/mvr_scene_node_reader.cpp
+               ../mvr/mvrimporter.cpp ../mvr/mvr_import_resource_resolver.cpp ../mvr/mvr_import_reference_resolver.cpp ../mvr/mvr_scene_node_reader.cpp
                ../mvr/mvr_scene_node_reader_support.cpp
                ../mvr/mvr_import_package.cpp
                ../core/fixture_visual_color.cpp ${PERASTAGE_TEST_MVR_CATALOG_SOURCES}
@@ -1097,7 +1109,7 @@ add_executable(project_support_userdata_roundtrip_test project_support_userdata_
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp ../mvr/mvr_import_resource_resolver.cpp ../mvr/mvr_scene_node_reader.cpp
+               ../mvr/mvrimporter.cpp ../mvr/mvr_import_resource_resolver.cpp ../mvr/mvr_import_reference_resolver.cpp ../mvr/mvr_scene_node_reader.cpp
                ../mvr/mvr_scene_node_reader_support.cpp
                ../mvr/mvr_import_package.cpp
                ../core/fixture_visual_color.cpp
@@ -1185,7 +1197,7 @@ add_executable(rider_truss_dictionary_normalization_test
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp ../mvr/mvr_import_resource_resolver.cpp ../mvr/mvr_scene_node_reader.cpp
+               ../mvr/mvrimporter.cpp ../mvr/mvr_import_resource_resolver.cpp ../mvr/mvr_import_reference_resolver.cpp ../mvr/mvr_scene_node_reader.cpp
                ../mvr/mvr_scene_node_reader_support.cpp
                ../mvr/mvr_import_package.cpp
                ../core/fixture_visual_color.cpp
@@ -1238,7 +1250,7 @@ add_executable(mvr_dmx_address_test mvr_dmx_address_test.cpp
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp ../mvr/mvr_import_resource_resolver.cpp ../mvr/mvr_scene_node_reader.cpp
+               ../mvr/mvrimporter.cpp ../mvr/mvr_import_resource_resolver.cpp ../mvr/mvr_import_reference_resolver.cpp ../mvr/mvr_scene_node_reader.cpp
                ../mvr/mvr_scene_node_reader_support.cpp
                ../mvr/mvr_import_package.cpp
                ../core/fixture_visual_color.cpp
@@ -1280,7 +1292,7 @@ add_executable(mvr_support_userdata_roundtrip_test mvr_support_userdata_roundtri
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp ../mvr/mvr_import_resource_resolver.cpp ../mvr/mvr_scene_node_reader.cpp
+               ../mvr/mvrimporter.cpp ../mvr/mvr_import_resource_resolver.cpp ../mvr/mvr_import_reference_resolver.cpp ../mvr/mvr_scene_node_reader.cpp
                ../mvr/mvr_scene_node_reader_support.cpp
                ../mvr/mvr_import_package.cpp
                ../core/fixture_visual_color.cpp
@@ -1322,7 +1334,7 @@ add_executable(mvr_perastage_metadata_recovery_test
                ../core/trussloader.cpp ../core/wx_path_utils.cpp
                ../core/runtime_storage.cpp ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp ../mvr/mvr_import_resource_resolver.cpp ../mvr/mvr_scene_node_reader.cpp
+               ../mvr/mvrimporter.cpp ../mvr/mvr_import_resource_resolver.cpp ../mvr/mvr_import_reference_resolver.cpp ../mvr/mvr_scene_node_reader.cpp
                ../mvr/mvr_scene_node_reader_support.cpp
                ../mvr/mvr_import_package.cpp
                ../core/fixture_visual_color.cpp ${PERASTAGE_TEST_MVR_CATALOG_SOURCES}
@@ -1368,7 +1380,7 @@ add_executable(mvr_layer_appearance_userdata_test mvr_layer_appearance_userdata_
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp ../mvr/mvr_import_resource_resolver.cpp ../mvr/mvr_scene_node_reader.cpp
+               ../mvr/mvrimporter.cpp ../mvr/mvr_import_resource_resolver.cpp ../mvr/mvr_import_reference_resolver.cpp ../mvr/mvr_scene_node_reader.cpp
                ../mvr/mvr_scene_node_reader_support.cpp
                ../mvr/mvr_import_package.cpp
                ../core/fixture_visual_color.cpp
@@ -1416,7 +1428,7 @@ add_executable(mvr_fixture_category_roundtrip_test mvr_fixture_category_roundtri
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp ../mvr/mvr_import_resource_resolver.cpp ../mvr/mvr_scene_node_reader.cpp
+               ../mvr/mvrimporter.cpp ../mvr/mvr_import_resource_resolver.cpp ../mvr/mvr_import_reference_resolver.cpp ../mvr/mvr_scene_node_reader.cpp
                ../mvr/mvr_scene_node_reader_support.cpp
                ../mvr/mvr_import_package.cpp
                ../core/fixture_visual_color.cpp
@@ -1462,7 +1474,7 @@ add_executable(mvr_sceneobject_symbol_identity_test mvr_sceneobject_symbol_ident
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp ../mvr/mvr_import_resource_resolver.cpp ../mvr/mvr_scene_node_reader.cpp
+               ../mvr/mvrimporter.cpp ../mvr/mvr_import_resource_resolver.cpp ../mvr/mvr_import_reference_resolver.cpp ../mvr/mvr_scene_node_reader.cpp
                ../mvr/mvr_scene_node_reader_support.cpp
                ../mvr/mvr_import_package.cpp
                ../core/fixture_visual_color.cpp
@@ -1513,7 +1525,7 @@ add_executable(mvr_truss_roundtrip_structure_test mvr_truss_roundtrip_structure_
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp ../mvr/mvr_import_resource_resolver.cpp ../mvr/mvr_scene_node_reader.cpp
+               ../mvr/mvrimporter.cpp ../mvr/mvr_import_resource_resolver.cpp ../mvr/mvr_import_reference_resolver.cpp ../mvr/mvr_scene_node_reader.cpp
                ../mvr/mvr_scene_node_reader_support.cpp
                ../mvr/mvr_import_package.cpp
                ../core/fixture_visual_color.cpp
@@ -1560,7 +1572,7 @@ add_executable(mvr_exporter_compliance_test mvr_exporter_compliance_test.cpp
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp ../mvr/mvr_import_resource_resolver.cpp ../mvr/mvr_scene_node_reader.cpp
+               ../mvr/mvrimporter.cpp ../mvr/mvr_import_resource_resolver.cpp ../mvr/mvr_import_reference_resolver.cpp ../mvr/mvr_scene_node_reader.cpp
                ../mvr/mvr_scene_node_reader_support.cpp
                ../mvr/mvr_import_package.cpp
                ../core/fixture_visual_color.cpp
@@ -1600,7 +1612,7 @@ add_executable(mvr_importer_archive_characterization_test
                ../core/trussdictionary.cpp ../core/trussloader.cpp
                ../core/wx_path_utils.cpp ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp ../mvr/mvr_import_resource_resolver.cpp ../mvr/mvr_scene_node_reader.cpp
+               ../mvr/mvrimporter.cpp ../mvr/mvr_import_resource_resolver.cpp ../mvr/mvr_import_reference_resolver.cpp ../mvr/mvr_scene_node_reader.cpp
                ../mvr/mvr_scene_node_reader_support.cpp
                ../mvr/mvr_import_package.cpp
                ../core/fixture_visual_color.cpp
@@ -1660,7 +1672,7 @@ add_executable(rider_save_roundtrip_test rider_save_roundtrip_test.cpp
                ../core/runtime_storage.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
-               ../mvr/mvrimporter.cpp ../mvr/mvr_import_resource_resolver.cpp ../mvr/mvr_scene_node_reader.cpp
+               ../mvr/mvrimporter.cpp ../mvr/mvr_import_resource_resolver.cpp ../mvr/mvr_import_reference_resolver.cpp ../mvr/mvr_scene_node_reader.cpp
                ../mvr/mvr_scene_node_reader_support.cpp
                ../mvr/mvr_import_package.cpp
                ../core/fixture_visual_color.cpp
@@ -2346,7 +2358,7 @@ add_executable(symbol_fixture_applier_gdtf_test symbol_fixture_applier_gdtf_test
                ../viewer3d/loader3ds.cpp
                ../viewer3d/loaderglb.cpp
                ../viewer3d/meshprimitives.cpp
-               ../mvr/mvrimporter.cpp ../mvr/mvr_import_resource_resolver.cpp ../mvr/mvr_scene_node_reader.cpp
+               ../mvr/mvrimporter.cpp ../mvr/mvr_import_resource_resolver.cpp ../mvr/mvr_import_reference_resolver.cpp ../mvr/mvr_scene_node_reader.cpp
                ../mvr/mvr_scene_node_reader_support.cpp
                ../mvr/mvr_import_package.cpp
                ../core/fixture_visual_color.cpp
@@ -2409,7 +2421,7 @@ add_executable(mvr_patched_gdtf_export_test mvr_patched_gdtf_export_test.cpp
                ../viewer3d/loader3ds.cpp
                ../viewer3d/loaderglb.cpp
                ../viewer3d/meshprimitives.cpp
-               ../mvr/mvrimporter.cpp ../mvr/mvr_import_resource_resolver.cpp ../mvr/mvr_scene_node_reader.cpp
+               ../mvr/mvrimporter.cpp ../mvr/mvr_import_resource_resolver.cpp ../mvr/mvr_import_reference_resolver.cpp ../mvr/mvr_scene_node_reader.cpp
                ../mvr/mvr_scene_node_reader_support.cpp
                ../mvr/mvr_import_package.cpp
                ../core/fixture_visual_color.cpp

--- a/tests/check_mvr_import_reference_resolver_boundary.sh
+++ b/tests/check_mvr_import_reference_resolver_boundary.sh
@@ -15,4 +15,14 @@ if rg -n 'unknown_motor_fixture_uuid|unknown_(hoist|truss)_info_uuid|unknown_pro
   exit 1
 fi
 
+if rg -n 'uuidRemap|fixtureUuidRemap' mvr/mvr_scene_node_reader.h mvr/mvr_scene_node_reader.cpp; then
+  echo "The MVR scene-node reader must not own or mutate fixture UUID remap storage." >&2
+  exit 1
+fi
+
+if ! rg -q 'services\.recordFixtureUuid\(rawFixtureUuid, fixture\.uuid\)' mvr/mvr_scene_node_reader.cpp; then
+  echo "The MVR scene-node reader must record fixture aliases through its service boundary." >&2
+  exit 1
+fi
+
 echo "MVR import reference resolver boundary check passed."

--- a/tests/check_mvr_import_reference_resolver_boundary.sh
+++ b/tests/check_mvr_import_reference_resolver_boundary.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+resolver_files=(mvr/mvr_import_reference_resolver.h mvr/mvr_import_reference_resolver.cpp)
+if rg -n '#include .*gui/|#include "(configmanager|consolepanel|logindialog)|wx(Dialog|Window|MessageBox)' "${resolver_files[@]}"; then
+  echo "The MVR import reference resolver must remain GUI and application-state independent." >&2
+  exit 1
+fi
+
+if rg -n 'unknown_motor_fixture_uuid|unknown_(hoist|truss)_info_uuid|unknown_project_fixture_metadata_uuid' mvr/mvrimporter.cpp; then
+  echo "MvrImporter must delegate post-parse reference diagnostics to the resolver." >&2
+  exit 1
+fi
+
+echo "MVR import reference resolver boundary check passed."

--- a/tests/mvr_import_reference_resolver_test.cpp
+++ b/tests/mvr_import_reference_resolver_test.cpp
@@ -72,6 +72,8 @@ void TestPositionNormalization() {
 void TestPostParseReconciliation() {
   mvr::MvrImportReferenceResolver resolver;
   const std::string fixtureAlias = "20000000000040008000000000000001";
+  resolver.RecordFixtureUuid("", kFixtureUuid);
+  resolver.RecordFixtureUuid(kFixtureUuid, kFixtureUuid);
   resolver.RecordFixtureUuid(fixtureAlias, kFixtureUuid);
 
   MvrImportResult result;
@@ -97,6 +99,9 @@ void TestPostParseReconciliation() {
   assert(result.scene.supports.at(valid.uuid).motorFixtureUuid == kFixtureUuid);
   assert(result.scene.supports.at(unknown.uuid).motorFixtureUuid.empty());
   assert(result.fixtureUuidRemap.at(fixtureAlias) == kFixtureUuid);
+  assert(result.fixtureUuidRemap.size() == 1);
+  assert(!result.fixtureUuidRemap.contains(""));
+  assert(!result.fixtureUuidRemap.contains(kFixtureUuid));
   assert(result.diagnostics.size() == 7);
   assert(result.diagnostics[0].code == "unknown_motor_fixture_uuid");
   assert(result.diagnostics[1].message.find("hoist-a") != std::string::npos);

--- a/tests/mvr_import_reference_resolver_test.cpp
+++ b/tests/mvr_import_reference_resolver_test.cpp
@@ -39,15 +39,33 @@ void TestStableIdentities() {
 void TestPositionNormalization() {
   mvr::MvrImportReferenceResolver resolver;
   MvrScene scene;
-  resolver.ImportPosition(kFixtureUuid, "Canonical", scene);
-  assert(scene.positions.at(kFixtureUuid) == "Canonical");
+  resolver.ImportPosition(kFixtureUuid, "  FOH Position  ", scene);
+  assert(scene.positions.at(kFixtureUuid) == "  FOH Position  ");
 
-  resolver.ImportPosition("legacy-position", "Legacy", scene);
+  resolver.ImportPosition("legacy-position", "  Legacy Position  ", scene);
   const std::string recovered =
       resolver.LegacyPositionRemap().at("legacy-position");
-  assert(CanonicalizeUuid(recovered) == recovered);
-  assert(scene.positions.at(recovered) == "Legacy");
-  assert(resolver.EnsurePosition("legacy-position", scene) == "Legacy");
+  assert(recovered ==
+         DeriveDeterministicUuid(
+             "mvr:legacy-position:legacy-position:Legacy Position"));
+  assert(scene.positions.at(recovered) == "  Legacy Position  ");
+  assert(resolver.EnsurePosition("legacy-position", scene) ==
+         "  Legacy Position  ");
+
+  resolver.ImportPosition("whitespace-position", "   \t  ", scene);
+  const std::string whitespaceUuid =
+      DeriveDeterministicUuid("mvr:legacy-position:whitespace-position:");
+  assert(scene.positions.at(whitespaceUuid) == "   \t  ");
+
+  resolver.ImportPosition("missing-name-position", std::nullopt, scene);
+  const std::string missingNameUuid =
+      DeriveDeterministicUuid("mvr:legacy-position:missing-name-position:");
+  assert(scene.positions.at(missingNameUuid) == "missing-name-position");
+
+  resolver.ImportPosition("empty-name-position", "", scene);
+  const std::string emptyNameUuid =
+      DeriveDeterministicUuid("mvr:legacy-position:empty-name-position:");
+  assert(scene.positions.at(emptyNameUuid).empty());
 }
 
 // Verifies complete-scene aliases, validation, diagnostics, and ordering.

--- a/tests/mvr_import_reference_resolver_test.cpp
+++ b/tests/mvr_import_reference_resolver_test.cpp
@@ -1,0 +1,100 @@
+#include "mvr_import_reference_resolver.h"
+
+#include "uuidutils.h"
+
+#include <cassert>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+namespace {
+
+constexpr const char *kFixtureUuid = "20000000-0000-4000-8000-000000000001";
+
+// Builds a repeatable imported identity context for resolver tests.
+mvr::MvrImportedIdentity Identity(const std::string &rawUuid) {
+  return {"Fixture", "Layer", "Fixture 1", "1,0,0,0,1,0,0,0,1,0,0,0",
+          rawUuid,   {}};
+}
+
+// Verifies canonical identities are preserved and legacy recovery is stable.
+void TestStableIdentities() {
+  mvr::MvrImportReferenceResolver first;
+  assert(first.ResolveStableUuid(Identity(kFixtureUuid)) == kFixtureUuid);
+
+  const std::string repaired = first.ResolveStableUuid(Identity("legacy-id"));
+  mvr::MvrImportReferenceResolver second;
+  assert(second.ResolveStableUuid(Identity("legacy-id")) == repaired);
+  assert(CanonicalizeUuid(repaired) == repaired);
+
+  const std::string collision = first.ResolveStableUuid(Identity(kFixtureUuid));
+  assert(collision != kFixtureUuid);
+  mvr::MvrImportReferenceResolver repeat;
+  repeat.ResolveStableUuid(Identity(kFixtureUuid));
+  assert(repeat.ResolveStableUuid(Identity(kFixtureUuid)) == collision);
+}
+
+// Verifies standard and legacy Position identities retain their import
+// behavior.
+void TestPositionNormalization() {
+  mvr::MvrImportReferenceResolver resolver;
+  MvrScene scene;
+  resolver.ImportPosition(kFixtureUuid, "Canonical", scene);
+  assert(scene.positions.at(kFixtureUuid) == "Canonical");
+
+  resolver.ImportPosition("legacy-position", "Legacy", scene);
+  const std::string recovered =
+      resolver.LegacyPositionRemap().at("legacy-position");
+  assert(CanonicalizeUuid(recovered) == recovered);
+  assert(scene.positions.at(recovered) == "Legacy");
+  assert(resolver.EnsurePosition("legacy-position", scene) == "Legacy");
+}
+
+// Verifies complete-scene aliases, validation, diagnostics, and ordering.
+void TestPostParseReconciliation() {
+  mvr::MvrImportReferenceResolver resolver;
+  const std::string fixtureAlias = "20000000000040008000000000000001";
+  resolver.RecordFixtureUuid(fixtureAlias, kFixtureUuid);
+
+  MvrImportResult result;
+  Fixture fixture;
+  fixture.uuid = kFixtureUuid;
+  result.scene.fixtures.emplace(fixture.uuid, fixture);
+  Support valid;
+  valid.uuid = "10000000-0000-4000-8000-000000000001";
+  valid.motorFixtureUuid = fixtureAlias;
+  result.scene.supports.emplace(valid.uuid, valid);
+  Support unknown;
+  unknown.uuid = "10000000-0000-4000-8000-000000000002";
+  unknown.motorFixtureUuid = "20000000-0000-4000-8000-000000000099";
+  result.scene.supports.emplace(unknown.uuid, unknown);
+
+  const std::unordered_set<std::string> truss = {"truss-b", "truss-a"};
+  const std::unordered_set<std::string> hoist = {"hoist-b", "hoist-a"};
+  const std::unordered_set<std::string> project = {"project-b", "project-a"};
+  const std::unordered_set<std::string> consumed;
+  resolver.Reconcile(result,
+                     {truss, consumed, hoist, consumed, project, consumed});
+
+  assert(result.scene.supports.at(valid.uuid).motorFixtureUuid == kFixtureUuid);
+  assert(result.scene.supports.at(unknown.uuid).motorFixtureUuid.empty());
+  assert(result.fixtureUuidRemap.at(fixtureAlias) == kFixtureUuid);
+  assert(result.diagnostics.size() == 7);
+  assert(result.diagnostics[0].code == "unknown_motor_fixture_uuid");
+  assert(result.diagnostics[1].message.find("hoist-a") != std::string::npos);
+  assert(result.diagnostics[2].message.find("hoist-b") != std::string::npos);
+  assert(result.diagnostics[3].message.find("truss-a") != std::string::npos);
+  assert(result.diagnostics[4].message.find("truss-b") != std::string::npos);
+  assert(result.diagnostics[5].message.find("project-a") != std::string::npos);
+  assert(result.diagnostics[6].message.find("project-b") != std::string::npos);
+}
+
+} // namespace
+
+// Runs the focused CH-104 reference normalization characterization tests.
+int main() {
+  TestStableIdentities();
+  TestPositionNormalization();
+  TestPostParseReconciliation();
+  return 0;
+}

--- a/tests/source_file_size_policy.json
+++ b/tests/source_file_size_policy.json
@@ -29,7 +29,7 @@
     "gui/mainwindow_menu.cpp": 2082,
     "gui/trusstablepanel.cpp": 1528,
     "mvr/mvrexporter.cpp": 4911,
-    "mvr/mvrimporter.cpp": 2991,
+    "mvr/mvrimporter.cpp": 2872,
     "tests/mvr_exporter_compliance_test.cpp": 1664,
     "viewer2d/pdf/layout_pdf_exporter.cpp": 2352,
     "viewer2d/viewer2dpanel.cpp": 4550,


### PR DESCRIPTION
### Motivation

- Reduce responsibility in `MvrImporter` by extracting UUID/reference normalization, legacy remapping and complete-scene post-parse reconciliation into a small, GUI-independent component while preserving existing tolerance and diagnostics.
- Keep scene-node parsing, package acquisition and resource resolution boundaries intact so the scene reader and `MvrImportResourceResolver` remain owners of their responsibilities.

### Description

- Added a focused resolver `mvr/mvr_import_reference_resolver.{h,cpp}` that owns stable-identity canonicalization, deterministic fallback generation, collision handling, fixture-UUID aliasing and legacy position remapping, and that emits compatibility warnings through a pluggable sink. The header exposes narrow APIs: `ResolveStableUuid`, `ReferenceUuid`, `ImportPosition`, `EnsurePosition`, `RecordFixtureUuid`, `FixtureUuidRemap`, `LegacyPositionRemap` and `Reconcile`.
- Moved post-parse reconciliation into the resolver: deterministic `Support::motorFixtureUuid` alias resolution, validation that resolved fixtures exist, clearing/diagnosing unknown motor fixtures, and deterministic diagnostics for unused/unconsumed `HoistInfo`, `TrussInfo` and project fixture metadata while preserving existing diagnostic codes/messages.
- Updated `MvrImporter` to construct the resolver, forward a minimal identity context (seed) to the scene reader via the resolver callbacks, provide the resolver-owned `fixtureUuidRemap` and legacy-position remap into the `MvrSceneReadState`/metadata, and invoke `Reconcile(...)` after scene nodes are read; `MvrImporter` remains orchestration-only for CH-104 scope.
- Added a focused characterization unit test `tests/mvr_import_reference_resolver_test.cpp` covering canonical UUID preservation, deterministic repair of malformed/legacy IDs, collision behavior, legacy position recovery, fixture alias application, motor-fixture reconciliation and deterministic ordering of metadata diagnostics.
- Added a repository policy check `tests/check_mvr_import_reference_resolver_boundary.sh` to assert the new resolver is GUI/application-state independent and that post-parse diagnostic ownership was moved out of `MvrImporter`.
- CMake and test integration: register new source files in `mvr/CMakeLists.txt`, wire the new test in `tests/CMakeLists.txt` and adjust the `tests/source_file_size_policy.json` baseline for `mvr/mvrimporter.cpp` (reduced from `2991` to `2872` physical lines), and added a short release-note entry in `docs/release-notes-draft.md` describing the internal change.

### Testing

- Ran the focused C++ characterization test by compiling with `-std=c++20 -Wall -Wextra -Werror` and executing it; the test passed locally.
- Ran repository and policy checks: `python3 tests/check_source_file_size.py`, `python3 tests/check_repository_hygiene.py`, `tests/check_perastage_tree_modules.sh`, `tests/check_no_configmanager_get_in_gui.sh`, `tests/check_mvr_import_package_boundary.sh`, `tests/check_mvr_import_resource_resolver_boundary.sh`, `tests/check_mvr_scene_node_reader_boundary.sh`, `tests/check_mvr_import_reference_resolver_boundary.sh`, `python3 tests/check_docs_links.py`, and `python3 tests/check_ci_workflow_architecture.py`; these passed in the local environment used for development.
- Per-environment limitation: a full CMake Debug configure/build could not complete locally because the host lacks the system `wxWidgets` development libraries, so full importer characterization/round-trip CTest suites were not executed locally; hosted CI remains authoritative for full Debug CTest runs (linux-debug, windows-debug, macos-debug and Core/MVR coverage).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6aa5773f0fa48324a3a47263c2583951)